### PR TITLE
Add U.S. House district in Onondaga County precinct returns

### DIFF
--- a/2016/20161108__ny__general__onondaga__precinct.csv
+++ b/2016/20161108__ny__general__onondaga__precinct.csv
@@ -2317,860 +2317,860 @@ Onondaga,W19P05,U.S. Senate,,,Write-ins,0
 Onondaga,W19P06,U.S. Senate,,,Write-ins,0
 Onondaga,W19P07,U.S. Senate,,,Write-ins,1
 Onondaga,Syracuse Total,U.S. Senate,,,Write-ins,25
-Onondaga,W01P01,U.S. House,,DEM,Colleen Deacon,155
-Onondaga,W01P02,U.S. House,,DEM,Colleen Deacon,218
-Onondaga,W01P03,U.S. House,,DEM,Colleen Deacon,108
-Onondaga,W01P04,U.S. House,,DEM,Colleen Deacon,182
-Onondaga,W01P05,U.S. House,,DEM,Colleen Deacon,210
-Onondaga,W01P07,U.S. House,,DEM,Colleen Deacon,13
-Onondaga,W01P08,U.S. House,,DEM,Colleen Deacon,100
-Onondaga,W01P09,U.S. House,,DEM,Colleen Deacon,9
-Onondaga,W02P01,U.S. House,,DEM,Colleen Deacon,322
-Onondaga,W02P02,U.S. House,,DEM,Colleen Deacon,325
-Onondaga,W03P01,U.S. House,,DEM,Colleen Deacon,172
-Onondaga,W03P03,U.S. House,,DEM,Colleen Deacon,346
-Onondaga,W03P04,U.S. House,,DEM,Colleen Deacon,153
-Onondaga,W03P05,U.S. House,,DEM,Colleen Deacon,256
-Onondaga,W03P06,U.S. House,,DEM,Colleen Deacon,88
-Onondaga,W04P01,U.S. House,,DEM,Colleen Deacon,179
-Onondaga,W04P02,U.S. House,,DEM,Colleen Deacon,185
-Onondaga,W04P03,U.S. House,,DEM,Colleen Deacon,196
-Onondaga,W04P04,U.S. House,,DEM,Colleen Deacon,227
-Onondaga,W04P05,U.S. House,,DEM,Colleen Deacon,210
-Onondaga,W04P07,U.S. House,,DEM,Colleen Deacon,298
-Onondaga,W04P08,U.S. House,,DEM,Colleen Deacon,251
-Onondaga,W04P09,U.S. House,,DEM,Colleen Deacon,256
-Onondaga,W05P01,U.S. House,,DEM,Colleen Deacon,264
-Onondaga,W05P02,U.S. House,,DEM,Colleen Deacon,113
-Onondaga,W05P03,U.S. House,,DEM,Colleen Deacon,146
-Onondaga,W05P04,U.S. House,,DEM,Colleen Deacon,202
-Onondaga,W05P05,U.S. House,,DEM,Colleen Deacon,161
-Onondaga,W05P06,U.S. House,,DEM,Colleen Deacon,216
-Onondaga,W05P07,U.S. House,,DEM,Colleen Deacon,198
-Onondaga,W05P08,U.S. House,,DEM,Colleen Deacon,0
-Onondaga,W05P09,U.S. House,,DEM,Colleen Deacon,160
-Onondaga,W05P10,U.S. House,,DEM,Colleen Deacon,246
-Onondaga,W05P11,U.S. House,,DEM,Colleen Deacon,236
-Onondaga,W06P01,U.S. House,,DEM,Colleen Deacon,367
-Onondaga,W06P02,U.S. House,,DEM,Colleen Deacon,210
-Onondaga,W06P03,U.S. House,,DEM,Colleen Deacon,185
-Onondaga,W06P04,U.S. House,,DEM,Colleen Deacon,75
-Onondaga,W06P05,U.S. House,,DEM,Colleen Deacon,200
-Onondaga,W06P06,U.S. House,,DEM,Colleen Deacon,168
-Onondaga,W07P01,U.S. House,,DEM,Colleen Deacon,238
-Onondaga,W07P02,U.S. House,,DEM,Colleen Deacon,289
-Onondaga,W08P01,U.S. House,,DEM,Colleen Deacon,197
-Onondaga,W08P02,U.S. House,,DEM,Colleen Deacon,223
-Onondaga,W08P03,U.S. House,,DEM,Colleen Deacon,159
-Onondaga,W08P04,U.S. House,,DEM,Colleen Deacon,170
-Onondaga,W09P01,U.S. House,,DEM,Colleen Deacon,189
-Onondaga,W09P02,U.S. House,,DEM,Colleen Deacon,159
-Onondaga,W09P04,U.S. House,,DEM,Colleen Deacon,39
-Onondaga,W09P05,U.S. House,,DEM,Colleen Deacon,240
-Onondaga,W10P01,U.S. House,,DEM,Colleen Deacon,105
-Onondaga,W10P02,U.S. House,,DEM,Colleen Deacon,59
-Onondaga,W10P03,U.S. House,,DEM,Colleen Deacon,238
-Onondaga,W10P04,U.S. House,,DEM,Colleen Deacon,193
-Onondaga,W11P01,U.S. House,,DEM,Colleen Deacon,250
-Onondaga,W11P02,U.S. House,,DEM,Colleen Deacon,204
-Onondaga,W11P03,U.S. House,,DEM,Colleen Deacon,196
-Onondaga,W11P04,U.S. House,,DEM,Colleen Deacon,298
-Onondaga,W11P07,U.S. House,,DEM,Colleen Deacon,180
-Onondaga,W11P08,U.S. House,,DEM,Colleen Deacon,6
-Onondaga,W11P09,U.S. House,,DEM,Colleen Deacon,15
-Onondaga,W12P01,U.S. House,,DEM,Colleen Deacon,316
-Onondaga,W12P02,U.S. House,,DEM,Colleen Deacon,174
-Onondaga,W12P03,U.S. House,,DEM,Colleen Deacon,29
-Onondaga,W12P04,U.S. House,,DEM,Colleen Deacon,253
-Onondaga,W12P05,U.S. House,,DEM,Colleen Deacon,353
-Onondaga,W13P01,U.S. House,,DEM,Colleen Deacon,373
-Onondaga,W13P02,U.S. House,,DEM,Colleen Deacon,185
-Onondaga,W13P03,U.S. House,,DEM,Colleen Deacon,266
-Onondaga,W13P04,U.S. House,,DEM,Colleen Deacon,207
-Onondaga,W13P05,U.S. House,,DEM,Colleen Deacon,340
-Onondaga,W13P06,U.S. House,,DEM,Colleen Deacon,350
-Onondaga,W13P07,U.S. House,,DEM,Colleen Deacon,183
-Onondaga,W13P08,U.S. House,,DEM,Colleen Deacon,210
-Onondaga,W13P09,U.S. House,,DEM,Colleen Deacon,130
-Onondaga,W14P01,U.S. House,,DEM,Colleen Deacon,450
-Onondaga,W14P02,U.S. House,,DEM,Colleen Deacon,191
-Onondaga,W14P03,U.S. House,,DEM,Colleen Deacon,337
-Onondaga,W14P04,U.S. House,,DEM,Colleen Deacon,230
-Onondaga,W14P06,U.S. House,,DEM,Colleen Deacon,238
-Onondaga,W14P07,U.S. House,,DEM,Colleen Deacon,196
-Onondaga,W14P08,U.S. House,,DEM,Colleen Deacon,243
-Onondaga,W14P09,U.S. House,,DEM,Colleen Deacon,167
-Onondaga,W14P10,U.S. House,,DEM,Colleen Deacon,130
-Onondaga,W14P11,U.S. House,,DEM,Colleen Deacon,324
-Onondaga,W14P12,U.S. House,,DEM,Colleen Deacon,217
-Onondaga,W15P01,U.S. House,,DEM,Colleen Deacon,99
-Onondaga,W15P02,U.S. House,,DEM,Colleen Deacon,43
-Onondaga,W15P03,U.S. House,,DEM,Colleen Deacon,90
-Onondaga,W16P01,U.S. House,,DEM,Colleen Deacon,319
-Onondaga,W16P02,U.S. House,,DEM,Colleen Deacon,328
-Onondaga,W16P03,U.S. House,,DEM,Colleen Deacon,294
-Onondaga,W16P04,U.S. House,,DEM,Colleen Deacon,502
-Onondaga,W17P01,U.S. House,,DEM,Colleen Deacon,7
-Onondaga,W17P02,U.S. House,,DEM,Colleen Deacon,432
-Onondaga,W17P03,U.S. House,,DEM,Colleen Deacon,284
-Onondaga,W17P04,U.S. House,,DEM,Colleen Deacon,281
-Onondaga,W17P05,U.S. House,,DEM,Colleen Deacon,190
-Onondaga,W17P06,U.S. House,,DEM,Colleen Deacon,232
-Onondaga,W17P07,U.S. House,,DEM,Colleen Deacon,342
-Onondaga,W17P08,U.S. House,,DEM,Colleen Deacon,289
-Onondaga,W17P09,U.S. House,,DEM,Colleen Deacon,345
-Onondaga,W17P10,U.S. House,,DEM,Colleen Deacon,339
-Onondaga,W17P11,U.S. House,,DEM,Colleen Deacon,235
-Onondaga,W17P12,U.S. House,,DEM,Colleen Deacon,290
-Onondaga,W17P13,U.S. House,,DEM,Colleen Deacon,280
-Onondaga,W17P14,U.S. House,,DEM,Colleen Deacon,332
-Onondaga,W17P15,U.S. House,,DEM,Colleen Deacon,370
-Onondaga,W17P16,U.S. House,,DEM,Colleen Deacon,215
-Onondaga,W17P17,U.S. House,,DEM,Colleen Deacon,136
-Onondaga,W17P18,U.S. House,,DEM,Colleen Deacon,0
-Onondaga,W17P19,U.S. House,,DEM,Colleen Deacon,27
-Onondaga,W18P01,U.S. House,,DEM,Colleen Deacon,281
-Onondaga,W18P02,U.S. House,,DEM,Colleen Deacon,346
-Onondaga,W19P01,U.S. House,,DEM,Colleen Deacon,259
-Onondaga,W19P02,U.S. House,,DEM,Colleen Deacon,392
-Onondaga,W19P03,U.S. House,,DEM,Colleen Deacon,464
-Onondaga,W19P04,U.S. House,,DEM,Colleen Deacon,159
-Onondaga,W19P05,U.S. House,,DEM,Colleen Deacon,280
-Onondaga,W19P06,U.S. House,,DEM,Colleen Deacon,484
-Onondaga,W19P07,U.S. House,,DEM,Colleen Deacon,226
-Onondaga,Syracuse Total,U.S. House,,DEM,Colleen Deacon,26537
-Onondaga,W01P01,U.S. House,,REP,John Katko,181
-Onondaga,W01P02,U.S. House,,REP,John Katko,160
-Onondaga,W01P03,U.S. House,,REP,John Katko,66
-Onondaga,W01P04,U.S. House,,REP,John Katko,98
-Onondaga,W01P05,U.S. House,,REP,John Katko,160
-Onondaga,W01P07,U.S. House,,REP,John Katko,10
-Onondaga,W01P08,U.S. House,,REP,John Katko,74
-Onondaga,W01P09,U.S. House,,REP,John Katko,2
-Onondaga,W02P01,U.S. House,,REP,John Katko,149
-Onondaga,W02P02,U.S. House,,REP,John Katko,184
-Onondaga,W03P01,U.S. House,,REP,John Katko,101
-Onondaga,W03P03,U.S. House,,REP,John Katko,313
-Onondaga,W03P04,U.S. House,,REP,John Katko,91
-Onondaga,W03P05,U.S. House,,REP,John Katko,228
-Onondaga,W03P06,U.S. House,,REP,John Katko,58
-Onondaga,W04P01,U.S. House,,REP,John Katko,69
-Onondaga,W04P02,U.S. House,,REP,John Katko,110
-Onondaga,W04P03,U.S. House,,REP,John Katko,158
-Onondaga,W04P04,U.S. House,,REP,John Katko,232
-Onondaga,W04P05,U.S. House,,REP,John Katko,198
-Onondaga,W04P07,U.S. House,,REP,John Katko,204
-Onondaga,W04P08,U.S. House,,REP,John Katko,114
-Onondaga,W04P09,U.S. House,,REP,John Katko,158
-Onondaga,W05P01,U.S. House,,REP,John Katko,146
-Onondaga,W05P02,U.S. House,,REP,John Katko,117
-Onondaga,W05P03,U.S. House,,REP,John Katko,102
-Onondaga,W05P04,U.S. House,,REP,John Katko,177
-Onondaga,W05P05,U.S. House,,REP,John Katko,155
-Onondaga,W05P06,U.S. House,,REP,John Katko,156
-Onondaga,W05P07,U.S. House,,REP,John Katko,172
-Onondaga,W05P08,U.S. House,,REP,John Katko,0
-Onondaga,W05P09,U.S. House,,REP,John Katko,192
-Onondaga,W05P10,U.S. House,,REP,John Katko,177
-Onondaga,W05P11,U.S. House,,REP,John Katko,174
-Onondaga,W06P01,U.S. House,,REP,John Katko,95
-Onondaga,W06P02,U.S. House,,REP,John Katko,90
-Onondaga,W06P03,U.S. House,,REP,John Katko,69
-Onondaga,W06P04,U.S. House,,REP,John Katko,47
-Onondaga,W06P05,U.S. House,,REP,John Katko,124
-Onondaga,W06P06,U.S. House,,REP,John Katko,80
-Onondaga,W07P01,U.S. House,,REP,John Katko,230
-Onondaga,W07P02,U.S. House,,REP,John Katko,303
-Onondaga,W08P01,U.S. House,,REP,John Katko,18
-Onondaga,W08P02,U.S. House,,REP,John Katko,211
-Onondaga,W08P03,U.S. House,,REP,John Katko,29
-Onondaga,W08P04,U.S. House,,REP,John Katko,156
-Onondaga,W09P01,U.S. House,,REP,John Katko,81
-Onondaga,W09P02,U.S. House,,REP,John Katko,49
-Onondaga,W09P04,U.S. House,,REP,John Katko,15
-Onondaga,W09P05,U.S. House,,REP,John Katko,18
-Onondaga,W10P01,U.S. House,,REP,John Katko,22
-Onondaga,W10P02,U.S. House,,REP,John Katko,12
-Onondaga,W10P03,U.S. House,,REP,John Katko,37
-Onondaga,W10P04,U.S. House,,REP,John Katko,17
-Onondaga,W11P01,U.S. House,,REP,John Katko,54
-Onondaga,W11P02,U.S. House,,REP,John Katko,64
-Onondaga,W11P03,U.S. House,,REP,John Katko,96
-Onondaga,W11P04,U.S. House,,REP,John Katko,205
-Onondaga,W11P07,U.S. House,,REP,John Katko,309
-Onondaga,W11P08,U.S. House,,REP,John Katko,1
-Onondaga,W11P09,U.S. House,,REP,John Katko,4
-Onondaga,W12P01,U.S. House,,REP,John Katko,24
-Onondaga,W12P02,U.S. House,,REP,John Katko,12
-Onondaga,W12P03,U.S. House,,REP,John Katko,11
-Onondaga,W12P04,U.S. House,,REP,John Katko,64
-Onondaga,W12P05,U.S. House,,REP,John Katko,238
-Onondaga,W13P01,U.S. House,,REP,John Katko,43
-Onondaga,W13P02,U.S. House,,REP,John Katko,55
-Onondaga,W13P03,U.S. House,,REP,John Katko,165
-Onondaga,W13P04,U.S. House,,REP,John Katko,91
-Onondaga,W13P05,U.S. House,,REP,John Katko,107
-Onondaga,W13P06,U.S. House,,REP,John Katko,33
-Onondaga,W13P07,U.S. House,,REP,John Katko,101
-Onondaga,W13P08,U.S. House,,REP,John Katko,79
-Onondaga,W13P09,U.S. House,,REP,John Katko,115
-Onondaga,W14P01,U.S. House,,REP,John Katko,54
-Onondaga,W14P02,U.S. House,,REP,John Katko,103
-Onondaga,W14P03,U.S. House,,REP,John Katko,34
-Onondaga,W14P04,U.S. House,,REP,John Katko,51
-Onondaga,W14P06,U.S. House,,REP,John Katko,164
-Onondaga,W14P07,U.S. House,,REP,John Katko,186
-Onondaga,W14P08,U.S. House,,REP,John Katko,63
-Onondaga,W14P09,U.S. House,,REP,John Katko,71
-Onondaga,W14P10,U.S. House,,REP,John Katko,34
-Onondaga,W14P11,U.S. House,,REP,John Katko,185
-Onondaga,W14P12,U.S. House,,REP,John Katko,104
-Onondaga,W15P01,U.S. House,,REP,John Katko,38
-Onondaga,W15P02,U.S. House,,REP,John Katko,4
-Onondaga,W15P03,U.S. House,,REP,John Katko,33
-Onondaga,W16P01,U.S. House,,REP,John Katko,88
-Onondaga,W16P02,U.S. House,,REP,John Katko,62
-Onondaga,W16P03,U.S. House,,REP,John Katko,71
-Onondaga,W16P04,U.S. House,,REP,John Katko,140
-Onondaga,W17P01,U.S. House,,REP,John Katko,4
-Onondaga,W17P02,U.S. House,,REP,John Katko,93
-Onondaga,W17P03,U.S. House,,REP,John Katko,56
-Onondaga,W17P04,U.S. House,,REP,John Katko,52
-Onondaga,W17P05,U.S. House,,REP,John Katko,32
-Onondaga,W17P06,U.S. House,,REP,John Katko,26
-Onondaga,W17P07,U.S. House,,REP,John Katko,54
-Onondaga,W17P08,U.S. House,,REP,John Katko,51
-Onondaga,W17P09,U.S. House,,REP,John Katko,110
-Onondaga,W17P10,U.S. House,,REP,John Katko,37
-Onondaga,W17P11,U.S. House,,REP,John Katko,25
-Onondaga,W17P12,U.S. House,,REP,John Katko,83
-Onondaga,W17P13,U.S. House,,REP,John Katko,140
-Onondaga,W17P14,U.S. House,,REP,John Katko,53
-Onondaga,W17P15,U.S. House,,REP,John Katko,139
-Onondaga,W17P16,U.S. House,,REP,John Katko,83
-Onondaga,W17P17,U.S. House,,REP,John Katko,39
-Onondaga,W17P18,U.S. House,,REP,John Katko,0
-Onondaga,W17P19,U.S. House,,REP,John Katko,4
-Onondaga,W18P01,U.S. House,,REP,John Katko,16
-Onondaga,W18P02,U.S. House,,REP,John Katko,27
-Onondaga,W19P01,U.S. House,,REP,John Katko,24
-Onondaga,W19P02,U.S. House,,REP,John Katko,29
-Onondaga,W19P03,U.S. House,,REP,John Katko,125
-Onondaga,W19P04,U.S. House,,REP,John Katko,51
-Onondaga,W19P05,U.S. House,,REP,John Katko,23
-Onondaga,W19P06,U.S. House,,REP,John Katko,78
-Onondaga,W19P07,U.S. House,,REP,John Katko,64
-Onondaga,Syracuse Total,U.S. House,,REP,John Katko,11263
-Onondaga,W01P01,U.S. House,,CON,John Katko,19
-Onondaga,W01P02,U.S. House,,CON,John Katko,24
-Onondaga,W01P03,U.S. House,,CON,John Katko,11
-Onondaga,W01P04,U.S. House,,CON,John Katko,16
-Onondaga,W01P05,U.S. House,,CON,John Katko,13
-Onondaga,W01P07,U.S. House,,CON,John Katko,1
-Onondaga,W01P08,U.S. House,,CON,John Katko,13
-Onondaga,W01P09,U.S. House,,CON,John Katko,0
-Onondaga,W02P01,U.S. House,,CON,John Katko,23
-Onondaga,W02P02,U.S. House,,CON,John Katko,17
-Onondaga,W03P01,U.S. House,,CON,John Katko,15
-Onondaga,W03P03,U.S. House,,CON,John Katko,38
-Onondaga,W03P04,U.S. House,,CON,John Katko,8
-Onondaga,W03P05,U.S. House,,CON,John Katko,24
-Onondaga,W03P06,U.S. House,,CON,John Katko,6
-Onondaga,W04P01,U.S. House,,CON,John Katko,14
-Onondaga,W04P02,U.S. House,,CON,John Katko,25
-Onondaga,W04P03,U.S. House,,CON,John Katko,29
-Onondaga,W04P04,U.S. House,,CON,John Katko,40
-Onondaga,W04P05,U.S. House,,CON,John Katko,29
-Onondaga,W04P07,U.S. House,,CON,John Katko,25
-Onondaga,W04P08,U.S. House,,CON,John Katko,21
-Onondaga,W04P09,U.S. House,,CON,John Katko,29
-Onondaga,W05P01,U.S. House,,CON,John Katko,14
-Onondaga,W05P02,U.S. House,,CON,John Katko,16
-Onondaga,W05P03,U.S. House,,CON,John Katko,11
-Onondaga,W05P04,U.S. House,,CON,John Katko,24
-Onondaga,W05P05,U.S. House,,CON,John Katko,18
-Onondaga,W05P06,U.S. House,,CON,John Katko,22
-Onondaga,W05P07,U.S. House,,CON,John Katko,27
-Onondaga,W05P08,U.S. House,,CON,John Katko,0
-Onondaga,W05P09,U.S. House,,CON,John Katko,23
-Onondaga,W05P10,U.S. House,,CON,John Katko,34
-Onondaga,W05P11,U.S. House,,CON,John Katko,20
-Onondaga,W06P01,U.S. House,,CON,John Katko,13
-Onondaga,W06P02,U.S. House,,CON,John Katko,17
-Onondaga,W06P03,U.S. House,,CON,John Katko,14
-Onondaga,W06P04,U.S. House,,CON,John Katko,7
-Onondaga,W06P05,U.S. House,,CON,John Katko,25
-Onondaga,W06P06,U.S. House,,CON,John Katko,17
-Onondaga,W07P01,U.S. House,,CON,John Katko,32
-Onondaga,W07P02,U.S. House,,CON,John Katko,30
-Onondaga,W08P01,U.S. House,,CON,John Katko,3
-Onondaga,W08P02,U.S. House,,CON,John Katko,28
-Onondaga,W08P03,U.S. House,,CON,John Katko,9
-Onondaga,W08P04,U.S. House,,CON,John Katko,12
-Onondaga,W09P01,U.S. House,,CON,John Katko,5
-Onondaga,W09P02,U.S. House,,CON,John Katko,13
-Onondaga,W09P04,U.S. House,,CON,John Katko,2
-Onondaga,W09P05,U.S. House,,CON,John Katko,3
-Onondaga,W10P01,U.S. House,,CON,John Katko,8
-Onondaga,W10P02,U.S. House,,CON,John Katko,2
-Onondaga,W10P03,U.S. House,,CON,John Katko,11
-Onondaga,W10P04,U.S. House,,CON,John Katko,3
-Onondaga,W11P01,U.S. House,,CON,John Katko,14
-Onondaga,W11P02,U.S. House,,CON,John Katko,12
-Onondaga,W11P03,U.S. House,,CON,John Katko,11
-Onondaga,W11P04,U.S. House,,CON,John Katko,28
-Onondaga,W11P07,U.S. House,,CON,John Katko,25
-Onondaga,W11P08,U.S. House,,CON,John Katko,5
-Onondaga,W11P09,U.S. House,,CON,John Katko,1
-Onondaga,W12P01,U.S. House,,CON,John Katko,4
-Onondaga,W12P02,U.S. House,,CON,John Katko,4
-Onondaga,W12P03,U.S. House,,CON,John Katko,2
-Onondaga,W12P04,U.S. House,,CON,John Katko,3
-Onondaga,W12P05,U.S. House,,CON,John Katko,41
-Onondaga,W13P01,U.S. House,,CON,John Katko,7
-Onondaga,W13P02,U.S. House,,CON,John Katko,5
-Onondaga,W13P03,U.S. House,,CON,John Katko,23
-Onondaga,W13P04,U.S. House,,CON,John Katko,20
-Onondaga,W13P05,U.S. House,,CON,John Katko,22
-Onondaga,W13P06,U.S. House,,CON,John Katko,4
-Onondaga,W13P07,U.S. House,,CON,John Katko,24
-Onondaga,W13P08,U.S. House,,CON,John Katko,15
-Onondaga,W13P09,U.S. House,,CON,John Katko,6
-Onondaga,W14P01,U.S. House,,CON,John Katko,7
-Onondaga,W14P02,U.S. House,,CON,John Katko,16
-Onondaga,W14P03,U.S. House,,CON,John Katko,8
-Onondaga,W14P04,U.S. House,,CON,John Katko,7
-Onondaga,W14P06,U.S. House,,CON,John Katko,19
-Onondaga,W14P07,U.S. House,,CON,John Katko,41
-Onondaga,W14P08,U.S. House,,CON,John Katko,10
-Onondaga,W14P09,U.S. House,,CON,John Katko,7
-Onondaga,W14P10,U.S. House,,CON,John Katko,9
-Onondaga,W14P11,U.S. House,,CON,John Katko,32
-Onondaga,W14P12,U.S. House,,CON,John Katko,15
-Onondaga,W15P01,U.S. House,,CON,John Katko,3
-Onondaga,W15P02,U.S. House,,CON,John Katko,1
-Onondaga,W15P03,U.S. House,,CON,John Katko,2
-Onondaga,W16P01,U.S. House,,CON,John Katko,11
-Onondaga,W16P02,U.S. House,,CON,John Katko,3
-Onondaga,W16P03,U.S. House,,CON,John Katko,6
-Onondaga,W16P04,U.S. House,,CON,John Katko,18
-Onondaga,W17P01,U.S. House,,CON,John Katko,0
-Onondaga,W17P02,U.S. House,,CON,John Katko,15
-Onondaga,W17P03,U.S. House,,CON,John Katko,9
-Onondaga,W17P04,U.S. House,,CON,John Katko,8
-Onondaga,W17P05,U.S. House,,CON,John Katko,9
-Onondaga,W17P06,U.S. House,,CON,John Katko,2
-Onondaga,W17P07,U.S. House,,CON,John Katko,7
-Onondaga,W17P08,U.S. House,,CON,John Katko,13
-Onondaga,W17P09,U.S. House,,CON,John Katko,6
-Onondaga,W17P10,U.S. House,,CON,John Katko,6
-Onondaga,W17P11,U.S. House,,CON,John Katko,4
-Onondaga,W17P12,U.S. House,,CON,John Katko,7
-Onondaga,W17P13,U.S. House,,CON,John Katko,16
-Onondaga,W17P14,U.S. House,,CON,John Katko,10
-Onondaga,W17P15,U.S. House,,CON,John Katko,13
-Onondaga,W17P16,U.S. House,,CON,John Katko,14
-Onondaga,W17P17,U.S. House,,CON,John Katko,6
-Onondaga,W17P18,U.S. House,,CON,John Katko,0
-Onondaga,W17P19,U.S. House,,CON,John Katko,0
-Onondaga,W18P01,U.S. House,,CON,John Katko,1
-Onondaga,W18P02,U.S. House,,CON,John Katko,7
-Onondaga,W19P01,U.S. House,,CON,John Katko,3
-Onondaga,W19P02,U.S. House,,CON,John Katko,11
-Onondaga,W19P03,U.S. House,,CON,John Katko,21
-Onondaga,W19P04,U.S. House,,CON,John Katko,9
-Onondaga,W19P05,U.S. House,,CON,John Katko,3
-Onondaga,W19P06,U.S. House,,CON,John Katko,12
-Onondaga,W19P07,U.S. House,,CON,John Katko,6
-Onondaga,Syracuse Total,U.S. House,,CON,John Katko,1612
-Onondaga,W01P01,U.S. House,,WOR,Colleen Deacon,14
-Onondaga,W01P02,U.S. House,,WOR,Colleen Deacon,18
-Onondaga,W01P03,U.S. House,,WOR,Colleen Deacon,9
-Onondaga,W01P04,U.S. House,,WOR,Colleen Deacon,14
-Onondaga,W01P05,U.S. House,,WOR,Colleen Deacon,19
-Onondaga,W01P07,U.S. House,,WOR,Colleen Deacon,0
-Onondaga,W01P08,U.S. House,,WOR,Colleen Deacon,6
-Onondaga,W01P09,U.S. House,,WOR,Colleen Deacon,0
-Onondaga,W02P01,U.S. House,,WOR,Colleen Deacon,35
-Onondaga,W02P02,U.S. House,,WOR,Colleen Deacon,20
-Onondaga,W03P01,U.S. House,,WOR,Colleen Deacon,23
-Onondaga,W03P03,U.S. House,,WOR,Colleen Deacon,22
-Onondaga,W03P04,U.S. House,,WOR,Colleen Deacon,8
-Onondaga,W03P05,U.S. House,,WOR,Colleen Deacon,26
-Onondaga,W03P06,U.S. House,,WOR,Colleen Deacon,6
-Onondaga,W04P01,U.S. House,,WOR,Colleen Deacon,15
-Onondaga,W04P02,U.S. House,,WOR,Colleen Deacon,16
-Onondaga,W04P03,U.S. House,,WOR,Colleen Deacon,10
-Onondaga,W04P04,U.S. House,,WOR,Colleen Deacon,23
-Onondaga,W04P05,U.S. House,,WOR,Colleen Deacon,22
-Onondaga,W04P07,U.S. House,,WOR,Colleen Deacon,17
-Onondaga,W04P08,U.S. House,,WOR,Colleen Deacon,21
-Onondaga,W04P09,U.S. House,,WOR,Colleen Deacon,19
-Onondaga,W05P01,U.S. House,,WOR,Colleen Deacon,36
-Onondaga,W05P02,U.S. House,,WOR,Colleen Deacon,13
-Onondaga,W05P03,U.S. House,,WOR,Colleen Deacon,9
-Onondaga,W05P04,U.S. House,,WOR,Colleen Deacon,18
-Onondaga,W05P05,U.S. House,,WOR,Colleen Deacon,13
-Onondaga,W05P06,U.S. House,,WOR,Colleen Deacon,15
-Onondaga,W05P07,U.S. House,,WOR,Colleen Deacon,15
-Onondaga,W05P08,U.S. House,,WOR,Colleen Deacon,0
-Onondaga,W05P09,U.S. House,,WOR,Colleen Deacon,12
-Onondaga,W05P10,U.S. House,,WOR,Colleen Deacon,27
-Onondaga,W05P11,U.S. House,,WOR,Colleen Deacon,17
-Onondaga,W06P01,U.S. House,,WOR,Colleen Deacon,24
-Onondaga,W06P02,U.S. House,,WOR,Colleen Deacon,18
-Onondaga,W06P03,U.S. House,,WOR,Colleen Deacon,9
-Onondaga,W06P04,U.S. House,,WOR,Colleen Deacon,4
-Onondaga,W06P05,U.S. House,,WOR,Colleen Deacon,13
-Onondaga,W06P06,U.S. House,,WOR,Colleen Deacon,23
-Onondaga,W07P01,U.S. House,,WOR,Colleen Deacon,25
-Onondaga,W07P02,U.S. House,,WOR,Colleen Deacon,28
-Onondaga,W08P01,U.S. House,,WOR,Colleen Deacon,12
-Onondaga,W08P02,U.S. House,,WOR,Colleen Deacon,20
-Onondaga,W08P03,U.S. House,,WOR,Colleen Deacon,6
-Onondaga,W08P04,U.S. House,,WOR,Colleen Deacon,14
-Onondaga,W09P01,U.S. House,,WOR,Colleen Deacon,5
-Onondaga,W09P02,U.S. House,,WOR,Colleen Deacon,10
-Onondaga,W09P04,U.S. House,,WOR,Colleen Deacon,4
-Onondaga,W09P05,U.S. House,,WOR,Colleen Deacon,10
-Onondaga,W10P01,U.S. House,,WOR,Colleen Deacon,6
-Onondaga,W10P02,U.S. House,,WOR,Colleen Deacon,1
-Onondaga,W10P03,U.S. House,,WOR,Colleen Deacon,13
-Onondaga,W10P04,U.S. House,,WOR,Colleen Deacon,2
-Onondaga,W11P01,U.S. House,,WOR,Colleen Deacon,14
-Onondaga,W11P02,U.S. House,,WOR,Colleen Deacon,11
-Onondaga,W11P03,U.S. House,,WOR,Colleen Deacon,24
-Onondaga,W11P04,U.S. House,,WOR,Colleen Deacon,22
-Onondaga,W11P07,U.S. House,,WOR,Colleen Deacon,8
-Onondaga,W11P08,U.S. House,,WOR,Colleen Deacon,0
-Onondaga,W11P09,U.S. House,,WOR,Colleen Deacon,3
-Onondaga,W12P01,U.S. House,,WOR,Colleen Deacon,13
-Onondaga,W12P02,U.S. House,,WOR,Colleen Deacon,9
-Onondaga,W12P03,U.S. House,,WOR,Colleen Deacon,4
-Onondaga,W12P04,U.S. House,,WOR,Colleen Deacon,11
-Onondaga,W12P05,U.S. House,,WOR,Colleen Deacon,35
-Onondaga,W13P01,U.S. House,,WOR,Colleen Deacon,18
-Onondaga,W13P02,U.S. House,,WOR,Colleen Deacon,16
-Onondaga,W13P03,U.S. House,,WOR,Colleen Deacon,23
-Onondaga,W13P04,U.S. House,,WOR,Colleen Deacon,13
-Onondaga,W13P05,U.S. House,,WOR,Colleen Deacon,14
-Onondaga,W13P06,U.S. House,,WOR,Colleen Deacon,11
-Onondaga,W13P07,U.S. House,,WOR,Colleen Deacon,14
-Onondaga,W13P08,U.S. House,,WOR,Colleen Deacon,12
-Onondaga,W13P09,U.S. House,,WOR,Colleen Deacon,7
-Onondaga,W14P01,U.S. House,,WOR,Colleen Deacon,21
-Onondaga,W14P02,U.S. House,,WOR,Colleen Deacon,11
-Onondaga,W14P03,U.S. House,,WOR,Colleen Deacon,17
-Onondaga,W14P04,U.S. House,,WOR,Colleen Deacon,9
-Onondaga,W14P06,U.S. House,,WOR,Colleen Deacon,16
-Onondaga,W14P07,U.S. House,,WOR,Colleen Deacon,15
-Onondaga,W14P08,U.S. House,,WOR,Colleen Deacon,9
-Onondaga,W14P09,U.S. House,,WOR,Colleen Deacon,10
-Onondaga,W14P10,U.S. House,,WOR,Colleen Deacon,4
-Onondaga,W14P11,U.S. House,,WOR,Colleen Deacon,23
-Onondaga,W14P12,U.S. House,,WOR,Colleen Deacon,9
-Onondaga,W15P01,U.S. House,,WOR,Colleen Deacon,6
-Onondaga,W15P02,U.S. House,,WOR,Colleen Deacon,2
-Onondaga,W15P03,U.S. House,,WOR,Colleen Deacon,2
-Onondaga,W16P01,U.S. House,,WOR,Colleen Deacon,12
-Onondaga,W16P02,U.S. House,,WOR,Colleen Deacon,39
-Onondaga,W16P03,U.S. House,,WOR,Colleen Deacon,30
-Onondaga,W16P04,U.S. House,,WOR,Colleen Deacon,17
-Onondaga,W17P01,U.S. House,,WOR,Colleen Deacon,0
-Onondaga,W17P02,U.S. House,,WOR,Colleen Deacon,60
-Onondaga,W17P03,U.S. House,,WOR,Colleen Deacon,69
-Onondaga,W17P04,U.S. House,,WOR,Colleen Deacon,29
-Onondaga,W17P05,U.S. House,,WOR,Colleen Deacon,30
-Onondaga,W17P06,U.S. House,,WOR,Colleen Deacon,6
-Onondaga,W17P07,U.S. House,,WOR,Colleen Deacon,31
-Onondaga,W17P08,U.S. House,,WOR,Colleen Deacon,19
-Onondaga,W17P09,U.S. House,,WOR,Colleen Deacon,39
-Onondaga,W17P10,U.S. House,,WOR,Colleen Deacon,9
-Onondaga,W17P11,U.S. House,,WOR,Colleen Deacon,11
-Onondaga,W17P12,U.S. House,,WOR,Colleen Deacon,36
-Onondaga,W17P13,U.S. House,,WOR,Colleen Deacon,21
-Onondaga,W17P14,U.S. House,,WOR,Colleen Deacon,23
-Onondaga,W17P15,U.S. House,,WOR,Colleen Deacon,30
-Onondaga,W17P16,U.S. House,,WOR,Colleen Deacon,11
-Onondaga,W17P17,U.S. House,,WOR,Colleen Deacon,8
-Onondaga,W17P18,U.S. House,,WOR,Colleen Deacon,0
-Onondaga,W17P19,U.S. House,,WOR,Colleen Deacon,4
-Onondaga,W18P01,U.S. House,,WOR,Colleen Deacon,5
-Onondaga,W18P02,U.S. House,,WOR,Colleen Deacon,9
-Onondaga,W19P01,U.S. House,,WOR,Colleen Deacon,8
-Onondaga,W19P02,U.S. House,,WOR,Colleen Deacon,11
-Onondaga,W19P03,U.S. House,,WOR,Colleen Deacon,23
-Onondaga,W19P04,U.S. House,,WOR,Colleen Deacon,23
-Onondaga,W19P05,U.S. House,,WOR,Colleen Deacon,11
-Onondaga,W19P06,U.S. House,,WOR,Colleen Deacon,45
-Onondaga,W19P07,U.S. House,,WOR,Colleen Deacon,23
-Onondaga,Syracuse Total,U.S. House,,WOR,Colleen Deacon,1913
-Onondaga,W01P01,U.S. House,,IDC,John Katko,21
-Onondaga,W01P02,U.S. House,,IDC,John Katko,19
-Onondaga,W01P03,U.S. House,,IDC,John Katko,8
-Onondaga,W01P04,U.S. House,,IDC,John Katko,7
-Onondaga,W01P05,U.S. House,,IDC,John Katko,4
-Onondaga,W01P07,U.S. House,,IDC,John Katko,1
-Onondaga,W01P08,U.S. House,,IDC,John Katko,6
-Onondaga,W01P09,U.S. House,,IDC,John Katko,0
-Onondaga,W02P01,U.S. House,,IDC,John Katko,11
-Onondaga,W02P02,U.S. House,,IDC,John Katko,13
-Onondaga,W03P01,U.S. House,,IDC,John Katko,13
-Onondaga,W03P03,U.S. House,,IDC,John Katko,27
-Onondaga,W03P04,U.S. House,,IDC,John Katko,7
-Onondaga,W03P05,U.S. House,,IDC,John Katko,18
-Onondaga,W03P06,U.S. House,,IDC,John Katko,4
-Onondaga,W04P01,U.S. House,,IDC,John Katko,6
-Onondaga,W04P02,U.S. House,,IDC,John Katko,13
-Onondaga,W04P03,U.S. House,,IDC,John Katko,16
-Onondaga,W04P04,U.S. House,,IDC,John Katko,17
-Onondaga,W04P05,U.S. House,,IDC,John Katko,8
-Onondaga,W04P07,U.S. House,,IDC,John Katko,25
-Onondaga,W04P08,U.S. House,,IDC,John Katko,9
-Onondaga,W04P09,U.S. House,,IDC,John Katko,19
-Onondaga,W05P01,U.S. House,,IDC,John Katko,5
-Onondaga,W05P02,U.S. House,,IDC,John Katko,6
-Onondaga,W05P03,U.S. House,,IDC,John Katko,13
-Onondaga,W05P04,U.S. House,,IDC,John Katko,16
-Onondaga,W05P05,U.S. House,,IDC,John Katko,7
-Onondaga,W05P06,U.S. House,,IDC,John Katko,17
-Onondaga,W05P07,U.S. House,,IDC,John Katko,17
-Onondaga,W05P08,U.S. House,,IDC,John Katko,0
-Onondaga,W05P09,U.S. House,,IDC,John Katko,12
-Onondaga,W05P10,U.S. House,,IDC,John Katko,18
-Onondaga,W05P11,U.S. House,,IDC,John Katko,9
-Onondaga,W06P01,U.S. House,,IDC,John Katko,13
-Onondaga,W06P02,U.S. House,,IDC,John Katko,12
-Onondaga,W06P03,U.S. House,,IDC,John Katko,4
-Onondaga,W06P04,U.S. House,,IDC,John Katko,4
-Onondaga,W06P05,U.S. House,,IDC,John Katko,9
-Onondaga,W06P06,U.S. House,,IDC,John Katko,10
-Onondaga,W07P01,U.S. House,,IDC,John Katko,23
-Onondaga,W07P02,U.S. House,,IDC,John Katko,26
-Onondaga,W08P01,U.S. House,,IDC,John Katko,5
-Onondaga,W08P02,U.S. House,,IDC,John Katko,20
-Onondaga,W08P03,U.S. House,,IDC,John Katko,5
-Onondaga,W08P04,U.S. House,,IDC,John Katko,27
-Onondaga,W09P01,U.S. House,,IDC,John Katko,6
-Onondaga,W09P02,U.S. House,,IDC,John Katko,4
-Onondaga,W09P04,U.S. House,,IDC,John Katko,0
-Onondaga,W09P05,U.S. House,,IDC,John Katko,5
-Onondaga,W10P01,U.S. House,,IDC,John Katko,2
-Onondaga,W10P02,U.S. House,,IDC,John Katko,1
-Onondaga,W10P03,U.S. House,,IDC,John Katko,13
-Onondaga,W10P04,U.S. House,,IDC,John Katko,3
-Onondaga,W11P01,U.S. House,,IDC,John Katko,8
-Onondaga,W11P02,U.S. House,,IDC,John Katko,6
-Onondaga,W11P03,U.S. House,,IDC,John Katko,9
-Onondaga,W11P04,U.S. House,,IDC,John Katko,24
-Onondaga,W11P07,U.S. House,,IDC,John Katko,22
-Onondaga,W11P08,U.S. House,,IDC,John Katko,0
-Onondaga,W11P09,U.S. House,,IDC,John Katko,2
-Onondaga,W12P01,U.S. House,,IDC,John Katko,5
-Onondaga,W12P02,U.S. House,,IDC,John Katko,0
-Onondaga,W12P03,U.S. House,,IDC,John Katko,0
-Onondaga,W12P04,U.S. House,,IDC,John Katko,8
-Onondaga,W12P05,U.S. House,,IDC,John Katko,30
-Onondaga,W13P01,U.S. House,,IDC,John Katko,5
-Onondaga,W13P02,U.S. House,,IDC,John Katko,8
-Onondaga,W13P03,U.S. House,,IDC,John Katko,10
-Onondaga,W13P04,U.S. House,,IDC,John Katko,10
-Onondaga,W13P05,U.S. House,,IDC,John Katko,6
-Onondaga,W13P06,U.S. House,,IDC,John Katko,5
-Onondaga,W13P07,U.S. House,,IDC,John Katko,9
-Onondaga,W13P08,U.S. House,,IDC,John Katko,9
-Onondaga,W13P09,U.S. House,,IDC,John Katko,14
-Onondaga,W14P01,U.S. House,,IDC,John Katko,6
-Onondaga,W14P02,U.S. House,,IDC,John Katko,8
-Onondaga,W14P03,U.S. House,,IDC,John Katko,7
-Onondaga,W14P04,U.S. House,,IDC,John Katko,9
-Onondaga,W14P06,U.S. House,,IDC,John Katko,20
-Onondaga,W14P07,U.S. House,,IDC,John Katko,16
-Onondaga,W14P08,U.S. House,,IDC,John Katko,5
-Onondaga,W14P09,U.S. House,,IDC,John Katko,8
-Onondaga,W14P10,U.S. House,,IDC,John Katko,3
-Onondaga,W14P11,U.S. House,,IDC,John Katko,13
-Onondaga,W14P12,U.S. House,,IDC,John Katko,7
-Onondaga,W15P01,U.S. House,,IDC,John Katko,0
-Onondaga,W15P02,U.S. House,,IDC,John Katko,1
-Onondaga,W15P03,U.S. House,,IDC,John Katko,2
-Onondaga,W16P01,U.S. House,,IDC,John Katko,4
-Onondaga,W16P02,U.S. House,,IDC,John Katko,8
-Onondaga,W16P03,U.S. House,,IDC,John Katko,6
-Onondaga,W16P04,U.S. House,,IDC,John Katko,15
-Onondaga,W17P01,U.S. House,,IDC,John Katko,0
-Onondaga,W17P02,U.S. House,,IDC,John Katko,7
-Onondaga,W17P03,U.S. House,,IDC,John Katko,13
-Onondaga,W17P04,U.S. House,,IDC,John Katko,11
-Onondaga,W17P05,U.S. House,,IDC,John Katko,8
-Onondaga,W17P06,U.S. House,,IDC,John Katko,4
-Onondaga,W17P07,U.S. House,,IDC,John Katko,8
-Onondaga,W17P08,U.S. House,,IDC,John Katko,8
-Onondaga,W17P09,U.S. House,,IDC,John Katko,6
-Onondaga,W17P10,U.S. House,,IDC,John Katko,6
-Onondaga,W17P11,U.S. House,,IDC,John Katko,5
-Onondaga,W17P12,U.S. House,,IDC,John Katko,7
-Onondaga,W17P13,U.S. House,,IDC,John Katko,10
-Onondaga,W17P14,U.S. House,,IDC,John Katko,10
-Onondaga,W17P15,U.S. House,,IDC,John Katko,19
-Onondaga,W17P16,U.S. House,,IDC,John Katko,12
-Onondaga,W17P17,U.S. House,,IDC,John Katko,3
-Onondaga,W17P18,U.S. House,,IDC,John Katko,0
-Onondaga,W17P19,U.S. House,,IDC,John Katko,0
-Onondaga,W18P01,U.S. House,,IDC,John Katko,3
-Onondaga,W18P02,U.S. House,,IDC,John Katko,3
-Onondaga,W19P01,U.S. House,,IDC,John Katko,6
-Onondaga,W19P02,U.S. House,,IDC,John Katko,2
-Onondaga,W19P03,U.S. House,,IDC,John Katko,13
-Onondaga,W19P04,U.S. House,,IDC,John Katko,9
-Onondaga,W19P05,U.S. House,,IDC,John Katko,5
-Onondaga,W19P06,U.S. House,,IDC,John Katko,12
-Onondaga,W19P07,U.S. House,,IDC,John Katko,14
-Onondaga,Syracuse Total,U.S. House,,IDC,John Katko,1116
-Onondaga,W01P01,U.S. House,,REF,John Katko,0
-Onondaga,W01P02,U.S. House,,REF,John Katko,4
-Onondaga,W01P03,U.S. House,,REF,John Katko,0
-Onondaga,W01P04,U.S. House,,REF,John Katko,1
-Onondaga,W01P05,U.S. House,,REF,John Katko,2
-Onondaga,W01P07,U.S. House,,REF,John Katko,0
-Onondaga,W01P08,U.S. House,,REF,John Katko,3
-Onondaga,W01P09,U.S. House,,REF,John Katko,0
-Onondaga,W02P01,U.S. House,,REF,John Katko,5
-Onondaga,W02P02,U.S. House,,REF,John Katko,6
-Onondaga,W03P01,U.S. House,,REF,John Katko,0
-Onondaga,W03P03,U.S. House,,REF,John Katko,2
-Onondaga,W03P04,U.S. House,,REF,John Katko,1
-Onondaga,W03P05,U.S. House,,REF,John Katko,2
-Onondaga,W03P06,U.S. House,,REF,John Katko,1
-Onondaga,W04P01,U.S. House,,REF,John Katko,0
-Onondaga,W04P02,U.S. House,,REF,John Katko,3
-Onondaga,W04P03,U.S. House,,REF,John Katko,3
-Onondaga,W04P04,U.S. House,,REF,John Katko,1
-Onondaga,W04P05,U.S. House,,REF,John Katko,0
-Onondaga,W04P07,U.S. House,,REF,John Katko,5
-Onondaga,W04P08,U.S. House,,REF,John Katko,1
-Onondaga,W04P09,U.S. House,,REF,John Katko,3
-Onondaga,W05P01,U.S. House,,REF,John Katko,2
-Onondaga,W05P02,U.S. House,,REF,John Katko,0
-Onondaga,W05P03,U.S. House,,REF,John Katko,0
-Onondaga,W05P04,U.S. House,,REF,John Katko,2
-Onondaga,W05P05,U.S. House,,REF,John Katko,2
-Onondaga,W05P06,U.S. House,,REF,John Katko,5
-Onondaga,W05P07,U.S. House,,REF,John Katko,4
-Onondaga,W05P08,U.S. House,,REF,John Katko,0
-Onondaga,W05P09,U.S. House,,REF,John Katko,4
-Onondaga,W05P10,U.S. House,,REF,John Katko,4
-Onondaga,W05P11,U.S. House,,REF,John Katko,1
-Onondaga,W06P01,U.S. House,,REF,John Katko,4
-Onondaga,W06P02,U.S. House,,REF,John Katko,5
-Onondaga,W06P03,U.S. House,,REF,John Katko,1
-Onondaga,W06P04,U.S. House,,REF,John Katko,0
-Onondaga,W06P05,U.S. House,,REF,John Katko,0
-Onondaga,W06P06,U.S. House,,REF,John Katko,0
-Onondaga,W07P01,U.S. House,,REF,John Katko,3
-Onondaga,W07P02,U.S. House,,REF,John Katko,6
-Onondaga,W08P01,U.S. House,,REF,John Katko,0
-Onondaga,W08P02,U.S. House,,REF,John Katko,1
-Onondaga,W08P03,U.S. House,,REF,John Katko,1
-Onondaga,W08P04,U.S. House,,REF,John Katko,2
-Onondaga,W09P01,U.S. House,,REF,John Katko,2
-Onondaga,W09P02,U.S. House,,REF,John Katko,1
-Onondaga,W09P04,U.S. House,,REF,John Katko,0
-Onondaga,W09P05,U.S. House,,REF,John Katko,0
-Onondaga,W10P01,U.S. House,,REF,John Katko,0
-Onondaga,W10P02,U.S. House,,REF,John Katko,0
-Onondaga,W10P03,U.S. House,,REF,John Katko,2
-Onondaga,W10P04,U.S. House,,REF,John Katko,0
-Onondaga,W11P01,U.S. House,,REF,John Katko,0
-Onondaga,W11P02,U.S. House,,REF,John Katko,0
-Onondaga,W11P03,U.S. House,,REF,John Katko,0
-Onondaga,W11P04,U.S. House,,REF,John Katko,1
-Onondaga,W11P07,U.S. House,,REF,John Katko,1
-Onondaga,W11P08,U.S. House,,REF,John Katko,0
-Onondaga,W11P09,U.S. House,,REF,John Katko,0
-Onondaga,W12P01,U.S. House,,REF,John Katko,2
-Onondaga,W12P02,U.S. House,,REF,John Katko,0
-Onondaga,W12P03,U.S. House,,REF,John Katko,0
-Onondaga,W12P04,U.S. House,,REF,John Katko,2
-Onondaga,W12P05,U.S. House,,REF,John Katko,3
-Onondaga,W13P01,U.S. House,,REF,John Katko,1
-Onondaga,W13P02,U.S. House,,REF,John Katko,0
-Onondaga,W13P03,U.S. House,,REF,John Katko,2
-Onondaga,W13P04,U.S. House,,REF,John Katko,2
-Onondaga,W13P05,U.S. House,,REF,John Katko,1
-Onondaga,W13P06,U.S. House,,REF,John Katko,1
-Onondaga,W13P07,U.S. House,,REF,John Katko,3
-Onondaga,W13P08,U.S. House,,REF,John Katko,1
-Onondaga,W13P09,U.S. House,,REF,John Katko,2
-Onondaga,W14P01,U.S. House,,REF,John Katko,0
-Onondaga,W14P02,U.S. House,,REF,John Katko,1
-Onondaga,W14P03,U.S. House,,REF,John Katko,3
-Onondaga,W14P04,U.S. House,,REF,John Katko,0
-Onondaga,W14P06,U.S. House,,REF,John Katko,2
-Onondaga,W14P07,U.S. House,,REF,John Katko,2
-Onondaga,W14P08,U.S. House,,REF,John Katko,2
-Onondaga,W14P09,U.S. House,,REF,John Katko,0
-Onondaga,W14P10,U.S. House,,REF,John Katko,0
-Onondaga,W14P11,U.S. House,,REF,John Katko,4
-Onondaga,W14P12,U.S. House,,REF,John Katko,3
-Onondaga,W15P01,U.S. House,,REF,John Katko,0
-Onondaga,W15P02,U.S. House,,REF,John Katko,0
-Onondaga,W15P03,U.S. House,,REF,John Katko,0
-Onondaga,W16P01,U.S. House,,REF,John Katko,1
-Onondaga,W16P02,U.S. House,,REF,John Katko,0
-Onondaga,W16P03,U.S. House,,REF,John Katko,1
-Onondaga,W16P04,U.S. House,,REF,John Katko,2
-Onondaga,W17P01,U.S. House,,REF,John Katko,0
-Onondaga,W17P02,U.S. House,,REF,John Katko,4
-Onondaga,W17P03,U.S. House,,REF,John Katko,0
-Onondaga,W17P04,U.S. House,,REF,John Katko,0
-Onondaga,W17P05,U.S. House,,REF,John Katko,0
-Onondaga,W17P06,U.S. House,,REF,John Katko,0
-Onondaga,W17P07,U.S. House,,REF,John Katko,0
-Onondaga,W17P08,U.S. House,,REF,John Katko,0
-Onondaga,W17P09,U.S. House,,REF,John Katko,0
-Onondaga,W17P10,U.S. House,,REF,John Katko,0
-Onondaga,W17P11,U.S. House,,REF,John Katko,0
-Onondaga,W17P12,U.S. House,,REF,John Katko,1
-Onondaga,W17P13,U.S. House,,REF,John Katko,0
-Onondaga,W17P14,U.S. House,,REF,John Katko,1
-Onondaga,W17P15,U.S. House,,REF,John Katko,0
-Onondaga,W17P16,U.S. House,,REF,John Katko,2
-Onondaga,W17P17,U.S. House,,REF,John Katko,0
-Onondaga,W17P18,U.S. House,,REF,John Katko,0
-Onondaga,W17P19,U.S. House,,REF,John Katko,0
-Onondaga,W18P01,U.S. House,,REF,John Katko,1
-Onondaga,W18P02,U.S. House,,REF,John Katko,0
-Onondaga,W19P01,U.S. House,,REF,John Katko,1
-Onondaga,W19P02,U.S. House,,REF,John Katko,0
-Onondaga,W19P03,U.S. House,,REF,John Katko,1
-Onondaga,W19P04,U.S. House,,REF,John Katko,1
-Onondaga,W19P05,U.S. House,,REF,John Katko,0
-Onondaga,W19P06,U.S. House,,REF,John Katko,3
-Onondaga,W19P07,U.S. House,,REF,John Katko,1
-Onondaga,Syracuse Total,U.S. House,,REF,John Katko,154
-Onondaga,W01P01,U.S. House,,,Write-ins,0
-Onondaga,W01P02,U.S. House,,,Write-ins,2
-Onondaga,W01P03,U.S. House,,,Write-ins,0
-Onondaga,W01P04,U.S. House,,,Write-ins,0
-Onondaga,W01P05,U.S. House,,,Write-ins,0
-Onondaga,W01P07,U.S. House,,,Write-ins,0
-Onondaga,W01P08,U.S. House,,,Write-ins,1
-Onondaga,W01P09,U.S. House,,,Write-ins,0
-Onondaga,W02P01,U.S. House,,,Write-ins,2
-Onondaga,W02P02,U.S. House,,,Write-ins,2
-Onondaga,W03P01,U.S. House,,,Write-ins,0
-Onondaga,W03P03,U.S. House,,,Write-ins,1
-Onondaga,W03P04,U.S. House,,,Write-ins,0
-Onondaga,W03P05,U.S. House,,,Write-ins,1
-Onondaga,W03P06,U.S. House,,,Write-ins,0
-Onondaga,W04P01,U.S. House,,,Write-ins,1
-Onondaga,W04P02,U.S. House,,,Write-ins,1
-Onondaga,W04P03,U.S. House,,,Write-ins,0
-Onondaga,W04P04,U.S. House,,,Write-ins,4
-Onondaga,W04P05,U.S. House,,,Write-ins,2
-Onondaga,W04P07,U.S. House,,,Write-ins,1
-Onondaga,W04P08,U.S. House,,,Write-ins,0
-Onondaga,W04P09,U.S. House,,,Write-ins,0
-Onondaga,W05P01,U.S. House,,,Write-ins,3
-Onondaga,W05P02,U.S. House,,,Write-ins,1
-Onondaga,W05P03,U.S. House,,,Write-ins,2
-Onondaga,W05P04,U.S. House,,,Write-ins,2
-Onondaga,W05P05,U.S. House,,,Write-ins,2
-Onondaga,W05P06,U.S. House,,,Write-ins,0
-Onondaga,W05P07,U.S. House,,,Write-ins,0
-Onondaga,W05P08,U.S. House,,,Write-ins,0
-Onondaga,W05P09,U.S. House,,,Write-ins,0
-Onondaga,W05P10,U.S. House,,,Write-ins,0
-Onondaga,W05P11,U.S. House,,,Write-ins,2
-Onondaga,W06P01,U.S. House,,,Write-ins,1
-Onondaga,W06P02,U.S. House,,,Write-ins,0
-Onondaga,W06P03,U.S. House,,,Write-ins,1
-Onondaga,W06P04,U.S. House,,,Write-ins,0
-Onondaga,W06P05,U.S. House,,,Write-ins,2
-Onondaga,W06P06,U.S. House,,,Write-ins,0
-Onondaga,W07P01,U.S. House,,,Write-ins,3
-Onondaga,W07P02,U.S. House,,,Write-ins,2
-Onondaga,W08P01,U.S. House,,,Write-ins,0
-Onondaga,W08P02,U.S. House,,,Write-ins,1
-Onondaga,W08P03,U.S. House,,,Write-ins,0
-Onondaga,W08P04,U.S. House,,,Write-ins,2
-Onondaga,W09P01,U.S. House,,,Write-ins,0
-Onondaga,W09P02,U.S. House,,,Write-ins,1
-Onondaga,W09P04,U.S. House,,,Write-ins,0
-Onondaga,W09P05,U.S. House,,,Write-ins,0
-Onondaga,W10P01,U.S. House,,,Write-ins,0
-Onondaga,W10P02,U.S. House,,,Write-ins,0
-Onondaga,W10P03,U.S. House,,,Write-ins,1
-Onondaga,W10P04,U.S. House,,,Write-ins,0
-Onondaga,W11P01,U.S. House,,,Write-ins,0
-Onondaga,W11P02,U.S. House,,,Write-ins,2
-Onondaga,W11P03,U.S. House,,,Write-ins,0
-Onondaga,W11P04,U.S. House,,,Write-ins,2
-Onondaga,W11P07,U.S. House,,,Write-ins,2
-Onondaga,W11P08,U.S. House,,,Write-ins,0
-Onondaga,W11P09,U.S. House,,,Write-ins,0
-Onondaga,W12P01,U.S. House,,,Write-ins,0
-Onondaga,W12P02,U.S. House,,,Write-ins,0
-Onondaga,W12P03,U.S. House,,,Write-ins,0
-Onondaga,W12P04,U.S. House,,,Write-ins,0
-Onondaga,W12P05,U.S. House,,,Write-ins,1
-Onondaga,W13P01,U.S. House,,,Write-ins,1
-Onondaga,W13P02,U.S. House,,,Write-ins,0
-Onondaga,W13P03,U.S. House,,,Write-ins,1
-Onondaga,W13P04,U.S. House,,,Write-ins,0
-Onondaga,W13P05,U.S. House,,,Write-ins,1
-Onondaga,W13P06,U.S. House,,,Write-ins,0
-Onondaga,W13P07,U.S. House,,,Write-ins,1
-Onondaga,W13P08,U.S. House,,,Write-ins,0
-Onondaga,W13P09,U.S. House,,,Write-ins,2
-Onondaga,W14P01,U.S. House,,,Write-ins,0
-Onondaga,W14P02,U.S. House,,,Write-ins,0
-Onondaga,W14P03,U.S. House,,,Write-ins,4
-Onondaga,W14P04,U.S. House,,,Write-ins,0
-Onondaga,W14P06,U.S. House,,,Write-ins,0
-Onondaga,W14P07,U.S. House,,,Write-ins,0
-Onondaga,W14P08,U.S. House,,,Write-ins,1
-Onondaga,W14P09,U.S. House,,,Write-ins,0
-Onondaga,W14P10,U.S. House,,,Write-ins,0
-Onondaga,W14P11,U.S. House,,,Write-ins,0
-Onondaga,W14P12,U.S. House,,,Write-ins,1
-Onondaga,W15P01,U.S. House,,,Write-ins,1
-Onondaga,W15P02,U.S. House,,,Write-ins,0
-Onondaga,W15P03,U.S. House,,,Write-ins,0
-Onondaga,W16P01,U.S. House,,,Write-ins,1
-Onondaga,W16P02,U.S. House,,,Write-ins,2
-Onondaga,W16P03,U.S. House,,,Write-ins,1
-Onondaga,W16P04,U.S. House,,,Write-ins,0
-Onondaga,W17P01,U.S. House,,,Write-ins,0
-Onondaga,W17P02,U.S. House,,,Write-ins,2
-Onondaga,W17P03,U.S. House,,,Write-ins,1
-Onondaga,W17P04,U.S. House,,,Write-ins,1
-Onondaga,W17P05,U.S. House,,,Write-ins,0
-Onondaga,W17P06,U.S. House,,,Write-ins,0
-Onondaga,W17P07,U.S. House,,,Write-ins,0
-Onondaga,W17P08,U.S. House,,,Write-ins,1
-Onondaga,W17P09,U.S. House,,,Write-ins,0
-Onondaga,W17P10,U.S. House,,,Write-ins,0
-Onondaga,W17P11,U.S. House,,,Write-ins,0
-Onondaga,W17P12,U.S. House,,,Write-ins,3
-Onondaga,W17P13,U.S. House,,,Write-ins,2
-Onondaga,W17P14,U.S. House,,,Write-ins,1
-Onondaga,W17P15,U.S. House,,,Write-ins,3
-Onondaga,W17P16,U.S. House,,,Write-ins,0
-Onondaga,W17P17,U.S. House,,,Write-ins,0
-Onondaga,W17P18,U.S. House,,,Write-ins,0
-Onondaga,W17P19,U.S. House,,,Write-ins,0
-Onondaga,W18P01,U.S. House,,,Write-ins,0
-Onondaga,W18P02,U.S. House,,,Write-ins,1
-Onondaga,W19P01,U.S. House,,,Write-ins,1
-Onondaga,W19P02,U.S. House,,,Write-ins,0
-Onondaga,W19P03,U.S. House,,,Write-ins,0
-Onondaga,W19P04,U.S. House,,,Write-ins,0
-Onondaga,W19P05,U.S. House,,,Write-ins,0
-Onondaga,W19P06,U.S. House,,,Write-ins,0
-Onondaga,W19P07,U.S. House,,,Write-ins,1
-Onondaga,Syracuse Total,U.S. House,,,Write-ins,85
+Onondaga,W01P01,U.S. House,24,DEM,Colleen Deacon,155
+Onondaga,W01P02,U.S. House,24,DEM,Colleen Deacon,218
+Onondaga,W01P03,U.S. House,24,DEM,Colleen Deacon,108
+Onondaga,W01P04,U.S. House,24,DEM,Colleen Deacon,182
+Onondaga,W01P05,U.S. House,24,DEM,Colleen Deacon,210
+Onondaga,W01P07,U.S. House,24,DEM,Colleen Deacon,13
+Onondaga,W01P08,U.S. House,24,DEM,Colleen Deacon,100
+Onondaga,W01P09,U.S. House,24,DEM,Colleen Deacon,9
+Onondaga,W02P01,U.S. House,24,DEM,Colleen Deacon,322
+Onondaga,W02P02,U.S. House,24,DEM,Colleen Deacon,325
+Onondaga,W03P01,U.S. House,24,DEM,Colleen Deacon,172
+Onondaga,W03P03,U.S. House,24,DEM,Colleen Deacon,346
+Onondaga,W03P04,U.S. House,24,DEM,Colleen Deacon,153
+Onondaga,W03P05,U.S. House,24,DEM,Colleen Deacon,256
+Onondaga,W03P06,U.S. House,24,DEM,Colleen Deacon,88
+Onondaga,W04P01,U.S. House,24,DEM,Colleen Deacon,179
+Onondaga,W04P02,U.S. House,24,DEM,Colleen Deacon,185
+Onondaga,W04P03,U.S. House,24,DEM,Colleen Deacon,196
+Onondaga,W04P04,U.S. House,24,DEM,Colleen Deacon,227
+Onondaga,W04P05,U.S. House,24,DEM,Colleen Deacon,210
+Onondaga,W04P07,U.S. House,24,DEM,Colleen Deacon,298
+Onondaga,W04P08,U.S. House,24,DEM,Colleen Deacon,251
+Onondaga,W04P09,U.S. House,24,DEM,Colleen Deacon,256
+Onondaga,W05P01,U.S. House,24,DEM,Colleen Deacon,264
+Onondaga,W05P02,U.S. House,24,DEM,Colleen Deacon,113
+Onondaga,W05P03,U.S. House,24,DEM,Colleen Deacon,146
+Onondaga,W05P04,U.S. House,24,DEM,Colleen Deacon,202
+Onondaga,W05P05,U.S. House,24,DEM,Colleen Deacon,161
+Onondaga,W05P06,U.S. House,24,DEM,Colleen Deacon,216
+Onondaga,W05P07,U.S. House,24,DEM,Colleen Deacon,198
+Onondaga,W05P08,U.S. House,24,DEM,Colleen Deacon,0
+Onondaga,W05P09,U.S. House,24,DEM,Colleen Deacon,160
+Onondaga,W05P10,U.S. House,24,DEM,Colleen Deacon,246
+Onondaga,W05P11,U.S. House,24,DEM,Colleen Deacon,236
+Onondaga,W06P01,U.S. House,24,DEM,Colleen Deacon,367
+Onondaga,W06P02,U.S. House,24,DEM,Colleen Deacon,210
+Onondaga,W06P03,U.S. House,24,DEM,Colleen Deacon,185
+Onondaga,W06P04,U.S. House,24,DEM,Colleen Deacon,75
+Onondaga,W06P05,U.S. House,24,DEM,Colleen Deacon,200
+Onondaga,W06P06,U.S. House,24,DEM,Colleen Deacon,168
+Onondaga,W07P01,U.S. House,24,DEM,Colleen Deacon,238
+Onondaga,W07P02,U.S. House,24,DEM,Colleen Deacon,289
+Onondaga,W08P01,U.S. House,24,DEM,Colleen Deacon,197
+Onondaga,W08P02,U.S. House,24,DEM,Colleen Deacon,223
+Onondaga,W08P03,U.S. House,24,DEM,Colleen Deacon,159
+Onondaga,W08P04,U.S. House,24,DEM,Colleen Deacon,170
+Onondaga,W09P01,U.S. House,24,DEM,Colleen Deacon,189
+Onondaga,W09P02,U.S. House,24,DEM,Colleen Deacon,159
+Onondaga,W09P04,U.S. House,24,DEM,Colleen Deacon,39
+Onondaga,W09P05,U.S. House,24,DEM,Colleen Deacon,240
+Onondaga,W10P01,U.S. House,24,DEM,Colleen Deacon,105
+Onondaga,W10P02,U.S. House,24,DEM,Colleen Deacon,59
+Onondaga,W10P03,U.S. House,24,DEM,Colleen Deacon,238
+Onondaga,W10P04,U.S. House,24,DEM,Colleen Deacon,193
+Onondaga,W11P01,U.S. House,24,DEM,Colleen Deacon,250
+Onondaga,W11P02,U.S. House,24,DEM,Colleen Deacon,204
+Onondaga,W11P03,U.S. House,24,DEM,Colleen Deacon,196
+Onondaga,W11P04,U.S. House,24,DEM,Colleen Deacon,298
+Onondaga,W11P07,U.S. House,24,DEM,Colleen Deacon,180
+Onondaga,W11P08,U.S. House,24,DEM,Colleen Deacon,6
+Onondaga,W11P09,U.S. House,24,DEM,Colleen Deacon,15
+Onondaga,W12P01,U.S. House,24,DEM,Colleen Deacon,316
+Onondaga,W12P02,U.S. House,24,DEM,Colleen Deacon,174
+Onondaga,W12P03,U.S. House,24,DEM,Colleen Deacon,29
+Onondaga,W12P04,U.S. House,24,DEM,Colleen Deacon,253
+Onondaga,W12P05,U.S. House,24,DEM,Colleen Deacon,353
+Onondaga,W13P01,U.S. House,24,DEM,Colleen Deacon,373
+Onondaga,W13P02,U.S. House,24,DEM,Colleen Deacon,185
+Onondaga,W13P03,U.S. House,24,DEM,Colleen Deacon,266
+Onondaga,W13P04,U.S. House,24,DEM,Colleen Deacon,207
+Onondaga,W13P05,U.S. House,24,DEM,Colleen Deacon,340
+Onondaga,W13P06,U.S. House,24,DEM,Colleen Deacon,350
+Onondaga,W13P07,U.S. House,24,DEM,Colleen Deacon,183
+Onondaga,W13P08,U.S. House,24,DEM,Colleen Deacon,210
+Onondaga,W13P09,U.S. House,24,DEM,Colleen Deacon,130
+Onondaga,W14P01,U.S. House,24,DEM,Colleen Deacon,450
+Onondaga,W14P02,U.S. House,24,DEM,Colleen Deacon,191
+Onondaga,W14P03,U.S. House,24,DEM,Colleen Deacon,337
+Onondaga,W14P04,U.S. House,24,DEM,Colleen Deacon,230
+Onondaga,W14P06,U.S. House,24,DEM,Colleen Deacon,238
+Onondaga,W14P07,U.S. House,24,DEM,Colleen Deacon,196
+Onondaga,W14P08,U.S. House,24,DEM,Colleen Deacon,243
+Onondaga,W14P09,U.S. House,24,DEM,Colleen Deacon,167
+Onondaga,W14P10,U.S. House,24,DEM,Colleen Deacon,130
+Onondaga,W14P11,U.S. House,24,DEM,Colleen Deacon,324
+Onondaga,W14P12,U.S. House,24,DEM,Colleen Deacon,217
+Onondaga,W15P01,U.S. House,24,DEM,Colleen Deacon,99
+Onondaga,W15P02,U.S. House,24,DEM,Colleen Deacon,43
+Onondaga,W15P03,U.S. House,24,DEM,Colleen Deacon,90
+Onondaga,W16P01,U.S. House,24,DEM,Colleen Deacon,319
+Onondaga,W16P02,U.S. House,24,DEM,Colleen Deacon,328
+Onondaga,W16P03,U.S. House,24,DEM,Colleen Deacon,294
+Onondaga,W16P04,U.S. House,24,DEM,Colleen Deacon,502
+Onondaga,W17P01,U.S. House,24,DEM,Colleen Deacon,7
+Onondaga,W17P02,U.S. House,24,DEM,Colleen Deacon,432
+Onondaga,W17P03,U.S. House,24,DEM,Colleen Deacon,284
+Onondaga,W17P04,U.S. House,24,DEM,Colleen Deacon,281
+Onondaga,W17P05,U.S. House,24,DEM,Colleen Deacon,190
+Onondaga,W17P06,U.S. House,24,DEM,Colleen Deacon,232
+Onondaga,W17P07,U.S. House,24,DEM,Colleen Deacon,342
+Onondaga,W17P08,U.S. House,24,DEM,Colleen Deacon,289
+Onondaga,W17P09,U.S. House,24,DEM,Colleen Deacon,345
+Onondaga,W17P10,U.S. House,24,DEM,Colleen Deacon,339
+Onondaga,W17P11,U.S. House,24,DEM,Colleen Deacon,235
+Onondaga,W17P12,U.S. House,24,DEM,Colleen Deacon,290
+Onondaga,W17P13,U.S. House,24,DEM,Colleen Deacon,280
+Onondaga,W17P14,U.S. House,24,DEM,Colleen Deacon,332
+Onondaga,W17P15,U.S. House,24,DEM,Colleen Deacon,370
+Onondaga,W17P16,U.S. House,24,DEM,Colleen Deacon,215
+Onondaga,W17P17,U.S. House,24,DEM,Colleen Deacon,136
+Onondaga,W17P18,U.S. House,24,DEM,Colleen Deacon,0
+Onondaga,W17P19,U.S. House,24,DEM,Colleen Deacon,27
+Onondaga,W18P01,U.S. House,24,DEM,Colleen Deacon,281
+Onondaga,W18P02,U.S. House,24,DEM,Colleen Deacon,346
+Onondaga,W19P01,U.S. House,24,DEM,Colleen Deacon,259
+Onondaga,W19P02,U.S. House,24,DEM,Colleen Deacon,392
+Onondaga,W19P03,U.S. House,24,DEM,Colleen Deacon,464
+Onondaga,W19P04,U.S. House,24,DEM,Colleen Deacon,159
+Onondaga,W19P05,U.S. House,24,DEM,Colleen Deacon,280
+Onondaga,W19P06,U.S. House,24,DEM,Colleen Deacon,484
+Onondaga,W19P07,U.S. House,24,DEM,Colleen Deacon,226
+Onondaga,Syracuse Total,U.S. House,24,DEM,Colleen Deacon,26537
+Onondaga,W01P01,U.S. House,24,REP,John Katko,181
+Onondaga,W01P02,U.S. House,24,REP,John Katko,160
+Onondaga,W01P03,U.S. House,24,REP,John Katko,66
+Onondaga,W01P04,U.S. House,24,REP,John Katko,98
+Onondaga,W01P05,U.S. House,24,REP,John Katko,160
+Onondaga,W01P07,U.S. House,24,REP,John Katko,10
+Onondaga,W01P08,U.S. House,24,REP,John Katko,74
+Onondaga,W01P09,U.S. House,24,REP,John Katko,2
+Onondaga,W02P01,U.S. House,24,REP,John Katko,149
+Onondaga,W02P02,U.S. House,24,REP,John Katko,184
+Onondaga,W03P01,U.S. House,24,REP,John Katko,101
+Onondaga,W03P03,U.S. House,24,REP,John Katko,313
+Onondaga,W03P04,U.S. House,24,REP,John Katko,91
+Onondaga,W03P05,U.S. House,24,REP,John Katko,228
+Onondaga,W03P06,U.S. House,24,REP,John Katko,58
+Onondaga,W04P01,U.S. House,24,REP,John Katko,69
+Onondaga,W04P02,U.S. House,24,REP,John Katko,110
+Onondaga,W04P03,U.S. House,24,REP,John Katko,158
+Onondaga,W04P04,U.S. House,24,REP,John Katko,232
+Onondaga,W04P05,U.S. House,24,REP,John Katko,198
+Onondaga,W04P07,U.S. House,24,REP,John Katko,204
+Onondaga,W04P08,U.S. House,24,REP,John Katko,114
+Onondaga,W04P09,U.S. House,24,REP,John Katko,158
+Onondaga,W05P01,U.S. House,24,REP,John Katko,146
+Onondaga,W05P02,U.S. House,24,REP,John Katko,117
+Onondaga,W05P03,U.S. House,24,REP,John Katko,102
+Onondaga,W05P04,U.S. House,24,REP,John Katko,177
+Onondaga,W05P05,U.S. House,24,REP,John Katko,155
+Onondaga,W05P06,U.S. House,24,REP,John Katko,156
+Onondaga,W05P07,U.S. House,24,REP,John Katko,172
+Onondaga,W05P08,U.S. House,24,REP,John Katko,0
+Onondaga,W05P09,U.S. House,24,REP,John Katko,192
+Onondaga,W05P10,U.S. House,24,REP,John Katko,177
+Onondaga,W05P11,U.S. House,24,REP,John Katko,174
+Onondaga,W06P01,U.S. House,24,REP,John Katko,95
+Onondaga,W06P02,U.S. House,24,REP,John Katko,90
+Onondaga,W06P03,U.S. House,24,REP,John Katko,69
+Onondaga,W06P04,U.S. House,24,REP,John Katko,47
+Onondaga,W06P05,U.S. House,24,REP,John Katko,124
+Onondaga,W06P06,U.S. House,24,REP,John Katko,80
+Onondaga,W07P01,U.S. House,24,REP,John Katko,230
+Onondaga,W07P02,U.S. House,24,REP,John Katko,303
+Onondaga,W08P01,U.S. House,24,REP,John Katko,18
+Onondaga,W08P02,U.S. House,24,REP,John Katko,211
+Onondaga,W08P03,U.S. House,24,REP,John Katko,29
+Onondaga,W08P04,U.S. House,24,REP,John Katko,156
+Onondaga,W09P01,U.S. House,24,REP,John Katko,81
+Onondaga,W09P02,U.S. House,24,REP,John Katko,49
+Onondaga,W09P04,U.S. House,24,REP,John Katko,15
+Onondaga,W09P05,U.S. House,24,REP,John Katko,18
+Onondaga,W10P01,U.S. House,24,REP,John Katko,22
+Onondaga,W10P02,U.S. House,24,REP,John Katko,12
+Onondaga,W10P03,U.S. House,24,REP,John Katko,37
+Onondaga,W10P04,U.S. House,24,REP,John Katko,17
+Onondaga,W11P01,U.S. House,24,REP,John Katko,54
+Onondaga,W11P02,U.S. House,24,REP,John Katko,64
+Onondaga,W11P03,U.S. House,24,REP,John Katko,96
+Onondaga,W11P04,U.S. House,24,REP,John Katko,205
+Onondaga,W11P07,U.S. House,24,REP,John Katko,309
+Onondaga,W11P08,U.S. House,24,REP,John Katko,1
+Onondaga,W11P09,U.S. House,24,REP,John Katko,4
+Onondaga,W12P01,U.S. House,24,REP,John Katko,24
+Onondaga,W12P02,U.S. House,24,REP,John Katko,12
+Onondaga,W12P03,U.S. House,24,REP,John Katko,11
+Onondaga,W12P04,U.S. House,24,REP,John Katko,64
+Onondaga,W12P05,U.S. House,24,REP,John Katko,238
+Onondaga,W13P01,U.S. House,24,REP,John Katko,43
+Onondaga,W13P02,U.S. House,24,REP,John Katko,55
+Onondaga,W13P03,U.S. House,24,REP,John Katko,165
+Onondaga,W13P04,U.S. House,24,REP,John Katko,91
+Onondaga,W13P05,U.S. House,24,REP,John Katko,107
+Onondaga,W13P06,U.S. House,24,REP,John Katko,33
+Onondaga,W13P07,U.S. House,24,REP,John Katko,101
+Onondaga,W13P08,U.S. House,24,REP,John Katko,79
+Onondaga,W13P09,U.S. House,24,REP,John Katko,115
+Onondaga,W14P01,U.S. House,24,REP,John Katko,54
+Onondaga,W14P02,U.S. House,24,REP,John Katko,103
+Onondaga,W14P03,U.S. House,24,REP,John Katko,34
+Onondaga,W14P04,U.S. House,24,REP,John Katko,51
+Onondaga,W14P06,U.S. House,24,REP,John Katko,164
+Onondaga,W14P07,U.S. House,24,REP,John Katko,186
+Onondaga,W14P08,U.S. House,24,REP,John Katko,63
+Onondaga,W14P09,U.S. House,24,REP,John Katko,71
+Onondaga,W14P10,U.S. House,24,REP,John Katko,34
+Onondaga,W14P11,U.S. House,24,REP,John Katko,185
+Onondaga,W14P12,U.S. House,24,REP,John Katko,104
+Onondaga,W15P01,U.S. House,24,REP,John Katko,38
+Onondaga,W15P02,U.S. House,24,REP,John Katko,4
+Onondaga,W15P03,U.S. House,24,REP,John Katko,33
+Onondaga,W16P01,U.S. House,24,REP,John Katko,88
+Onondaga,W16P02,U.S. House,24,REP,John Katko,62
+Onondaga,W16P03,U.S. House,24,REP,John Katko,71
+Onondaga,W16P04,U.S. House,24,REP,John Katko,140
+Onondaga,W17P01,U.S. House,24,REP,John Katko,4
+Onondaga,W17P02,U.S. House,24,REP,John Katko,93
+Onondaga,W17P03,U.S. House,24,REP,John Katko,56
+Onondaga,W17P04,U.S. House,24,REP,John Katko,52
+Onondaga,W17P05,U.S. House,24,REP,John Katko,32
+Onondaga,W17P06,U.S. House,24,REP,John Katko,26
+Onondaga,W17P07,U.S. House,24,REP,John Katko,54
+Onondaga,W17P08,U.S. House,24,REP,John Katko,51
+Onondaga,W17P09,U.S. House,24,REP,John Katko,110
+Onondaga,W17P10,U.S. House,24,REP,John Katko,37
+Onondaga,W17P11,U.S. House,24,REP,John Katko,25
+Onondaga,W17P12,U.S. House,24,REP,John Katko,83
+Onondaga,W17P13,U.S. House,24,REP,John Katko,140
+Onondaga,W17P14,U.S. House,24,REP,John Katko,53
+Onondaga,W17P15,U.S. House,24,REP,John Katko,139
+Onondaga,W17P16,U.S. House,24,REP,John Katko,83
+Onondaga,W17P17,U.S. House,24,REP,John Katko,39
+Onondaga,W17P18,U.S. House,24,REP,John Katko,0
+Onondaga,W17P19,U.S. House,24,REP,John Katko,4
+Onondaga,W18P01,U.S. House,24,REP,John Katko,16
+Onondaga,W18P02,U.S. House,24,REP,John Katko,27
+Onondaga,W19P01,U.S. House,24,REP,John Katko,24
+Onondaga,W19P02,U.S. House,24,REP,John Katko,29
+Onondaga,W19P03,U.S. House,24,REP,John Katko,125
+Onondaga,W19P04,U.S. House,24,REP,John Katko,51
+Onondaga,W19P05,U.S. House,24,REP,John Katko,23
+Onondaga,W19P06,U.S. House,24,REP,John Katko,78
+Onondaga,W19P07,U.S. House,24,REP,John Katko,64
+Onondaga,Syracuse Total,U.S. House,24,REP,John Katko,11263
+Onondaga,W01P01,U.S. House,24,CON,John Katko,19
+Onondaga,W01P02,U.S. House,24,CON,John Katko,24
+Onondaga,W01P03,U.S. House,24,CON,John Katko,11
+Onondaga,W01P04,U.S. House,24,CON,John Katko,16
+Onondaga,W01P05,U.S. House,24,CON,John Katko,13
+Onondaga,W01P07,U.S. House,24,CON,John Katko,1
+Onondaga,W01P08,U.S. House,24,CON,John Katko,13
+Onondaga,W01P09,U.S. House,24,CON,John Katko,0
+Onondaga,W02P01,U.S. House,24,CON,John Katko,23
+Onondaga,W02P02,U.S. House,24,CON,John Katko,17
+Onondaga,W03P01,U.S. House,24,CON,John Katko,15
+Onondaga,W03P03,U.S. House,24,CON,John Katko,38
+Onondaga,W03P04,U.S. House,24,CON,John Katko,8
+Onondaga,W03P05,U.S. House,24,CON,John Katko,24
+Onondaga,W03P06,U.S. House,24,CON,John Katko,6
+Onondaga,W04P01,U.S. House,24,CON,John Katko,14
+Onondaga,W04P02,U.S. House,24,CON,John Katko,25
+Onondaga,W04P03,U.S. House,24,CON,John Katko,29
+Onondaga,W04P04,U.S. House,24,CON,John Katko,40
+Onondaga,W04P05,U.S. House,24,CON,John Katko,29
+Onondaga,W04P07,U.S. House,24,CON,John Katko,25
+Onondaga,W04P08,U.S. House,24,CON,John Katko,21
+Onondaga,W04P09,U.S. House,24,CON,John Katko,29
+Onondaga,W05P01,U.S. House,24,CON,John Katko,14
+Onondaga,W05P02,U.S. House,24,CON,John Katko,16
+Onondaga,W05P03,U.S. House,24,CON,John Katko,11
+Onondaga,W05P04,U.S. House,24,CON,John Katko,24
+Onondaga,W05P05,U.S. House,24,CON,John Katko,18
+Onondaga,W05P06,U.S. House,24,CON,John Katko,22
+Onondaga,W05P07,U.S. House,24,CON,John Katko,27
+Onondaga,W05P08,U.S. House,24,CON,John Katko,0
+Onondaga,W05P09,U.S. House,24,CON,John Katko,23
+Onondaga,W05P10,U.S. House,24,CON,John Katko,34
+Onondaga,W05P11,U.S. House,24,CON,John Katko,20
+Onondaga,W06P01,U.S. House,24,CON,John Katko,13
+Onondaga,W06P02,U.S. House,24,CON,John Katko,17
+Onondaga,W06P03,U.S. House,24,CON,John Katko,14
+Onondaga,W06P04,U.S. House,24,CON,John Katko,7
+Onondaga,W06P05,U.S. House,24,CON,John Katko,25
+Onondaga,W06P06,U.S. House,24,CON,John Katko,17
+Onondaga,W07P01,U.S. House,24,CON,John Katko,32
+Onondaga,W07P02,U.S. House,24,CON,John Katko,30
+Onondaga,W08P01,U.S. House,24,CON,John Katko,3
+Onondaga,W08P02,U.S. House,24,CON,John Katko,28
+Onondaga,W08P03,U.S. House,24,CON,John Katko,9
+Onondaga,W08P04,U.S. House,24,CON,John Katko,12
+Onondaga,W09P01,U.S. House,24,CON,John Katko,5
+Onondaga,W09P02,U.S. House,24,CON,John Katko,13
+Onondaga,W09P04,U.S. House,24,CON,John Katko,2
+Onondaga,W09P05,U.S. House,24,CON,John Katko,3
+Onondaga,W10P01,U.S. House,24,CON,John Katko,8
+Onondaga,W10P02,U.S. House,24,CON,John Katko,2
+Onondaga,W10P03,U.S. House,24,CON,John Katko,11
+Onondaga,W10P04,U.S. House,24,CON,John Katko,3
+Onondaga,W11P01,U.S. House,24,CON,John Katko,14
+Onondaga,W11P02,U.S. House,24,CON,John Katko,12
+Onondaga,W11P03,U.S. House,24,CON,John Katko,11
+Onondaga,W11P04,U.S. House,24,CON,John Katko,28
+Onondaga,W11P07,U.S. House,24,CON,John Katko,25
+Onondaga,W11P08,U.S. House,24,CON,John Katko,5
+Onondaga,W11P09,U.S. House,24,CON,John Katko,1
+Onondaga,W12P01,U.S. House,24,CON,John Katko,4
+Onondaga,W12P02,U.S. House,24,CON,John Katko,4
+Onondaga,W12P03,U.S. House,24,CON,John Katko,2
+Onondaga,W12P04,U.S. House,24,CON,John Katko,3
+Onondaga,W12P05,U.S. House,24,CON,John Katko,41
+Onondaga,W13P01,U.S. House,24,CON,John Katko,7
+Onondaga,W13P02,U.S. House,24,CON,John Katko,5
+Onondaga,W13P03,U.S. House,24,CON,John Katko,23
+Onondaga,W13P04,U.S. House,24,CON,John Katko,20
+Onondaga,W13P05,U.S. House,24,CON,John Katko,22
+Onondaga,W13P06,U.S. House,24,CON,John Katko,4
+Onondaga,W13P07,U.S. House,24,CON,John Katko,24
+Onondaga,W13P08,U.S. House,24,CON,John Katko,15
+Onondaga,W13P09,U.S. House,24,CON,John Katko,6
+Onondaga,W14P01,U.S. House,24,CON,John Katko,7
+Onondaga,W14P02,U.S. House,24,CON,John Katko,16
+Onondaga,W14P03,U.S. House,24,CON,John Katko,8
+Onondaga,W14P04,U.S. House,24,CON,John Katko,7
+Onondaga,W14P06,U.S. House,24,CON,John Katko,19
+Onondaga,W14P07,U.S. House,24,CON,John Katko,41
+Onondaga,W14P08,U.S. House,24,CON,John Katko,10
+Onondaga,W14P09,U.S. House,24,CON,John Katko,7
+Onondaga,W14P10,U.S. House,24,CON,John Katko,9
+Onondaga,W14P11,U.S. House,24,CON,John Katko,32
+Onondaga,W14P12,U.S. House,24,CON,John Katko,15
+Onondaga,W15P01,U.S. House,24,CON,John Katko,3
+Onondaga,W15P02,U.S. House,24,CON,John Katko,1
+Onondaga,W15P03,U.S. House,24,CON,John Katko,2
+Onondaga,W16P01,U.S. House,24,CON,John Katko,11
+Onondaga,W16P02,U.S. House,24,CON,John Katko,3
+Onondaga,W16P03,U.S. House,24,CON,John Katko,6
+Onondaga,W16P04,U.S. House,24,CON,John Katko,18
+Onondaga,W17P01,U.S. House,24,CON,John Katko,0
+Onondaga,W17P02,U.S. House,24,CON,John Katko,15
+Onondaga,W17P03,U.S. House,24,CON,John Katko,9
+Onondaga,W17P04,U.S. House,24,CON,John Katko,8
+Onondaga,W17P05,U.S. House,24,CON,John Katko,9
+Onondaga,W17P06,U.S. House,24,CON,John Katko,2
+Onondaga,W17P07,U.S. House,24,CON,John Katko,7
+Onondaga,W17P08,U.S. House,24,CON,John Katko,13
+Onondaga,W17P09,U.S. House,24,CON,John Katko,6
+Onondaga,W17P10,U.S. House,24,CON,John Katko,6
+Onondaga,W17P11,U.S. House,24,CON,John Katko,4
+Onondaga,W17P12,U.S. House,24,CON,John Katko,7
+Onondaga,W17P13,U.S. House,24,CON,John Katko,16
+Onondaga,W17P14,U.S. House,24,CON,John Katko,10
+Onondaga,W17P15,U.S. House,24,CON,John Katko,13
+Onondaga,W17P16,U.S. House,24,CON,John Katko,14
+Onondaga,W17P17,U.S. House,24,CON,John Katko,6
+Onondaga,W17P18,U.S. House,24,CON,John Katko,0
+Onondaga,W17P19,U.S. House,24,CON,John Katko,0
+Onondaga,W18P01,U.S. House,24,CON,John Katko,1
+Onondaga,W18P02,U.S. House,24,CON,John Katko,7
+Onondaga,W19P01,U.S. House,24,CON,John Katko,3
+Onondaga,W19P02,U.S. House,24,CON,John Katko,11
+Onondaga,W19P03,U.S. House,24,CON,John Katko,21
+Onondaga,W19P04,U.S. House,24,CON,John Katko,9
+Onondaga,W19P05,U.S. House,24,CON,John Katko,3
+Onondaga,W19P06,U.S. House,24,CON,John Katko,12
+Onondaga,W19P07,U.S. House,24,CON,John Katko,6
+Onondaga,Syracuse Total,U.S. House,24,CON,John Katko,1612
+Onondaga,W01P01,U.S. House,24,WOR,Colleen Deacon,14
+Onondaga,W01P02,U.S. House,24,WOR,Colleen Deacon,18
+Onondaga,W01P03,U.S. House,24,WOR,Colleen Deacon,9
+Onondaga,W01P04,U.S. House,24,WOR,Colleen Deacon,14
+Onondaga,W01P05,U.S. House,24,WOR,Colleen Deacon,19
+Onondaga,W01P07,U.S. House,24,WOR,Colleen Deacon,0
+Onondaga,W01P08,U.S. House,24,WOR,Colleen Deacon,6
+Onondaga,W01P09,U.S. House,24,WOR,Colleen Deacon,0
+Onondaga,W02P01,U.S. House,24,WOR,Colleen Deacon,35
+Onondaga,W02P02,U.S. House,24,WOR,Colleen Deacon,20
+Onondaga,W03P01,U.S. House,24,WOR,Colleen Deacon,23
+Onondaga,W03P03,U.S. House,24,WOR,Colleen Deacon,22
+Onondaga,W03P04,U.S. House,24,WOR,Colleen Deacon,8
+Onondaga,W03P05,U.S. House,24,WOR,Colleen Deacon,26
+Onondaga,W03P06,U.S. House,24,WOR,Colleen Deacon,6
+Onondaga,W04P01,U.S. House,24,WOR,Colleen Deacon,15
+Onondaga,W04P02,U.S. House,24,WOR,Colleen Deacon,16
+Onondaga,W04P03,U.S. House,24,WOR,Colleen Deacon,10
+Onondaga,W04P04,U.S. House,24,WOR,Colleen Deacon,23
+Onondaga,W04P05,U.S. House,24,WOR,Colleen Deacon,22
+Onondaga,W04P07,U.S. House,24,WOR,Colleen Deacon,17
+Onondaga,W04P08,U.S. House,24,WOR,Colleen Deacon,21
+Onondaga,W04P09,U.S. House,24,WOR,Colleen Deacon,19
+Onondaga,W05P01,U.S. House,24,WOR,Colleen Deacon,36
+Onondaga,W05P02,U.S. House,24,WOR,Colleen Deacon,13
+Onondaga,W05P03,U.S. House,24,WOR,Colleen Deacon,9
+Onondaga,W05P04,U.S. House,24,WOR,Colleen Deacon,18
+Onondaga,W05P05,U.S. House,24,WOR,Colleen Deacon,13
+Onondaga,W05P06,U.S. House,24,WOR,Colleen Deacon,15
+Onondaga,W05P07,U.S. House,24,WOR,Colleen Deacon,15
+Onondaga,W05P08,U.S. House,24,WOR,Colleen Deacon,0
+Onondaga,W05P09,U.S. House,24,WOR,Colleen Deacon,12
+Onondaga,W05P10,U.S. House,24,WOR,Colleen Deacon,27
+Onondaga,W05P11,U.S. House,24,WOR,Colleen Deacon,17
+Onondaga,W06P01,U.S. House,24,WOR,Colleen Deacon,24
+Onondaga,W06P02,U.S. House,24,WOR,Colleen Deacon,18
+Onondaga,W06P03,U.S. House,24,WOR,Colleen Deacon,9
+Onondaga,W06P04,U.S. House,24,WOR,Colleen Deacon,4
+Onondaga,W06P05,U.S. House,24,WOR,Colleen Deacon,13
+Onondaga,W06P06,U.S. House,24,WOR,Colleen Deacon,23
+Onondaga,W07P01,U.S. House,24,WOR,Colleen Deacon,25
+Onondaga,W07P02,U.S. House,24,WOR,Colleen Deacon,28
+Onondaga,W08P01,U.S. House,24,WOR,Colleen Deacon,12
+Onondaga,W08P02,U.S. House,24,WOR,Colleen Deacon,20
+Onondaga,W08P03,U.S. House,24,WOR,Colleen Deacon,6
+Onondaga,W08P04,U.S. House,24,WOR,Colleen Deacon,14
+Onondaga,W09P01,U.S. House,24,WOR,Colleen Deacon,5
+Onondaga,W09P02,U.S. House,24,WOR,Colleen Deacon,10
+Onondaga,W09P04,U.S. House,24,WOR,Colleen Deacon,4
+Onondaga,W09P05,U.S. House,24,WOR,Colleen Deacon,10
+Onondaga,W10P01,U.S. House,24,WOR,Colleen Deacon,6
+Onondaga,W10P02,U.S. House,24,WOR,Colleen Deacon,1
+Onondaga,W10P03,U.S. House,24,WOR,Colleen Deacon,13
+Onondaga,W10P04,U.S. House,24,WOR,Colleen Deacon,2
+Onondaga,W11P01,U.S. House,24,WOR,Colleen Deacon,14
+Onondaga,W11P02,U.S. House,24,WOR,Colleen Deacon,11
+Onondaga,W11P03,U.S. House,24,WOR,Colleen Deacon,24
+Onondaga,W11P04,U.S. House,24,WOR,Colleen Deacon,22
+Onondaga,W11P07,U.S. House,24,WOR,Colleen Deacon,8
+Onondaga,W11P08,U.S. House,24,WOR,Colleen Deacon,0
+Onondaga,W11P09,U.S. House,24,WOR,Colleen Deacon,3
+Onondaga,W12P01,U.S. House,24,WOR,Colleen Deacon,13
+Onondaga,W12P02,U.S. House,24,WOR,Colleen Deacon,9
+Onondaga,W12P03,U.S. House,24,WOR,Colleen Deacon,4
+Onondaga,W12P04,U.S. House,24,WOR,Colleen Deacon,11
+Onondaga,W12P05,U.S. House,24,WOR,Colleen Deacon,35
+Onondaga,W13P01,U.S. House,24,WOR,Colleen Deacon,18
+Onondaga,W13P02,U.S. House,24,WOR,Colleen Deacon,16
+Onondaga,W13P03,U.S. House,24,WOR,Colleen Deacon,23
+Onondaga,W13P04,U.S. House,24,WOR,Colleen Deacon,13
+Onondaga,W13P05,U.S. House,24,WOR,Colleen Deacon,14
+Onondaga,W13P06,U.S. House,24,WOR,Colleen Deacon,11
+Onondaga,W13P07,U.S. House,24,WOR,Colleen Deacon,14
+Onondaga,W13P08,U.S. House,24,WOR,Colleen Deacon,12
+Onondaga,W13P09,U.S. House,24,WOR,Colleen Deacon,7
+Onondaga,W14P01,U.S. House,24,WOR,Colleen Deacon,21
+Onondaga,W14P02,U.S. House,24,WOR,Colleen Deacon,11
+Onondaga,W14P03,U.S. House,24,WOR,Colleen Deacon,17
+Onondaga,W14P04,U.S. House,24,WOR,Colleen Deacon,9
+Onondaga,W14P06,U.S. House,24,WOR,Colleen Deacon,16
+Onondaga,W14P07,U.S. House,24,WOR,Colleen Deacon,15
+Onondaga,W14P08,U.S. House,24,WOR,Colleen Deacon,9
+Onondaga,W14P09,U.S. House,24,WOR,Colleen Deacon,10
+Onondaga,W14P10,U.S. House,24,WOR,Colleen Deacon,4
+Onondaga,W14P11,U.S. House,24,WOR,Colleen Deacon,23
+Onondaga,W14P12,U.S. House,24,WOR,Colleen Deacon,9
+Onondaga,W15P01,U.S. House,24,WOR,Colleen Deacon,6
+Onondaga,W15P02,U.S. House,24,WOR,Colleen Deacon,2
+Onondaga,W15P03,U.S. House,24,WOR,Colleen Deacon,2
+Onondaga,W16P01,U.S. House,24,WOR,Colleen Deacon,12
+Onondaga,W16P02,U.S. House,24,WOR,Colleen Deacon,39
+Onondaga,W16P03,U.S. House,24,WOR,Colleen Deacon,30
+Onondaga,W16P04,U.S. House,24,WOR,Colleen Deacon,17
+Onondaga,W17P01,U.S. House,24,WOR,Colleen Deacon,0
+Onondaga,W17P02,U.S. House,24,WOR,Colleen Deacon,60
+Onondaga,W17P03,U.S. House,24,WOR,Colleen Deacon,69
+Onondaga,W17P04,U.S. House,24,WOR,Colleen Deacon,29
+Onondaga,W17P05,U.S. House,24,WOR,Colleen Deacon,30
+Onondaga,W17P06,U.S. House,24,WOR,Colleen Deacon,6
+Onondaga,W17P07,U.S. House,24,WOR,Colleen Deacon,31
+Onondaga,W17P08,U.S. House,24,WOR,Colleen Deacon,19
+Onondaga,W17P09,U.S. House,24,WOR,Colleen Deacon,39
+Onondaga,W17P10,U.S. House,24,WOR,Colleen Deacon,9
+Onondaga,W17P11,U.S. House,24,WOR,Colleen Deacon,11
+Onondaga,W17P12,U.S. House,24,WOR,Colleen Deacon,36
+Onondaga,W17P13,U.S. House,24,WOR,Colleen Deacon,21
+Onondaga,W17P14,U.S. House,24,WOR,Colleen Deacon,23
+Onondaga,W17P15,U.S. House,24,WOR,Colleen Deacon,30
+Onondaga,W17P16,U.S. House,24,WOR,Colleen Deacon,11
+Onondaga,W17P17,U.S. House,24,WOR,Colleen Deacon,8
+Onondaga,W17P18,U.S. House,24,WOR,Colleen Deacon,0
+Onondaga,W17P19,U.S. House,24,WOR,Colleen Deacon,4
+Onondaga,W18P01,U.S. House,24,WOR,Colleen Deacon,5
+Onondaga,W18P02,U.S. House,24,WOR,Colleen Deacon,9
+Onondaga,W19P01,U.S. House,24,WOR,Colleen Deacon,8
+Onondaga,W19P02,U.S. House,24,WOR,Colleen Deacon,11
+Onondaga,W19P03,U.S. House,24,WOR,Colleen Deacon,23
+Onondaga,W19P04,U.S. House,24,WOR,Colleen Deacon,23
+Onondaga,W19P05,U.S. House,24,WOR,Colleen Deacon,11
+Onondaga,W19P06,U.S. House,24,WOR,Colleen Deacon,45
+Onondaga,W19P07,U.S. House,24,WOR,Colleen Deacon,23
+Onondaga,Syracuse Total,U.S. House,24,WOR,Colleen Deacon,1913
+Onondaga,W01P01,U.S. House,24,IDC,John Katko,21
+Onondaga,W01P02,U.S. House,24,IDC,John Katko,19
+Onondaga,W01P03,U.S. House,24,IDC,John Katko,8
+Onondaga,W01P04,U.S. House,24,IDC,John Katko,7
+Onondaga,W01P05,U.S. House,24,IDC,John Katko,4
+Onondaga,W01P07,U.S. House,24,IDC,John Katko,1
+Onondaga,W01P08,U.S. House,24,IDC,John Katko,6
+Onondaga,W01P09,U.S. House,24,IDC,John Katko,0
+Onondaga,W02P01,U.S. House,24,IDC,John Katko,11
+Onondaga,W02P02,U.S. House,24,IDC,John Katko,13
+Onondaga,W03P01,U.S. House,24,IDC,John Katko,13
+Onondaga,W03P03,U.S. House,24,IDC,John Katko,27
+Onondaga,W03P04,U.S. House,24,IDC,John Katko,7
+Onondaga,W03P05,U.S. House,24,IDC,John Katko,18
+Onondaga,W03P06,U.S. House,24,IDC,John Katko,4
+Onondaga,W04P01,U.S. House,24,IDC,John Katko,6
+Onondaga,W04P02,U.S. House,24,IDC,John Katko,13
+Onondaga,W04P03,U.S. House,24,IDC,John Katko,16
+Onondaga,W04P04,U.S. House,24,IDC,John Katko,17
+Onondaga,W04P05,U.S. House,24,IDC,John Katko,8
+Onondaga,W04P07,U.S. House,24,IDC,John Katko,25
+Onondaga,W04P08,U.S. House,24,IDC,John Katko,9
+Onondaga,W04P09,U.S. House,24,IDC,John Katko,19
+Onondaga,W05P01,U.S. House,24,IDC,John Katko,5
+Onondaga,W05P02,U.S. House,24,IDC,John Katko,6
+Onondaga,W05P03,U.S. House,24,IDC,John Katko,13
+Onondaga,W05P04,U.S. House,24,IDC,John Katko,16
+Onondaga,W05P05,U.S. House,24,IDC,John Katko,7
+Onondaga,W05P06,U.S. House,24,IDC,John Katko,17
+Onondaga,W05P07,U.S. House,24,IDC,John Katko,17
+Onondaga,W05P08,U.S. House,24,IDC,John Katko,0
+Onondaga,W05P09,U.S. House,24,IDC,John Katko,12
+Onondaga,W05P10,U.S. House,24,IDC,John Katko,18
+Onondaga,W05P11,U.S. House,24,IDC,John Katko,9
+Onondaga,W06P01,U.S. House,24,IDC,John Katko,13
+Onondaga,W06P02,U.S. House,24,IDC,John Katko,12
+Onondaga,W06P03,U.S. House,24,IDC,John Katko,4
+Onondaga,W06P04,U.S. House,24,IDC,John Katko,4
+Onondaga,W06P05,U.S. House,24,IDC,John Katko,9
+Onondaga,W06P06,U.S. House,24,IDC,John Katko,10
+Onondaga,W07P01,U.S. House,24,IDC,John Katko,23
+Onondaga,W07P02,U.S. House,24,IDC,John Katko,26
+Onondaga,W08P01,U.S. House,24,IDC,John Katko,5
+Onondaga,W08P02,U.S. House,24,IDC,John Katko,20
+Onondaga,W08P03,U.S. House,24,IDC,John Katko,5
+Onondaga,W08P04,U.S. House,24,IDC,John Katko,27
+Onondaga,W09P01,U.S. House,24,IDC,John Katko,6
+Onondaga,W09P02,U.S. House,24,IDC,John Katko,4
+Onondaga,W09P04,U.S. House,24,IDC,John Katko,0
+Onondaga,W09P05,U.S. House,24,IDC,John Katko,5
+Onondaga,W10P01,U.S. House,24,IDC,John Katko,2
+Onondaga,W10P02,U.S. House,24,IDC,John Katko,1
+Onondaga,W10P03,U.S. House,24,IDC,John Katko,13
+Onondaga,W10P04,U.S. House,24,IDC,John Katko,3
+Onondaga,W11P01,U.S. House,24,IDC,John Katko,8
+Onondaga,W11P02,U.S. House,24,IDC,John Katko,6
+Onondaga,W11P03,U.S. House,24,IDC,John Katko,9
+Onondaga,W11P04,U.S. House,24,IDC,John Katko,24
+Onondaga,W11P07,U.S. House,24,IDC,John Katko,22
+Onondaga,W11P08,U.S. House,24,IDC,John Katko,0
+Onondaga,W11P09,U.S. House,24,IDC,John Katko,2
+Onondaga,W12P01,U.S. House,24,IDC,John Katko,5
+Onondaga,W12P02,U.S. House,24,IDC,John Katko,0
+Onondaga,W12P03,U.S. House,24,IDC,John Katko,0
+Onondaga,W12P04,U.S. House,24,IDC,John Katko,8
+Onondaga,W12P05,U.S. House,24,IDC,John Katko,30
+Onondaga,W13P01,U.S. House,24,IDC,John Katko,5
+Onondaga,W13P02,U.S. House,24,IDC,John Katko,8
+Onondaga,W13P03,U.S. House,24,IDC,John Katko,10
+Onondaga,W13P04,U.S. House,24,IDC,John Katko,10
+Onondaga,W13P05,U.S. House,24,IDC,John Katko,6
+Onondaga,W13P06,U.S. House,24,IDC,John Katko,5
+Onondaga,W13P07,U.S. House,24,IDC,John Katko,9
+Onondaga,W13P08,U.S. House,24,IDC,John Katko,9
+Onondaga,W13P09,U.S. House,24,IDC,John Katko,14
+Onondaga,W14P01,U.S. House,24,IDC,John Katko,6
+Onondaga,W14P02,U.S. House,24,IDC,John Katko,8
+Onondaga,W14P03,U.S. House,24,IDC,John Katko,7
+Onondaga,W14P04,U.S. House,24,IDC,John Katko,9
+Onondaga,W14P06,U.S. House,24,IDC,John Katko,20
+Onondaga,W14P07,U.S. House,24,IDC,John Katko,16
+Onondaga,W14P08,U.S. House,24,IDC,John Katko,5
+Onondaga,W14P09,U.S. House,24,IDC,John Katko,8
+Onondaga,W14P10,U.S. House,24,IDC,John Katko,3
+Onondaga,W14P11,U.S. House,24,IDC,John Katko,13
+Onondaga,W14P12,U.S. House,24,IDC,John Katko,7
+Onondaga,W15P01,U.S. House,24,IDC,John Katko,0
+Onondaga,W15P02,U.S. House,24,IDC,John Katko,1
+Onondaga,W15P03,U.S. House,24,IDC,John Katko,2
+Onondaga,W16P01,U.S. House,24,IDC,John Katko,4
+Onondaga,W16P02,U.S. House,24,IDC,John Katko,8
+Onondaga,W16P03,U.S. House,24,IDC,John Katko,6
+Onondaga,W16P04,U.S. House,24,IDC,John Katko,15
+Onondaga,W17P01,U.S. House,24,IDC,John Katko,0
+Onondaga,W17P02,U.S. House,24,IDC,John Katko,7
+Onondaga,W17P03,U.S. House,24,IDC,John Katko,13
+Onondaga,W17P04,U.S. House,24,IDC,John Katko,11
+Onondaga,W17P05,U.S. House,24,IDC,John Katko,8
+Onondaga,W17P06,U.S. House,24,IDC,John Katko,4
+Onondaga,W17P07,U.S. House,24,IDC,John Katko,8
+Onondaga,W17P08,U.S. House,24,IDC,John Katko,8
+Onondaga,W17P09,U.S. House,24,IDC,John Katko,6
+Onondaga,W17P10,U.S. House,24,IDC,John Katko,6
+Onondaga,W17P11,U.S. House,24,IDC,John Katko,5
+Onondaga,W17P12,U.S. House,24,IDC,John Katko,7
+Onondaga,W17P13,U.S. House,24,IDC,John Katko,10
+Onondaga,W17P14,U.S. House,24,IDC,John Katko,10
+Onondaga,W17P15,U.S. House,24,IDC,John Katko,19
+Onondaga,W17P16,U.S. House,24,IDC,John Katko,12
+Onondaga,W17P17,U.S. House,24,IDC,John Katko,3
+Onondaga,W17P18,U.S. House,24,IDC,John Katko,0
+Onondaga,W17P19,U.S. House,24,IDC,John Katko,0
+Onondaga,W18P01,U.S. House,24,IDC,John Katko,3
+Onondaga,W18P02,U.S. House,24,IDC,John Katko,3
+Onondaga,W19P01,U.S. House,24,IDC,John Katko,6
+Onondaga,W19P02,U.S. House,24,IDC,John Katko,2
+Onondaga,W19P03,U.S. House,24,IDC,John Katko,13
+Onondaga,W19P04,U.S. House,24,IDC,John Katko,9
+Onondaga,W19P05,U.S. House,24,IDC,John Katko,5
+Onondaga,W19P06,U.S. House,24,IDC,John Katko,12
+Onondaga,W19P07,U.S. House,24,IDC,John Katko,14
+Onondaga,Syracuse Total,U.S. House,24,IDC,John Katko,1116
+Onondaga,W01P01,U.S. House,24,REF,John Katko,0
+Onondaga,W01P02,U.S. House,24,REF,John Katko,4
+Onondaga,W01P03,U.S. House,24,REF,John Katko,0
+Onondaga,W01P04,U.S. House,24,REF,John Katko,1
+Onondaga,W01P05,U.S. House,24,REF,John Katko,2
+Onondaga,W01P07,U.S. House,24,REF,John Katko,0
+Onondaga,W01P08,U.S. House,24,REF,John Katko,3
+Onondaga,W01P09,U.S. House,24,REF,John Katko,0
+Onondaga,W02P01,U.S. House,24,REF,John Katko,5
+Onondaga,W02P02,U.S. House,24,REF,John Katko,6
+Onondaga,W03P01,U.S. House,24,REF,John Katko,0
+Onondaga,W03P03,U.S. House,24,REF,John Katko,2
+Onondaga,W03P04,U.S. House,24,REF,John Katko,1
+Onondaga,W03P05,U.S. House,24,REF,John Katko,2
+Onondaga,W03P06,U.S. House,24,REF,John Katko,1
+Onondaga,W04P01,U.S. House,24,REF,John Katko,0
+Onondaga,W04P02,U.S. House,24,REF,John Katko,3
+Onondaga,W04P03,U.S. House,24,REF,John Katko,3
+Onondaga,W04P04,U.S. House,24,REF,John Katko,1
+Onondaga,W04P05,U.S. House,24,REF,John Katko,0
+Onondaga,W04P07,U.S. House,24,REF,John Katko,5
+Onondaga,W04P08,U.S. House,24,REF,John Katko,1
+Onondaga,W04P09,U.S. House,24,REF,John Katko,3
+Onondaga,W05P01,U.S. House,24,REF,John Katko,2
+Onondaga,W05P02,U.S. House,24,REF,John Katko,0
+Onondaga,W05P03,U.S. House,24,REF,John Katko,0
+Onondaga,W05P04,U.S. House,24,REF,John Katko,2
+Onondaga,W05P05,U.S. House,24,REF,John Katko,2
+Onondaga,W05P06,U.S. House,24,REF,John Katko,5
+Onondaga,W05P07,U.S. House,24,REF,John Katko,4
+Onondaga,W05P08,U.S. House,24,REF,John Katko,0
+Onondaga,W05P09,U.S. House,24,REF,John Katko,4
+Onondaga,W05P10,U.S. House,24,REF,John Katko,4
+Onondaga,W05P11,U.S. House,24,REF,John Katko,1
+Onondaga,W06P01,U.S. House,24,REF,John Katko,4
+Onondaga,W06P02,U.S. House,24,REF,John Katko,5
+Onondaga,W06P03,U.S. House,24,REF,John Katko,1
+Onondaga,W06P04,U.S. House,24,REF,John Katko,0
+Onondaga,W06P05,U.S. House,24,REF,John Katko,0
+Onondaga,W06P06,U.S. House,24,REF,John Katko,0
+Onondaga,W07P01,U.S. House,24,REF,John Katko,3
+Onondaga,W07P02,U.S. House,24,REF,John Katko,6
+Onondaga,W08P01,U.S. House,24,REF,John Katko,0
+Onondaga,W08P02,U.S. House,24,REF,John Katko,1
+Onondaga,W08P03,U.S. House,24,REF,John Katko,1
+Onondaga,W08P04,U.S. House,24,REF,John Katko,2
+Onondaga,W09P01,U.S. House,24,REF,John Katko,2
+Onondaga,W09P02,U.S. House,24,REF,John Katko,1
+Onondaga,W09P04,U.S. House,24,REF,John Katko,0
+Onondaga,W09P05,U.S. House,24,REF,John Katko,0
+Onondaga,W10P01,U.S. House,24,REF,John Katko,0
+Onondaga,W10P02,U.S. House,24,REF,John Katko,0
+Onondaga,W10P03,U.S. House,24,REF,John Katko,2
+Onondaga,W10P04,U.S. House,24,REF,John Katko,0
+Onondaga,W11P01,U.S. House,24,REF,John Katko,0
+Onondaga,W11P02,U.S. House,24,REF,John Katko,0
+Onondaga,W11P03,U.S. House,24,REF,John Katko,0
+Onondaga,W11P04,U.S. House,24,REF,John Katko,1
+Onondaga,W11P07,U.S. House,24,REF,John Katko,1
+Onondaga,W11P08,U.S. House,24,REF,John Katko,0
+Onondaga,W11P09,U.S. House,24,REF,John Katko,0
+Onondaga,W12P01,U.S. House,24,REF,John Katko,2
+Onondaga,W12P02,U.S. House,24,REF,John Katko,0
+Onondaga,W12P03,U.S. House,24,REF,John Katko,0
+Onondaga,W12P04,U.S. House,24,REF,John Katko,2
+Onondaga,W12P05,U.S. House,24,REF,John Katko,3
+Onondaga,W13P01,U.S. House,24,REF,John Katko,1
+Onondaga,W13P02,U.S. House,24,REF,John Katko,0
+Onondaga,W13P03,U.S. House,24,REF,John Katko,2
+Onondaga,W13P04,U.S. House,24,REF,John Katko,2
+Onondaga,W13P05,U.S. House,24,REF,John Katko,1
+Onondaga,W13P06,U.S. House,24,REF,John Katko,1
+Onondaga,W13P07,U.S. House,24,REF,John Katko,3
+Onondaga,W13P08,U.S. House,24,REF,John Katko,1
+Onondaga,W13P09,U.S. House,24,REF,John Katko,2
+Onondaga,W14P01,U.S. House,24,REF,John Katko,0
+Onondaga,W14P02,U.S. House,24,REF,John Katko,1
+Onondaga,W14P03,U.S. House,24,REF,John Katko,3
+Onondaga,W14P04,U.S. House,24,REF,John Katko,0
+Onondaga,W14P06,U.S. House,24,REF,John Katko,2
+Onondaga,W14P07,U.S. House,24,REF,John Katko,2
+Onondaga,W14P08,U.S. House,24,REF,John Katko,2
+Onondaga,W14P09,U.S. House,24,REF,John Katko,0
+Onondaga,W14P10,U.S. House,24,REF,John Katko,0
+Onondaga,W14P11,U.S. House,24,REF,John Katko,4
+Onondaga,W14P12,U.S. House,24,REF,John Katko,3
+Onondaga,W15P01,U.S. House,24,REF,John Katko,0
+Onondaga,W15P02,U.S. House,24,REF,John Katko,0
+Onondaga,W15P03,U.S. House,24,REF,John Katko,0
+Onondaga,W16P01,U.S. House,24,REF,John Katko,1
+Onondaga,W16P02,U.S. House,24,REF,John Katko,0
+Onondaga,W16P03,U.S. House,24,REF,John Katko,1
+Onondaga,W16P04,U.S. House,24,REF,John Katko,2
+Onondaga,W17P01,U.S. House,24,REF,John Katko,0
+Onondaga,W17P02,U.S. House,24,REF,John Katko,4
+Onondaga,W17P03,U.S. House,24,REF,John Katko,0
+Onondaga,W17P04,U.S. House,24,REF,John Katko,0
+Onondaga,W17P05,U.S. House,24,REF,John Katko,0
+Onondaga,W17P06,U.S. House,24,REF,John Katko,0
+Onondaga,W17P07,U.S. House,24,REF,John Katko,0
+Onondaga,W17P08,U.S. House,24,REF,John Katko,0
+Onondaga,W17P09,U.S. House,24,REF,John Katko,0
+Onondaga,W17P10,U.S. House,24,REF,John Katko,0
+Onondaga,W17P11,U.S. House,24,REF,John Katko,0
+Onondaga,W17P12,U.S. House,24,REF,John Katko,1
+Onondaga,W17P13,U.S. House,24,REF,John Katko,0
+Onondaga,W17P14,U.S. House,24,REF,John Katko,1
+Onondaga,W17P15,U.S. House,24,REF,John Katko,0
+Onondaga,W17P16,U.S. House,24,REF,John Katko,2
+Onondaga,W17P17,U.S. House,24,REF,John Katko,0
+Onondaga,W17P18,U.S. House,24,REF,John Katko,0
+Onondaga,W17P19,U.S. House,24,REF,John Katko,0
+Onondaga,W18P01,U.S. House,24,REF,John Katko,1
+Onondaga,W18P02,U.S. House,24,REF,John Katko,0
+Onondaga,W19P01,U.S. House,24,REF,John Katko,1
+Onondaga,W19P02,U.S. House,24,REF,John Katko,0
+Onondaga,W19P03,U.S. House,24,REF,John Katko,1
+Onondaga,W19P04,U.S. House,24,REF,John Katko,1
+Onondaga,W19P05,U.S. House,24,REF,John Katko,0
+Onondaga,W19P06,U.S. House,24,REF,John Katko,3
+Onondaga,W19P07,U.S. House,24,REF,John Katko,1
+Onondaga,Syracuse Total,U.S. House,24,REF,John Katko,154
+Onondaga,W01P01,U.S. House,24,,Write-ins,0
+Onondaga,W01P02,U.S. House,24,,Write-ins,2
+Onondaga,W01P03,U.S. House,24,,Write-ins,0
+Onondaga,W01P04,U.S. House,24,,Write-ins,0
+Onondaga,W01P05,U.S. House,24,,Write-ins,0
+Onondaga,W01P07,U.S. House,24,,Write-ins,0
+Onondaga,W01P08,U.S. House,24,,Write-ins,1
+Onondaga,W01P09,U.S. House,24,,Write-ins,0
+Onondaga,W02P01,U.S. House,24,,Write-ins,2
+Onondaga,W02P02,U.S. House,24,,Write-ins,2
+Onondaga,W03P01,U.S. House,24,,Write-ins,0
+Onondaga,W03P03,U.S. House,24,,Write-ins,1
+Onondaga,W03P04,U.S. House,24,,Write-ins,0
+Onondaga,W03P05,U.S. House,24,,Write-ins,1
+Onondaga,W03P06,U.S. House,24,,Write-ins,0
+Onondaga,W04P01,U.S. House,24,,Write-ins,1
+Onondaga,W04P02,U.S. House,24,,Write-ins,1
+Onondaga,W04P03,U.S. House,24,,Write-ins,0
+Onondaga,W04P04,U.S. House,24,,Write-ins,4
+Onondaga,W04P05,U.S. House,24,,Write-ins,2
+Onondaga,W04P07,U.S. House,24,,Write-ins,1
+Onondaga,W04P08,U.S. House,24,,Write-ins,0
+Onondaga,W04P09,U.S. House,24,,Write-ins,0
+Onondaga,W05P01,U.S. House,24,,Write-ins,3
+Onondaga,W05P02,U.S. House,24,,Write-ins,1
+Onondaga,W05P03,U.S. House,24,,Write-ins,2
+Onondaga,W05P04,U.S. House,24,,Write-ins,2
+Onondaga,W05P05,U.S. House,24,,Write-ins,2
+Onondaga,W05P06,U.S. House,24,,Write-ins,0
+Onondaga,W05P07,U.S. House,24,,Write-ins,0
+Onondaga,W05P08,U.S. House,24,,Write-ins,0
+Onondaga,W05P09,U.S. House,24,,Write-ins,0
+Onondaga,W05P10,U.S. House,24,,Write-ins,0
+Onondaga,W05P11,U.S. House,24,,Write-ins,2
+Onondaga,W06P01,U.S. House,24,,Write-ins,1
+Onondaga,W06P02,U.S. House,24,,Write-ins,0
+Onondaga,W06P03,U.S. House,24,,Write-ins,1
+Onondaga,W06P04,U.S. House,24,,Write-ins,0
+Onondaga,W06P05,U.S. House,24,,Write-ins,2
+Onondaga,W06P06,U.S. House,24,,Write-ins,0
+Onondaga,W07P01,U.S. House,24,,Write-ins,3
+Onondaga,W07P02,U.S. House,24,,Write-ins,2
+Onondaga,W08P01,U.S. House,24,,Write-ins,0
+Onondaga,W08P02,U.S. House,24,,Write-ins,1
+Onondaga,W08P03,U.S. House,24,,Write-ins,0
+Onondaga,W08P04,U.S. House,24,,Write-ins,2
+Onondaga,W09P01,U.S. House,24,,Write-ins,0
+Onondaga,W09P02,U.S. House,24,,Write-ins,1
+Onondaga,W09P04,U.S. House,24,,Write-ins,0
+Onondaga,W09P05,U.S. House,24,,Write-ins,0
+Onondaga,W10P01,U.S. House,24,,Write-ins,0
+Onondaga,W10P02,U.S. House,24,,Write-ins,0
+Onondaga,W10P03,U.S. House,24,,Write-ins,1
+Onondaga,W10P04,U.S. House,24,,Write-ins,0
+Onondaga,W11P01,U.S. House,24,,Write-ins,0
+Onondaga,W11P02,U.S. House,24,,Write-ins,2
+Onondaga,W11P03,U.S. House,24,,Write-ins,0
+Onondaga,W11P04,U.S. House,24,,Write-ins,2
+Onondaga,W11P07,U.S. House,24,,Write-ins,2
+Onondaga,W11P08,U.S. House,24,,Write-ins,0
+Onondaga,W11P09,U.S. House,24,,Write-ins,0
+Onondaga,W12P01,U.S. House,24,,Write-ins,0
+Onondaga,W12P02,U.S. House,24,,Write-ins,0
+Onondaga,W12P03,U.S. House,24,,Write-ins,0
+Onondaga,W12P04,U.S. House,24,,Write-ins,0
+Onondaga,W12P05,U.S. House,24,,Write-ins,1
+Onondaga,W13P01,U.S. House,24,,Write-ins,1
+Onondaga,W13P02,U.S. House,24,,Write-ins,0
+Onondaga,W13P03,U.S. House,24,,Write-ins,1
+Onondaga,W13P04,U.S. House,24,,Write-ins,0
+Onondaga,W13P05,U.S. House,24,,Write-ins,1
+Onondaga,W13P06,U.S. House,24,,Write-ins,0
+Onondaga,W13P07,U.S. House,24,,Write-ins,1
+Onondaga,W13P08,U.S. House,24,,Write-ins,0
+Onondaga,W13P09,U.S. House,24,,Write-ins,2
+Onondaga,W14P01,U.S. House,24,,Write-ins,0
+Onondaga,W14P02,U.S. House,24,,Write-ins,0
+Onondaga,W14P03,U.S. House,24,,Write-ins,4
+Onondaga,W14P04,U.S. House,24,,Write-ins,0
+Onondaga,W14P06,U.S. House,24,,Write-ins,0
+Onondaga,W14P07,U.S. House,24,,Write-ins,0
+Onondaga,W14P08,U.S. House,24,,Write-ins,1
+Onondaga,W14P09,U.S. House,24,,Write-ins,0
+Onondaga,W14P10,U.S. House,24,,Write-ins,0
+Onondaga,W14P11,U.S. House,24,,Write-ins,0
+Onondaga,W14P12,U.S. House,24,,Write-ins,1
+Onondaga,W15P01,U.S. House,24,,Write-ins,1
+Onondaga,W15P02,U.S. House,24,,Write-ins,0
+Onondaga,W15P03,U.S. House,24,,Write-ins,0
+Onondaga,W16P01,U.S. House,24,,Write-ins,1
+Onondaga,W16P02,U.S. House,24,,Write-ins,2
+Onondaga,W16P03,U.S. House,24,,Write-ins,1
+Onondaga,W16P04,U.S. House,24,,Write-ins,0
+Onondaga,W17P01,U.S. House,24,,Write-ins,0
+Onondaga,W17P02,U.S. House,24,,Write-ins,2
+Onondaga,W17P03,U.S. House,24,,Write-ins,1
+Onondaga,W17P04,U.S. House,24,,Write-ins,1
+Onondaga,W17P05,U.S. House,24,,Write-ins,0
+Onondaga,W17P06,U.S. House,24,,Write-ins,0
+Onondaga,W17P07,U.S. House,24,,Write-ins,0
+Onondaga,W17P08,U.S. House,24,,Write-ins,1
+Onondaga,W17P09,U.S. House,24,,Write-ins,0
+Onondaga,W17P10,U.S. House,24,,Write-ins,0
+Onondaga,W17P11,U.S. House,24,,Write-ins,0
+Onondaga,W17P12,U.S. House,24,,Write-ins,3
+Onondaga,W17P13,U.S. House,24,,Write-ins,2
+Onondaga,W17P14,U.S. House,24,,Write-ins,1
+Onondaga,W17P15,U.S. House,24,,Write-ins,3
+Onondaga,W17P16,U.S. House,24,,Write-ins,0
+Onondaga,W17P17,U.S. House,24,,Write-ins,0
+Onondaga,W17P18,U.S. House,24,,Write-ins,0
+Onondaga,W17P19,U.S. House,24,,Write-ins,0
+Onondaga,W18P01,U.S. House,24,,Write-ins,0
+Onondaga,W18P02,U.S. House,24,,Write-ins,1
+Onondaga,W19P01,U.S. House,24,,Write-ins,1
+Onondaga,W19P02,U.S. House,24,,Write-ins,0
+Onondaga,W19P03,U.S. House,24,,Write-ins,0
+Onondaga,W19P04,U.S. House,24,,Write-ins,0
+Onondaga,W19P05,U.S. House,24,,Write-ins,0
+Onondaga,W19P06,U.S. House,24,,Write-ins,0
+Onondaga,W19P07,U.S. House,24,,Write-ins,1
+Onondaga,Syracuse Total,U.S. House,24,,Write-ins,85
 Onondaga,W01P04,State Senate,50,REP,John DeFrancisco,139
 Onondaga,W01P07,State Senate,50,REP,John DeFrancisco,16
 Onondaga,W01P09,State Senate,50,REP,John DeFrancisco,6


### PR DESCRIPTION
Not all precinct-level Onondaga County returns for the 2016 U.S. House race were associated with a district. Onondaga is in the [24th](https://en.wikipedia.org/wiki/New_York%27s_24th_congressional_district), and this PR populates the missing `district` values with `24`.