### PR TITLE
Add Jefferson Co 2018 general results

### DIFF
--- a/2018/20181106__ny__general__jefferson__precinct.csv
+++ b/2018/20181106__ny__general__jefferson__precinct.csv
@@ -1,0 +1,4298 @@
+county,precinct,office,district,party,candidate,votes
+Jefferson,Adams 1,Governor,,DEM,Cuomo,153
+Jefferson,Adams 1,Lt. Governor,,DEM,Hochul,153
+Jefferson,Adams 1,Governor,,REP,Molinaro,277
+Jefferson,Adams 1,Lt. Governor,,REP,Killian,277
+Jefferson,Adams 1,Governor,,CON,Molinaro,30
+Jefferson,Adams 1,Lt. Governor,,CON,Killian,30
+Jefferson,Adams 1,Governor,,GREEN,Hawkins,12
+Jefferson,Adams 1,Lt. Governor,,GREEN,Lee,12
+Jefferson,Adams 1,Governor,,WF,Cuomo,1
+Jefferson,Adams 1,Lt. Governor,,WF,Hochul,1
+Jefferson,Adams 1,Governor,,IND,Cuomo,3
+Jefferson,Adams 1,Lt. Governor,,IND,Hochul,3
+Jefferson,Adams 1,Governor,,WEP,Cuomo,0
+Jefferson,Adams 1,Lt. Governor,,WEP,Hochul,0
+Jefferson,Adams 1,Governor,,REF,Molinaro,2
+Jefferson,Adams 1,Lt. Governor,,REF,Killian,2
+Jefferson,Adams 1,Governor,,SAM,Miner,10
+Jefferson,Adams 1,Lt. Governor,,SAM,Volpe,10
+Jefferson,Adams 1,Governor,,LIB,Sharpe,26
+Jefferson,Adams 1,Lt. Governor,,LIB,Hollister,26
+Jefferson,Adams 1,Governor,,,Write-In,0
+Jefferson,Adams 2,Governor,,DEM,Cuomo,90
+Jefferson,Adams 2,Lt. Governor,,DEM,Hochul,90
+Jefferson,Adams 2,Governor,,REP,Molinaro,231
+Jefferson,Adams 2,Lt. Governor,,REP,Killian,231
+Jefferson,Adams 2,Governor,,CON,Molinaro,29
+Jefferson,Adams 2,Lt. Governor,,CON,Killian,29
+Jefferson,Adams 2,Governor,,GREEN,Hawkins,4
+Jefferson,Adams 2,Lt. Governor,,GREEN,Lee,4
+Jefferson,Adams 2,Governor,,WF,Cuomo,3
+Jefferson,Adams 2,Lt. Governor,,WF,Hochul,3
+Jefferson,Adams 2,Governor,,IND,Cuomo,3
+Jefferson,Adams 2,Lt. Governor,,IND,Hochul,3
+Jefferson,Adams 2,Governor,,WEP,Cuomo,2
+Jefferson,Adams 2,Lt. Governor,,WEP,Hochul,2
+Jefferson,Adams 2,Governor,,REF,Molinaro,3
+Jefferson,Adams 2,Lt. Governor,,REF,Killian,3
+Jefferson,Adams 2,Governor,,SAM,Miner,1
+Jefferson,Adams 2,Lt. Governor,,SAM,Volpe,1
+Jefferson,Adams 2,Governor,,LIB,Sharpe,10
+Jefferson,Adams 2,Lt. Governor,,LIB,Hollister,10
+Jefferson,Adams 2,Governor,,,Write-In,0
+Jefferson,Adams 3,Governor,,DEM,Cuomo,170
+Jefferson,Adams 3,Lt. Governor,,DEM,Hochul,170
+Jefferson,Adams 3,Governor,,REP,Molinaro,456
+Jefferson,Adams 3,Lt. Governor,,REP,Killian,456
+Jefferson,Adams 3,Governor,,CON,Molinaro,57
+Jefferson,Adams 3,Lt. Governor,,CON,Killian,57
+Jefferson,Adams 3,Governor,,GREEN,Hawkins,14
+Jefferson,Adams 3,Lt. Governor,,GREEN,Lee,14
+Jefferson,Adams 3,Governor,,WF,Cuomo,3
+Jefferson,Adams 3,Lt. Governor,,WF,Hochul,3
+Jefferson,Adams 3,Governor,,IND,Cuomo,8
+Jefferson,Adams 3,Lt. Governor,,IND,Hochul,8
+Jefferson,Adams 3,Governor,,WEP,Cuomo,2
+Jefferson,Adams 3,Lt. Governor,,WEP,Hochul,2
+Jefferson,Adams 3,Governor,,REF,Molinaro,9
+Jefferson,Adams 3,Lt. Governor,,REF,Killian,9
+Jefferson,Adams 3,Governor,,SAM,Miner,11
+Jefferson,Adams 3,Lt. Governor,,SAM,Volpe,11
+Jefferson,Adams 3,Governor,,LIB,Sharpe,34
+Jefferson,Adams 3,Lt. Governor,,LIB,Hollister,34
+Jefferson,Adams 3,Governor,,,Write-In,0
+Jefferson,Alexandria 1,Governor,,DEM,Cuomo,132
+Jefferson,Alexandria 1,Lt. Governor,,DEM,Hochul,132
+Jefferson,Alexandria 1,Governor,,REP,Molinaro,187
+Jefferson,Alexandria 1,Lt. Governor,,REP,Killian,187
+Jefferson,Alexandria 1,Governor,,CON,Molinaro,16
+Jefferson,Alexandria 1,Lt. Governor,,CON,Killian,16
+Jefferson,Alexandria 1,Governor,,GREEN,Hawkins,6
+Jefferson,Alexandria 1,Lt. Governor,,GREEN,Lee,6
+Jefferson,Alexandria 1,Governor,,WF,Cuomo,7
+Jefferson,Alexandria 1,Lt. Governor,,WF,Hochul,7
+Jefferson,Alexandria 1,Governor,,IND,Cuomo,3
+Jefferson,Alexandria 1,Lt. Governor,,IND,Hochul,3
+Jefferson,Alexandria 1,Governor,,WEP,Cuomo,0
+Jefferson,Alexandria 1,Lt. Governor,,WEP,Hochul,0
+Jefferson,Alexandria 1,Governor,,REF,Molinaro,5
+Jefferson,Alexandria 1,Lt. Governor,,REF,Killian,5
+Jefferson,Alexandria 1,Governor,,SAM,Miner,10
+Jefferson,Alexandria 1,Lt. Governor,,SAM,Volpe,10
+Jefferson,Alexandria 1,Governor,,LIB,Sharpe,8
+Jefferson,Alexandria 1,Lt. Governor,,LIB,Hollister,8
+Jefferson,Alexandria 1,Governor,,,Write-In,1
+Jefferson,Alexandria 2,Governor,,DEM,Cuomo,131
+Jefferson,Alexandria 2,Lt. Governor,,DEM,Hochul,131
+Jefferson,Alexandria 2,Governor,,REP,Molinaro,321
+Jefferson,Alexandria 2,Lt. Governor,,REP,Killian,321
+Jefferson,Alexandria 2,Governor,,CON,Molinaro,47
+Jefferson,Alexandria 2,Lt. Governor,,CON,Killian,47
+Jefferson,Alexandria 2,Governor,,GREEN,Hawkins,3
+Jefferson,Alexandria 2,Lt. Governor,,GREEN,Lee,3
+Jefferson,Alexandria 2,Governor,,WF,Cuomo,4
+Jefferson,Alexandria 2,Lt. Governor,,WF,Hochul,4
+Jefferson,Alexandria 2,Governor,,IND,Cuomo,3
+Jefferson,Alexandria 2,Lt. Governor,,IND,Hochul,3
+Jefferson,Alexandria 2,Governor,,WEP,Cuomo,0
+Jefferson,Alexandria 2,Lt. Governor,,WEP,Hochul,0
+Jefferson,Alexandria 2,Governor,,REF,Molinaro,6
+Jefferson,Alexandria 2,Lt. Governor,,REF,Killian,6
+Jefferson,Alexandria 2,Governor,,SAM,Miner,9
+Jefferson,Alexandria 2,Lt. Governor,,SAM,Volpe,9
+Jefferson,Alexandria 2,Governor,,LIB,Sharpe,10
+Jefferson,Alexandria 2,Lt. Governor,,LIB,Hollister,10
+Jefferson,Alexandria 2,Governor,,,Write-In,0
+Jefferson,Alexandria 3,Governor,,DEM,Cuomo,164
+Jefferson,Alexandria 3,Lt. Governor,,DEM,Hochul,164
+Jefferson,Alexandria 3,Governor,,REP,Molinaro,433
+Jefferson,Alexandria 3,Lt. Governor,,REP,Killian,433
+Jefferson,Alexandria 3,Governor,,CON,Molinaro,42
+Jefferson,Alexandria 3,Lt. Governor,,CON,Killian,42
+Jefferson,Alexandria 3,Governor,,GREEN,Hawkins,9
+Jefferson,Alexandria 3,Lt. Governor,,GREEN,Lee,9
+Jefferson,Alexandria 3,Governor,,WF,Cuomo,1
+Jefferson,Alexandria 3,Lt. Governor,,WF,Hochul,1
+Jefferson,Alexandria 3,Governor,,IND,Cuomo,4
+Jefferson,Alexandria 3,Lt. Governor,,IND,Hochul,4
+Jefferson,Alexandria 3,Governor,,WEP,Cuomo,0
+Jefferson,Alexandria 3,Lt. Governor,,WEP,Hochul,0
+Jefferson,Alexandria 3,Governor,,REF,Molinaro,6
+Jefferson,Alexandria 3,Lt. Governor,,REF,Killian,6
+Jefferson,Alexandria 3,Governor,,SAM,Miner,8
+Jefferson,Alexandria 3,Lt. Governor,,SAM,Volpe,8
+Jefferson,Alexandria 3,Governor,,LIB,Sharpe,30
+Jefferson,Alexandria 3,Lt. Governor,,LIB,Hollister,30
+Jefferson,Alexandria 3,Governor,,,Write-In,1
+Jefferson,Antwerp 1,Governor,,DEM,Cuomo,45
+Jefferson,Antwerp 1,Lt. Governor,,DEM,Hochul,45
+Jefferson,Antwerp 1,Governor,,REP,Molinaro,106
+Jefferson,Antwerp 1,Lt. Governor,,REP,Killian,106
+Jefferson,Antwerp 1,Governor,,CON,Molinaro,11
+Jefferson,Antwerp 1,Lt. Governor,,CON,Killian,11
+Jefferson,Antwerp 1,Governor,,GREEN,Hawkins,1
+Jefferson,Antwerp 1,Lt. Governor,,GREEN,Lee,1
+Jefferson,Antwerp 1,Governor,,WF,Cuomo,1
+Jefferson,Antwerp 1,Lt. Governor,,WF,Hochul,1
+Jefferson,Antwerp 1,Governor,,IND,Cuomo,2
+Jefferson,Antwerp 1,Lt. Governor,,IND,Hochul,2
+Jefferson,Antwerp 1,Governor,,WEP,Cuomo,0
+Jefferson,Antwerp 1,Lt. Governor,,WEP,Hochul,0
+Jefferson,Antwerp 1,Governor,,REF,Molinaro,1
+Jefferson,Antwerp 1,Lt. Governor,,REF,Killian,1
+Jefferson,Antwerp 1,Governor,,SAM,Miner,7
+Jefferson,Antwerp 1,Lt. Governor,,SAM,Volpe,7
+Jefferson,Antwerp 1,Governor,,LIB,Sharpe,6
+Jefferson,Antwerp 1,Lt. Governor,,LIB,Hollister,6
+Jefferson,Antwerp 1,Governor,,,Write-In,0
+Jefferson,Antwerp 2,Governor,,DEM,Cuomo,75
+Jefferson,Antwerp 2,Lt. Governor,,DEM,Hochul,75
+Jefferson,Antwerp 2,Governor,,REP,Molinaro,234
+Jefferson,Antwerp 2,Lt. Governor,,REP,Killian,234
+Jefferson,Antwerp 2,Governor,,CON,Molinaro,29
+Jefferson,Antwerp 2,Lt. Governor,,CON,Killian,29
+Jefferson,Antwerp 2,Governor,,GREEN,Hawkins,4
+Jefferson,Antwerp 2,Lt. Governor,,GREEN,Lee,4
+Jefferson,Antwerp 2,Governor,,WF,Cuomo,3
+Jefferson,Antwerp 2,Lt. Governor,,WF,Hochul,3
+Jefferson,Antwerp 2,Governor,,IND,Cuomo,2
+Jefferson,Antwerp 2,Lt. Governor,,IND,Hochul,2
+Jefferson,Antwerp 2,Governor,,WEP,Cuomo,0
+Jefferson,Antwerp 2,Lt. Governor,,WEP,Hochul,0
+Jefferson,Antwerp 2,Governor,,REF,Molinaro,3
+Jefferson,Antwerp 2,Lt. Governor,,REF,Killian,3
+Jefferson,Antwerp 2,Governor,,SAM,Miner,8
+Jefferson,Antwerp 2,Lt. Governor,,SAM,Volpe,8
+Jefferson,Antwerp 2,Governor,,LIB,Sharpe,9
+Jefferson,Antwerp 2,Lt. Governor,,LIB,Hollister,9
+Jefferson,Antwerp 2,Governor,,,Write-In,0
+Jefferson,Brownville 1,Governor,,DEM,Cuomo,82
+Jefferson,Brownville 1,Lt. Governor,,DEM,Hochul,82
+Jefferson,Brownville 1,Governor,,REP,Molinaro,270
+Jefferson,Brownville 1,Lt. Governor,,REP,Killian,270
+Jefferson,Brownville 1,Governor,,CON,Molinaro,30
+Jefferson,Brownville 1,Lt. Governor,,CON,Killian,30
+Jefferson,Brownville 1,Governor,,GREEN,Hawkins,2
+Jefferson,Brownville 1,Lt. Governor,,GREEN,Lee,2
+Jefferson,Brownville 1,Governor,,WF,Cuomo,1
+Jefferson,Brownville 1,Lt. Governor,,WF,Hochul,1
+Jefferson,Brownville 1,Governor,,IND,Cuomo,5
+Jefferson,Brownville 1,Lt. Governor,,IND,Hochul,5
+Jefferson,Brownville 1,Governor,,WEP,Cuomo,1
+Jefferson,Brownville 1,Lt. Governor,,WEP,Hochul,1
+Jefferson,Brownville 1,Governor,,REF,Molinaro,1
+Jefferson,Brownville 1,Lt. Governor,,REF,Killian,1
+Jefferson,Brownville 1,Governor,,SAM,Miner,7
+Jefferson,Brownville 1,Lt. Governor,,SAM,Volpe,7
+Jefferson,Brownville 1,Governor,,LIB,Sharpe,9
+Jefferson,Brownville 1,Lt. Governor,,LIB,Hollister,9
+Jefferson,Brownville 1,Governor,,,Write-In,0
+Jefferson,Brownville 2,Governor,,DEM,Cuomo,89
+Jefferson,Brownville 2,Lt. Governor,,DEM,Hochul,89
+Jefferson,Brownville 2,Governor,,REP,Molinaro,196
+Jefferson,Brownville 2,Lt. Governor,,REP,Killian,196
+Jefferson,Brownville 2,Governor,,CON,Molinaro,23
+Jefferson,Brownville 2,Lt. Governor,,CON,Killian,23
+Jefferson,Brownville 2,Governor,,GREEN,Hawkins,4
+Jefferson,Brownville 2,Lt. Governor,,GREEN,Lee,4
+Jefferson,Brownville 2,Governor,,WF,Cuomo,3
+Jefferson,Brownville 2,Lt. Governor,,WF,Hochul,3
+Jefferson,Brownville 2,Governor,,IND,Cuomo,2
+Jefferson,Brownville 2,Lt. Governor,,IND,Hochul,2
+Jefferson,Brownville 2,Governor,,WEP,Cuomo,0
+Jefferson,Brownville 2,Lt. Governor,,WEP,Hochul,0
+Jefferson,Brownville 2,Governor,,REF,Molinaro,1
+Jefferson,Brownville 2,Lt. Governor,,REF,Killian,1
+Jefferson,Brownville 2,Governor,,SAM,Miner,7
+Jefferson,Brownville 2,Lt. Governor,,SAM,Volpe,7
+Jefferson,Brownville 2,Governor,,LIB,Sharpe,11
+Jefferson,Brownville 2,Lt. Governor,,LIB,Hollister,11
+Jefferson,Brownville 2,Governor,,,Write-In,0
+Jefferson,Brownville 3,Governor,,DEM,Cuomo,120
+Jefferson,Brownville 3,Lt. Governor,,DEM,Hochul,120
+Jefferson,Brownville 3,Governor,,REP,Molinaro,297
+Jefferson,Brownville 3,Lt. Governor,,REP,Killian,297
+Jefferson,Brownville 3,Governor,,CON,Molinaro,29
+Jefferson,Brownville 3,Lt. Governor,,CON,Killian,29
+Jefferson,Brownville 3,Governor,,GREEN,Hawkins,2
+Jefferson,Brownville 3,Lt. Governor,,GREEN,Lee,2
+Jefferson,Brownville 3,Governor,,WF,Cuomo,2
+Jefferson,Brownville 3,Lt. Governor,,WF,Hochul,2
+Jefferson,Brownville 3,Governor,,IND,Cuomo,5
+Jefferson,Brownville 3,Lt. Governor,,IND,Hochul,5
+Jefferson,Brownville 3,Governor,,WEP,Cuomo,2
+Jefferson,Brownville 3,Lt. Governor,,WEP,Hochul,2
+Jefferson,Brownville 3,Governor,,REF,Molinaro,5
+Jefferson,Brownville 3,Lt. Governor,,REF,Killian,5
+Jefferson,Brownville 3,Governor,,SAM,Miner,12
+Jefferson,Brownville 3,Lt. Governor,,SAM,Volpe,12
+Jefferson,Brownville 3,Governor,,LIB,Sharpe,17
+Jefferson,Brownville 3,Lt. Governor,,LIB,Hollister,17
+Jefferson,Brownville 3,Governor,,,Write-In,0
+Jefferson,Brownville 4,Governor,,DEM,Cuomo,85
+Jefferson,Brownville 4,Lt. Governor,,DEM,Hochul,85
+Jefferson,Brownville 4,Governor,,REP,Molinaro,198
+Jefferson,Brownville 4,Lt. Governor,,REP,Killian,198
+Jefferson,Brownville 4,Governor,,CON,Molinaro,9
+Jefferson,Brownville 4,Lt. Governor,,CON,Killian,9
+Jefferson,Brownville 4,Governor,,GREEN,Hawkins,4
+Jefferson,Brownville 4,Lt. Governor,,GREEN,Lee,4
+Jefferson,Brownville 4,Governor,,WF,Cuomo,1
+Jefferson,Brownville 4,Lt. Governor,,WF,Hochul,1
+Jefferson,Brownville 4,Governor,,IND,Cuomo,3
+Jefferson,Brownville 4,Lt. Governor,,IND,Hochul,3
+Jefferson,Brownville 4,Governor,,WEP,Cuomo,2
+Jefferson,Brownville 4,Lt. Governor,,WEP,Hochul,2
+Jefferson,Brownville 4,Governor,,REF,Molinaro,2
+Jefferson,Brownville 4,Lt. Governor,,REF,Killian,2
+Jefferson,Brownville 4,Governor,,SAM,Miner,9
+Jefferson,Brownville 4,Lt. Governor,,SAM,Volpe,9
+Jefferson,Brownville 4,Governor,,LIB,Sharpe,14
+Jefferson,Brownville 4,Lt. Governor,,LIB,Hollister,14
+Jefferson,Brownville 4,Governor,,,Write-In,0
+Jefferson,Brownville 5,Governor,,DEM,Cuomo,127
+Jefferson,Brownville 5,Lt. Governor,,DEM,Hochul,127
+Jefferson,Brownville 5,Governor,,REP,Molinaro,308
+Jefferson,Brownville 5,Lt. Governor,,REP,Killian,308
+Jefferson,Brownville 5,Governor,,CON,Molinaro,36
+Jefferson,Brownville 5,Lt. Governor,,CON,Killian,36
+Jefferson,Brownville 5,Governor,,GREEN,Hawkins,8
+Jefferson,Brownville 5,Lt. Governor,,GREEN,Lee,8
+Jefferson,Brownville 5,Governor,,WF,Cuomo,1
+Jefferson,Brownville 5,Lt. Governor,,WF,Hochul,1
+Jefferson,Brownville 5,Governor,,IND,Cuomo,3
+Jefferson,Brownville 5,Lt. Governor,,IND,Hochul,3
+Jefferson,Brownville 5,Governor,,WEP,Cuomo,0
+Jefferson,Brownville 5,Lt. Governor,,WEP,Hochul,0
+Jefferson,Brownville 5,Governor,,REF,Molinaro,6
+Jefferson,Brownville 5,Lt. Governor,,REF,Killian,6
+Jefferson,Brownville 5,Governor,,SAM,Miner,13
+Jefferson,Brownville 5,Lt. Governor,,SAM,Volpe,13
+Jefferson,Brownville 5,Governor,,LIB,Sharpe,14
+Jefferson,Brownville 5,Lt. Governor,,LIB,Hollister,14
+Jefferson,Brownville 5,Governor,,,Write-In,1
+Jefferson,Cape Vincent 1,Governor,,DEM,Cuomo,105
+Jefferson,Cape Vincent 1,Lt. Governor,,DEM,Hochul,105
+Jefferson,Cape Vincent 1,Governor,,REP,Molinaro,220
+Jefferson,Cape Vincent 1,Lt. Governor,,REP,Killian,220
+Jefferson,Cape Vincent 1,Governor,,CON,Molinaro,21
+Jefferson,Cape Vincent 1,Lt. Governor,,CON,Killian,21
+Jefferson,Cape Vincent 1,Governor,,GREEN,Hawkins,7
+Jefferson,Cape Vincent 1,Lt. Governor,,GREEN,Lee,7
+Jefferson,Cape Vincent 1,Governor,,WF,Cuomo,2
+Jefferson,Cape Vincent 1,Lt. Governor,,WF,Hochul,2
+Jefferson,Cape Vincent 1,Governor,,IND,Cuomo,5
+Jefferson,Cape Vincent 1,Lt. Governor,,IND,Hochul,5
+Jefferson,Cape Vincent 1,Governor,,WEP,Cuomo,4
+Jefferson,Cape Vincent 1,Lt. Governor,,WEP,Hochul,4
+Jefferson,Cape Vincent 1,Governor,,REF,Molinaro,4
+Jefferson,Cape Vincent 1,Lt. Governor,,REF,Killian,4
+Jefferson,Cape Vincent 1,Governor,,SAM,Miner,7
+Jefferson,Cape Vincent 1,Lt. Governor,,SAM,Volpe,7
+Jefferson,Cape Vincent 1,Governor,,LIB,Sharpe,5
+Jefferson,Cape Vincent 1,Lt. Governor,,LIB,Hollister,5
+Jefferson,Cape Vincent 1,Governor,,,Write-In,1
+Jefferson,Cape Vincent 2,Governor,,DEM,Cuomo,166
+Jefferson,Cape Vincent 2,Lt. Governor,,DEM,Hochul,166
+Jefferson,Cape Vincent 2,Governor,,REP,Molinaro,458
+Jefferson,Cape Vincent 2,Lt. Governor,,REP,Killian,458
+Jefferson,Cape Vincent 2,Governor,,CON,Molinaro,48
+Jefferson,Cape Vincent 2,Lt. Governor,,CON,Killian,48
+Jefferson,Cape Vincent 2,Governor,,GREEN,Hawkins,9
+Jefferson,Cape Vincent 2,Lt. Governor,,GREEN,Lee,9
+Jefferson,Cape Vincent 2,Governor,,WF,Cuomo,3
+Jefferson,Cape Vincent 2,Lt. Governor,,WF,Hochul,3
+Jefferson,Cape Vincent 2,Governor,,IND,Cuomo,3
+Jefferson,Cape Vincent 2,Lt. Governor,,IND,Hochul,3
+Jefferson,Cape Vincent 2,Governor,,WEP,Cuomo,3
+Jefferson,Cape Vincent 2,Lt. Governor,,WEP,Hochul,3
+Jefferson,Cape Vincent 2,Governor,,REF,Molinaro,4
+Jefferson,Cape Vincent 2,Lt. Governor,,REF,Killian,4
+Jefferson,Cape Vincent 2,Governor,,SAM,Miner,17
+Jefferson,Cape Vincent 2,Lt. Governor,,SAM,Volpe,17
+Jefferson,Cape Vincent 2,Governor,,LIB,Sharpe,18
+Jefferson,Cape Vincent 2,Lt. Governor,,LIB,Hollister,18
+Jefferson,Cape Vincent 2,Governor,,,Write-In,0
+Jefferson,Champion 1,Governor,,DEM,Cuomo,162
+Jefferson,Champion 1,Lt. Governor,,DEM,Hochul,162
+Jefferson,Champion 1,Governor,,REP,Molinaro,511
+Jefferson,Champion 1,Lt. Governor,,REP,Killian,511
+Jefferson,Champion 1,Governor,,CON,Molinaro,38
+Jefferson,Champion 1,Lt. Governor,,CON,Killian,38
+Jefferson,Champion 1,Governor,,GREEN,Hawkins,11
+Jefferson,Champion 1,Lt. Governor,,GREEN,Lee,11
+Jefferson,Champion 1,Governor,,WF,Cuomo,5
+Jefferson,Champion 1,Lt. Governor,,WF,Hochul,5
+Jefferson,Champion 1,Governor,,IND,Cuomo,10
+Jefferson,Champion 1,Lt. Governor,,IND,Hochul,10
+Jefferson,Champion 1,Governor,,WEP,Cuomo,2
+Jefferson,Champion 1,Lt. Governor,,WEP,Hochul,2
+Jefferson,Champion 1,Governor,,REF,Molinaro,6
+Jefferson,Champion 1,Lt. Governor,,REF,Killian,6
+Jefferson,Champion 1,Governor,,SAM,Miner,12
+Jefferson,Champion 1,Lt. Governor,,SAM,Volpe,12
+Jefferson,Champion 1,Governor,,LIB,Sharpe,18
+Jefferson,Champion 1,Lt. Governor,,LIB,Hollister,18
+Jefferson,Champion 1,Governor,,,Write-In,0
+Jefferson,Champion 2,Governor,,DEM,Cuomo,122
+Jefferson,Champion 2,Lt. Governor,,DEM,Hochul,122
+Jefferson,Champion 2,Governor,,REP,Molinaro,231
+Jefferson,Champion 2,Lt. Governor,,REP,Killian,231
+Jefferson,Champion 2,Governor,,CON,Molinaro,27
+Jefferson,Champion 2,Lt. Governor,,CON,Killian,27
+Jefferson,Champion 2,Governor,,GREEN,Hawkins,4
+Jefferson,Champion 2,Lt. Governor,,GREEN,Lee,4
+Jefferson,Champion 2,Governor,,WF,Cuomo,2
+Jefferson,Champion 2,Lt. Governor,,WF,Hochul,2
+Jefferson,Champion 2,Governor,,IND,Cuomo,6
+Jefferson,Champion 2,Lt. Governor,,IND,Hochul,6
+Jefferson,Champion 2,Governor,,WEP,Cuomo,2
+Jefferson,Champion 2,Lt. Governor,,WEP,Hochul,2
+Jefferson,Champion 2,Governor,,REF,Molinaro,1
+Jefferson,Champion 2,Lt. Governor,,REF,Killian,1
+Jefferson,Champion 2,Governor,,SAM,Miner,14
+Jefferson,Champion 2,Lt. Governor,,SAM,Volpe,14
+Jefferson,Champion 2,Governor,,LIB,Sharpe,12
+Jefferson,Champion 2,Lt. Governor,,LIB,Hollister,12
+Jefferson,Champion 2,Governor,,,Write-In,0
+Jefferson,Clayton 1,Governor,,DEM,Cuomo,69
+Jefferson,Clayton 1,Lt. Governor,,DEM,Hochul,69
+Jefferson,Clayton 1,Governor,,REP,Molinaro,294
+Jefferson,Clayton 1,Lt. Governor,,REP,Killian,294
+Jefferson,Clayton 1,Governor,,CON,Molinaro,38
+Jefferson,Clayton 1,Lt. Governor,,CON,Killian,38
+Jefferson,Clayton 1,Governor,,GREEN,Hawkins,5
+Jefferson,Clayton 1,Lt. Governor,,GREEN,Lee,5
+Jefferson,Clayton 1,Governor,,WF,Cuomo,1
+Jefferson,Clayton 1,Lt. Governor,,WF,Hochul,1
+Jefferson,Clayton 1,Governor,,IND,Cuomo,4
+Jefferson,Clayton 1,Lt. Governor,,IND,Hochul,4
+Jefferson,Clayton 1,Governor,,WEP,Cuomo,0
+Jefferson,Clayton 1,Lt. Governor,,WEP,Hochul,0
+Jefferson,Clayton 1,Governor,,REF,Molinaro,3
+Jefferson,Clayton 1,Lt. Governor,,REF,Killian,3
+Jefferson,Clayton 1,Governor,,SAM,Miner,4
+Jefferson,Clayton 1,Lt. Governor,,SAM,Volpe,4
+Jefferson,Clayton 1,Governor,,LIB,Sharpe,37
+Jefferson,Clayton 1,Lt. Governor,,LIB,Hollister,37
+Jefferson,Clayton 1,Governor,,,Write-In,0
+Jefferson,Clayton 2,Governor,,DEM,Cuomo,214
+Jefferson,Clayton 2,Lt. Governor,,DEM,Hochul,214
+Jefferson,Clayton 2,Governor,,REP,Molinaro,348
+Jefferson,Clayton 2,Lt. Governor,,REP,Killian,348
+Jefferson,Clayton 2,Governor,,CON,Molinaro,37
+Jefferson,Clayton 2,Lt. Governor,,CON,Killian,37
+Jefferson,Clayton 2,Governor,,GREEN,Hawkins,11
+Jefferson,Clayton 2,Lt. Governor,,GREEN,Lee,11
+Jefferson,Clayton 2,Governor,,WF,Cuomo,4
+Jefferson,Clayton 2,Lt. Governor,,WF,Hochul,4
+Jefferson,Clayton 2,Governor,,IND,Cuomo,7
+Jefferson,Clayton 2,Lt. Governor,,IND,Hochul,7
+Jefferson,Clayton 2,Governor,,WEP,Cuomo,2
+Jefferson,Clayton 2,Lt. Governor,,WEP,Hochul,2
+Jefferson,Clayton 2,Governor,,REF,Molinaro,1
+Jefferson,Clayton 2,Lt. Governor,,REF,Killian,1
+Jefferson,Clayton 2,Governor,,SAM,Miner,19
+Jefferson,Clayton 2,Lt. Governor,,SAM,Volpe,19
+Jefferson,Clayton 2,Governor,,LIB,Sharpe,32
+Jefferson,Clayton 2,Lt. Governor,,LIB,Hollister,32
+Jefferson,Clayton 2,Governor,,,Write-In,0
+Jefferson,Clayton 3,Governor,,DEM,Cuomo,203
+Jefferson,Clayton 3,Lt. Governor,,DEM,Hochul,203
+Jefferson,Clayton 3,Governor,,REP,Molinaro,462
+Jefferson,Clayton 3,Lt. Governor,,REP,Killian,462
+Jefferson,Clayton 3,Governor,,CON,Molinaro,47
+Jefferson,Clayton 3,Lt. Governor,,CON,Killian,47
+Jefferson,Clayton 3,Governor,,GREEN,Hawkins,12
+Jefferson,Clayton 3,Lt. Governor,,GREEN,Lee,12
+Jefferson,Clayton 3,Governor,,WF,Cuomo,9
+Jefferson,Clayton 3,Lt. Governor,,WF,Hochul,9
+Jefferson,Clayton 3,Governor,,IND,Cuomo,10
+Jefferson,Clayton 3,Lt. Governor,,IND,Hochul,10
+Jefferson,Clayton 3,Governor,,WEP,Cuomo,2
+Jefferson,Clayton 3,Lt. Governor,,WEP,Hochul,2
+Jefferson,Clayton 3,Governor,,REF,Molinaro,5
+Jefferson,Clayton 3,Lt. Governor,,REF,Killian,5
+Jefferson,Clayton 3,Governor,,SAM,Miner,17
+Jefferson,Clayton 3,Lt. Governor,,SAM,Volpe,17
+Jefferson,Clayton 3,Governor,,LIB,Sharpe,32
+Jefferson,Clayton 3,Lt. Governor,,LIB,Hollister,32
+Jefferson,Clayton 3,Governor,,,Write-In,0
+Jefferson,Ellisburg 1,Governor,,DEM,Cuomo,33
+Jefferson,Ellisburg 1,Lt. Governor,,DEM,Hochul,33
+Jefferson,Ellisburg 1,Governor,,REP,Molinaro,88
+Jefferson,Ellisburg 1,Lt. Governor,,REP,Killian,88
+Jefferson,Ellisburg 1,Governor,,CON,Molinaro,6
+Jefferson,Ellisburg 1,Lt. Governor,,CON,Killian,6
+Jefferson,Ellisburg 1,Governor,,GREEN,Hawkins,4
+Jefferson,Ellisburg 1,Lt. Governor,,GREEN,Lee,4
+Jefferson,Ellisburg 1,Governor,,WF,Cuomo,1
+Jefferson,Ellisburg 1,Lt. Governor,,WF,Hochul,1
+Jefferson,Ellisburg 1,Governor,,IND,Cuomo,1
+Jefferson,Ellisburg 1,Lt. Governor,,IND,Hochul,1
+Jefferson,Ellisburg 1,Governor,,WEP,Cuomo,0
+Jefferson,Ellisburg 1,Lt. Governor,,WEP,Hochul,0
+Jefferson,Ellisburg 1,Governor,,REF,Molinaro,0
+Jefferson,Ellisburg 1,Lt. Governor,,REF,Killian,0
+Jefferson,Ellisburg 1,Governor,,SAM,Miner,1
+Jefferson,Ellisburg 1,Lt. Governor,,SAM,Volpe,1
+Jefferson,Ellisburg 1,Governor,,LIB,Sharpe,8
+Jefferson,Ellisburg 1,Lt. Governor,,LIB,Hollister,8
+Jefferson,Ellisburg 1,Governor,,,Write-In,0
+Jefferson,Elllisburg 2,Governor,,DEM,Cuomo,69
+Jefferson,Elllisburg 2,Lt. Governor,,DEM,Hochul,69
+Jefferson,Elllisburg 2,Governor,,REP,Molinaro,276
+Jefferson,Elllisburg 2,Lt. Governor,,REP,Killian,276
+Jefferson,Elllisburg 2,Governor,,CON,Molinaro,18
+Jefferson,Elllisburg 2,Lt. Governor,,CON,Killian,18
+Jefferson,Elllisburg 2,Governor,,GREEN,Hawkins,4
+Jefferson,Elllisburg 2,Lt. Governor,,GREEN,Lee,4
+Jefferson,Elllisburg 2,Governor,,WF,Cuomo,0
+Jefferson,Elllisburg 2,Lt. Governor,,WF,Hochul,0
+Jefferson,Elllisburg 2,Governor,,IND,Cuomo,4
+Jefferson,Elllisburg 2,Lt. Governor,,IND,Hochul,4
+Jefferson,Elllisburg 2,Governor,,WEP,Cuomo,2
+Jefferson,Elllisburg 2,Lt. Governor,,WEP,Hochul,2
+Jefferson,Elllisburg 2,Governor,,REF,Molinaro,1
+Jefferson,Elllisburg 2,Lt. Governor,,REF,Killian,1
+Jefferson,Elllisburg 2,Governor,,SAM,Miner,8
+Jefferson,Elllisburg 2,Lt. Governor,,SAM,Volpe,8
+Jefferson,Elllisburg 2,Governor,,LIB,Sharpe,12
+Jefferson,Elllisburg 2,Lt. Governor,,LIB,Hollister,12
+Jefferson,Elllisburg 2,Governor,,,Write-In,0
+Jefferson,Ellisburg 3,Governor,,DEM,Cuomo,25
+Jefferson,Ellisburg 3,Lt. Governor,,DEM,Hochul,25
+Jefferson,Ellisburg 3,Governor,,REP,Molinaro,52
+Jefferson,Ellisburg 3,Lt. Governor,,REP,Killian,52
+Jefferson,Ellisburg 3,Governor,,CON,Molinaro,5
+Jefferson,Ellisburg 3,Lt. Governor,,CON,Killian,5
+Jefferson,Ellisburg 3,Governor,,GREEN,Hawkins,2
+Jefferson,Ellisburg 3,Lt. Governor,,GREEN,Lee,2
+Jefferson,Ellisburg 3,Governor,,WF,Cuomo,3
+Jefferson,Ellisburg 3,Lt. Governor,,WF,Hochul,3
+Jefferson,Ellisburg 3,Governor,,IND,Cuomo,0
+Jefferson,Ellisburg 3,Lt. Governor,,IND,Hochul,0
+Jefferson,Ellisburg 3,Governor,,WEP,Cuomo,1
+Jefferson,Ellisburg 3,Lt. Governor,,WEP,Hochul,1
+Jefferson,Ellisburg 3,Governor,,REF,Molinaro,0
+Jefferson,Ellisburg 3,Lt. Governor,,REF,Killian,0
+Jefferson,Ellisburg 3,Governor,,SAM,Miner,0
+Jefferson,Ellisburg 3,Lt. Governor,,SAM,Volpe,0
+Jefferson,Ellisburg 3,Governor,,LIB,Sharpe,2
+Jefferson,Ellisburg 3,Lt. Governor,,LIB,Hollister,2
+Jefferson,Ellisburg 3,Governor,,,Write-In,0
+Jefferson,Ellisburg 4,Governor,,DEM,Cuomo,117
+Jefferson,Ellisburg 4,Lt. Governor,,DEM,Hochul,117
+Jefferson,Ellisburg 4,Governor,,REP,Molinaro,315
+Jefferson,Ellisburg 4,Lt. Governor,,REP,Killian,315
+Jefferson,Ellisburg 4,Governor,,CON,Molinaro,29
+Jefferson,Ellisburg 4,Lt. Governor,,CON,Killian,29
+Jefferson,Ellisburg 4,Governor,,GREEN,Hawkins,6
+Jefferson,Ellisburg 4,Lt. Governor,,GREEN,Lee,6
+Jefferson,Ellisburg 4,Governor,,WF,Cuomo,5
+Jefferson,Ellisburg 4,Lt. Governor,,WF,Hochul,5
+Jefferson,Ellisburg 4,Governor,,IND,Cuomo,3
+Jefferson,Ellisburg 4,Lt. Governor,,IND,Hochul,3
+Jefferson,Ellisburg 4,Governor,,WEP,Cuomo,1
+Jefferson,Ellisburg 4,Lt. Governor,,WEP,Hochul,1
+Jefferson,Ellisburg 4,Governor,,REF,Molinaro,4
+Jefferson,Ellisburg 4,Lt. Governor,,REF,Killian,4
+Jefferson,Ellisburg 4,Governor,,SAM,Miner,10
+Jefferson,Ellisburg 4,Lt. Governor,,SAM,Volpe,10
+Jefferson,Ellisburg 4,Governor,,LIB,Sharpe,18
+Jefferson,Ellisburg 4,Lt. Governor,,LIB,Hollister,18
+Jefferson,Ellisburg 4,Governor,,,Write-In,0
+Jefferson,Henderson 1,Governor,,DEM,Cuomo,181
+Jefferson,Henderson 1,Lt. Governor,,DEM,Hochul,181
+Jefferson,Henderson 1,Governor,,REP,Molinaro,403
+Jefferson,Henderson 1,Lt. Governor,,REP,Killian,403
+Jefferson,Henderson 1,Governor,,CON,Molinaro,37
+Jefferson,Henderson 1,Lt. Governor,,CON,Killian,37
+Jefferson,Henderson 1,Governor,,GREEN,Hawkins,5
+Jefferson,Henderson 1,Lt. Governor,,GREEN,Lee,5
+Jefferson,Henderson 1,Governor,,WF,Cuomo,3
+Jefferson,Henderson 1,Lt. Governor,,WF,Hochul,3
+Jefferson,Henderson 1,Governor,,IND,Cuomo,3
+Jefferson,Henderson 1,Lt. Governor,,IND,Hochul,3
+Jefferson,Henderson 1,Governor,,WEP,Cuomo,1
+Jefferson,Henderson 1,Lt. Governor,,WEP,Hochul,1
+Jefferson,Henderson 1,Governor,,REF,Molinaro,3
+Jefferson,Henderson 1,Lt. Governor,,REF,Killian,3
+Jefferson,Henderson 1,Governor,,SAM,Miner,18
+Jefferson,Henderson 1,Lt. Governor,,SAM,Volpe,18
+Jefferson,Henderson 1,Governor,,LIB,Sharpe,6
+Jefferson,Henderson 1,Lt. Governor,,LIB,Hollister,6
+Jefferson,Henderson 1,Governor,,,Write-In,0
+Jefferson,Hounsfield 1,Governor,,DEM,Cuomo,230
+Jefferson,Hounsfield 1,Lt. Governor,,DEM,Hochul,230
+Jefferson,Hounsfield 1,Governor,,REP,Molinaro,237
+Jefferson,Hounsfield 1,Lt. Governor,,REP,Killian,237
+Jefferson,Hounsfield 1,Governor,,CON,Molinaro,30
+Jefferson,Hounsfield 1,Lt. Governor,,CON,Killian,30
+Jefferson,Hounsfield 1,Governor,,GREEN,Hawkins,14
+Jefferson,Hounsfield 1,Lt. Governor,,GREEN,Lee,14
+Jefferson,Hounsfield 1,Governor,,WF,Cuomo,4
+Jefferson,Hounsfield 1,Lt. Governor,,WF,Hochul,4
+Jefferson,Hounsfield 1,Governor,,IND,Cuomo,0
+Jefferson,Hounsfield 1,Lt. Governor,,IND,Hochul,0
+Jefferson,Hounsfield 1,Governor,,WEP,Cuomo,1
+Jefferson,Hounsfield 1,Lt. Governor,,WEP,Hochul,1
+Jefferson,Hounsfield 1,Governor,,REF,Molinaro,6
+Jefferson,Hounsfield 1,Lt. Governor,,REF,Killian,6
+Jefferson,Hounsfield 1,Governor,,SAM,Miner,13
+Jefferson,Hounsfield 1,Lt. Governor,,SAM,Volpe,13
+Jefferson,Hounsfield 1,Governor,,LIB,Sharpe,14
+Jefferson,Hounsfield 1,Lt. Governor,,LIB,Hollister,14
+Jefferson,Hounsfield 1,Governor,,,Write-In,0
+Jefferson,Hounsfield 2,Governor,,DEM,Cuomo,192
+Jefferson,Hounsfield 2,Lt. Governor,,DEM,Hochul,192
+Jefferson,Hounsfield 2,Governor,,REP,Molinaro,427
+Jefferson,Hounsfield 2,Lt. Governor,,REP,Killian,427
+Jefferson,Hounsfield 2,Governor,,CON,Molinaro,54
+Jefferson,Hounsfield 2,Lt. Governor,,CON,Killian,54
+Jefferson,Hounsfield 2,Governor,,GREEN,Hawkins,9
+Jefferson,Hounsfield 2,Lt. Governor,,GREEN,Lee,9
+Jefferson,Hounsfield 2,Governor,,WF,Cuomo,4
+Jefferson,Hounsfield 2,Lt. Governor,,WF,Hochul,4
+Jefferson,Hounsfield 2,Governor,,IND,Cuomo,9
+Jefferson,Hounsfield 2,Lt. Governor,,IND,Hochul,9
+Jefferson,Hounsfield 2,Governor,,WEP,Cuomo,7
+Jefferson,Hounsfield 2,Lt. Governor,,WEP,Hochul,7
+Jefferson,Hounsfield 2,Governor,,REF,Molinaro,10
+Jefferson,Hounsfield 2,Lt. Governor,,REF,Killian,10
+Jefferson,Hounsfield 2,Governor,,SAM,Miner,14
+Jefferson,Hounsfield 2,Lt. Governor,,SAM,Volpe,14
+Jefferson,Hounsfield 2,Governor,,LIB,Sharpe,28
+Jefferson,Hounsfield 2,Lt. Governor,,LIB,Hollister,28
+Jefferson,Hounsfield 2,Governor,,,Write-In,0
+Jefferson,LeRay 1,Governor,,DEM,Cuomo,44
+Jefferson,LeRay 1,Lt. Governor,,DEM,Hochul,44
+Jefferson,LeRay 1,Governor,,REP,Molinaro,131
+Jefferson,LeRay 1,Lt. Governor,,REP,Killian,131
+Jefferson,LeRay 1,Governor,,CON,Molinaro,9
+Jefferson,LeRay 1,Lt. Governor,,CON,Killian,9
+Jefferson,LeRay 1,Governor,,GREEN,Hawkins,0
+Jefferson,LeRay 1,Lt. Governor,,GREEN,Lee,0
+Jefferson,LeRay 1,Governor,,WF,Cuomo,1
+Jefferson,LeRay 1,Lt. Governor,,WF,Hochul,1
+Jefferson,LeRay 1,Governor,,IND,Cuomo,0
+Jefferson,LeRay 1,Lt. Governor,,IND,Hochul,0
+Jefferson,LeRay 1,Governor,,WEP,Cuomo,0
+Jefferson,LeRay 1,Lt. Governor,,WEP,Hochul,0
+Jefferson,LeRay 1,Governor,,REF,Molinaro,1
+Jefferson,LeRay 1,Lt. Governor,,REF,Killian,1
+Jefferson,LeRay 1,Governor,,SAM,Miner,7
+Jefferson,LeRay 1,Lt. Governor,,SAM,Volpe,7
+Jefferson,LeRay 1,Governor,,LIB,Sharpe,4
+Jefferson,LeRay 1,Lt. Governor,,LIB,Hollister,4
+Jefferson,LeRay 1,Governor,,,Write-In,0
+Jefferson,LeRay 2,Governor,,DEM,Cuomo,21
+Jefferson,LeRay 2,Lt. Governor,,DEM,Hochul,21
+Jefferson,LeRay 2,Governor,,REP,Molinaro,70
+Jefferson,LeRay 2,Lt. Governor,,REP,Killian,70
+Jefferson,LeRay 2,Governor,,CON,Molinaro,9
+Jefferson,LeRay 2,Lt. Governor,,CON,Killian,9
+Jefferson,LeRay 2,Governor,,GREEN,Hawkins,1
+Jefferson,LeRay 2,Lt. Governor,,GREEN,Lee,1
+Jefferson,LeRay 2,Governor,,WF,Cuomo,1
+Jefferson,LeRay 2,Lt. Governor,,WF,Hochul,1
+Jefferson,LeRay 2,Governor,,IND,Cuomo,1
+Jefferson,LeRay 2,Lt. Governor,,IND,Hochul,1
+Jefferson,LeRay 2,Governor,,WEP,Cuomo,0
+Jefferson,LeRay 2,Lt. Governor,,WEP,Hochul,0
+Jefferson,LeRay 2,Governor,,REF,Molinaro,0
+Jefferson,LeRay 2,Lt. Governor,,REF,Killian,0
+Jefferson,LeRay 2,Governor,,SAM,Miner,0
+Jefferson,LeRay 2,Lt. Governor,,SAM,Volpe,0
+Jefferson,LeRay 2,Governor,,LIB,Sharpe,1
+Jefferson,LeRay 2,Lt. Governor,,LIB,Hollister,1
+Jefferson,LeRay 2,Governor,,,Write-In,0
+Jefferson,LeRay 3,Governor,,DEM,Cuomo,44
+Jefferson,LeRay 3,Lt. Governor,,DEM,Hochul,44
+Jefferson,LeRay 3,Governor,,REP,Molinaro,99
+Jefferson,LeRay 3,Lt. Governor,,REP,Killian,99
+Jefferson,LeRay 3,Governor,,CON,Molinaro,8
+Jefferson,LeRay 3,Lt. Governor,,CON,Killian,8
+Jefferson,LeRay 3,Governor,,GREEN,Hawkins,2
+Jefferson,LeRay 3,Lt. Governor,,GREEN,Lee,2
+Jefferson,LeRay 3,Governor,,WF,Cuomo,0
+Jefferson,LeRay 3,Lt. Governor,,WF,Hochul,0
+Jefferson,LeRay 3,Governor,,IND,Cuomo,0
+Jefferson,LeRay 3,Lt. Governor,,IND,Hochul,0
+Jefferson,LeRay 3,Governor,,WEP,Cuomo,0
+Jefferson,LeRay 3,Lt. Governor,,WEP,Hochul,0
+Jefferson,LeRay 3,Governor,,REF,Molinaro,2
+Jefferson,LeRay 3,Lt. Governor,,REF,Killian,2
+Jefferson,LeRay 3,Governor,,SAM,Miner,2
+Jefferson,LeRay 3,Lt. Governor,,SAM,Volpe,2
+Jefferson,LeRay 3,Governor,,LIB,Sharpe,7
+Jefferson,LeRay 3,Lt. Governor,,LIB,Hollister,7
+Jefferson,LeRay 3,Governor,,,Write-In,0
+Jefferson,LeRay 4,Governor,,DEM,Cuomo,173
+Jefferson,LeRay 4,Lt. Governor,,DEM,Hochul,173
+Jefferson,LeRay 4,Governor,,REP,Molinaro,261
+Jefferson,LeRay 4,Lt. Governor,,REP,Killian,261
+Jefferson,LeRay 4,Governor,,CON,Molinaro,22
+Jefferson,LeRay 4,Lt. Governor,,CON,Killian,22
+Jefferson,LeRay 4,Governor,,GREEN,Hawkins,6
+Jefferson,LeRay 4,Lt. Governor,,GREEN,Lee,6
+Jefferson,LeRay 4,Governor,,WF,Cuomo,1
+Jefferson,LeRay 4,Lt. Governor,,WF,Hochul,1
+Jefferson,LeRay 4,Governor,,IND,Cuomo,6
+Jefferson,LeRay 4,Lt. Governor,,IND,Hochul,6
+Jefferson,LeRay 4,Governor,,WEP,Cuomo,2
+Jefferson,LeRay 4,Lt. Governor,,WEP,Hochul,2
+Jefferson,LeRay 4,Governor,,REF,Molinaro,1
+Jefferson,LeRay 4,Lt. Governor,,REF,Killian,1
+Jefferson,LeRay 4,Governor,,SAM,Miner,8
+Jefferson,LeRay 4,Lt. Governor,,SAM,Volpe,8
+Jefferson,LeRay 4,Governor,,LIB,Sharpe,9
+Jefferson,LeRay 4,Lt. Governor,,LIB,Hollister,9
+Jefferson,LeRay 4,Governor,,,Write-In,0
+Jefferson,LeRay 5,Governor,,DEM,Cuomo,70
+Jefferson,LeRay 5,Lt. Governor,,DEM,Hochul,70
+Jefferson,LeRay 5,Governor,,REP,Molinaro,128
+Jefferson,LeRay 5,Lt. Governor,,REP,Killian,128
+Jefferson,LeRay 5,Governor,,CON,Molinaro,9
+Jefferson,LeRay 5,Lt. Governor,,CON,Killian,9
+Jefferson,LeRay 5,Governor,,GREEN,Hawkins,3
+Jefferson,LeRay 5,Lt. Governor,,GREEN,Lee,3
+Jefferson,LeRay 5,Governor,,WF,Cuomo,2
+Jefferson,LeRay 5,Lt. Governor,,WF,Hochul,2
+Jefferson,LeRay 5,Governor,,IND,Cuomo,4
+Jefferson,LeRay 5,Lt. Governor,,IND,Hochul,4
+Jefferson,LeRay 5,Governor,,WEP,Cuomo,0
+Jefferson,LeRay 5,Lt. Governor,,WEP,Hochul,0
+Jefferson,LeRay 5,Governor,,REF,Molinaro,3
+Jefferson,LeRay 5,Lt. Governor,,REF,Killian,3
+Jefferson,LeRay 5,Governor,,SAM,Miner,12
+Jefferson,LeRay 5,Lt. Governor,,SAM,Volpe,12
+Jefferson,LeRay 5,Governor,,LIB,Sharpe,4
+Jefferson,LeRay 5,Lt. Governor,,LIB,Hollister,4
+Jefferson,LeRay 5,Governor,,,Write-In,0
+Jefferson,LeRay 6,Governor,,DEM,Cuomo,30
+Jefferson,LeRay 6,Lt. Governor,,DEM,Hochul,30
+Jefferson,LeRay 6,Governor,,REP,Molinaro,65
+Jefferson,LeRay 6,Lt. Governor,,REP,Killian,65
+Jefferson,LeRay 6,Governor,,CON,Molinaro,8
+Jefferson,LeRay 6,Lt. Governor,,CON,Killian,8
+Jefferson,LeRay 6,Governor,,GREEN,Hawkins,0
+Jefferson,LeRay 6,Lt. Governor,,GREEN,Lee,0
+Jefferson,LeRay 6,Governor,,WF,Cuomo,1
+Jefferson,LeRay 6,Lt. Governor,,WF,Hochul,1
+Jefferson,LeRay 6,Governor,,IND,Cuomo,3
+Jefferson,LeRay 6,Lt. Governor,,IND,Hochul,3
+Jefferson,LeRay 6,Governor,,WEP,Cuomo,1
+Jefferson,LeRay 6,Lt. Governor,,WEP,Hochul,1
+Jefferson,LeRay 6,Governor,,REF,Molinaro,2
+Jefferson,LeRay 6,Lt. Governor,,REF,Killian,2
+Jefferson,LeRay 6,Governor,,SAM,Miner,0
+Jefferson,LeRay 6,Lt. Governor,,SAM,Volpe,0
+Jefferson,LeRay 6,Governor,,LIB,Sharpe,4
+Jefferson,LeRay 6,Lt. Governor,,LIB,Hollister,4
+Jefferson,LeRay 6,Governor,,,Write-In,0
+Jefferson,LeRay 7,Governor,,DEM,Cuomo,29
+Jefferson,LeRay 7,Lt. Governor,,DEM,Hochul,29
+Jefferson,LeRay 7,Governor,,REP,Molinaro,24
+Jefferson,LeRay 7,Lt. Governor,,REP,Killian,24
+Jefferson,LeRay 7,Governor,,CON,Molinaro,3
+Jefferson,LeRay 7,Lt. Governor,,CON,Killian,3
+Jefferson,LeRay 7,Governor,,GREEN,Hawkins,1
+Jefferson,LeRay 7,Lt. Governor,,GREEN,Lee,1
+Jefferson,LeRay 7,Governor,,WF,Cuomo,0
+Jefferson,LeRay 7,Lt. Governor,,WF,Hochul,0
+Jefferson,LeRay 7,Governor,,IND,Cuomo,0
+Jefferson,LeRay 7,Lt. Governor,,IND,Hochul,0
+Jefferson,LeRay 7,Governor,,WEP,Cuomo,0
+Jefferson,LeRay 7,Lt. Governor,,WEP,Hochul,0
+Jefferson,LeRay 7,Governor,,REF,Molinaro,0
+Jefferson,LeRay 7,Lt. Governor,,REF,Killian,0
+Jefferson,LeRay 7,Governor,,SAM,Miner,1
+Jefferson,LeRay 7,Lt. Governor,,SAM,Volpe,1
+Jefferson,LeRay 7,Governor,,LIB,Sharpe,1
+Jefferson,LeRay 7,Lt. Governor,,LIB,Hollister,1
+Jefferson,LeRay 7,Governor,,,Write-In,0
+Jefferson,LeRay 8,Governor,,DEM,Cuomo,120
+Jefferson,LeRay 8,Lt. Governor,,DEM,Hochul,120
+Jefferson,LeRay 8,Governor,,REP,Molinaro,200
+Jefferson,LeRay 8,Lt. Governor,,REP,Killian,200
+Jefferson,LeRay 8,Governor,,CON,Molinaro,20
+Jefferson,LeRay 8,Lt. Governor,,CON,Killian,20
+Jefferson,LeRay 8,Governor,,GREEN,Hawkins,5
+Jefferson,LeRay 8,Lt. Governor,,GREEN,Lee,5
+Jefferson,LeRay 8,Governor,,WF,Cuomo,2
+Jefferson,LeRay 8,Lt. Governor,,WF,Hochul,2
+Jefferson,LeRay 8,Governor,,IND,Cuomo,4
+Jefferson,LeRay 8,Lt. Governor,,IND,Hochul,4
+Jefferson,LeRay 8,Governor,,WEP,Cuomo,3
+Jefferson,LeRay 8,Lt. Governor,,WEP,Hochul,3
+Jefferson,LeRay 8,Governor,,REF,Molinaro,1
+Jefferson,LeRay 8,Lt. Governor,,REF,Killian,1
+Jefferson,LeRay 8,Governor,,SAM,Miner,11
+Jefferson,LeRay 8,Lt. Governor,,SAM,Volpe,11
+Jefferson,LeRay 8,Governor,,LIB,Sharpe,9
+Jefferson,LeRay 8,Lt. Governor,,LIB,Hollister,9
+Jefferson,LeRay 8,Governor,,,Write-In,0
+Jefferson,Lorraine 1,Governor,,DEM,Cuomo,45
+Jefferson,Lorraine 1,Lt. Governor,,DEM,Hochul,45
+Jefferson,Lorraine 1,Governor,,REP,Molinaro,247
+Jefferson,Lorraine 1,Lt. Governor,,REP,Killian,247
+Jefferson,Lorraine 1,Governor,,CON,Molinaro,20
+Jefferson,Lorraine 1,Lt. Governor,,CON,Killian,20
+Jefferson,Lorraine 1,Governor,,GREEN,Hawkins,3
+Jefferson,Lorraine 1,Lt. Governor,,GREEN,Lee,3
+Jefferson,Lorraine 1,Governor,,WF,Cuomo,2
+Jefferson,Lorraine 1,Lt. Governor,,WF,Hochul,2
+Jefferson,Lorraine 1,Governor,,IND,Cuomo,2
+Jefferson,Lorraine 1,Lt. Governor,,IND,Hochul,2
+Jefferson,Lorraine 1,Governor,,WEP,Cuomo,1
+Jefferson,Lorraine 1,Lt. Governor,,WEP,Hochul,1
+Jefferson,Lorraine 1,Governor,,REF,Molinaro,4
+Jefferson,Lorraine 1,Lt. Governor,,REF,Killian,4
+Jefferson,Lorraine 1,Governor,,SAM,Miner,9
+Jefferson,Lorraine 1,Lt. Governor,,SAM,Volpe,9
+Jefferson,Lorraine 1,Governor,,LIB,Sharpe,16
+Jefferson,Lorraine 1,Lt. Governor,,LIB,Hollister,16
+Jefferson,Lorraine 1,Governor,,,Write-In,0
+Jefferson,Lyme 1,Governor,,DEM,Cuomo,80
+Jefferson,Lyme 1,Lt. Governor,,DEM,Hochul,80
+Jefferson,Lyme 1,Governor,,REP,Molinaro,219
+Jefferson,Lyme 1,Lt. Governor,,REP,Killian,219
+Jefferson,Lyme 1,Governor,,CON,Molinaro,24
+Jefferson,Lyme 1,Lt. Governor,,CON,Killian,24
+Jefferson,Lyme 1,Governor,,GREEN,Hawkins,7
+Jefferson,Lyme 1,Lt. Governor,,GREEN,Lee,7
+Jefferson,Lyme 1,Governor,,WF,Cuomo,3
+Jefferson,Lyme 1,Lt. Governor,,WF,Hochul,3
+Jefferson,Lyme 1,Governor,,IND,Cuomo,3
+Jefferson,Lyme 1,Lt. Governor,,IND,Hochul,3
+Jefferson,Lyme 1,Governor,,WEP,Cuomo,1
+Jefferson,Lyme 1,Lt. Governor,,WEP,Hochul,1
+Jefferson,Lyme 1,Governor,,REF,Molinaro,2
+Jefferson,Lyme 1,Lt. Governor,,REF,Killian,2
+Jefferson,Lyme 1,Governor,,SAM,Miner,15
+Jefferson,Lyme 1,Lt. Governor,,SAM,Volpe,15
+Jefferson,Lyme 1,Governor,,LIB,Sharpe,5
+Jefferson,Lyme 1,Lt. Governor,,LIB,Hollister,5
+Jefferson,Lyme 1,Governor,,,Write-In,0
+Jefferson,Lyme 2,Governor,,DEM,Cuomo,141
+Jefferson,Lyme 2,Lt. Governor,,DEM,Hochul,141
+Jefferson,Lyme 2,Governor,,REP,Molinaro,251
+Jefferson,Lyme 2,Lt. Governor,,REP,Killian,251
+Jefferson,Lyme 2,Governor,,CON,Molinaro,39
+Jefferson,Lyme 2,Lt. Governor,,CON,Killian,39
+Jefferson,Lyme 2,Governor,,GREEN,Hawkins,4
+Jefferson,Lyme 2,Lt. Governor,,GREEN,Lee,4
+Jefferson,Lyme 2,Governor,,WF,Cuomo,2
+Jefferson,Lyme 2,Lt. Governor,,WF,Hochul,2
+Jefferson,Lyme 2,Governor,,IND,Cuomo,3
+Jefferson,Lyme 2,Lt. Governor,,IND,Hochul,3
+Jefferson,Lyme 2,Governor,,WEP,Cuomo,0
+Jefferson,Lyme 2,Lt. Governor,,WEP,Hochul,0
+Jefferson,Lyme 2,Governor,,REF,Molinaro,7
+Jefferson,Lyme 2,Lt. Governor,,REF,Killian,7
+Jefferson,Lyme 2,Governor,,SAM,Miner,7
+Jefferson,Lyme 2,Lt. Governor,,SAM,Volpe,7
+Jefferson,Lyme 2,Governor,,LIB,Sharpe,7
+Jefferson,Lyme 2,Lt. Governor,,LIB,Hollister,7
+Jefferson,Lyme 2,Governor,,,Write-In,0
+Jefferson,Lyme 3,Governor,,DEM,Cuomo,64
+Jefferson,Lyme 3,Lt. Governor,,DEM,Hochul,64
+Jefferson,Lyme 3,Governor,,REP,Molinaro,145
+Jefferson,Lyme 3,Lt. Governor,,REP,Killian,145
+Jefferson,Lyme 3,Governor,,CON,Molinaro,16
+Jefferson,Lyme 3,Lt. Governor,,CON,Killian,16
+Jefferson,Lyme 3,Governor,,GREEN,Hawkins,1
+Jefferson,Lyme 3,Lt. Governor,,GREEN,Lee,1
+Jefferson,Lyme 3,Governor,,WF,Cuomo,2
+Jefferson,Lyme 3,Lt. Governor,,WF,Hochul,2
+Jefferson,Lyme 3,Governor,,IND,Cuomo,3
+Jefferson,Lyme 3,Lt. Governor,,IND,Hochul,3
+Jefferson,Lyme 3,Governor,,WEP,Cuomo,1
+Jefferson,Lyme 3,Lt. Governor,,WEP,Hochul,1
+Jefferson,Lyme 3,Governor,,REF,Molinaro,1
+Jefferson,Lyme 3,Lt. Governor,,REF,Killian,1
+Jefferson,Lyme 3,Governor,,SAM,Miner,7
+Jefferson,Lyme 3,Lt. Governor,,SAM,Volpe,7
+Jefferson,Lyme 3,Governor,,LIB,Sharpe,8
+Jefferson,Lyme 3,Lt. Governor,,LIB,Hollister,8
+Jefferson,Lyme 3,Governor,,,Write-In,0
+Jefferson,Orleans 1,Governor,,DEM,Cuomo,113
+Jefferson,Orleans 1,Lt. Governor,,DEM,Hochul,113
+Jefferson,Orleans 1,Governor,,REP,Molinaro,408
+Jefferson,Orleans 1,Lt. Governor,,REP,Killian,408
+Jefferson,Orleans 1,Governor,,CON,Molinaro,28
+Jefferson,Orleans 1,Lt. Governor,,CON,Killian,28
+Jefferson,Orleans 1,Governor,,GREEN,Hawkins,4
+Jefferson,Orleans 1,Lt. Governor,,GREEN,Lee,4
+Jefferson,Orleans 1,Governor,,WF,Cuomo,2
+Jefferson,Orleans 1,Lt. Governor,,WF,Hochul,2
+Jefferson,Orleans 1,Governor,,IND,Cuomo,5
+Jefferson,Orleans 1,Lt. Governor,,IND,Hochul,5
+Jefferson,Orleans 1,Governor,,WEP,Cuomo,1
+Jefferson,Orleans 1,Lt. Governor,,WEP,Hochul,1
+Jefferson,Orleans 1,Governor,,REF,Molinaro,6
+Jefferson,Orleans 1,Lt. Governor,,REF,Killian,6
+Jefferson,Orleans 1,Governor,,SAM,Miner,8
+Jefferson,Orleans 1,Lt. Governor,,SAM,Volpe,8
+Jefferson,Orleans 1,Governor,,LIB,Sharpe,21
+Jefferson,Orleans 1,Lt. Governor,,LIB,Hollister,21
+Jefferson,Orleans 1,Governor,,,Write-In,2
+Jefferson,Orleans 2,Governor,,DEM,Cuomo,120
+Jefferson,Orleans 2,Lt. Governor,,DEM,Hochul,120
+Jefferson,Orleans 2,Governor,,REP,Molinaro,224
+Jefferson,Orleans 2,Lt. Governor,,REP,Killian,224
+Jefferson,Orleans 2,Governor,,CON,Molinaro,20
+Jefferson,Orleans 2,Lt. Governor,,CON,Killian,20
+Jefferson,Orleans 2,Governor,,GREEN,Hawkins,8
+Jefferson,Orleans 2,Lt. Governor,,GREEN,Lee,8
+Jefferson,Orleans 2,Governor,,WF,Cuomo,1
+Jefferson,Orleans 2,Lt. Governor,,WF,Hochul,1
+Jefferson,Orleans 2,Governor,,IND,Cuomo,4
+Jefferson,Orleans 2,Lt. Governor,,IND,Hochul,4
+Jefferson,Orleans 2,Governor,,WEP,Cuomo,1
+Jefferson,Orleans 2,Lt. Governor,,WEP,Hochul,1
+Jefferson,Orleans 2,Governor,,REF,Molinaro,7
+Jefferson,Orleans 2,Lt. Governor,,REF,Killian,7
+Jefferson,Orleans 2,Governor,,SAM,Miner,8
+Jefferson,Orleans 2,Lt. Governor,,SAM,Volpe,8
+Jefferson,Orleans 2,Governor,,LIB,Sharpe,6
+Jefferson,Orleans 2,Lt. Governor,,LIB,Hollister,6
+Jefferson,Orleans 2,Governor,,,Write-In,0
+Jefferson,Pamelia 1,Governor,,DEM,Cuomo,97
+Jefferson,Pamelia 1,Lt. Governor,,DEM,Hochul,97
+Jefferson,Pamelia 1,Governor,,REP,Molinaro,344
+Jefferson,Pamelia 1,Lt. Governor,,REP,Killian,344
+Jefferson,Pamelia 1,Governor,,CON,Molinaro,31
+Jefferson,Pamelia 1,Lt. Governor,,CON,Killian,31
+Jefferson,Pamelia 1,Governor,,GREEN,Hawkins,7
+Jefferson,Pamelia 1,Lt. Governor,,GREEN,Lee,7
+Jefferson,Pamelia 1,Governor,,WF,Cuomo,2
+Jefferson,Pamelia 1,Lt. Governor,,WF,Hochul,2
+Jefferson,Pamelia 1,Governor,,IND,Cuomo,9
+Jefferson,Pamelia 1,Lt. Governor,,IND,Hochul,9
+Jefferson,Pamelia 1,Governor,,WEP,Cuomo,3
+Jefferson,Pamelia 1,Lt. Governor,,WEP,Hochul,3
+Jefferson,Pamelia 1,Governor,,REF,Molinaro,3
+Jefferson,Pamelia 1,Lt. Governor,,REF,Killian,3
+Jefferson,Pamelia 1,Governor,,SAM,Miner,7
+Jefferson,Pamelia 1,Lt. Governor,,SAM,Volpe,7
+Jefferson,Pamelia 1,Governor,,LIB,Sharpe,12
+Jefferson,Pamelia 1,Lt. Governor,,LIB,Hollister,12
+Jefferson,Pamelia 1,Governor,,,Write-In,1
+Jefferson,Pamelia 2,Governor,,DEM,Cuomo,137
+Jefferson,Pamelia 2,Lt. Governor,,DEM,Hochul,137
+Jefferson,Pamelia 2,Governor,,REP,Molinaro,292
+Jefferson,Pamelia 2,Lt. Governor,,REP,Killian,292
+Jefferson,Pamelia 2,Governor,,CON,Molinaro,28
+Jefferson,Pamelia 2,Lt. Governor,,CON,Killian,28
+Jefferson,Pamelia 2,Governor,,GREEN,Hawkins,6
+Jefferson,Pamelia 2,Lt. Governor,,GREEN,Lee,6
+Jefferson,Pamelia 2,Governor,,WF,Cuomo,2
+Jefferson,Pamelia 2,Lt. Governor,,WF,Hochul,2
+Jefferson,Pamelia 2,Governor,,IND,Cuomo,10
+Jefferson,Pamelia 2,Lt. Governor,,IND,Hochul,10
+Jefferson,Pamelia 2,Governor,,WEP,Cuomo,1
+Jefferson,Pamelia 2,Lt. Governor,,WEP,Hochul,1
+Jefferson,Pamelia 2,Governor,,REF,Molinaro,4
+Jefferson,Pamelia 2,Lt. Governor,,REF,Killian,4
+Jefferson,Pamelia 2,Governor,,SAM,Miner,10
+Jefferson,Pamelia 2,Lt. Governor,,SAM,Volpe,10
+Jefferson,Pamelia 2,Governor,,LIB,Sharpe,17
+Jefferson,Pamelia 2,Lt. Governor,,LIB,Hollister,17
+Jefferson,Pamelia 2,Governor,,,Write-In,1
+Jefferson,Philadelphia 1,Governor,,DEM,Cuomo,65
+Jefferson,Philadelphia 1,Lt. Governor,,DEM,Hochul,65
+Jefferson,Philadelphia 1,Governor,,REP,Molinaro,146
+Jefferson,Philadelphia 1,Lt. Governor,,REP,Killian,146
+Jefferson,Philadelphia 1,Governor,,CON,Molinaro,11
+Jefferson,Philadelphia 1,Lt. Governor,,CON,Killian,11
+Jefferson,Philadelphia 1,Governor,,GREEN,Hawkins,3
+Jefferson,Philadelphia 1,Lt. Governor,,GREEN,Lee,3
+Jefferson,Philadelphia 1,Governor,,WF,Cuomo,2
+Jefferson,Philadelphia 1,Lt. Governor,,WF,Hochul,2
+Jefferson,Philadelphia 1,Governor,,IND,Cuomo,0
+Jefferson,Philadelphia 1,Lt. Governor,,IND,Hochul,0
+Jefferson,Philadelphia 1,Governor,,WEP,Cuomo,0
+Jefferson,Philadelphia 1,Lt. Governor,,WEP,Hochul,0
+Jefferson,Philadelphia 1,Governor,,REF,Molinaro,5
+Jefferson,Philadelphia 1,Lt. Governor,,REF,Killian,5
+Jefferson,Philadelphia 1,Governor,,SAM,Miner,4
+Jefferson,Philadelphia 1,Lt. Governor,,SAM,Volpe,4
+Jefferson,Philadelphia 1,Governor,,LIB,Sharpe,8
+Jefferson,Philadelphia 1,Lt. Governor,,LIB,Hollister,8
+Jefferson,Philadelphia 1,Governor,,,Write-In,0
+Jefferson,Philadelphia 2,Governor,,DEM,Cuomo,61
+Jefferson,Philadelphia 2,Lt. Governor,,DEM,Hochul,61
+Jefferson,Philadelphia 2,Governor,,REP,Molinaro,163
+Jefferson,Philadelphia 2,Lt. Governor,,REP,Killian,163
+Jefferson,Philadelphia 2,Governor,,CON,Molinaro,18
+Jefferson,Philadelphia 2,Lt. Governor,,CON,Killian,18
+Jefferson,Philadelphia 2,Governor,,GREEN,Hawkins,3
+Jefferson,Philadelphia 2,Lt. Governor,,GREEN,Lee,3
+Jefferson,Philadelphia 2,Governor,,WF,Cuomo,1
+Jefferson,Philadelphia 2,Lt. Governor,,WF,Hochul,1
+Jefferson,Philadelphia 2,Governor,,IND,Cuomo,2
+Jefferson,Philadelphia 2,Lt. Governor,,IND,Hochul,2
+Jefferson,Philadelphia 2,Governor,,WEP,Cuomo,1
+Jefferson,Philadelphia 2,Lt. Governor,,WEP,Hochul,1
+Jefferson,Philadelphia 2,Governor,,REF,Molinaro,6
+Jefferson,Philadelphia 2,Lt. Governor,,REF,Killian,6
+Jefferson,Philadelphia 2,Governor,,SAM,Miner,2
+Jefferson,Philadelphia 2,Lt. Governor,,SAM,Volpe,2
+Jefferson,Philadelphia 2,Governor,,LIB,Sharpe,9
+Jefferson,Philadelphia 2,Lt. Governor,,LIB,Hollister,9
+Jefferson,Philadelphia 2,Governor,,,Write-In,0
+Jefferson,Rodman 1,Governor,,DEM,Cuomo,77
+Jefferson,Rodman 1,Lt. Governor,,DEM,Hochul,77
+Jefferson,Rodman 1,Governor,,REP,Molinaro,308
+Jefferson,Rodman 1,Lt. Governor,,REP,Killian,308
+Jefferson,Rodman 1,Governor,,CON,Molinaro,29
+Jefferson,Rodman 1,Lt. Governor,,CON,Killian,29
+Jefferson,Rodman 1,Governor,,GREEN,Hawkins,9
+Jefferson,Rodman 1,Lt. Governor,,GREEN,Lee,9
+Jefferson,Rodman 1,Governor,,WF,Cuomo,2
+Jefferson,Rodman 1,Lt. Governor,,WF,Hochul,2
+Jefferson,Rodman 1,Governor,,IND,Cuomo,3
+Jefferson,Rodman 1,Lt. Governor,,IND,Hochul,3
+Jefferson,Rodman 1,Governor,,WEP,Cuomo,0
+Jefferson,Rodman 1,Lt. Governor,,WEP,Hochul,0
+Jefferson,Rodman 1,Governor,,REF,Molinaro,4
+Jefferson,Rodman 1,Lt. Governor,,REF,Killian,4
+Jefferson,Rodman 1,Governor,,SAM,Miner,8
+Jefferson,Rodman 1,Lt. Governor,,SAM,Volpe,8
+Jefferson,Rodman 1,Governor,,LIB,Sharpe,18
+Jefferson,Rodman 1,Lt. Governor,,LIB,Hollister,18
+Jefferson,Rodman 1,Governor,,,Write-In,0
+Jefferson,Rutland 1,Governor,,DEM,Cuomo,79
+Jefferson,Rutland 1,Lt. Governor,,DEM,Hochul,79
+Jefferson,Rutland 1,Governor,,REP,Molinaro,284
+Jefferson,Rutland 1,Lt. Governor,,REP,Killian,284
+Jefferson,Rutland 1,Governor,,CON,Molinaro,24
+Jefferson,Rutland 1,Lt. Governor,,CON,Killian,24
+Jefferson,Rutland 1,Governor,,GREEN,Hawkins,6
+Jefferson,Rutland 1,Lt. Governor,,GREEN,Lee,6
+Jefferson,Rutland 1,Governor,,WF,Cuomo,2
+Jefferson,Rutland 1,Lt. Governor,,WF,Hochul,2
+Jefferson,Rutland 1,Governor,,IND,Cuomo,2
+Jefferson,Rutland 1,Lt. Governor,,IND,Hochul,2
+Jefferson,Rutland 1,Governor,,WEP,Cuomo,4
+Jefferson,Rutland 1,Lt. Governor,,WEP,Hochul,4
+Jefferson,Rutland 1,Governor,,REF,Molinaro,1
+Jefferson,Rutland 1,Lt. Governor,,REF,Killian,1
+Jefferson,Rutland 1,Governor,,SAM,Miner,2
+Jefferson,Rutland 1,Lt. Governor,,SAM,Volpe,2
+Jefferson,Rutland 1,Governor,,LIB,Sharpe,16
+Jefferson,Rutland 1,Lt. Governor,,LIB,Hollister,16
+Jefferson,Rutland 1,Governor,,,Write-In,0
+Jefferson,Rutland 2,Governor,,DEM,Cuomo,56
+Jefferson,Rutland 2,Lt. Governor,,DEM,Hochul,56
+Jefferson,Rutland 2,Governor,,REP,Molinaro,229
+Jefferson,Rutland 2,Lt. Governor,,REP,Killian,229
+Jefferson,Rutland 2,Governor,,CON,Molinaro,22
+Jefferson,Rutland 2,Lt. Governor,,CON,Killian,22
+Jefferson,Rutland 2,Governor,,GREEN,Hawkins,5
+Jefferson,Rutland 2,Lt. Governor,,GREEN,Lee,5
+Jefferson,Rutland 2,Governor,,WF,Cuomo,1
+Jefferson,Rutland 2,Lt. Governor,,WF,Hochul,1
+Jefferson,Rutland 2,Governor,,IND,Cuomo,3
+Jefferson,Rutland 2,Lt. Governor,,IND,Hochul,3
+Jefferson,Rutland 2,Governor,,WEP,Cuomo,2
+Jefferson,Rutland 2,Lt. Governor,,WEP,Hochul,2
+Jefferson,Rutland 2,Governor,,REF,Molinaro,2
+Jefferson,Rutland 2,Lt. Governor,,REF,Killian,2
+Jefferson,Rutland 2,Governor,,SAM,Miner,1
+Jefferson,Rutland 2,Lt. Governor,,SAM,Volpe,1
+Jefferson,Rutland 2,Governor,,LIB,Sharpe,9
+Jefferson,Rutland 2,Lt. Governor,,LIB,Hollister,9
+Jefferson,Rutland 2,Governor,,,Write-In,0
+Jefferson,Rutland 3,Governor,,DEM,Cuomo,36
+Jefferson,Rutland 3,Lt. Governor,,DEM,Hochul,36
+Jefferson,Rutland 3,Governor,,REP,Molinaro,61
+Jefferson,Rutland 3,Lt. Governor,,REP,Killian,61
+Jefferson,Rutland 3,Governor,,CON,Molinaro,10
+Jefferson,Rutland 3,Lt. Governor,,CON,Killian,10
+Jefferson,Rutland 3,Governor,,GREEN,Hawkins,2
+Jefferson,Rutland 3,Lt. Governor,,GREEN,Lee,2
+Jefferson,Rutland 3,Governor,,WF,Cuomo,2
+Jefferson,Rutland 3,Lt. Governor,,WF,Hochul,2
+Jefferson,Rutland 3,Governor,,IND,Cuomo,1
+Jefferson,Rutland 3,Lt. Governor,,IND,Hochul,1
+Jefferson,Rutland 3,Governor,,WEP,Cuomo,1
+Jefferson,Rutland 3,Lt. Governor,,WEP,Hochul,1
+Jefferson,Rutland 3,Governor,,REF,Molinaro,1
+Jefferson,Rutland 3,Lt. Governor,,REF,Killian,1
+Jefferson,Rutland 3,Governor,,SAM,Miner,0
+Jefferson,Rutland 3,Lt. Governor,,SAM,Volpe,0
+Jefferson,Rutland 3,Governor,,LIB,Sharpe,2
+Jefferson,Rutland 3,Lt. Governor,,LIB,Hollister,2
+Jefferson,Rutland 3,Governor,,,Write-In,1
+Jefferson,Theresa 1,Governor,,DEM,Cuomo,193
+Jefferson,Theresa 1,Lt. Governor,,DEM,Hochul,193
+Jefferson,Theresa 1,Governor,,REP,Molinaro,530
+Jefferson,Theresa 1,Lt. Governor,,REP,Killian,530
+Jefferson,Theresa 1,Governor,,CON,Molinaro,38
+Jefferson,Theresa 1,Lt. Governor,,CON,Killian,38
+Jefferson,Theresa 1,Governor,,GREEN,Hawkins,13
+Jefferson,Theresa 1,Lt. Governor,,GREEN,Lee,13
+Jefferson,Theresa 1,Governor,,WF,Cuomo,7
+Jefferson,Theresa 1,Lt. Governor,,WF,Hochul,7
+Jefferson,Theresa 1,Governor,,IND,Cuomo,8
+Jefferson,Theresa 1,Lt. Governor,,IND,Hochul,8
+Jefferson,Theresa 1,Governor,,WEP,Cuomo,2
+Jefferson,Theresa 1,Lt. Governor,,WEP,Hochul,2
+Jefferson,Theresa 1,Governor,,REF,Molinaro,10
+Jefferson,Theresa 1,Lt. Governor,,REF,Killian,10
+Jefferson,Theresa 1,Governor,,SAM,Miner,9
+Jefferson,Theresa 1,Lt. Governor,,SAM,Volpe,9
+Jefferson,Theresa 1,Governor,,LIB,Sharpe,23
+Jefferson,Theresa 1,Lt. Governor,,LIB,Hollister,23
+Jefferson,Theresa 1,Governor,,,Write-In,0
+Jefferson,Watertown 1,Governor,,DEM,Cuomo,294
+Jefferson,Watertown 1,Lt. Governor,,DEM,Hochul,294
+Jefferson,Watertown 1,Governor,,REP,Molinaro,444
+Jefferson,Watertown 1,Lt. Governor,,REP,Killian,444
+Jefferson,Watertown 1,Governor,,CON,Molinaro,45
+Jefferson,Watertown 1,Lt. Governor,,CON,Killian,45
+Jefferson,Watertown 1,Governor,,GREEN,Hawkins,9
+Jefferson,Watertown 1,Lt. Governor,,GREEN,Lee,9
+Jefferson,Watertown 1,Governor,,WF,Cuomo,2
+Jefferson,Watertown 1,Lt. Governor,,WF,Hochul,2
+Jefferson,Watertown 1,Governor,,IND,Cuomo,8
+Jefferson,Watertown 1,Lt. Governor,,IND,Hochul,8
+Jefferson,Watertown 1,Governor,,WEP,Cuomo,3
+Jefferson,Watertown 1,Lt. Governor,,WEP,Hochul,3
+Jefferson,Watertown 1,Governor,,REF,Molinaro,3
+Jefferson,Watertown 1,Lt. Governor,,REF,Killian,3
+Jefferson,Watertown 1,Governor,,SAM,Miner,13
+Jefferson,Watertown 1,Lt. Governor,,SAM,Volpe,13
+Jefferson,Watertown 1,Governor,,LIB,Sharpe,10
+Jefferson,Watertown 1,Lt. Governor,,LIB,Hollister,10
+Jefferson,Watertown 1,Governor,,,Write-In,1
+Jefferson,Watertown 2,Governor,,DEM,Cuomo,162
+Jefferson,Watertown 2,Lt. Governor,,DEM,Hochul,162
+Jefferson,Watertown 2,Governor,,REP,Molinaro,509
+Jefferson,Watertown 2,Lt. Governor,,REP,Killian,509
+Jefferson,Watertown 2,Governor,,CON,Molinaro,47
+Jefferson,Watertown 2,Lt. Governor,,CON,Killian,47
+Jefferson,Watertown 2,Governor,,GREEN,Hawkins,6
+Jefferson,Watertown 2,Lt. Governor,,GREEN,Lee,6
+Jefferson,Watertown 2,Governor,,WF,Cuomo,6
+Jefferson,Watertown 2,Lt. Governor,,WF,Hochul,6
+Jefferson,Watertown 2,Governor,,IND,Cuomo,8
+Jefferson,Watertown 2,Lt. Governor,,IND,Hochul,8
+Jefferson,Watertown 2,Governor,,WEP,Cuomo,1
+Jefferson,Watertown 2,Lt. Governor,,WEP,Hochul,1
+Jefferson,Watertown 2,Governor,,REF,Molinaro,5
+Jefferson,Watertown 2,Lt. Governor,,REF,Killian,5
+Jefferson,Watertown 2,Governor,,SAM,Miner,13
+Jefferson,Watertown 2,Lt. Governor,,SAM,Volpe,13
+Jefferson,Watertown 2,Governor,,LIB,Sharpe,32
+Jefferson,Watertown 2,Lt. Governor,,LIB,Hollister,32
+Jefferson,Watertown 2,Governor,,,Write-In,0
+Jefferson,Wilna 1,Governor,,DEM,Cuomo,210
+Jefferson,Wilna 1,Lt. Governor,,DEM,Hochul,210
+Jefferson,Wilna 1,Governor,,REP,Molinaro,335
+Jefferson,Wilna 1,Lt. Governor,,REP,Killian,335
+Jefferson,Wilna 1,Governor,,CON,Molinaro,39
+Jefferson,Wilna 1,Lt. Governor,,CON,Killian,39
+Jefferson,Wilna 1,Governor,,GREEN,Hawkins,8
+Jefferson,Wilna 1,Lt. Governor,,GREEN,Lee,8
+Jefferson,Wilna 1,Governor,,WF,Cuomo,4
+Jefferson,Wilna 1,Lt. Governor,,WF,Hochul,4
+Jefferson,Wilna 1,Governor,,IND,Cuomo,4
+Jefferson,Wilna 1,Lt. Governor,,IND,Hochul,4
+Jefferson,Wilna 1,Governor,,WEP,Cuomo,3
+Jefferson,Wilna 1,Lt. Governor,,WEP,Hochul,3
+Jefferson,Wilna 1,Governor,,REF,Molinaro,5
+Jefferson,Wilna 1,Lt. Governor,,REF,Killian,5
+Jefferson,Wilna 1,Governor,,SAM,Miner,9
+Jefferson,Wilna 1,Lt. Governor,,SAM,Volpe,9
+Jefferson,Wilna 1,Governor,,LIB,Sharpe,19
+Jefferson,Wilna 1,Lt. Governor,,LIB,Hollister,19
+Jefferson,Wilna 1,Governor,,,Write-In,0
+Jefferson,Wilna 2,Governor,,DEM,Cuomo,6
+Jefferson,Wilna 2,Lt. Governor,,DEM,Hochul,6
+Jefferson,Wilna 2,Governor,,REP,Molinaro,10
+Jefferson,Wilna 2,Lt. Governor,,REP,Killian,10
+Jefferson,Wilna 2,Governor,,CON,Molinaro,0
+Jefferson,Wilna 2,Lt. Governor,,CON,Killian,0
+Jefferson,Wilna 2,Governor,,GREEN,Hawkins,3
+Jefferson,Wilna 2,Lt. Governor,,GREEN,Lee,3
+Jefferson,Wilna 2,Governor,,WF,Cuomo,0
+Jefferson,Wilna 2,Lt. Governor,,WF,Hochul,0
+Jefferson,Wilna 2,Governor,,IND,Cuomo,1
+Jefferson,Wilna 2,Lt. Governor,,IND,Hochul,1
+Jefferson,Wilna 2,Governor,,WEP,Cuomo,0
+Jefferson,Wilna 2,Lt. Governor,,WEP,Hochul,0
+Jefferson,Wilna 2,Governor,,REF,Molinaro,0
+Jefferson,Wilna 2,Lt. Governor,,REF,Killian,0
+Jefferson,Wilna 2,Governor,,SAM,Miner,0
+Jefferson,Wilna 2,Lt. Governor,,SAM,Volpe,0
+Jefferson,Wilna 2,Governor,,LIB,Sharpe,2
+Jefferson,Wilna 2,Lt. Governor,,LIB,Hollister,2
+Jefferson,Wilna 2,Governor,,,Write-In,0
+Jefferson,Wilna 3,Governor,,DEM,Cuomo,15
+Jefferson,Wilna 3,Lt. Governor,,DEM,Hochul,15
+Jefferson,Wilna 3,Governor,,REP,Molinaro,45
+Jefferson,Wilna 3,Lt. Governor,,REP,Killian,45
+Jefferson,Wilna 3,Governor,,CON,Molinaro,3
+Jefferson,Wilna 3,Lt. Governor,,CON,Killian,3
+Jefferson,Wilna 3,Governor,,GREEN,Hawkins,2
+Jefferson,Wilna 3,Lt. Governor,,GREEN,Lee,2
+Jefferson,Wilna 3,Governor,,WF,Cuomo,0
+Jefferson,Wilna 3,Lt. Governor,,WF,Hochul,0
+Jefferson,Wilna 3,Governor,,IND,Cuomo,0
+Jefferson,Wilna 3,Lt. Governor,,IND,Hochul,0
+Jefferson,Wilna 3,Governor,,WEP,Cuomo,0
+Jefferson,Wilna 3,Lt. Governor,,WEP,Hochul,0
+Jefferson,Wilna 3,Governor,,REF,Molinaro,0
+Jefferson,Wilna 3,Lt. Governor,,REF,Killian,0
+Jefferson,Wilna 3,Governor,,SAM,Miner,1
+Jefferson,Wilna 3,Lt. Governor,,SAM,Volpe,1
+Jefferson,Wilna 3,Governor,,LIB,Sharpe,6
+Jefferson,Wilna 3,Lt. Governor,,LIB,Hollister,6
+Jefferson,Wilna 3,Governor,,,Write-In,0
+Jefferson,Wilna 4,Governor,,DEM,Cuomo,18
+Jefferson,Wilna 4,Lt. Governor,,DEM,Hochul,18
+Jefferson,Wilna 4,Governor,,REP,Molinaro,133
+Jefferson,Wilna 4,Lt. Governor,,REP,Killian,133
+Jefferson,Wilna 4,Governor,,CON,Molinaro,15
+Jefferson,Wilna 4,Lt. Governor,,CON,Killian,15
+Jefferson,Wilna 4,Governor,,GREEN,Hawkins,0
+Jefferson,Wilna 4,Lt. Governor,,GREEN,Lee,0
+Jefferson,Wilna 4,Governor,,WF,Cuomo,1
+Jefferson,Wilna 4,Lt. Governor,,WF,Hochul,1
+Jefferson,Wilna 4,Governor,,IND,Cuomo,1
+Jefferson,Wilna 4,Lt. Governor,,IND,Hochul,1
+Jefferson,Wilna 4,Governor,,WEP,Cuomo,1
+Jefferson,Wilna 4,Lt. Governor,,WEP,Hochul,1
+Jefferson,Wilna 4,Governor,,REF,Molinaro,1
+Jefferson,Wilna 4,Lt. Governor,,REF,Killian,1
+Jefferson,Wilna 4,Governor,,SAM,Miner,2
+Jefferson,Wilna 4,Lt. Governor,,SAM,Volpe,2
+Jefferson,Wilna 4,Governor,,LIB,Sharpe,2
+Jefferson,Wilna 4,Lt. Governor,,LIB,Hollister,2
+Jefferson,Wilna 4,Governor,,,Write-In,0
+Jefferson,Wilna 5,Governor,,DEM,Cuomo,73
+Jefferson,Wilna 5,Lt. Governor,,DEM,Hochul,73
+Jefferson,Wilna 5,Governor,,REP,Molinaro,267
+Jefferson,Wilna 5,Lt. Governor,,REP,Killian,267
+Jefferson,Wilna 5,Governor,,CON,Molinaro,15
+Jefferson,Wilna 5,Lt. Governor,,CON,Killian,15
+Jefferson,Wilna 5,Governor,,GREEN,Hawkins,3
+Jefferson,Wilna 5,Lt. Governor,,GREEN,Lee,3
+Jefferson,Wilna 5,Governor,,WF,Cuomo,2
+Jefferson,Wilna 5,Lt. Governor,,WF,Hochul,2
+Jefferson,Wilna 5,Governor,,IND,Cuomo,1
+Jefferson,Wilna 5,Lt. Governor,,IND,Hochul,1
+Jefferson,Wilna 5,Governor,,WEP,Cuomo,1
+Jefferson,Wilna 5,Lt. Governor,,WEP,Hochul,1
+Jefferson,Wilna 5,Governor,,REF,Molinaro,1
+Jefferson,Wilna 5,Lt. Governor,,REF,Killian,1
+Jefferson,Wilna 5,Governor,,SAM,Miner,4
+Jefferson,Wilna 5,Lt. Governor,,SAM,Volpe,4
+Jefferson,Wilna 5,Governor,,LIB,Sharpe,7
+Jefferson,Wilna 5,Lt. Governor,,LIB,Hollister,7
+Jefferson,Wilna 5,Governor,,,Write-In,0
+Jefferson,Worth 1,Governor,,DEM,Cuomo,19
+Jefferson,Worth 1,Lt. Governor,,DEM,Hochul,19
+Jefferson,Worth 1,Governor,,REP,Molinaro,76
+Jefferson,Worth 1,Lt. Governor,,REP,Killian,76
+Jefferson,Worth 1,Governor,,CON,Molinaro,6
+Jefferson,Worth 1,Lt. Governor,,CON,Killian,6
+Jefferson,Worth 1,Governor,,GREEN,Hawkins,3
+Jefferson,Worth 1,Lt. Governor,,GREEN,Lee,3
+Jefferson,Worth 1,Governor,,WF,Cuomo,0
+Jefferson,Worth 1,Lt. Governor,,WF,Hochul,0
+Jefferson,Worth 1,Governor,,IND,Cuomo,1
+Jefferson,Worth 1,Lt. Governor,,IND,Hochul,1
+Jefferson,Worth 1,Governor,,WEP,Cuomo,0
+Jefferson,Worth 1,Lt. Governor,,WEP,Hochul,0
+Jefferson,Worth 1,Governor,,REF,Molinaro,2
+Jefferson,Worth 1,Lt. Governor,,REF,Killian,2
+Jefferson,Worth 1,Governor,,SAM,Miner,1
+Jefferson,Worth 1,Lt. Governor,,SAM,Volpe,1
+Jefferson,Worth 1,Governor,,LIB,Sharpe,2
+Jefferson,Worth 1,Lt. Governor,,LIB,Hollister,2
+Jefferson,Worth 1,Governor,,,Write-In,0
+Jefferson,Adams 1,Comptroller,,DEM,DiNapoli,2
+Jefferson,Adams 1,Comptroller,,REP,Trichter,2
+Jefferson,Adams 1,Comptroller,,CON,Trichter,2
+Jefferson,Adams 1,Comptroller,,GRE,Dunlea,2
+Jefferson,Adams 1,Comptroller,,WF,DiNapoli,2
+Jefferson,Adams 1,Comptroller,,IND,DiNapoli,2
+Jefferson,Adams 1,Comptroller,,WEP,DiNapoli,2
+Jefferson,Adams 1,Comptroller,,REF,DiNapoli,2
+Jefferson,Adams 1,Comptroller,,LIB,Gallaudet,2
+Jefferson,Adams 1,Comptroller,,,Write-ins,2
+Jefferson,Adams 2,Comptroller,,DEM,DiNapoli,0
+Jefferson,Adams 2,Comptroller,,REP,Trichter,0
+Jefferson,Adams 2,Comptroller,,CON,Trichter,0
+Jefferson,Adams 2,Comptroller,,GRE,Dunlea,0
+Jefferson,Adams 2,Comptroller,,WF,DiNapoli,0
+Jefferson,Adams 2,Comptroller,,IND,DiNapoli,0
+Jefferson,Adams 2,Comptroller,,WEP,DiNapoli,0
+Jefferson,Adams 2,Comptroller,,REF,DiNapoli,0
+Jefferson,Adams 2,Comptroller,,LIB,Gallaudet,0
+Jefferson,Adams 2,Comptroller,,,Write-ins,0
+Jefferson,Adams 3,Comptroller,,DEM,DiNapoli,4
+Jefferson,Adams 3,Comptroller,,REP,Trichter,4
+Jefferson,Adams 3,Comptroller,,CON,Trichter,4
+Jefferson,Adams 3,Comptroller,,GRE,Dunlea,4
+Jefferson,Adams 3,Comptroller,,WF,DiNapoli,4
+Jefferson,Adams 3,Comptroller,,IND,DiNapoli,4
+Jefferson,Adams 3,Comptroller,,WEP,DiNapoli,4
+Jefferson,Adams 3,Comptroller,,REF,DiNapoli,4
+Jefferson,Adams 3,Comptroller,,LIB,Gallaudet,4
+Jefferson,Adams 3,Comptroller,,,Write-ins,4
+Jefferson,Alexandria 1,Comptroller,,DEM,DiNapoli,3
+Jefferson,Alexandria 1,Comptroller,,REP,Trichter,3
+Jefferson,Alexandria 1,Comptroller,,CON,Trichter,3
+Jefferson,Alexandria 1,Comptroller,,GRE,Dunlea,3
+Jefferson,Alexandria 1,Comptroller,,WF,DiNapoli,3
+Jefferson,Alexandria 1,Comptroller,,IND,DiNapoli,3
+Jefferson,Alexandria 1,Comptroller,,WEP,DiNapoli,3
+Jefferson,Alexandria 1,Comptroller,,REF,DiNapoli,3
+Jefferson,Alexandria 1,Comptroller,,LIB,Gallaudet,3
+Jefferson,Alexandria 1,Comptroller,,,Write-ins,3
+Jefferson,Alexandria 2,Comptroller,,DEM,DiNapoli,2
+Jefferson,Alexandria 2,Comptroller,,REP,Trichter,2
+Jefferson,Alexandria 2,Comptroller,,CON,Trichter,2
+Jefferson,Alexandria 2,Comptroller,,GRE,Dunlea,2
+Jefferson,Alexandria 2,Comptroller,,WF,DiNapoli,2
+Jefferson,Alexandria 2,Comptroller,,IND,DiNapoli,2
+Jefferson,Alexandria 2,Comptroller,,WEP,DiNapoli,2
+Jefferson,Alexandria 2,Comptroller,,REF,DiNapoli,2
+Jefferson,Alexandria 2,Comptroller,,LIB,Gallaudet,2
+Jefferson,Alexandria 2,Comptroller,,,Write-ins,2
+Jefferson,Alexandria 3,Comptroller,,DEM,DiNapoli,1
+Jefferson,Alexandria 3,Comptroller,,REP,Trichter,1
+Jefferson,Alexandria 3,Comptroller,,CON,Trichter,1
+Jefferson,Alexandria 3,Comptroller,,GRE,Dunlea,1
+Jefferson,Alexandria 3,Comptroller,,WF,DiNapoli,1
+Jefferson,Alexandria 3,Comptroller,,IND,DiNapoli,1
+Jefferson,Alexandria 3,Comptroller,,WEP,DiNapoli,1
+Jefferson,Alexandria 3,Comptroller,,REF,DiNapoli,1
+Jefferson,Alexandria 3,Comptroller,,LIB,Gallaudet,1
+Jefferson,Alexandria 3,Comptroller,,,Write-ins,1
+Jefferson,Antwerp 1,Comptroller,,DEM,DiNapoli,1
+Jefferson,Antwerp 1,Comptroller,,REP,Trichter,1
+Jefferson,Antwerp 1,Comptroller,,CON,Trichter,1
+Jefferson,Antwerp 1,Comptroller,,GRE,Dunlea,1
+Jefferson,Antwerp 1,Comptroller,,WF,DiNapoli,1
+Jefferson,Antwerp 1,Comptroller,,IND,DiNapoli,1
+Jefferson,Antwerp 1,Comptroller,,WEP,DiNapoli,1
+Jefferson,Antwerp 1,Comptroller,,REF,DiNapoli,1
+Jefferson,Antwerp 1,Comptroller,,LIB,Gallaudet,1
+Jefferson,Antwerp 1,Comptroller,,,Write-ins,1
+Jefferson,Antwerp 2,Comptroller,,DEM,DiNapoli,0
+Jefferson,Antwerp 2,Comptroller,,REP,Trichter,0
+Jefferson,Antwerp 2,Comptroller,,CON,Trichter,0
+Jefferson,Antwerp 2,Comptroller,,GRE,Dunlea,0
+Jefferson,Antwerp 2,Comptroller,,WF,DiNapoli,0
+Jefferson,Antwerp 2,Comptroller,,IND,DiNapoli,0
+Jefferson,Antwerp 2,Comptroller,,WEP,DiNapoli,0
+Jefferson,Antwerp 2,Comptroller,,REF,DiNapoli,0
+Jefferson,Antwerp 2,Comptroller,,LIB,Gallaudet,0
+Jefferson,Antwerp 2,Comptroller,,,Write-ins,0
+Jefferson,Brownville 1,Comptroller,,DEM,DiNapoli,2
+Jefferson,Brownville 1,Comptroller,,REP,Trichter,2
+Jefferson,Brownville 1,Comptroller,,CON,Trichter,2
+Jefferson,Brownville 1,Comptroller,,GRE,Dunlea,2
+Jefferson,Brownville 1,Comptroller,,WF,DiNapoli,2
+Jefferson,Brownville 1,Comptroller,,IND,DiNapoli,2
+Jefferson,Brownville 1,Comptroller,,WEP,DiNapoli,2
+Jefferson,Brownville 1,Comptroller,,REF,DiNapoli,2
+Jefferson,Brownville 1,Comptroller,,LIB,Gallaudet,2
+Jefferson,Brownville 1,Comptroller,,,Write-ins,2
+Jefferson,Brownville 2,Comptroller,,DEM,DiNapoli,1
+Jefferson,Brownville 2,Comptroller,,REP,Trichter,1
+Jefferson,Brownville 2,Comptroller,,CON,Trichter,1
+Jefferson,Brownville 2,Comptroller,,GRE,Dunlea,1
+Jefferson,Brownville 2,Comptroller,,WF,DiNapoli,1
+Jefferson,Brownville 2,Comptroller,,IND,DiNapoli,1
+Jefferson,Brownville 2,Comptroller,,WEP,DiNapoli,1
+Jefferson,Brownville 2,Comptroller,,REF,DiNapoli,1
+Jefferson,Brownville 2,Comptroller,,LIB,Gallaudet,1
+Jefferson,Brownville 2,Comptroller,,,Write-ins,1
+Jefferson,Brownville 3,Comptroller,,DEM,DiNapoli,2
+Jefferson,Brownville 3,Comptroller,,REP,Trichter,2
+Jefferson,Brownville 3,Comptroller,,CON,Trichter,2
+Jefferson,Brownville 3,Comptroller,,GRE,Dunlea,2
+Jefferson,Brownville 3,Comptroller,,WF,DiNapoli,2
+Jefferson,Brownville 3,Comptroller,,IND,DiNapoli,2
+Jefferson,Brownville 3,Comptroller,,WEP,DiNapoli,2
+Jefferson,Brownville 3,Comptroller,,REF,DiNapoli,2
+Jefferson,Brownville 3,Comptroller,,LIB,Gallaudet,2
+Jefferson,Brownville 3,Comptroller,,,Write-ins,2
+Jefferson,Brownville 4,Comptroller,,DEM,DiNapoli,2
+Jefferson,Brownville 4,Comptroller,,REP,Trichter,2
+Jefferson,Brownville 4,Comptroller,,CON,Trichter,2
+Jefferson,Brownville 4,Comptroller,,GRE,Dunlea,2
+Jefferson,Brownville 4,Comptroller,,WF,DiNapoli,2
+Jefferson,Brownville 4,Comptroller,,IND,DiNapoli,2
+Jefferson,Brownville 4,Comptroller,,WEP,DiNapoli,2
+Jefferson,Brownville 4,Comptroller,,REF,DiNapoli,2
+Jefferson,Brownville 4,Comptroller,,LIB,Gallaudet,2
+Jefferson,Brownville 4,Comptroller,,,Write-ins,2
+Jefferson,Brownville 5,Comptroller,,DEM,DiNapoli,0
+Jefferson,Brownville 5,Comptroller,,REP,Trichter,0
+Jefferson,Brownville 5,Comptroller,,CON,Trichter,0
+Jefferson,Brownville 5,Comptroller,,GRE,Dunlea,0
+Jefferson,Brownville 5,Comptroller,,WF,DiNapoli,0
+Jefferson,Brownville 5,Comptroller,,IND,DiNapoli,0
+Jefferson,Brownville 5,Comptroller,,WEP,DiNapoli,0
+Jefferson,Brownville 5,Comptroller,,REF,DiNapoli,0
+Jefferson,Brownville 5,Comptroller,,LIB,Gallaudet,0
+Jefferson,Brownville 5,Comptroller,,,Write-ins,0
+Jefferson,Cape Vincent 1,Comptroller,,DEM,DiNapoli,0
+Jefferson,Cape Vincent 1,Comptroller,,REP,Trichter,0
+Jefferson,Cape Vincent 1,Comptroller,,CON,Trichter,0
+Jefferson,Cape Vincent 1,Comptroller,,GRE,Dunlea,0
+Jefferson,Cape Vincent 1,Comptroller,,WF,DiNapoli,0
+Jefferson,Cape Vincent 1,Comptroller,,IND,DiNapoli,0
+Jefferson,Cape Vincent 1,Comptroller,,WEP,DiNapoli,0
+Jefferson,Cape Vincent 1,Comptroller,,REF,DiNapoli,0
+Jefferson,Cape Vincent 1,Comptroller,,LIB,Gallaudet,0
+Jefferson,Cape Vincent 1,Comptroller,,,Write-ins,0
+Jefferson,Cape Vincent 2,Comptroller,,DEM,DiNapoli,3
+Jefferson,Cape Vincent 2,Comptroller,,REP,Trichter,3
+Jefferson,Cape Vincent 2,Comptroller,,CON,Trichter,3
+Jefferson,Cape Vincent 2,Comptroller,,GRE,Dunlea,3
+Jefferson,Cape Vincent 2,Comptroller,,WF,DiNapoli,3
+Jefferson,Cape Vincent 2,Comptroller,,IND,DiNapoli,3
+Jefferson,Cape Vincent 2,Comptroller,,WEP,DiNapoli,3
+Jefferson,Cape Vincent 2,Comptroller,,REF,DiNapoli,3
+Jefferson,Cape Vincent 2,Comptroller,,LIB,Gallaudet,3
+Jefferson,Cape Vincent 2,Comptroller,,,Write-ins,3
+Jefferson,Champion 1,Comptroller,,DEM,DiNapoli,4
+Jefferson,Champion 1,Comptroller,,REP,Trichter,4
+Jefferson,Champion 1,Comptroller,,CON,Trichter,4
+Jefferson,Champion 1,Comptroller,,GRE,Dunlea,4
+Jefferson,Champion 1,Comptroller,,WF,DiNapoli,4
+Jefferson,Champion 1,Comptroller,,IND,DiNapoli,4
+Jefferson,Champion 1,Comptroller,,WEP,DiNapoli,4
+Jefferson,Champion 1,Comptroller,,REF,DiNapoli,4
+Jefferson,Champion 1,Comptroller,,LIB,Gallaudet,4
+Jefferson,Champion 1,Comptroller,,,Write-ins,4
+Jefferson,Champion 2,Comptroller,,DEM,DiNapoli,0
+Jefferson,Champion 2,Comptroller,,REP,Trichter,0
+Jefferson,Champion 2,Comptroller,,CON,Trichter,0
+Jefferson,Champion 2,Comptroller,,GRE,Dunlea,0
+Jefferson,Champion 2,Comptroller,,WF,DiNapoli,0
+Jefferson,Champion 2,Comptroller,,IND,DiNapoli,0
+Jefferson,Champion 2,Comptroller,,WEP,DiNapoli,0
+Jefferson,Champion 2,Comptroller,,REF,DiNapoli,0
+Jefferson,Champion 2,Comptroller,,LIB,Gallaudet,0
+Jefferson,Champion 2,Comptroller,,,Write-ins,0
+Jefferson,Clayton 1,Comptroller,,DEM,DiNapoli,1
+Jefferson,Clayton 1,Comptroller,,REP,Trichter,1
+Jefferson,Clayton 1,Comptroller,,CON,Trichter,1
+Jefferson,Clayton 1,Comptroller,,GRE,Dunlea,1
+Jefferson,Clayton 1,Comptroller,,WF,DiNapoli,1
+Jefferson,Clayton 1,Comptroller,,IND,DiNapoli,1
+Jefferson,Clayton 1,Comptroller,,WEP,DiNapoli,1
+Jefferson,Clayton 1,Comptroller,,REF,DiNapoli,1
+Jefferson,Clayton 1,Comptroller,,LIB,Gallaudet,1
+Jefferson,Clayton 1,Comptroller,,,Write-ins,1
+Jefferson,Clayton 2,Comptroller,,DEM,DiNapoli,1
+Jefferson,Clayton 2,Comptroller,,REP,Trichter,1
+Jefferson,Clayton 2,Comptroller,,CON,Trichter,1
+Jefferson,Clayton 2,Comptroller,,GRE,Dunlea,1
+Jefferson,Clayton 2,Comptroller,,WF,DiNapoli,1
+Jefferson,Clayton 2,Comptroller,,IND,DiNapoli,1
+Jefferson,Clayton 2,Comptroller,,WEP,DiNapoli,1
+Jefferson,Clayton 2,Comptroller,,REF,DiNapoli,1
+Jefferson,Clayton 2,Comptroller,,LIB,Gallaudet,1
+Jefferson,Clayton 2,Comptroller,,,Write-ins,1
+Jefferson,Clayton 3,Comptroller,,DEM,DiNapoli,2
+Jefferson,Clayton 3,Comptroller,,REP,Trichter,2
+Jefferson,Clayton 3,Comptroller,,CON,Trichter,2
+Jefferson,Clayton 3,Comptroller,,GRE,Dunlea,2
+Jefferson,Clayton 3,Comptroller,,WF,DiNapoli,2
+Jefferson,Clayton 3,Comptroller,,IND,DiNapoli,2
+Jefferson,Clayton 3,Comptroller,,WEP,DiNapoli,2
+Jefferson,Clayton 3,Comptroller,,REF,DiNapoli,2
+Jefferson,Clayton 3,Comptroller,,LIB,Gallaudet,2
+Jefferson,Clayton 3,Comptroller,,,Write-ins,2
+Jefferson,Ellisburg 1,Comptroller,,DEM,DiNapoli,2
+Jefferson,Ellisburg 1,Comptroller,,REP,Trichter,2
+Jefferson,Ellisburg 1,Comptroller,,CON,Trichter,2
+Jefferson,Ellisburg 1,Comptroller,,GRE,Dunlea,2
+Jefferson,Ellisburg 1,Comptroller,,WF,DiNapoli,2
+Jefferson,Ellisburg 1,Comptroller,,IND,DiNapoli,2
+Jefferson,Ellisburg 1,Comptroller,,WEP,DiNapoli,2
+Jefferson,Ellisburg 1,Comptroller,,REF,DiNapoli,2
+Jefferson,Ellisburg 1,Comptroller,,LIB,Gallaudet,2
+Jefferson,Ellisburg 1,Comptroller,,,Write-ins,2
+Jefferson,Elllisburg 2,Comptroller,,DEM,DiNapoli,1
+Jefferson,Elllisburg 2,Comptroller,,REP,Trichter,1
+Jefferson,Elllisburg 2,Comptroller,,CON,Trichter,1
+Jefferson,Elllisburg 2,Comptroller,,GRE,Dunlea,1
+Jefferson,Elllisburg 2,Comptroller,,WF,DiNapoli,1
+Jefferson,Elllisburg 2,Comptroller,,IND,DiNapoli,1
+Jefferson,Elllisburg 2,Comptroller,,WEP,DiNapoli,1
+Jefferson,Elllisburg 2,Comptroller,,REF,DiNapoli,1
+Jefferson,Elllisburg 2,Comptroller,,LIB,Gallaudet,1
+Jefferson,Elllisburg 2,Comptroller,,,Write-ins,1
+Jefferson,Ellisburg 3,Comptroller,,DEM,DiNapoli,0
+Jefferson,Ellisburg 3,Comptroller,,REP,Trichter,0
+Jefferson,Ellisburg 3,Comptroller,,CON,Trichter,0
+Jefferson,Ellisburg 3,Comptroller,,GRE,Dunlea,0
+Jefferson,Ellisburg 3,Comptroller,,WF,DiNapoli,0
+Jefferson,Ellisburg 3,Comptroller,,IND,DiNapoli,0
+Jefferson,Ellisburg 3,Comptroller,,WEP,DiNapoli,0
+Jefferson,Ellisburg 3,Comptroller,,REF,DiNapoli,0
+Jefferson,Ellisburg 3,Comptroller,,LIB,Gallaudet,0
+Jefferson,Ellisburg 3,Comptroller,,,Write-ins,0
+Jefferson,Ellisburg 4,Comptroller,,DEM,DiNapoli,1
+Jefferson,Ellisburg 4,Comptroller,,REP,Trichter,1
+Jefferson,Ellisburg 4,Comptroller,,CON,Trichter,1
+Jefferson,Ellisburg 4,Comptroller,,GRE,Dunlea,1
+Jefferson,Ellisburg 4,Comptroller,,WF,DiNapoli,1
+Jefferson,Ellisburg 4,Comptroller,,IND,DiNapoli,1
+Jefferson,Ellisburg 4,Comptroller,,WEP,DiNapoli,1
+Jefferson,Ellisburg 4,Comptroller,,REF,DiNapoli,1
+Jefferson,Ellisburg 4,Comptroller,,LIB,Gallaudet,1
+Jefferson,Ellisburg 4,Comptroller,,,Write-ins,1
+Jefferson,Henderson 1,Comptroller,,DEM,DiNapoli,3
+Jefferson,Henderson 1,Comptroller,,REP,Trichter,3
+Jefferson,Henderson 1,Comptroller,,CON,Trichter,3
+Jefferson,Henderson 1,Comptroller,,GRE,Dunlea,3
+Jefferson,Henderson 1,Comptroller,,WF,DiNapoli,3
+Jefferson,Henderson 1,Comptroller,,IND,DiNapoli,3
+Jefferson,Henderson 1,Comptroller,,WEP,DiNapoli,3
+Jefferson,Henderson 1,Comptroller,,REF,DiNapoli,3
+Jefferson,Henderson 1,Comptroller,,LIB,Gallaudet,3
+Jefferson,Henderson 1,Comptroller,,,Write-ins,3
+Jefferson,Hounsfield 1,Comptroller,,DEM,DiNapoli,1
+Jefferson,Hounsfield 1,Comptroller,,REP,Trichter,1
+Jefferson,Hounsfield 1,Comptroller,,CON,Trichter,1
+Jefferson,Hounsfield 1,Comptroller,,GRE,Dunlea,1
+Jefferson,Hounsfield 1,Comptroller,,WF,DiNapoli,1
+Jefferson,Hounsfield 1,Comptroller,,IND,DiNapoli,1
+Jefferson,Hounsfield 1,Comptroller,,WEP,DiNapoli,1
+Jefferson,Hounsfield 1,Comptroller,,REF,DiNapoli,1
+Jefferson,Hounsfield 1,Comptroller,,LIB,Gallaudet,1
+Jefferson,Hounsfield 1,Comptroller,,,Write-ins,1
+Jefferson,Hounsfield 2,Comptroller,,DEM,DiNapoli,0
+Jefferson,Hounsfield 2,Comptroller,,REP,Trichter,0
+Jefferson,Hounsfield 2,Comptroller,,CON,Trichter,0
+Jefferson,Hounsfield 2,Comptroller,,GRE,Dunlea,0
+Jefferson,Hounsfield 2,Comptroller,,WF,DiNapoli,0
+Jefferson,Hounsfield 2,Comptroller,,IND,DiNapoli,0
+Jefferson,Hounsfield 2,Comptroller,,WEP,DiNapoli,0
+Jefferson,Hounsfield 2,Comptroller,,REF,DiNapoli,0
+Jefferson,Hounsfield 2,Comptroller,,LIB,Gallaudet,0
+Jefferson,Hounsfield 2,Comptroller,,,Write-ins,0
+Jefferson,LeRay 1,Comptroller,,DEM,DiNapoli,0
+Jefferson,LeRay 1,Comptroller,,REP,Trichter,0
+Jefferson,LeRay 1,Comptroller,,CON,Trichter,0
+Jefferson,LeRay 1,Comptroller,,GRE,Dunlea,0
+Jefferson,LeRay 1,Comptroller,,WF,DiNapoli,0
+Jefferson,LeRay 1,Comptroller,,IND,DiNapoli,0
+Jefferson,LeRay 1,Comptroller,,WEP,DiNapoli,0
+Jefferson,LeRay 1,Comptroller,,REF,DiNapoli,0
+Jefferson,LeRay 1,Comptroller,,LIB,Gallaudet,0
+Jefferson,LeRay 1,Comptroller,,,Write-ins,0
+Jefferson,LeRay 2,Comptroller,,DEM,DiNapoli,1
+Jefferson,LeRay 2,Comptroller,,REP,Trichter,1
+Jefferson,LeRay 2,Comptroller,,CON,Trichter,1
+Jefferson,LeRay 2,Comptroller,,GRE,Dunlea,1
+Jefferson,LeRay 2,Comptroller,,WF,DiNapoli,1
+Jefferson,LeRay 2,Comptroller,,IND,DiNapoli,1
+Jefferson,LeRay 2,Comptroller,,WEP,DiNapoli,1
+Jefferson,LeRay 2,Comptroller,,REF,DiNapoli,1
+Jefferson,LeRay 2,Comptroller,,LIB,Gallaudet,1
+Jefferson,LeRay 2,Comptroller,,,Write-ins,1
+Jefferson,LeRay 3,Comptroller,,DEM,DiNapoli,1
+Jefferson,LeRay 3,Comptroller,,REP,Trichter,1
+Jefferson,LeRay 3,Comptroller,,CON,Trichter,1
+Jefferson,LeRay 3,Comptroller,,GRE,Dunlea,1
+Jefferson,LeRay 3,Comptroller,,WF,DiNapoli,1
+Jefferson,LeRay 3,Comptroller,,IND,DiNapoli,1
+Jefferson,LeRay 3,Comptroller,,WEP,DiNapoli,1
+Jefferson,LeRay 3,Comptroller,,REF,DiNapoli,1
+Jefferson,LeRay 3,Comptroller,,LIB,Gallaudet,1
+Jefferson,LeRay 3,Comptroller,,,Write-ins,1
+Jefferson,LeRay 4,Comptroller,,DEM,DiNapoli,0
+Jefferson,LeRay 4,Comptroller,,REP,Trichter,0
+Jefferson,LeRay 4,Comptroller,,CON,Trichter,0
+Jefferson,LeRay 4,Comptroller,,GRE,Dunlea,0
+Jefferson,LeRay 4,Comptroller,,WF,DiNapoli,0
+Jefferson,LeRay 4,Comptroller,,IND,DiNapoli,0
+Jefferson,LeRay 4,Comptroller,,WEP,DiNapoli,0
+Jefferson,LeRay 4,Comptroller,,REF,DiNapoli,0
+Jefferson,LeRay 4,Comptroller,,LIB,Gallaudet,0
+Jefferson,LeRay 4,Comptroller,,,Write-ins,0
+Jefferson,LeRay 5,Comptroller,,DEM,DiNapoli,1
+Jefferson,LeRay 5,Comptroller,,REP,Trichter,1
+Jefferson,LeRay 5,Comptroller,,CON,Trichter,1
+Jefferson,LeRay 5,Comptroller,,GRE,Dunlea,1
+Jefferson,LeRay 5,Comptroller,,WF,DiNapoli,1
+Jefferson,LeRay 5,Comptroller,,IND,DiNapoli,1
+Jefferson,LeRay 5,Comptroller,,WEP,DiNapoli,1
+Jefferson,LeRay 5,Comptroller,,REF,DiNapoli,1
+Jefferson,LeRay 5,Comptroller,,LIB,Gallaudet,1
+Jefferson,LeRay 5,Comptroller,,,Write-ins,1
+Jefferson,LeRay 6,Comptroller,,DEM,DiNapoli,0
+Jefferson,LeRay 6,Comptroller,,REP,Trichter,0
+Jefferson,LeRay 6,Comptroller,,CON,Trichter,0
+Jefferson,LeRay 6,Comptroller,,GRE,Dunlea,0
+Jefferson,LeRay 6,Comptroller,,WF,DiNapoli,0
+Jefferson,LeRay 6,Comptroller,,IND,DiNapoli,0
+Jefferson,LeRay 6,Comptroller,,WEP,DiNapoli,0
+Jefferson,LeRay 6,Comptroller,,REF,DiNapoli,0
+Jefferson,LeRay 6,Comptroller,,LIB,Gallaudet,0
+Jefferson,LeRay 6,Comptroller,,,Write-ins,0
+Jefferson,LeRay 7,Comptroller,,DEM,DiNapoli,0
+Jefferson,LeRay 7,Comptroller,,REP,Trichter,0
+Jefferson,LeRay 7,Comptroller,,CON,Trichter,0
+Jefferson,LeRay 7,Comptroller,,GRE,Dunlea,0
+Jefferson,LeRay 7,Comptroller,,WF,DiNapoli,0
+Jefferson,LeRay 7,Comptroller,,IND,DiNapoli,0
+Jefferson,LeRay 7,Comptroller,,WEP,DiNapoli,0
+Jefferson,LeRay 7,Comptroller,,REF,DiNapoli,0
+Jefferson,LeRay 7,Comptroller,,LIB,Gallaudet,0
+Jefferson,LeRay 7,Comptroller,,,Write-ins,0
+Jefferson,LeRay 8,Comptroller,,DEM,DiNapoli,2
+Jefferson,LeRay 8,Comptroller,,REP,Trichter,2
+Jefferson,LeRay 8,Comptroller,,CON,Trichter,2
+Jefferson,LeRay 8,Comptroller,,GRE,Dunlea,2
+Jefferson,LeRay 8,Comptroller,,WF,DiNapoli,2
+Jefferson,LeRay 8,Comptroller,,IND,DiNapoli,2
+Jefferson,LeRay 8,Comptroller,,WEP,DiNapoli,2
+Jefferson,LeRay 8,Comptroller,,REF,DiNapoli,2
+Jefferson,LeRay 8,Comptroller,,LIB,Gallaudet,2
+Jefferson,LeRay 8,Comptroller,,,Write-ins,2
+Jefferson,Lorraine 1,Comptroller,,DEM,DiNapoli,0
+Jefferson,Lorraine 1,Comptroller,,REP,Trichter,0
+Jefferson,Lorraine 1,Comptroller,,CON,Trichter,0
+Jefferson,Lorraine 1,Comptroller,,GRE,Dunlea,0
+Jefferson,Lorraine 1,Comptroller,,WF,DiNapoli,0
+Jefferson,Lorraine 1,Comptroller,,IND,DiNapoli,0
+Jefferson,Lorraine 1,Comptroller,,WEP,DiNapoli,0
+Jefferson,Lorraine 1,Comptroller,,REF,DiNapoli,0
+Jefferson,Lorraine 1,Comptroller,,LIB,Gallaudet,0
+Jefferson,Lorraine 1,Comptroller,,,Write-ins,0
+Jefferson,Lyme 1,Comptroller,,DEM,DiNapoli,0
+Jefferson,Lyme 1,Comptroller,,REP,Trichter,0
+Jefferson,Lyme 1,Comptroller,,CON,Trichter,0
+Jefferson,Lyme 1,Comptroller,,GRE,Dunlea,0
+Jefferson,Lyme 1,Comptroller,,WF,DiNapoli,0
+Jefferson,Lyme 1,Comptroller,,IND,DiNapoli,0
+Jefferson,Lyme 1,Comptroller,,WEP,DiNapoli,0
+Jefferson,Lyme 1,Comptroller,,REF,DiNapoli,0
+Jefferson,Lyme 1,Comptroller,,LIB,Gallaudet,0
+Jefferson,Lyme 1,Comptroller,,,Write-ins,0
+Jefferson,Lyme 2,Comptroller,,DEM,DiNapoli,4
+Jefferson,Lyme 2,Comptroller,,REP,Trichter,4
+Jefferson,Lyme 2,Comptroller,,CON,Trichter,4
+Jefferson,Lyme 2,Comptroller,,GRE,Dunlea,4
+Jefferson,Lyme 2,Comptroller,,WF,DiNapoli,4
+Jefferson,Lyme 2,Comptroller,,IND,DiNapoli,4
+Jefferson,Lyme 2,Comptroller,,WEP,DiNapoli,4
+Jefferson,Lyme 2,Comptroller,,REF,DiNapoli,4
+Jefferson,Lyme 2,Comptroller,,LIB,Gallaudet,4
+Jefferson,Lyme 2,Comptroller,,,Write-ins,4
+Jefferson,Lyme 3,Comptroller,,DEM,DiNapoli,1
+Jefferson,Lyme 3,Comptroller,,REP,Trichter,1
+Jefferson,Lyme 3,Comptroller,,CON,Trichter,1
+Jefferson,Lyme 3,Comptroller,,GRE,Dunlea,1
+Jefferson,Lyme 3,Comptroller,,WF,DiNapoli,1
+Jefferson,Lyme 3,Comptroller,,IND,DiNapoli,1
+Jefferson,Lyme 3,Comptroller,,WEP,DiNapoli,1
+Jefferson,Lyme 3,Comptroller,,REF,DiNapoli,1
+Jefferson,Lyme 3,Comptroller,,LIB,Gallaudet,1
+Jefferson,Lyme 3,Comptroller,,,Write-ins,1
+Jefferson,Orleans 1,Comptroller,,DEM,DiNapoli,2
+Jefferson,Orleans 1,Comptroller,,REP,Trichter,2
+Jefferson,Orleans 1,Comptroller,,CON,Trichter,2
+Jefferson,Orleans 1,Comptroller,,GRE,Dunlea,2
+Jefferson,Orleans 1,Comptroller,,WF,DiNapoli,2
+Jefferson,Orleans 1,Comptroller,,IND,DiNapoli,2
+Jefferson,Orleans 1,Comptroller,,WEP,DiNapoli,2
+Jefferson,Orleans 1,Comptroller,,REF,DiNapoli,2
+Jefferson,Orleans 1,Comptroller,,LIB,Gallaudet,2
+Jefferson,Orleans 1,Comptroller,,,Write-ins,2
+Jefferson,Orleans 2,Comptroller,,DEM,DiNapoli,1
+Jefferson,Orleans 2,Comptroller,,REP,Trichter,1
+Jefferson,Orleans 2,Comptroller,,CON,Trichter,1
+Jefferson,Orleans 2,Comptroller,,GRE,Dunlea,1
+Jefferson,Orleans 2,Comptroller,,WF,DiNapoli,1
+Jefferson,Orleans 2,Comptroller,,IND,DiNapoli,1
+Jefferson,Orleans 2,Comptroller,,WEP,DiNapoli,1
+Jefferson,Orleans 2,Comptroller,,REF,DiNapoli,1
+Jefferson,Orleans 2,Comptroller,,LIB,Gallaudet,1
+Jefferson,Orleans 2,Comptroller,,,Write-ins,1
+Jefferson,Pamelia 1,Comptroller,,DEM,DiNapoli,2
+Jefferson,Pamelia 1,Comptroller,,REP,Trichter,2
+Jefferson,Pamelia 1,Comptroller,,CON,Trichter,2
+Jefferson,Pamelia 1,Comptroller,,GRE,Dunlea,2
+Jefferson,Pamelia 1,Comptroller,,WF,DiNapoli,2
+Jefferson,Pamelia 1,Comptroller,,IND,DiNapoli,2
+Jefferson,Pamelia 1,Comptroller,,WEP,DiNapoli,2
+Jefferson,Pamelia 1,Comptroller,,REF,DiNapoli,2
+Jefferson,Pamelia 1,Comptroller,,LIB,Gallaudet,2
+Jefferson,Pamelia 1,Comptroller,,,Write-ins,2
+Jefferson,Pamelia 2,Comptroller,,DEM,DiNapoli,2
+Jefferson,Pamelia 2,Comptroller,,REP,Trichter,2
+Jefferson,Pamelia 2,Comptroller,,CON,Trichter,2
+Jefferson,Pamelia 2,Comptroller,,GRE,Dunlea,2
+Jefferson,Pamelia 2,Comptroller,,WF,DiNapoli,2
+Jefferson,Pamelia 2,Comptroller,,IND,DiNapoli,2
+Jefferson,Pamelia 2,Comptroller,,WEP,DiNapoli,2
+Jefferson,Pamelia 2,Comptroller,,REF,DiNapoli,2
+Jefferson,Pamelia 2,Comptroller,,LIB,Gallaudet,2
+Jefferson,Pamelia 2,Comptroller,,,Write-ins,2
+Jefferson,Philadelphia 1,Comptroller,,DEM,DiNapoli,2
+Jefferson,Philadelphia 1,Comptroller,,REP,Trichter,2
+Jefferson,Philadelphia 1,Comptroller,,CON,Trichter,2
+Jefferson,Philadelphia 1,Comptroller,,GRE,Dunlea,2
+Jefferson,Philadelphia 1,Comptroller,,WF,DiNapoli,2
+Jefferson,Philadelphia 1,Comptroller,,IND,DiNapoli,2
+Jefferson,Philadelphia 1,Comptroller,,WEP,DiNapoli,2
+Jefferson,Philadelphia 1,Comptroller,,REF,DiNapoli,2
+Jefferson,Philadelphia 1,Comptroller,,LIB,Gallaudet,2
+Jefferson,Philadelphia 1,Comptroller,,,Write-ins,2
+Jefferson,Philadelphia 2,Comptroller,,DEM,DiNapoli,3
+Jefferson,Philadelphia 2,Comptroller,,REP,Trichter,3
+Jefferson,Philadelphia 2,Comptroller,,CON,Trichter,3
+Jefferson,Philadelphia 2,Comptroller,,GRE,Dunlea,3
+Jefferson,Philadelphia 2,Comptroller,,WF,DiNapoli,3
+Jefferson,Philadelphia 2,Comptroller,,IND,DiNapoli,3
+Jefferson,Philadelphia 2,Comptroller,,WEP,DiNapoli,3
+Jefferson,Philadelphia 2,Comptroller,,REF,DiNapoli,3
+Jefferson,Philadelphia 2,Comptroller,,LIB,Gallaudet,3
+Jefferson,Philadelphia 2,Comptroller,,,Write-ins,3
+Jefferson,Rodman 1,Comptroller,,DEM,DiNapoli,1
+Jefferson,Rodman 1,Comptroller,,REP,Trichter,1
+Jefferson,Rodman 1,Comptroller,,CON,Trichter,1
+Jefferson,Rodman 1,Comptroller,,GRE,Dunlea,1
+Jefferson,Rodman 1,Comptroller,,WF,DiNapoli,1
+Jefferson,Rodman 1,Comptroller,,IND,DiNapoli,1
+Jefferson,Rodman 1,Comptroller,,WEP,DiNapoli,1
+Jefferson,Rodman 1,Comptroller,,REF,DiNapoli,1
+Jefferson,Rodman 1,Comptroller,,LIB,Gallaudet,1
+Jefferson,Rodman 1,Comptroller,,,Write-ins,1
+Jefferson,Rutland 1,Comptroller,,DEM,DiNapoli,0
+Jefferson,Rutland 1,Comptroller,,REP,Trichter,0
+Jefferson,Rutland 1,Comptroller,,CON,Trichter,0
+Jefferson,Rutland 1,Comptroller,,GRE,Dunlea,0
+Jefferson,Rutland 1,Comptroller,,WF,DiNapoli,0
+Jefferson,Rutland 1,Comptroller,,IND,DiNapoli,0
+Jefferson,Rutland 1,Comptroller,,WEP,DiNapoli,0
+Jefferson,Rutland 1,Comptroller,,REF,DiNapoli,0
+Jefferson,Rutland 1,Comptroller,,LIB,Gallaudet,0
+Jefferson,Rutland 1,Comptroller,,,Write-ins,0
+Jefferson,Rutland 2,Comptroller,,DEM,DiNapoli,2
+Jefferson,Rutland 2,Comptroller,,REP,Trichter,2
+Jefferson,Rutland 2,Comptroller,,CON,Trichter,2
+Jefferson,Rutland 2,Comptroller,,GRE,Dunlea,2
+Jefferson,Rutland 2,Comptroller,,WF,DiNapoli,2
+Jefferson,Rutland 2,Comptroller,,IND,DiNapoli,2
+Jefferson,Rutland 2,Comptroller,,WEP,DiNapoli,2
+Jefferson,Rutland 2,Comptroller,,REF,DiNapoli,2
+Jefferson,Rutland 2,Comptroller,,LIB,Gallaudet,2
+Jefferson,Rutland 2,Comptroller,,,Write-ins,2
+Jefferson,Rutland 3,Comptroller,,DEM,DiNapoli,1
+Jefferson,Rutland 3,Comptroller,,REP,Trichter,1
+Jefferson,Rutland 3,Comptroller,,CON,Trichter,1
+Jefferson,Rutland 3,Comptroller,,GRE,Dunlea,1
+Jefferson,Rutland 3,Comptroller,,WF,DiNapoli,1
+Jefferson,Rutland 3,Comptroller,,IND,DiNapoli,1
+Jefferson,Rutland 3,Comptroller,,WEP,DiNapoli,1
+Jefferson,Rutland 3,Comptroller,,REF,DiNapoli,1
+Jefferson,Rutland 3,Comptroller,,LIB,Gallaudet,1
+Jefferson,Rutland 3,Comptroller,,,Write-ins,1
+Jefferson,Theresa 1,Comptroller,,DEM,DiNapoli,3
+Jefferson,Theresa 1,Comptroller,,REP,Trichter,3
+Jefferson,Theresa 1,Comptroller,,CON,Trichter,3
+Jefferson,Theresa 1,Comptroller,,GRE,Dunlea,3
+Jefferson,Theresa 1,Comptroller,,WF,DiNapoli,3
+Jefferson,Theresa 1,Comptroller,,IND,DiNapoli,3
+Jefferson,Theresa 1,Comptroller,,WEP,DiNapoli,3
+Jefferson,Theresa 1,Comptroller,,REF,DiNapoli,3
+Jefferson,Theresa 1,Comptroller,,LIB,Gallaudet,3
+Jefferson,Theresa 1,Comptroller,,,Write-ins,3
+Jefferson,Watertown 1,Comptroller,,DEM,DiNapoli,0
+Jefferson,Watertown 1,Comptroller,,REP,Trichter,0
+Jefferson,Watertown 1,Comptroller,,CON,Trichter,0
+Jefferson,Watertown 1,Comptroller,,GRE,Dunlea,0
+Jefferson,Watertown 1,Comptroller,,WF,DiNapoli,0
+Jefferson,Watertown 1,Comptroller,,IND,DiNapoli,0
+Jefferson,Watertown 1,Comptroller,,WEP,DiNapoli,0
+Jefferson,Watertown 1,Comptroller,,REF,DiNapoli,0
+Jefferson,Watertown 1,Comptroller,,LIB,Gallaudet,0
+Jefferson,Watertown 1,Comptroller,,,Write-ins,0
+Jefferson,Watertown 2,Comptroller,,DEM,DiNapoli,0
+Jefferson,Watertown 2,Comptroller,,REP,Trichter,0
+Jefferson,Watertown 2,Comptroller,,CON,Trichter,0
+Jefferson,Watertown 2,Comptroller,,GRE,Dunlea,0
+Jefferson,Watertown 2,Comptroller,,WF,DiNapoli,0
+Jefferson,Watertown 2,Comptroller,,IND,DiNapoli,0
+Jefferson,Watertown 2,Comptroller,,WEP,DiNapoli,0
+Jefferson,Watertown 2,Comptroller,,REF,DiNapoli,0
+Jefferson,Watertown 2,Comptroller,,LIB,Gallaudet,0
+Jefferson,Watertown 2,Comptroller,,,Write-ins,0
+Jefferson,Wilna 1,Comptroller,,DEM,DiNapoli,2
+Jefferson,Wilna 1,Comptroller,,REP,Trichter,2
+Jefferson,Wilna 1,Comptroller,,CON,Trichter,2
+Jefferson,Wilna 1,Comptroller,,GRE,Dunlea,2
+Jefferson,Wilna 1,Comptroller,,WF,DiNapoli,2
+Jefferson,Wilna 1,Comptroller,,IND,DiNapoli,2
+Jefferson,Wilna 1,Comptroller,,WEP,DiNapoli,2
+Jefferson,Wilna 1,Comptroller,,REF,DiNapoli,2
+Jefferson,Wilna 1,Comptroller,,LIB,Gallaudet,2
+Jefferson,Wilna 1,Comptroller,,,Write-ins,2
+Jefferson,Wilna 2,Comptroller,,DEM,DiNapoli,0
+Jefferson,Wilna 2,Comptroller,,REP,Trichter,0
+Jefferson,Wilna 2,Comptroller,,CON,Trichter,0
+Jefferson,Wilna 2,Comptroller,,GRE,Dunlea,0
+Jefferson,Wilna 2,Comptroller,,WF,DiNapoli,0
+Jefferson,Wilna 2,Comptroller,,IND,DiNapoli,0
+Jefferson,Wilna 2,Comptroller,,WEP,DiNapoli,0
+Jefferson,Wilna 2,Comptroller,,REF,DiNapoli,0
+Jefferson,Wilna 2,Comptroller,,LIB,Gallaudet,0
+Jefferson,Wilna 2,Comptroller,,,Write-ins,0
+Jefferson,Wilna 3,Comptroller,,DEM,DiNapoli,0
+Jefferson,Wilna 3,Comptroller,,REP,Trichter,0
+Jefferson,Wilna 3,Comptroller,,CON,Trichter,0
+Jefferson,Wilna 3,Comptroller,,GRE,Dunlea,0
+Jefferson,Wilna 3,Comptroller,,WF,DiNapoli,0
+Jefferson,Wilna 3,Comptroller,,IND,DiNapoli,0
+Jefferson,Wilna 3,Comptroller,,WEP,DiNapoli,0
+Jefferson,Wilna 3,Comptroller,,REF,DiNapoli,0
+Jefferson,Wilna 3,Comptroller,,LIB,Gallaudet,0
+Jefferson,Wilna 3,Comptroller,,,Write-ins,0
+Jefferson,Wilna 4,Comptroller,,DEM,DiNapoli,0
+Jefferson,Wilna 4,Comptroller,,REP,Trichter,0
+Jefferson,Wilna 4,Comptroller,,CON,Trichter,0
+Jefferson,Wilna 4,Comptroller,,GRE,Dunlea,0
+Jefferson,Wilna 4,Comptroller,,WF,DiNapoli,0
+Jefferson,Wilna 4,Comptroller,,IND,DiNapoli,0
+Jefferson,Wilna 4,Comptroller,,WEP,DiNapoli,0
+Jefferson,Wilna 4,Comptroller,,REF,DiNapoli,0
+Jefferson,Wilna 4,Comptroller,,LIB,Gallaudet,0
+Jefferson,Wilna 4,Comptroller,,,Write-ins,0
+Jefferson,Wilna 5,Comptroller,,DEM,DiNapoli,3
+Jefferson,Wilna 5,Comptroller,,REP,Trichter,3
+Jefferson,Wilna 5,Comptroller,,CON,Trichter,3
+Jefferson,Wilna 5,Comptroller,,GRE,Dunlea,3
+Jefferson,Wilna 5,Comptroller,,WF,DiNapoli,3
+Jefferson,Wilna 5,Comptroller,,IND,DiNapoli,3
+Jefferson,Wilna 5,Comptroller,,WEP,DiNapoli,3
+Jefferson,Wilna 5,Comptroller,,REF,DiNapoli,3
+Jefferson,Wilna 5,Comptroller,,LIB,Gallaudet,3
+Jefferson,Wilna 5,Comptroller,,,Write-ins,3
+Jefferson,Worth 1,Comptroller,,DEM,DiNapoli,1
+Jefferson,Worth 1,Comptroller,,REP,Trichter,1
+Jefferson,Worth 1,Comptroller,,CON,Trichter,1
+Jefferson,Worth 1,Comptroller,,GRE,Dunlea,1
+Jefferson,Worth 1,Comptroller,,WF,DiNapoli,1
+Jefferson,Worth 1,Comptroller,,IND,DiNapoli,1
+Jefferson,Worth 1,Comptroller,,WEP,DiNapoli,1
+Jefferson,Worth 1,Comptroller,,REF,DiNapoli,1
+Jefferson,Worth 1,Comptroller,,LIB,Gallaudet,1
+Jefferson,Worth 1,Comptroller,,,Write-ins,1
+Jefferson,Adams 2,Attorney General,,DEM,James,1
+Jefferson,Adams 2,Attorney General,,REP,Wofford,1
+Jefferson,Adams 2,Attorney General,,CON,Wofford,1
+Jefferson,Adams 2,Attorney General,,GREEN,Sussman,1
+Jefferson,Adams 2,Attorney General,,WF,James,1
+Jefferson,Adams 2,Attorney General,,IND,James,1
+Jefferson,Adams 2,Attorney General,,REF,Sliwa,1
+Jefferson,Adams 2,Attorney General,,LIB,Garvey,1
+Jefferson,Adams 2,Attorney General,,,Write-ins,1
+Jefferson,Adams 3,Attorney General,,DEM,James,10
+Jefferson,Adams 3,Attorney General,,REP,Wofford,10
+Jefferson,Adams 3,Attorney General,,CON,Wofford,10
+Jefferson,Adams 3,Attorney General,,GREEN,Sussman,10
+Jefferson,Adams 3,Attorney General,,WF,James,10
+Jefferson,Adams 3,Attorney General,,IND,James,10
+Jefferson,Adams 3,Attorney General,,REF,Sliwa,10
+Jefferson,Adams 3,Attorney General,,LIB,Garvey,10
+Jefferson,Adams 3,Attorney General,,,Write-ins,10
+Jefferson,Alexandria 1,Attorney General,,DEM,James,5
+Jefferson,Alexandria 1,Attorney General,,REP,Wofford,5
+Jefferson,Alexandria 1,Attorney General,,CON,Wofford,5
+Jefferson,Alexandria 1,Attorney General,,GREEN,Sussman,5
+Jefferson,Alexandria 1,Attorney General,,WF,James,5
+Jefferson,Alexandria 1,Attorney General,,IND,James,5
+Jefferson,Alexandria 1,Attorney General,,REF,Sliwa,5
+Jefferson,Alexandria 1,Attorney General,,LIB,Garvey,5
+Jefferson,Alexandria 1,Attorney General,,,Write-ins,5
+Jefferson,Alexandria 2,Attorney General,,DEM,James,4
+Jefferson,Alexandria 2,Attorney General,,REP,Wofford,4
+Jefferson,Alexandria 2,Attorney General,,CON,Wofford,4
+Jefferson,Alexandria 2,Attorney General,,GREEN,Sussman,4
+Jefferson,Alexandria 2,Attorney General,,WF,James,4
+Jefferson,Alexandria 2,Attorney General,,IND,James,4
+Jefferson,Alexandria 2,Attorney General,,REF,Sliwa,4
+Jefferson,Alexandria 2,Attorney General,,LIB,Garvey,4
+Jefferson,Alexandria 2,Attorney General,,,Write-ins,4
+Jefferson,Alexandria 3,Attorney General,,DEM,James,8
+Jefferson,Alexandria 3,Attorney General,,REP,Wofford,8
+Jefferson,Alexandria 3,Attorney General,,CON,Wofford,8
+Jefferson,Alexandria 3,Attorney General,,GREEN,Sussman,8
+Jefferson,Alexandria 3,Attorney General,,WF,James,8
+Jefferson,Alexandria 3,Attorney General,,IND,James,8
+Jefferson,Alexandria 3,Attorney General,,REF,Sliwa,8
+Jefferson,Alexandria 3,Attorney General,,LIB,Garvey,8
+Jefferson,Alexandria 3,Attorney General,,,Write-ins,8
+Jefferson,Antwerp 1,Attorney General,,DEM,James,1
+Jefferson,Antwerp 1,Attorney General,,REP,Wofford,1
+Jefferson,Antwerp 1,Attorney General,,CON,Wofford,1
+Jefferson,Antwerp 1,Attorney General,,GREEN,Sussman,1
+Jefferson,Antwerp 1,Attorney General,,WF,James,1
+Jefferson,Antwerp 1,Attorney General,,IND,James,1
+Jefferson,Antwerp 1,Attorney General,,REF,Sliwa,1
+Jefferson,Antwerp 1,Attorney General,,LIB,Garvey,1
+Jefferson,Antwerp 1,Attorney General,,,Write-ins,1
+Jefferson,Antwerp 2,Attorney General,,DEM,James,3
+Jefferson,Antwerp 2,Attorney General,,REP,Wofford,3
+Jefferson,Antwerp 2,Attorney General,,CON,Wofford,3
+Jefferson,Antwerp 2,Attorney General,,GREEN,Sussman,3
+Jefferson,Antwerp 2,Attorney General,,WF,James,3
+Jefferson,Antwerp 2,Attorney General,,IND,James,3
+Jefferson,Antwerp 2,Attorney General,,REF,Sliwa,3
+Jefferson,Antwerp 2,Attorney General,,LIB,Garvey,3
+Jefferson,Antwerp 2,Attorney General,,,Write-ins,3
+Jefferson,Brownville 1,Attorney General,,DEM,James,5
+Jefferson,Brownville 1,Attorney General,,REP,Wofford,5
+Jefferson,Brownville 1,Attorney General,,CON,Wofford,5
+Jefferson,Brownville 1,Attorney General,,GREEN,Sussman,5
+Jefferson,Brownville 1,Attorney General,,WF,James,5
+Jefferson,Brownville 1,Attorney General,,IND,James,5
+Jefferson,Brownville 1,Attorney General,,REF,Sliwa,5
+Jefferson,Brownville 1,Attorney General,,LIB,Garvey,5
+Jefferson,Brownville 1,Attorney General,,,Write-ins,5
+Jefferson,Brownville 2,Attorney General,,DEM,James,4
+Jefferson,Brownville 2,Attorney General,,REP,Wofford,4
+Jefferson,Brownville 2,Attorney General,,CON,Wofford,4
+Jefferson,Brownville 2,Attorney General,,GREEN,Sussman,4
+Jefferson,Brownville 2,Attorney General,,WF,James,4
+Jefferson,Brownville 2,Attorney General,,IND,James,4
+Jefferson,Brownville 2,Attorney General,,REF,Sliwa,4
+Jefferson,Brownville 2,Attorney General,,LIB,Garvey,4
+Jefferson,Brownville 2,Attorney General,,,Write-ins,4
+Jefferson,Brownville 3,Attorney General,,DEM,James,5
+Jefferson,Brownville 3,Attorney General,,REP,Wofford,5
+Jefferson,Brownville 3,Attorney General,,CON,Wofford,5
+Jefferson,Brownville 3,Attorney General,,GREEN,Sussman,5
+Jefferson,Brownville 3,Attorney General,,WF,James,5
+Jefferson,Brownville 3,Attorney General,,IND,James,5
+Jefferson,Brownville 3,Attorney General,,REF,Sliwa,5
+Jefferson,Brownville 3,Attorney General,,LIB,Garvey,5
+Jefferson,Brownville 3,Attorney General,,,Write-ins,5
+Jefferson,Brownville 4,Attorney General,,DEM,James,4
+Jefferson,Brownville 4,Attorney General,,REP,Wofford,4
+Jefferson,Brownville 4,Attorney General,,CON,Wofford,4
+Jefferson,Brownville 4,Attorney General,,GREEN,Sussman,4
+Jefferson,Brownville 4,Attorney General,,WF,James,4
+Jefferson,Brownville 4,Attorney General,,IND,James,4
+Jefferson,Brownville 4,Attorney General,,REF,Sliwa,4
+Jefferson,Brownville 4,Attorney General,,LIB,Garvey,4
+Jefferson,Brownville 4,Attorney General,,,Write-ins,4
+Jefferson,Brownville 5,Attorney General,,DEM,James,4
+Jefferson,Brownville 5,Attorney General,,REP,Wofford,4
+Jefferson,Brownville 5,Attorney General,,CON,Wofford,4
+Jefferson,Brownville 5,Attorney General,,GREEN,Sussman,4
+Jefferson,Brownville 5,Attorney General,,WF,James,4
+Jefferson,Brownville 5,Attorney General,,IND,James,4
+Jefferson,Brownville 5,Attorney General,,REF,Sliwa,4
+Jefferson,Brownville 5,Attorney General,,LIB,Garvey,4
+Jefferson,Brownville 5,Attorney General,,,Write-ins,4
+Jefferson,Cape Vincent 1,Attorney General,,DEM,James,3
+Jefferson,Cape Vincent 1,Attorney General,,REP,Wofford,3
+Jefferson,Cape Vincent 1,Attorney General,,CON,Wofford,3
+Jefferson,Cape Vincent 1,Attorney General,,GREEN,Sussman,3
+Jefferson,Cape Vincent 1,Attorney General,,WF,James,3
+Jefferson,Cape Vincent 1,Attorney General,,IND,James,3
+Jefferson,Cape Vincent 1,Attorney General,,REF,Sliwa,3
+Jefferson,Cape Vincent 1,Attorney General,,LIB,Garvey,3
+Jefferson,Cape Vincent 1,Attorney General,,,Write-ins,3
+Jefferson,Cape Vincent 2,Attorney General,,DEM,James,4
+Jefferson,Cape Vincent 2,Attorney General,,REP,Wofford,4
+Jefferson,Cape Vincent 2,Attorney General,,CON,Wofford,4
+Jefferson,Cape Vincent 2,Attorney General,,GREEN,Sussman,4
+Jefferson,Cape Vincent 2,Attorney General,,WF,James,4
+Jefferson,Cape Vincent 2,Attorney General,,IND,James,4
+Jefferson,Cape Vincent 2,Attorney General,,REF,Sliwa,4
+Jefferson,Cape Vincent 2,Attorney General,,LIB,Garvey,4
+Jefferson,Cape Vincent 2,Attorney General,,,Write-ins,4
+Jefferson,Champion 1,Attorney General,,DEM,James,6
+Jefferson,Champion 1,Attorney General,,REP,Wofford,6
+Jefferson,Champion 1,Attorney General,,CON,Wofford,6
+Jefferson,Champion 1,Attorney General,,GREEN,Sussman,6
+Jefferson,Champion 1,Attorney General,,WF,James,6
+Jefferson,Champion 1,Attorney General,,IND,James,6
+Jefferson,Champion 1,Attorney General,,REF,Sliwa,6
+Jefferson,Champion 1,Attorney General,,LIB,Garvey,6
+Jefferson,Champion 1,Attorney General,,,Write-ins,6
+Jefferson,Champion 2,Attorney General,,DEM,James,8
+Jefferson,Champion 2,Attorney General,,REP,Wofford,8
+Jefferson,Champion 2,Attorney General,,CON,Wofford,8
+Jefferson,Champion 2,Attorney General,,GREEN,Sussman,8
+Jefferson,Champion 2,Attorney General,,WF,James,8
+Jefferson,Champion 2,Attorney General,,IND,James,8
+Jefferson,Champion 2,Attorney General,,REF,Sliwa,8
+Jefferson,Champion 2,Attorney General,,LIB,Garvey,8
+Jefferson,Champion 2,Attorney General,,,Write-ins,8
+Jefferson,Clayton 1,Attorney General,,DEM,James,7
+Jefferson,Clayton 1,Attorney General,,REP,Wofford,7
+Jefferson,Clayton 1,Attorney General,,CON,Wofford,7
+Jefferson,Clayton 1,Attorney General,,GREEN,Sussman,7
+Jefferson,Clayton 1,Attorney General,,WF,James,7
+Jefferson,Clayton 1,Attorney General,,IND,James,7
+Jefferson,Clayton 1,Attorney General,,REF,Sliwa,7
+Jefferson,Clayton 1,Attorney General,,LIB,Garvey,7
+Jefferson,Clayton 1,Attorney General,,,Write-ins,7
+Jefferson,Clayton 2,Attorney General,,DEM,James,8
+Jefferson,Clayton 2,Attorney General,,REP,Wofford,8
+Jefferson,Clayton 2,Attorney General,,CON,Wofford,8
+Jefferson,Clayton 2,Attorney General,,GREEN,Sussman,8
+Jefferson,Clayton 2,Attorney General,,WF,James,8
+Jefferson,Clayton 2,Attorney General,,IND,James,8
+Jefferson,Clayton 2,Attorney General,,REF,Sliwa,8
+Jefferson,Clayton 2,Attorney General,,LIB,Garvey,8
+Jefferson,Clayton 2,Attorney General,,,Write-ins,8
+Jefferson,Clayton 3,Attorney General,,DEM,James,8
+Jefferson,Clayton 3,Attorney General,,REP,Wofford,8
+Jefferson,Clayton 3,Attorney General,,CON,Wofford,8
+Jefferson,Clayton 3,Attorney General,,GREEN,Sussman,8
+Jefferson,Clayton 3,Attorney General,,WF,James,8
+Jefferson,Clayton 3,Attorney General,,IND,James,8
+Jefferson,Clayton 3,Attorney General,,REF,Sliwa,8
+Jefferson,Clayton 3,Attorney General,,LIB,Garvey,8
+Jefferson,Clayton 3,Attorney General,,,Write-ins,8
+Jefferson,Ellisburg 1,Attorney General,,DEM,James,0
+Jefferson,Ellisburg 1,Attorney General,,REP,Wofford,0
+Jefferson,Ellisburg 1,Attorney General,,CON,Wofford,0
+Jefferson,Ellisburg 1,Attorney General,,GREEN,Sussman,0
+Jefferson,Ellisburg 1,Attorney General,,WF,James,0
+Jefferson,Ellisburg 1,Attorney General,,IND,James,0
+Jefferson,Ellisburg 1,Attorney General,,REF,Sliwa,0
+Jefferson,Ellisburg 1,Attorney General,,LIB,Garvey,0
+Jefferson,Ellisburg 1,Attorney General,,,Write-ins,0
+Jefferson,Elllisburg 2,Attorney General,,DEM,James,5
+Jefferson,Elllisburg 2,Attorney General,,REP,Wofford,5
+Jefferson,Elllisburg 2,Attorney General,,CON,Wofford,5
+Jefferson,Elllisburg 2,Attorney General,,GREEN,Sussman,5
+Jefferson,Elllisburg 2,Attorney General,,WF,James,5
+Jefferson,Elllisburg 2,Attorney General,,IND,James,5
+Jefferson,Elllisburg 2,Attorney General,,REF,Sliwa,5
+Jefferson,Elllisburg 2,Attorney General,,LIB,Garvey,5
+Jefferson,Elllisburg 2,Attorney General,,,Write-ins,5
+Jefferson,Ellisburg 3,Attorney General,,DEM,James,0
+Jefferson,Ellisburg 3,Attorney General,,REP,Wofford,0
+Jefferson,Ellisburg 3,Attorney General,,CON,Wofford,0
+Jefferson,Ellisburg 3,Attorney General,,GREEN,Sussman,0
+Jefferson,Ellisburg 3,Attorney General,,WF,James,0
+Jefferson,Ellisburg 3,Attorney General,,IND,James,0
+Jefferson,Ellisburg 3,Attorney General,,REF,Sliwa,0
+Jefferson,Ellisburg 3,Attorney General,,LIB,Garvey,0
+Jefferson,Ellisburg 3,Attorney General,,,Write-ins,0
+Jefferson,Ellisburg 4,Attorney General,,DEM,James,5
+Jefferson,Ellisburg 4,Attorney General,,REP,Wofford,5
+Jefferson,Ellisburg 4,Attorney General,,CON,Wofford,5
+Jefferson,Ellisburg 4,Attorney General,,GREEN,Sussman,5
+Jefferson,Ellisburg 4,Attorney General,,WF,James,5
+Jefferson,Ellisburg 4,Attorney General,,IND,James,5
+Jefferson,Ellisburg 4,Attorney General,,REF,Sliwa,5
+Jefferson,Ellisburg 4,Attorney General,,LIB,Garvey,5
+Jefferson,Ellisburg 4,Attorney General,,,Write-ins,5
+Jefferson,Henderson 1,Attorney General,,DEM,James,1
+Jefferson,Henderson 1,Attorney General,,REP,Wofford,1
+Jefferson,Henderson 1,Attorney General,,CON,Wofford,1
+Jefferson,Henderson 1,Attorney General,,GREEN,Sussman,1
+Jefferson,Henderson 1,Attorney General,,WF,James,1
+Jefferson,Henderson 1,Attorney General,,IND,James,1
+Jefferson,Henderson 1,Attorney General,,REF,Sliwa,1
+Jefferson,Henderson 1,Attorney General,,LIB,Garvey,1
+Jefferson,Henderson 1,Attorney General,,,Write-ins,1
+Jefferson,Hounsfield 1,Attorney General,,DEM,James,3
+Jefferson,Hounsfield 1,Attorney General,,REP,Wofford,3
+Jefferson,Hounsfield 1,Attorney General,,CON,Wofford,3
+Jefferson,Hounsfield 1,Attorney General,,GREEN,Sussman,3
+Jefferson,Hounsfield 1,Attorney General,,WF,James,3
+Jefferson,Hounsfield 1,Attorney General,,IND,James,3
+Jefferson,Hounsfield 1,Attorney General,,REF,Sliwa,3
+Jefferson,Hounsfield 1,Attorney General,,LIB,Garvey,3
+Jefferson,Hounsfield 1,Attorney General,,,Write-ins,3
+Jefferson,Hounsfield 2,Attorney General,,DEM,James,4
+Jefferson,Hounsfield 2,Attorney General,,REP,Wofford,4
+Jefferson,Hounsfield 2,Attorney General,,CON,Wofford,4
+Jefferson,Hounsfield 2,Attorney General,,GREEN,Sussman,4
+Jefferson,Hounsfield 2,Attorney General,,WF,James,4
+Jefferson,Hounsfield 2,Attorney General,,IND,James,4
+Jefferson,Hounsfield 2,Attorney General,,REF,Sliwa,4
+Jefferson,Hounsfield 2,Attorney General,,LIB,Garvey,4
+Jefferson,Hounsfield 2,Attorney General,,,Write-ins,4
+Jefferson,LeRay 1,Attorney General,,DEM,James,1
+Jefferson,LeRay 1,Attorney General,,REP,Wofford,1
+Jefferson,LeRay 1,Attorney General,,CON,Wofford,1
+Jefferson,LeRay 1,Attorney General,,GREEN,Sussman,1
+Jefferson,LeRay 1,Attorney General,,WF,James,1
+Jefferson,LeRay 1,Attorney General,,IND,James,1
+Jefferson,LeRay 1,Attorney General,,REF,Sliwa,1
+Jefferson,LeRay 1,Attorney General,,LIB,Garvey,1
+Jefferson,LeRay 1,Attorney General,,,Write-ins,1
+Jefferson,LeRay 2,Attorney General,,DEM,James,0
+Jefferson,LeRay 2,Attorney General,,REP,Wofford,0
+Jefferson,LeRay 2,Attorney General,,CON,Wofford,0
+Jefferson,LeRay 2,Attorney General,,GREEN,Sussman,0
+Jefferson,LeRay 2,Attorney General,,WF,James,0
+Jefferson,LeRay 2,Attorney General,,IND,James,0
+Jefferson,LeRay 2,Attorney General,,REF,Sliwa,0
+Jefferson,LeRay 2,Attorney General,,LIB,Garvey,0
+Jefferson,LeRay 2,Attorney General,,,Write-ins,0
+Jefferson,LeRay 3,Attorney General,,DEM,James,2
+Jefferson,LeRay 3,Attorney General,,REP,Wofford,2
+Jefferson,LeRay 3,Attorney General,,CON,Wofford,2
+Jefferson,LeRay 3,Attorney General,,GREEN,Sussman,2
+Jefferson,LeRay 3,Attorney General,,WF,James,2
+Jefferson,LeRay 3,Attorney General,,IND,James,2
+Jefferson,LeRay 3,Attorney General,,REF,Sliwa,2
+Jefferson,LeRay 3,Attorney General,,LIB,Garvey,2
+Jefferson,LeRay 3,Attorney General,,,Write-ins,2
+Jefferson,LeRay 4,Attorney General,,DEM,James,8
+Jefferson,LeRay 4,Attorney General,,REP,Wofford,8
+Jefferson,LeRay 4,Attorney General,,CON,Wofford,8
+Jefferson,LeRay 4,Attorney General,,GREEN,Sussman,8
+Jefferson,LeRay 4,Attorney General,,WF,James,8
+Jefferson,LeRay 4,Attorney General,,IND,James,8
+Jefferson,LeRay 4,Attorney General,,REF,Sliwa,8
+Jefferson,LeRay 4,Attorney General,,LIB,Garvey,8
+Jefferson,LeRay 4,Attorney General,,,Write-ins,8
+Jefferson,LeRay 5,Attorney General,,DEM,James,1
+Jefferson,LeRay 5,Attorney General,,REP,Wofford,1
+Jefferson,LeRay 5,Attorney General,,CON,Wofford,1
+Jefferson,LeRay 5,Attorney General,,GREEN,Sussman,1
+Jefferson,LeRay 5,Attorney General,,WF,James,1
+Jefferson,LeRay 5,Attorney General,,IND,James,1
+Jefferson,LeRay 5,Attorney General,,REF,Sliwa,1
+Jefferson,LeRay 5,Attorney General,,LIB,Garvey,1
+Jefferson,LeRay 5,Attorney General,,,Write-ins,1
+Jefferson,LeRay 6,Attorney General,,DEM,James,3
+Jefferson,LeRay 6,Attorney General,,REP,Wofford,3
+Jefferson,LeRay 6,Attorney General,,CON,Wofford,3
+Jefferson,LeRay 6,Attorney General,,GREEN,Sussman,3
+Jefferson,LeRay 6,Attorney General,,WF,James,3
+Jefferson,LeRay 6,Attorney General,,IND,James,3
+Jefferson,LeRay 6,Attorney General,,REF,Sliwa,3
+Jefferson,LeRay 6,Attorney General,,LIB,Garvey,3
+Jefferson,LeRay 6,Attorney General,,,Write-ins,3
+Jefferson,LeRay 7,Attorney General,,DEM,James,0
+Jefferson,LeRay 7,Attorney General,,REP,Wofford,0
+Jefferson,LeRay 7,Attorney General,,CON,Wofford,0
+Jefferson,LeRay 7,Attorney General,,GREEN,Sussman,0
+Jefferson,LeRay 7,Attorney General,,WF,James,0
+Jefferson,LeRay 7,Attorney General,,IND,James,0
+Jefferson,LeRay 7,Attorney General,,REF,Sliwa,0
+Jefferson,LeRay 7,Attorney General,,LIB,Garvey,0
+Jefferson,LeRay 7,Attorney General,,,Write-ins,0
+Jefferson,LeRay 8,Attorney General,,DEM,James,8
+Jefferson,LeRay 8,Attorney General,,REP,Wofford,8
+Jefferson,LeRay 8,Attorney General,,CON,Wofford,8
+Jefferson,LeRay 8,Attorney General,,GREEN,Sussman,8
+Jefferson,LeRay 8,Attorney General,,WF,James,8
+Jefferson,LeRay 8,Attorney General,,IND,James,8
+Jefferson,LeRay 8,Attorney General,,REF,Sliwa,8
+Jefferson,LeRay 8,Attorney General,,LIB,Garvey,8
+Jefferson,LeRay 8,Attorney General,,,Write-ins,8
+Jefferson,Lorraine 1,Attorney General,,DEM,James,3
+Jefferson,Lorraine 1,Attorney General,,REP,Wofford,3
+Jefferson,Lorraine 1,Attorney General,,CON,Wofford,3
+Jefferson,Lorraine 1,Attorney General,,GREEN,Sussman,3
+Jefferson,Lorraine 1,Attorney General,,WF,James,3
+Jefferson,Lorraine 1,Attorney General,,IND,James,3
+Jefferson,Lorraine 1,Attorney General,,REF,Sliwa,3
+Jefferson,Lorraine 1,Attorney General,,LIB,Garvey,3
+Jefferson,Lorraine 1,Attorney General,,,Write-ins,3
+Jefferson,Lyme 1,Attorney General,,DEM,James,4
+Jefferson,Lyme 1,Attorney General,,REP,Wofford,4
+Jefferson,Lyme 1,Attorney General,,CON,Wofford,4
+Jefferson,Lyme 1,Attorney General,,GREEN,Sussman,4
+Jefferson,Lyme 1,Attorney General,,WF,James,4
+Jefferson,Lyme 1,Attorney General,,IND,James,4
+Jefferson,Lyme 1,Attorney General,,REF,Sliwa,4
+Jefferson,Lyme 1,Attorney General,,LIB,Garvey,4
+Jefferson,Lyme 1,Attorney General,,,Write-ins,4
+Jefferson,Lyme 2,Attorney General,,DEM,James,2
+Jefferson,Lyme 2,Attorney General,,REP,Wofford,2
+Jefferson,Lyme 2,Attorney General,,CON,Wofford,2
+Jefferson,Lyme 2,Attorney General,,GREEN,Sussman,2
+Jefferson,Lyme 2,Attorney General,,WF,James,2
+Jefferson,Lyme 2,Attorney General,,IND,James,2
+Jefferson,Lyme 2,Attorney General,,REF,Sliwa,2
+Jefferson,Lyme 2,Attorney General,,LIB,Garvey,2
+Jefferson,Lyme 2,Attorney General,,,Write-ins,2
+Jefferson,Lyme 3,Attorney General,,DEM,James,2
+Jefferson,Lyme 3,Attorney General,,REP,Wofford,2
+Jefferson,Lyme 3,Attorney General,,CON,Wofford,2
+Jefferson,Lyme 3,Attorney General,,GREEN,Sussman,2
+Jefferson,Lyme 3,Attorney General,,WF,James,2
+Jefferson,Lyme 3,Attorney General,,IND,James,2
+Jefferson,Lyme 3,Attorney General,,REF,Sliwa,2
+Jefferson,Lyme 3,Attorney General,,LIB,Garvey,2
+Jefferson,Lyme 3,Attorney General,,,Write-ins,2
+Jefferson,Orleans 1,Attorney General,,DEM,James,3
+Jefferson,Orleans 1,Attorney General,,REP,Wofford,3
+Jefferson,Orleans 1,Attorney General,,CON,Wofford,3
+Jefferson,Orleans 1,Attorney General,,GREEN,Sussman,3
+Jefferson,Orleans 1,Attorney General,,WF,James,3
+Jefferson,Orleans 1,Attorney General,,IND,James,3
+Jefferson,Orleans 1,Attorney General,,REF,Sliwa,3
+Jefferson,Orleans 1,Attorney General,,LIB,Garvey,3
+Jefferson,Orleans 1,Attorney General,,,Write-ins,3
+Jefferson,Orleans 2,Attorney General,,DEM,James,2
+Jefferson,Orleans 2,Attorney General,,REP,Wofford,2
+Jefferson,Orleans 2,Attorney General,,CON,Wofford,2
+Jefferson,Orleans 2,Attorney General,,GREEN,Sussman,2
+Jefferson,Orleans 2,Attorney General,,WF,James,2
+Jefferson,Orleans 2,Attorney General,,IND,James,2
+Jefferson,Orleans 2,Attorney General,,REF,Sliwa,2
+Jefferson,Orleans 2,Attorney General,,LIB,Garvey,2
+Jefferson,Orleans 2,Attorney General,,,Write-ins,2
+Jefferson,Pamelia 1,Attorney General,,DEM,James,4
+Jefferson,Pamelia 1,Attorney General,,REP,Wofford,4
+Jefferson,Pamelia 1,Attorney General,,CON,Wofford,4
+Jefferson,Pamelia 1,Attorney General,,GREEN,Sussman,4
+Jefferson,Pamelia 1,Attorney General,,WF,James,4
+Jefferson,Pamelia 1,Attorney General,,IND,James,4
+Jefferson,Pamelia 1,Attorney General,,REF,Sliwa,4
+Jefferson,Pamelia 1,Attorney General,,LIB,Garvey,4
+Jefferson,Pamelia 1,Attorney General,,,Write-ins,4
+Jefferson,Pamelia 2,Attorney General,,DEM,James,8
+Jefferson,Pamelia 2,Attorney General,,REP,Wofford,8
+Jefferson,Pamelia 2,Attorney General,,CON,Wofford,8
+Jefferson,Pamelia 2,Attorney General,,GREEN,Sussman,8
+Jefferson,Pamelia 2,Attorney General,,WF,James,8
+Jefferson,Pamelia 2,Attorney General,,IND,James,8
+Jefferson,Pamelia 2,Attorney General,,REF,Sliwa,8
+Jefferson,Pamelia 2,Attorney General,,LIB,Garvey,8
+Jefferson,Pamelia 2,Attorney General,,,Write-ins,8
+Jefferson,Philadelphia 1,Attorney General,,DEM,James,1
+Jefferson,Philadelphia 1,Attorney General,,REP,Wofford,1
+Jefferson,Philadelphia 1,Attorney General,,CON,Wofford,1
+Jefferson,Philadelphia 1,Attorney General,,GREEN,Sussman,1
+Jefferson,Philadelphia 1,Attorney General,,WF,James,1
+Jefferson,Philadelphia 1,Attorney General,,IND,James,1
+Jefferson,Philadelphia 1,Attorney General,,REF,Sliwa,1
+Jefferson,Philadelphia 1,Attorney General,,LIB,Garvey,1
+Jefferson,Philadelphia 1,Attorney General,,,Write-ins,1
+Jefferson,Philadelphia 2,Attorney General,,DEM,James,1
+Jefferson,Philadelphia 2,Attorney General,,REP,Wofford,1
+Jefferson,Philadelphia 2,Attorney General,,CON,Wofford,1
+Jefferson,Philadelphia 2,Attorney General,,GREEN,Sussman,1
+Jefferson,Philadelphia 2,Attorney General,,WF,James,1
+Jefferson,Philadelphia 2,Attorney General,,IND,James,1
+Jefferson,Philadelphia 2,Attorney General,,REF,Sliwa,1
+Jefferson,Philadelphia 2,Attorney General,,LIB,Garvey,1
+Jefferson,Philadelphia 2,Attorney General,,,Write-ins,1
+Jefferson,Rodman 1,Attorney General,,DEM,James,3
+Jefferson,Rodman 1,Attorney General,,REP,Wofford,3
+Jefferson,Rodman 1,Attorney General,,CON,Wofford,3
+Jefferson,Rodman 1,Attorney General,,GREEN,Sussman,3
+Jefferson,Rodman 1,Attorney General,,WF,James,3
+Jefferson,Rodman 1,Attorney General,,IND,James,3
+Jefferson,Rodman 1,Attorney General,,REF,Sliwa,3
+Jefferson,Rodman 1,Attorney General,,LIB,Garvey,3
+Jefferson,Rodman 1,Attorney General,,,Write-ins,3
+Jefferson,Rutland 1,Attorney General,,DEM,James,1
+Jefferson,Rutland 1,Attorney General,,REP,Wofford,1
+Jefferson,Rutland 1,Attorney General,,CON,Wofford,1
+Jefferson,Rutland 1,Attorney General,,GREEN,Sussman,1
+Jefferson,Rutland 1,Attorney General,,WF,James,1
+Jefferson,Rutland 1,Attorney General,,IND,James,1
+Jefferson,Rutland 1,Attorney General,,REF,Sliwa,1
+Jefferson,Rutland 1,Attorney General,,LIB,Garvey,1
+Jefferson,Rutland 1,Attorney General,,,Write-ins,1
+Jefferson,Rutland 2,Attorney General,,DEM,James,5
+Jefferson,Rutland 2,Attorney General,,REP,Wofford,5
+Jefferson,Rutland 2,Attorney General,,CON,Wofford,5
+Jefferson,Rutland 2,Attorney General,,GREEN,Sussman,5
+Jefferson,Rutland 2,Attorney General,,WF,James,5
+Jefferson,Rutland 2,Attorney General,,IND,James,5
+Jefferson,Rutland 2,Attorney General,,REF,Sliwa,5
+Jefferson,Rutland 2,Attorney General,,LIB,Garvey,5
+Jefferson,Rutland 2,Attorney General,,,Write-ins,5
+Jefferson,Rutland 3,Attorney General,,DEM,James,2
+Jefferson,Rutland 3,Attorney General,,REP,Wofford,2
+Jefferson,Rutland 3,Attorney General,,CON,Wofford,2
+Jefferson,Rutland 3,Attorney General,,GREEN,Sussman,2
+Jefferson,Rutland 3,Attorney General,,WF,James,2
+Jefferson,Rutland 3,Attorney General,,IND,James,2
+Jefferson,Rutland 3,Attorney General,,REF,Sliwa,2
+Jefferson,Rutland 3,Attorney General,,LIB,Garvey,2
+Jefferson,Rutland 3,Attorney General,,,Write-ins,2
+Jefferson,Theresa 1,Attorney General,,DEM,James,4
+Jefferson,Theresa 1,Attorney General,,REP,Wofford,4
+Jefferson,Theresa 1,Attorney General,,CON,Wofford,4
+Jefferson,Theresa 1,Attorney General,,GREEN,Sussman,4
+Jefferson,Theresa 1,Attorney General,,WF,James,4
+Jefferson,Theresa 1,Attorney General,,IND,James,4
+Jefferson,Theresa 1,Attorney General,,REF,Sliwa,4
+Jefferson,Theresa 1,Attorney General,,LIB,Garvey,4
+Jefferson,Theresa 1,Attorney General,,,Write-ins,4
+Jefferson,Watertown 1,Attorney General,,DEM,James,3
+Jefferson,Watertown 1,Attorney General,,REP,Wofford,3
+Jefferson,Watertown 1,Attorney General,,CON,Wofford,3
+Jefferson,Watertown 1,Attorney General,,GREEN,Sussman,3
+Jefferson,Watertown 1,Attorney General,,WF,James,3
+Jefferson,Watertown 1,Attorney General,,IND,James,3
+Jefferson,Watertown 1,Attorney General,,REF,Sliwa,3
+Jefferson,Watertown 1,Attorney General,,LIB,Garvey,3
+Jefferson,Watertown 1,Attorney General,,,Write-ins,3
+Jefferson,Watertown 2,Attorney General,,DEM,James,4
+Jefferson,Watertown 2,Attorney General,,REP,Wofford,4
+Jefferson,Watertown 2,Attorney General,,CON,Wofford,4
+Jefferson,Watertown 2,Attorney General,,GREEN,Sussman,4
+Jefferson,Watertown 2,Attorney General,,WF,James,4
+Jefferson,Watertown 2,Attorney General,,IND,James,4
+Jefferson,Watertown 2,Attorney General,,REF,Sliwa,4
+Jefferson,Watertown 2,Attorney General,,LIB,Garvey,4
+Jefferson,Watertown 2,Attorney General,,,Write-ins,4
+Jefferson,Wilna 1,Attorney General,,DEM,James,10
+Jefferson,Wilna 1,Attorney General,,REP,Wofford,10
+Jefferson,Wilna 1,Attorney General,,CON,Wofford,10
+Jefferson,Wilna 1,Attorney General,,GREEN,Sussman,10
+Jefferson,Wilna 1,Attorney General,,WF,James,10
+Jefferson,Wilna 1,Attorney General,,IND,James,10
+Jefferson,Wilna 1,Attorney General,,REF,Sliwa,10
+Jefferson,Wilna 1,Attorney General,,LIB,Garvey,10
+Jefferson,Wilna 1,Attorney General,,,Write-ins,10
+Jefferson,Wilna 2,Attorney General,,DEM,James,0
+Jefferson,Wilna 2,Attorney General,,REP,Wofford,0
+Jefferson,Wilna 2,Attorney General,,CON,Wofford,0
+Jefferson,Wilna 2,Attorney General,,GREEN,Sussman,0
+Jefferson,Wilna 2,Attorney General,,WF,James,0
+Jefferson,Wilna 2,Attorney General,,IND,James,0
+Jefferson,Wilna 2,Attorney General,,REF,Sliwa,0
+Jefferson,Wilna 2,Attorney General,,LIB,Garvey,0
+Jefferson,Wilna 2,Attorney General,,,Write-ins,0
+Jefferson,Wilna 3,Attorney General,,DEM,James,4
+Jefferson,Wilna 3,Attorney General,,REP,Wofford,4
+Jefferson,Wilna 3,Attorney General,,CON,Wofford,4
+Jefferson,Wilna 3,Attorney General,,GREEN,Sussman,4
+Jefferson,Wilna 3,Attorney General,,WF,James,4
+Jefferson,Wilna 3,Attorney General,,IND,James,4
+Jefferson,Wilna 3,Attorney General,,REF,Sliwa,4
+Jefferson,Wilna 3,Attorney General,,LIB,Garvey,4
+Jefferson,Wilna 3,Attorney General,,,Write-ins,4
+Jefferson,Wilna 4,Attorney General,,DEM,James,0
+Jefferson,Wilna 4,Attorney General,,REP,Wofford,0
+Jefferson,Wilna 4,Attorney General,,CON,Wofford,0
+Jefferson,Wilna 4,Attorney General,,GREEN,Sussman,0
+Jefferson,Wilna 4,Attorney General,,WF,James,0
+Jefferson,Wilna 4,Attorney General,,IND,James,0
+Jefferson,Wilna 4,Attorney General,,REF,Sliwa,0
+Jefferson,Wilna 4,Attorney General,,LIB,Garvey,0
+Jefferson,Wilna 4,Attorney General,,,Write-ins,0
+Jefferson,Wilna 5,Attorney General,,DEM,James,4
+Jefferson,Wilna 5,Attorney General,,REP,Wofford,4
+Jefferson,Wilna 5,Attorney General,,CON,Wofford,4
+Jefferson,Wilna 5,Attorney General,,GREEN,Sussman,4
+Jefferson,Wilna 5,Attorney General,,WF,James,4
+Jefferson,Wilna 5,Attorney General,,IND,James,4
+Jefferson,Wilna 5,Attorney General,,REF,Sliwa,4
+Jefferson,Wilna 5,Attorney General,,LIB,Garvey,4
+Jefferson,Wilna 5,Attorney General,,,Write-ins,4
+Jefferson,Worth 1,Attorney General,,DEM,James,1
+Jefferson,Worth 1,Attorney General,,REP,Wofford,1
+Jefferson,Worth 1,Attorney General,,CON,Wofford,1
+Jefferson,Worth 1,Attorney General,,GREEN,Sussman,1
+Jefferson,Worth 1,Attorney General,,WF,James,1
+Jefferson,Worth 1,Attorney General,,IND,James,1
+Jefferson,Worth 1,Attorney General,,REF,Sliwa,1
+Jefferson,Worth 1,Attorney General,,LIB,Garvey,1
+Jefferson,Worth 1,Attorney General,,,Write-ins,1
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+,,,,,,
+Jefferson,Adams 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Adams 1,U.S. Senate,,REP,Farley,0
+Jefferson,Adams 1,U.S. Senate,,CON,Farley,0
+Jefferson,Adams 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Adams 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Adams 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Adams 1,U.S. Senate,,REF,Farley,0
+Jefferson,Adams 1,U.S. Senate,,,Write-ins,0
+Jefferson,Adams 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Adams 2,U.S. Senate,,REP,Farley,0
+Jefferson,Adams 2,U.S. Senate,,CON,Farley,0
+Jefferson,Adams 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Adams 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Adams 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Adams 2,U.S. Senate,,REF,Farley,0
+Jefferson,Adams 2,U.S. Senate,,,Write-ins,0
+Jefferson,Adams 3,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Adams 3,U.S. Senate,,REP,Farley,0
+Jefferson,Adams 3,U.S. Senate,,CON,Farley,0
+Jefferson,Adams 3,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Adams 3,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Adams 3,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Adams 3,U.S. Senate,,REF,Farley,0
+Jefferson,Adams 3,U.S. Senate,,,Write-ins,0
+Jefferson,Alexandria 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Alexandria 1,U.S. Senate,,REP,Farley,0
+Jefferson,Alexandria 1,U.S. Senate,,CON,Farley,0
+Jefferson,Alexandria 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Alexandria 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Alexandria 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Alexandria 1,U.S. Senate,,REF,Farley,0
+Jefferson,Alexandria 1,U.S. Senate,,,Write-ins,0
+Jefferson,Alexandria 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Alexandria 2,U.S. Senate,,REP,Farley,0
+Jefferson,Alexandria 2,U.S. Senate,,CON,Farley,0
+Jefferson,Alexandria 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Alexandria 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Alexandria 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Alexandria 2,U.S. Senate,,REF,Farley,0
+Jefferson,Alexandria 2,U.S. Senate,,,Write-ins,0
+Jefferson,Alexandria 3,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Alexandria 3,U.S. Senate,,REP,Farley,0
+Jefferson,Alexandria 3,U.S. Senate,,CON,Farley,0
+Jefferson,Alexandria 3,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Alexandria 3,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Alexandria 3,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Alexandria 3,U.S. Senate,,REF,Farley,0
+Jefferson,Alexandria 3,U.S. Senate,,,Write-ins,0
+Jefferson,Antwerp 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Antwerp 1,U.S. Senate,,REP,Farley,0
+Jefferson,Antwerp 1,U.S. Senate,,CON,Farley,0
+Jefferson,Antwerp 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Antwerp 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Antwerp 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Antwerp 1,U.S. Senate,,REF,Farley,0
+Jefferson,Antwerp 1,U.S. Senate,,,Write-ins,0
+Jefferson,Antwerp 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Antwerp 2,U.S. Senate,,REP,Farley,0
+Jefferson,Antwerp 2,U.S. Senate,,CON,Farley,0
+Jefferson,Antwerp 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Antwerp 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Antwerp 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Antwerp 2,U.S. Senate,,REF,Farley,0
+Jefferson,Antwerp 2,U.S. Senate,,,Write-ins,0
+Jefferson,Brownville 1,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,Brownville 1,U.S. Senate,,REP,Farley,1
+Jefferson,Brownville 1,U.S. Senate,,CON,Farley,1
+Jefferson,Brownville 1,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,Brownville 1,U.S. Senate,,IND,Gillibrand,1
+Jefferson,Brownville 1,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,Brownville 1,U.S. Senate,,REF,Farley,1
+Jefferson,Brownville 1,U.S. Senate,,,Write-ins,1
+Jefferson,Brownville 2,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,Brownville 2,U.S. Senate,,REP,Farley,1
+Jefferson,Brownville 2,U.S. Senate,,CON,Farley,1
+Jefferson,Brownville 2,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,Brownville 2,U.S. Senate,,IND,Gillibrand,1
+Jefferson,Brownville 2,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,Brownville 2,U.S. Senate,,REF,Farley,1
+Jefferson,Brownville 2,U.S. Senate,,,Write-ins,1
+Jefferson,Brownville 3,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Brownville 3,U.S. Senate,,REP,Farley,0
+Jefferson,Brownville 3,U.S. Senate,,CON,Farley,0
+Jefferson,Brownville 3,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Brownville 3,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Brownville 3,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Brownville 3,U.S. Senate,,REF,Farley,0
+Jefferson,Brownville 3,U.S. Senate,,,Write-ins,0
+Jefferson,Brownville 4,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Brownville 4,U.S. Senate,,REP,Farley,0
+Jefferson,Brownville 4,U.S. Senate,,CON,Farley,0
+Jefferson,Brownville 4,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Brownville 4,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Brownville 4,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Brownville 4,U.S. Senate,,REF,Farley,0
+Jefferson,Brownville 4,U.S. Senate,,,Write-ins,0
+Jefferson,Brownville 5,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Brownville 5,U.S. Senate,,REP,Farley,0
+Jefferson,Brownville 5,U.S. Senate,,CON,Farley,0
+Jefferson,Brownville 5,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Brownville 5,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Brownville 5,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Brownville 5,U.S. Senate,,REF,Farley,0
+Jefferson,Brownville 5,U.S. Senate,,,Write-ins,0
+Jefferson,Cape Vincent 1,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,Cape Vincent 1,U.S. Senate,,REP,Farley,1
+Jefferson,Cape Vincent 1,U.S. Senate,,CON,Farley,1
+Jefferson,Cape Vincent 1,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,Cape Vincent 1,U.S. Senate,,IND,Gillibrand,1
+Jefferson,Cape Vincent 1,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,Cape Vincent 1,U.S. Senate,,REF,Farley,1
+Jefferson,Cape Vincent 1,U.S. Senate,,,Write-ins,1
+Jefferson,Cape Vincent 2,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,Cape Vincent 2,U.S. Senate,,REP,Farley,1
+Jefferson,Cape Vincent 2,U.S. Senate,,CON,Farley,1
+Jefferson,Cape Vincent 2,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,Cape Vincent 2,U.S. Senate,,IND,Gillibrand,1
+Jefferson,Cape Vincent 2,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,Cape Vincent 2,U.S. Senate,,REF,Farley,1
+Jefferson,Cape Vincent 2,U.S. Senate,,,Write-ins,1
+Jefferson,Champion 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Champion 1,U.S. Senate,,REP,Farley,0
+Jefferson,Champion 1,U.S. Senate,,CON,Farley,0
+Jefferson,Champion 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Champion 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Champion 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Champion 1,U.S. Senate,,REF,Farley,0
+Jefferson,Champion 1,U.S. Senate,,,Write-ins,0
+Jefferson,Champion 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Champion 2,U.S. Senate,,REP,Farley,0
+Jefferson,Champion 2,U.S. Senate,,CON,Farley,0
+Jefferson,Champion 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Champion 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Champion 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Champion 2,U.S. Senate,,REF,Farley,0
+Jefferson,Champion 2,U.S. Senate,,,Write-ins,0
+Jefferson,Clayton 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Clayton 1,U.S. Senate,,REP,Farley,0
+Jefferson,Clayton 1,U.S. Senate,,CON,Farley,0
+Jefferson,Clayton 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Clayton 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Clayton 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Clayton 1,U.S. Senate,,REF,Farley,0
+Jefferson,Clayton 1,U.S. Senate,,,Write-ins,0
+Jefferson,Clayton 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Clayton 2,U.S. Senate,,REP,Farley,0
+Jefferson,Clayton 2,U.S. Senate,,CON,Farley,0
+Jefferson,Clayton 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Clayton 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Clayton 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Clayton 2,U.S. Senate,,REF,Farley,0
+Jefferson,Clayton 2,U.S. Senate,,,Write-ins,0
+Jefferson,Clayton 3,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Clayton 3,U.S. Senate,,REP,Farley,0
+Jefferson,Clayton 3,U.S. Senate,,CON,Farley,0
+Jefferson,Clayton 3,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Clayton 3,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Clayton 3,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Clayton 3,U.S. Senate,,REF,Farley,0
+Jefferson,Clayton 3,U.S. Senate,,,Write-ins,0
+Jefferson,Ellisburg 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Ellisburg 1,U.S. Senate,,REP,Farley,0
+Jefferson,Ellisburg 1,U.S. Senate,,CON,Farley,0
+Jefferson,Ellisburg 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Ellisburg 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Ellisburg 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Ellisburg 1,U.S. Senate,,REF,Farley,0
+Jefferson,Ellisburg 1,U.S. Senate,,,Write-ins,0
+Jefferson,Elllisburg 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Elllisburg 2,U.S. Senate,,REP,Farley,0
+Jefferson,Elllisburg 2,U.S. Senate,,CON,Farley,0
+Jefferson,Elllisburg 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Elllisburg 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Elllisburg 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Elllisburg 2,U.S. Senate,,REF,Farley,0
+Jefferson,Elllisburg 2,U.S. Senate,,,Write-ins,0
+Jefferson,Ellisburg 3,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Ellisburg 3,U.S. Senate,,REP,Farley,0
+Jefferson,Ellisburg 3,U.S. Senate,,CON,Farley,0
+Jefferson,Ellisburg 3,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Ellisburg 3,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Ellisburg 3,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Ellisburg 3,U.S. Senate,,REF,Farley,0
+Jefferson,Ellisburg 3,U.S. Senate,,,Write-ins,0
+Jefferson,Ellisburg 4,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Ellisburg 4,U.S. Senate,,REP,Farley,0
+Jefferson,Ellisburg 4,U.S. Senate,,CON,Farley,0
+Jefferson,Ellisburg 4,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Ellisburg 4,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Ellisburg 4,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Ellisburg 4,U.S. Senate,,REF,Farley,0
+Jefferson,Ellisburg 4,U.S. Senate,,,Write-ins,0
+Jefferson,Henderson 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Henderson 1,U.S. Senate,,REP,Farley,0
+Jefferson,Henderson 1,U.S. Senate,,CON,Farley,0
+Jefferson,Henderson 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Henderson 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Henderson 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Henderson 1,U.S. Senate,,REF,Farley,0
+Jefferson,Henderson 1,U.S. Senate,,,Write-ins,0
+Jefferson,Hounsfield 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Hounsfield 1,U.S. Senate,,REP,Farley,0
+Jefferson,Hounsfield 1,U.S. Senate,,CON,Farley,0
+Jefferson,Hounsfield 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Hounsfield 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Hounsfield 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Hounsfield 1,U.S. Senate,,REF,Farley,0
+Jefferson,Hounsfield 1,U.S. Senate,,,Write-ins,0
+Jefferson,Hounsfield 2,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,Hounsfield 2,U.S. Senate,,REP,Farley,1
+Jefferson,Hounsfield 2,U.S. Senate,,CON,Farley,1
+Jefferson,Hounsfield 2,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,Hounsfield 2,U.S. Senate,,IND,Gillibrand,1
+Jefferson,Hounsfield 2,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,Hounsfield 2,U.S. Senate,,REF,Farley,1
+Jefferson,Hounsfield 2,U.S. Senate,,,Write-ins,1
+Jefferson,LeRay 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,LeRay 1,U.S. Senate,,REP,Farley,0
+Jefferson,LeRay 1,U.S. Senate,,CON,Farley,0
+Jefferson,LeRay 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,LeRay 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,LeRay 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,LeRay 1,U.S. Senate,,REF,Farley,0
+Jefferson,LeRay 1,U.S. Senate,,,Write-ins,0
+Jefferson,LeRay 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,LeRay 2,U.S. Senate,,REP,Farley,0
+Jefferson,LeRay 2,U.S. Senate,,CON,Farley,0
+Jefferson,LeRay 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,LeRay 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,LeRay 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,LeRay 2,U.S. Senate,,REF,Farley,0
+Jefferson,LeRay 2,U.S. Senate,,,Write-ins,0
+Jefferson,LeRay 3,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,LeRay 3,U.S. Senate,,REP,Farley,0
+Jefferson,LeRay 3,U.S. Senate,,CON,Farley,0
+Jefferson,LeRay 3,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,LeRay 3,U.S. Senate,,IND,Gillibrand,0
+Jefferson,LeRay 3,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,LeRay 3,U.S. Senate,,REF,Farley,0
+Jefferson,LeRay 3,U.S. Senate,,,Write-ins,0
+Jefferson,LeRay 4,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,LeRay 4,U.S. Senate,,REP,Farley,1
+Jefferson,LeRay 4,U.S. Senate,,CON,Farley,1
+Jefferson,LeRay 4,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,LeRay 4,U.S. Senate,,IND,Gillibrand,1
+Jefferson,LeRay 4,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,LeRay 4,U.S. Senate,,REF,Farley,1
+Jefferson,LeRay 4,U.S. Senate,,,Write-ins,1
+Jefferson,LeRay 5,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,LeRay 5,U.S. Senate,,REP,Farley,1
+Jefferson,LeRay 5,U.S. Senate,,CON,Farley,1
+Jefferson,LeRay 5,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,LeRay 5,U.S. Senate,,IND,Gillibrand,1
+Jefferson,LeRay 5,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,LeRay 5,U.S. Senate,,REF,Farley,1
+Jefferson,LeRay 5,U.S. Senate,,,Write-ins,1
+Jefferson,LeRay 6,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,LeRay 6,U.S. Senate,,REP,Farley,0
+Jefferson,LeRay 6,U.S. Senate,,CON,Farley,0
+Jefferson,LeRay 6,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,LeRay 6,U.S. Senate,,IND,Gillibrand,0
+Jefferson,LeRay 6,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,LeRay 6,U.S. Senate,,REF,Farley,0
+Jefferson,LeRay 6,U.S. Senate,,,Write-ins,0
+Jefferson,LeRay 7,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,LeRay 7,U.S. Senate,,REP,Farley,0
+Jefferson,LeRay 7,U.S. Senate,,CON,Farley,0
+Jefferson,LeRay 7,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,LeRay 7,U.S. Senate,,IND,Gillibrand,0
+Jefferson,LeRay 7,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,LeRay 7,U.S. Senate,,REF,Farley,0
+Jefferson,LeRay 7,U.S. Senate,,,Write-ins,0
+Jefferson,LeRay 8,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,LeRay 8,U.S. Senate,,REP,Farley,0
+Jefferson,LeRay 8,U.S. Senate,,CON,Farley,0
+Jefferson,LeRay 8,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,LeRay 8,U.S. Senate,,IND,Gillibrand,0
+Jefferson,LeRay 8,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,LeRay 8,U.S. Senate,,REF,Farley,0
+Jefferson,LeRay 8,U.S. Senate,,,Write-ins,0
+Jefferson,Lorraine 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Lorraine 1,U.S. Senate,,REP,Farley,0
+Jefferson,Lorraine 1,U.S. Senate,,CON,Farley,0
+Jefferson,Lorraine 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Lorraine 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Lorraine 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Lorraine 1,U.S. Senate,,REF,Farley,0
+Jefferson,Lorraine 1,U.S. Senate,,,Write-ins,0
+Jefferson,Lyme 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Lyme 1,U.S. Senate,,REP,Farley,0
+Jefferson,Lyme 1,U.S. Senate,,CON,Farley,0
+Jefferson,Lyme 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Lyme 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Lyme 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Lyme 1,U.S. Senate,,REF,Farley,0
+Jefferson,Lyme 1,U.S. Senate,,,Write-ins,0
+Jefferson,Lyme 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Lyme 2,U.S. Senate,,REP,Farley,0
+Jefferson,Lyme 2,U.S. Senate,,CON,Farley,0
+Jefferson,Lyme 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Lyme 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Lyme 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Lyme 2,U.S. Senate,,REF,Farley,0
+Jefferson,Lyme 2,U.S. Senate,,,Write-ins,0
+Jefferson,Lyme 3,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Lyme 3,U.S. Senate,,REP,Farley,0
+Jefferson,Lyme 3,U.S. Senate,,CON,Farley,0
+Jefferson,Lyme 3,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Lyme 3,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Lyme 3,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Lyme 3,U.S. Senate,,REF,Farley,0
+Jefferson,Lyme 3,U.S. Senate,,,Write-ins,0
+Jefferson,Orleans 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Orleans 1,U.S. Senate,,REP,Farley,0
+Jefferson,Orleans 1,U.S. Senate,,CON,Farley,0
+Jefferson,Orleans 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Orleans 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Orleans 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Orleans 1,U.S. Senate,,REF,Farley,0
+Jefferson,Orleans 1,U.S. Senate,,,Write-ins,0
+Jefferson,Orleans 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Orleans 2,U.S. Senate,,REP,Farley,0
+Jefferson,Orleans 2,U.S. Senate,,CON,Farley,0
+Jefferson,Orleans 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Orleans 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Orleans 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Orleans 2,U.S. Senate,,REF,Farley,0
+Jefferson,Orleans 2,U.S. Senate,,,Write-ins,0
+Jefferson,Pamelia 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Pamelia 1,U.S. Senate,,REP,Farley,0
+Jefferson,Pamelia 1,U.S. Senate,,CON,Farley,0
+Jefferson,Pamelia 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Pamelia 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Pamelia 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Pamelia 1,U.S. Senate,,REF,Farley,0
+Jefferson,Pamelia 1,U.S. Senate,,,Write-ins,0
+Jefferson,Pamelia 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Pamelia 2,U.S. Senate,,REP,Farley,0
+Jefferson,Pamelia 2,U.S. Senate,,CON,Farley,0
+Jefferson,Pamelia 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Pamelia 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Pamelia 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Pamelia 2,U.S. Senate,,REF,Farley,0
+Jefferson,Pamelia 2,U.S. Senate,,,Write-ins,0
+Jefferson,Philadelphia 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Philadelphia 1,U.S. Senate,,REP,Farley,0
+Jefferson,Philadelphia 1,U.S. Senate,,CON,Farley,0
+Jefferson,Philadelphia 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Philadelphia 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Philadelphia 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Philadelphia 1,U.S. Senate,,REF,Farley,0
+Jefferson,Philadelphia 1,U.S. Senate,,,Write-ins,0
+Jefferson,Philadelphia 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Philadelphia 2,U.S. Senate,,REP,Farley,0
+Jefferson,Philadelphia 2,U.S. Senate,,CON,Farley,0
+Jefferson,Philadelphia 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Philadelphia 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Philadelphia 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Philadelphia 2,U.S. Senate,,REF,Farley,0
+Jefferson,Philadelphia 2,U.S. Senate,,,Write-ins,0
+Jefferson,Rodman 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Rodman 1,U.S. Senate,,REP,Farley,0
+Jefferson,Rodman 1,U.S. Senate,,CON,Farley,0
+Jefferson,Rodman 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Rodman 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Rodman 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Rodman 1,U.S. Senate,,REF,Farley,0
+Jefferson,Rodman 1,U.S. Senate,,,Write-ins,0
+Jefferson,Rutland 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Rutland 1,U.S. Senate,,REP,Farley,0
+Jefferson,Rutland 1,U.S. Senate,,CON,Farley,0
+Jefferson,Rutland 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Rutland 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Rutland 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Rutland 1,U.S. Senate,,REF,Farley,0
+Jefferson,Rutland 1,U.S. Senate,,,Write-ins,0
+Jefferson,Rutland 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Rutland 2,U.S. Senate,,REP,Farley,0
+Jefferson,Rutland 2,U.S. Senate,,CON,Farley,0
+Jefferson,Rutland 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Rutland 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Rutland 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Rutland 2,U.S. Senate,,REF,Farley,0
+Jefferson,Rutland 2,U.S. Senate,,,Write-ins,0
+Jefferson,Rutland 3,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,Rutland 3,U.S. Senate,,REP,Farley,1
+Jefferson,Rutland 3,U.S. Senate,,CON,Farley,1
+Jefferson,Rutland 3,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,Rutland 3,U.S. Senate,,IND,Gillibrand,1
+Jefferson,Rutland 3,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,Rutland 3,U.S. Senate,,REF,Farley,1
+Jefferson,Rutland 3,U.S. Senate,,,Write-ins,1
+Jefferson,Theresa 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Theresa 1,U.S. Senate,,REP,Farley,0
+Jefferson,Theresa 1,U.S. Senate,,CON,Farley,0
+Jefferson,Theresa 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Theresa 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Theresa 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Theresa 1,U.S. Senate,,REF,Farley,0
+Jefferson,Theresa 1,U.S. Senate,,,Write-ins,0
+Jefferson,Watertown 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Watertown 1,U.S. Senate,,REP,Farley,0
+Jefferson,Watertown 1,U.S. Senate,,CON,Farley,0
+Jefferson,Watertown 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Watertown 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Watertown 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Watertown 1,U.S. Senate,,REF,Farley,0
+Jefferson,Watertown 1,U.S. Senate,,,Write-ins,0
+Jefferson,Watertown 2,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,Watertown 2,U.S. Senate,,REP,Farley,1
+Jefferson,Watertown 2,U.S. Senate,,CON,Farley,1
+Jefferson,Watertown 2,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,Watertown 2,U.S. Senate,,IND,Gillibrand,1
+Jefferson,Watertown 2,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,Watertown 2,U.S. Senate,,REF,Farley,1
+Jefferson,Watertown 2,U.S. Senate,,,Write-ins,1
+Jefferson,Wilna 1,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,Wilna 1,U.S. Senate,,REP,Farley,1
+Jefferson,Wilna 1,U.S. Senate,,CON,Farley,1
+Jefferson,Wilna 1,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,Wilna 1,U.S. Senate,,IND,Gillibrand,1
+Jefferson,Wilna 1,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,Wilna 1,U.S. Senate,,REF,Farley,1
+Jefferson,Wilna 1,U.S. Senate,,,Write-ins,1
+Jefferson,Wilna 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Wilna 2,U.S. Senate,,REP,Farley,0
+Jefferson,Wilna 2,U.S. Senate,,CON,Farley,0
+Jefferson,Wilna 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Wilna 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Wilna 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Wilna 2,U.S. Senate,,REF,Farley,0
+Jefferson,Wilna 2,U.S. Senate,,,Write-ins,0
+Jefferson,Wilna 3,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Wilna 3,U.S. Senate,,REP,Farley,0
+Jefferson,Wilna 3,U.S. Senate,,CON,Farley,0
+Jefferson,Wilna 3,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Wilna 3,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Wilna 3,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Wilna 3,U.S. Senate,,REF,Farley,0
+Jefferson,Wilna 3,U.S. Senate,,,Write-ins,0
+Jefferson,Wilna 4,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,Wilna 4,U.S. Senate,,REP,Farley,1
+Jefferson,Wilna 4,U.S. Senate,,CON,Farley,1
+Jefferson,Wilna 4,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,Wilna 4,U.S. Senate,,IND,Gillibrand,1
+Jefferson,Wilna 4,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,Wilna 4,U.S. Senate,,REF,Farley,1
+Jefferson,Wilna 4,U.S. Senate,,,Write-ins,1
+Jefferson,Wilna 5,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Wilna 5,U.S. Senate,,REP,Farley,0
+Jefferson,Wilna 5,U.S. Senate,,CON,Farley,0
+Jefferson,Wilna 5,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Wilna 5,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Wilna 5,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Wilna 5,U.S. Senate,,REF,Farley,0
+Jefferson,Wilna 5,U.S. Senate,,,Write-ins,0
+Jefferson,Worth 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Worth 1,U.S. Senate,,REP,Farley,0
+Jefferson,Worth 1,U.S. Senate,,CON,Farley,0
+Jefferson,Worth 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Worth 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Worth 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Worth 1,U.S. Senate,,REF,Farley,0
+Jefferson,Worth 1,U.S. Senate,,,Write-ins,0
+Jefferson,Adams 1,U.S. House,21,DEM,Cobb,1
+Jefferson,Adams 1,U.S. House,21,REP,Stefanik,1
+Jefferson,Adams 1,U.S. House,21,CON,Stefanik,1
+Jefferson,Adams 1,U.S. House,21,GREEN,Kahn,1
+Jefferson,Adams 1,U.S. House,21,WF,Cobb,1
+Jefferson,Adams 1,U.S. House,21,IND,Stefanik,1
+Jefferson,Adams 1,U.S. House,21,WE,Cobb,1
+Jefferson,Adams 1,U.S. House,21,REF,Stefanik,1
+Jefferson,Adams 1,U.S. House,21,,Write-ins,1
+Jefferson,Adams 2,U.S. House,21,DEM,Cobb,1
+Jefferson,Adams 2,U.S. House,21,REP,Stefanik,1
+Jefferson,Adams 2,U.S. House,21,CON,Stefanik,1
+Jefferson,Adams 2,U.S. House,21,GREEN,Kahn,1
+Jefferson,Adams 2,U.S. House,21,WF,Cobb,1
+Jefferson,Adams 2,U.S. House,21,IND,Stefanik,1
+Jefferson,Adams 2,U.S. House,21,WE,Cobb,1
+Jefferson,Adams 2,U.S. House,21,REF,Stefanik,1
+Jefferson,Adams 2,U.S. House,21,,Write-ins,1
+Jefferson,Adams 3,U.S. House,21,DEM,Cobb,1
+Jefferson,Adams 3,U.S. House,21,REP,Stefanik,1
+Jefferson,Adams 3,U.S. House,21,CON,Stefanik,1
+Jefferson,Adams 3,U.S. House,21,GREEN,Kahn,1
+Jefferson,Adams 3,U.S. House,21,WF,Cobb,1
+Jefferson,Adams 3,U.S. House,21,IND,Stefanik,1
+Jefferson,Adams 3,U.S. House,21,WE,Cobb,1
+Jefferson,Adams 3,U.S. House,21,REF,Stefanik,1
+Jefferson,Adams 3,U.S. House,21,,Write-ins,1
+Jefferson,Alexandria 1,U.S. House,21,DEM,Cobb,3
+Jefferson,Alexandria 1,U.S. House,21,REP,Stefanik,3
+Jefferson,Alexandria 1,U.S. House,21,CON,Stefanik,3
+Jefferson,Alexandria 1,U.S. House,21,GREEN,Kahn,3
+Jefferson,Alexandria 1,U.S. House,21,WF,Cobb,3
+Jefferson,Alexandria 1,U.S. House,21,IND,Stefanik,3
+Jefferson,Alexandria 1,U.S. House,21,WE,Cobb,3
+Jefferson,Alexandria 1,U.S. House,21,REF,Stefanik,3
+Jefferson,Alexandria 1,U.S. House,21,,Write-ins,3
+Jefferson,Alexandria 2,U.S. House,21,DEM,Cobb,1
+Jefferson,Alexandria 2,U.S. House,21,REP,Stefanik,1
+Jefferson,Alexandria 2,U.S. House,21,CON,Stefanik,1
+Jefferson,Alexandria 2,U.S. House,21,GREEN,Kahn,1
+Jefferson,Alexandria 2,U.S. House,21,WF,Cobb,1
+Jefferson,Alexandria 2,U.S. House,21,IND,Stefanik,1
+Jefferson,Alexandria 2,U.S. House,21,WE,Cobb,1
+Jefferson,Alexandria 2,U.S. House,21,REF,Stefanik,1
+Jefferson,Alexandria 2,U.S. House,21,,Write-ins,1
+Jefferson,Alexandria 3,U.S. House,21,DEM,Cobb,7
+Jefferson,Alexandria 3,U.S. House,21,REP,Stefanik,7
+Jefferson,Alexandria 3,U.S. House,21,CON,Stefanik,7
+Jefferson,Alexandria 3,U.S. House,21,GREEN,Kahn,7
+Jefferson,Alexandria 3,U.S. House,21,WF,Cobb,7
+Jefferson,Alexandria 3,U.S. House,21,IND,Stefanik,7
+Jefferson,Alexandria 3,U.S. House,21,WE,Cobb,7
+Jefferson,Alexandria 3,U.S. House,21,REF,Stefanik,7
+Jefferson,Alexandria 3,U.S. House,21,,Write-ins,7
+Jefferson,Antwerp 1,U.S. House,21,DEM,Cobb,1
+Jefferson,Antwerp 1,U.S. House,21,REP,Stefanik,1
+Jefferson,Antwerp 1,U.S. House,21,CON,Stefanik,1
+Jefferson,Antwerp 1,U.S. House,21,GREEN,Kahn,1
+Jefferson,Antwerp 1,U.S. House,21,WF,Cobb,1
+Jefferson,Antwerp 1,U.S. House,21,IND,Stefanik,1
+Jefferson,Antwerp 1,U.S. House,21,WE,Cobb,1
+Jefferson,Antwerp 1,U.S. House,21,REF,Stefanik,1
+Jefferson,Antwerp 1,U.S. House,21,,Write-ins,1
+Jefferson,Antwerp 2,U.S. House,21,DEM,Cobb,3
+Jefferson,Antwerp 2,U.S. House,21,REP,Stefanik,3
+Jefferson,Antwerp 2,U.S. House,21,CON,Stefanik,3
+Jefferson,Antwerp 2,U.S. House,21,GREEN,Kahn,3
+Jefferson,Antwerp 2,U.S. House,21,WF,Cobb,3
+Jefferson,Antwerp 2,U.S. House,21,IND,Stefanik,3
+Jefferson,Antwerp 2,U.S. House,21,WE,Cobb,3
+Jefferson,Antwerp 2,U.S. House,21,REF,Stefanik,3
+Jefferson,Antwerp 2,U.S. House,21,,Write-ins,3
+Jefferson,Brownville 1,U.S. House,21,DEM,Cobb,0
+Jefferson,Brownville 1,U.S. House,21,REP,Stefanik,0
+Jefferson,Brownville 1,U.S. House,21,CON,Stefanik,0
+Jefferson,Brownville 1,U.S. House,21,GREEN,Kahn,0
+Jefferson,Brownville 1,U.S. House,21,WF,Cobb,0
+Jefferson,Brownville 1,U.S. House,21,IND,Stefanik,0
+Jefferson,Brownville 1,U.S. House,21,WE,Cobb,0
+Jefferson,Brownville 1,U.S. House,21,REF,Stefanik,0
+Jefferson,Brownville 1,U.S. House,21,,Write-ins,0
+Jefferson,Brownville 2,U.S. House,21,DEM,Cobb,2
+Jefferson,Brownville 2,U.S. House,21,REP,Stefanik,2
+Jefferson,Brownville 2,U.S. House,21,CON,Stefanik,2
+Jefferson,Brownville 2,U.S. House,21,GREEN,Kahn,2
+Jefferson,Brownville 2,U.S. House,21,WF,Cobb,2
+Jefferson,Brownville 2,U.S. House,21,IND,Stefanik,2
+Jefferson,Brownville 2,U.S. House,21,WE,Cobb,2
+Jefferson,Brownville 2,U.S. House,21,REF,Stefanik,2
+Jefferson,Brownville 2,U.S. House,21,,Write-ins,2
+Jefferson,Brownville 3,U.S. House,21,DEM,Cobb,0
+Jefferson,Brownville 3,U.S. House,21,REP,Stefanik,0
+Jefferson,Brownville 3,U.S. House,21,CON,Stefanik,0
+Jefferson,Brownville 3,U.S. House,21,GREEN,Kahn,0
+Jefferson,Brownville 3,U.S. House,21,WF,Cobb,0
+Jefferson,Brownville 3,U.S. House,21,IND,Stefanik,0
+Jefferson,Brownville 3,U.S. House,21,WE,Cobb,0
+Jefferson,Brownville 3,U.S. House,21,REF,Stefanik,0
+Jefferson,Brownville 3,U.S. House,21,,Write-ins,0
+Jefferson,Brownville 4,U.S. House,21,DEM,Cobb,0
+Jefferson,Brownville 4,U.S. House,21,REP,Stefanik,0
+Jefferson,Brownville 4,U.S. House,21,CON,Stefanik,0
+Jefferson,Brownville 4,U.S. House,21,GREEN,Kahn,0
+Jefferson,Brownville 4,U.S. House,21,WF,Cobb,0
+Jefferson,Brownville 4,U.S. House,21,IND,Stefanik,0
+Jefferson,Brownville 4,U.S. House,21,WE,Cobb,0
+Jefferson,Brownville 4,U.S. House,21,REF,Stefanik,0
+Jefferson,Brownville 4,U.S. House,21,,Write-ins,0
+Jefferson,Brownville 5,U.S. House,21,DEM,Cobb,0
+Jefferson,Brownville 5,U.S. House,21,REP,Stefanik,0
+Jefferson,Brownville 5,U.S. House,21,CON,Stefanik,0
+Jefferson,Brownville 5,U.S. House,21,GREEN,Kahn,0
+Jefferson,Brownville 5,U.S. House,21,WF,Cobb,0
+Jefferson,Brownville 5,U.S. House,21,IND,Stefanik,0
+Jefferson,Brownville 5,U.S. House,21,WE,Cobb,0
+Jefferson,Brownville 5,U.S. House,21,REF,Stefanik,0
+Jefferson,Brownville 5,U.S. House,21,,Write-ins,0
+Jefferson,Cape Vincent 1,U.S. House,21,DEM,Cobb,2
+Jefferson,Cape Vincent 1,U.S. House,21,REP,Stefanik,2
+Jefferson,Cape Vincent 1,U.S. House,21,CON,Stefanik,2
+Jefferson,Cape Vincent 1,U.S. House,21,GREEN,Kahn,2
+Jefferson,Cape Vincent 1,U.S. House,21,WF,Cobb,2
+Jefferson,Cape Vincent 1,U.S. House,21,IND,Stefanik,2
+Jefferson,Cape Vincent 1,U.S. House,21,WE,Cobb,2
+Jefferson,Cape Vincent 1,U.S. House,21,REF,Stefanik,2
+Jefferson,Cape Vincent 1,U.S. House,21,,Write-ins,2
+Jefferson,Cape Vincent 2,U.S. House,21,DEM,Cobb,3
+Jefferson,Cape Vincent 2,U.S. House,21,REP,Stefanik,3
+Jefferson,Cape Vincent 2,U.S. House,21,CON,Stefanik,3
+Jefferson,Cape Vincent 2,U.S. House,21,GREEN,Kahn,3
+Jefferson,Cape Vincent 2,U.S. House,21,WF,Cobb,3
+Jefferson,Cape Vincent 2,U.S. House,21,IND,Stefanik,3
+Jefferson,Cape Vincent 2,U.S. House,21,WE,Cobb,3
+Jefferson,Cape Vincent 2,U.S. House,21,REF,Stefanik,3
+Jefferson,Cape Vincent 2,U.S. House,21,,Write-ins,3
+Jefferson,Champion 1,U.S. House,21,DEM,Cobb,3
+Jefferson,Champion 1,U.S. House,21,REP,Stefanik,3
+Jefferson,Champion 1,U.S. House,21,CON,Stefanik,3
+Jefferson,Champion 1,U.S. House,21,GREEN,Kahn,3
+Jefferson,Champion 1,U.S. House,21,WF,Cobb,3
+Jefferson,Champion 1,U.S. House,21,IND,Stefanik,3
+Jefferson,Champion 1,U.S. House,21,WE,Cobb,3
+Jefferson,Champion 1,U.S. House,21,REF,Stefanik,3
+Jefferson,Champion 1,U.S. House,21,,Write-ins,3
+Jefferson,Champion 2,U.S. House,21,DEM,Cobb,2
+Jefferson,Champion 2,U.S. House,21,REP,Stefanik,2
+Jefferson,Champion 2,U.S. House,21,CON,Stefanik,2
+Jefferson,Champion 2,U.S. House,21,GREEN,Kahn,2
+Jefferson,Champion 2,U.S. House,21,WF,Cobb,2
+Jefferson,Champion 2,U.S. House,21,IND,Stefanik,2
+Jefferson,Champion 2,U.S. House,21,WE,Cobb,2
+Jefferson,Champion 2,U.S. House,21,REF,Stefanik,2
+Jefferson,Champion 2,U.S. House,21,,Write-ins,2
+Jefferson,Clayton 1,U.S. House,21,DEM,Cobb,0
+Jefferson,Clayton 1,U.S. House,21,REP,Stefanik,0
+Jefferson,Clayton 1,U.S. House,21,CON,Stefanik,0
+Jefferson,Clayton 1,U.S. House,21,GREEN,Kahn,0
+Jefferson,Clayton 1,U.S. House,21,WF,Cobb,0
+Jefferson,Clayton 1,U.S. House,21,IND,Stefanik,0
+Jefferson,Clayton 1,U.S. House,21,WE,Cobb,0
+Jefferson,Clayton 1,U.S. House,21,REF,Stefanik,0
+Jefferson,Clayton 1,U.S. House,21,,Write-ins,0
+Jefferson,Clayton 2,U.S. House,21,DEM,Cobb,0
+Jefferson,Clayton 2,U.S. House,21,REP,Stefanik,0
+Jefferson,Clayton 2,U.S. House,21,CON,Stefanik,0
+Jefferson,Clayton 2,U.S. House,21,GREEN,Kahn,0
+Jefferson,Clayton 2,U.S. House,21,WF,Cobb,0
+Jefferson,Clayton 2,U.S. House,21,IND,Stefanik,0
+Jefferson,Clayton 2,U.S. House,21,WE,Cobb,0
+Jefferson,Clayton 2,U.S. House,21,REF,Stefanik,0
+Jefferson,Clayton 2,U.S. House,21,,Write-ins,0
+Jefferson,Clayton 3,U.S. House,21,DEM,Cobb,3
+Jefferson,Clayton 3,U.S. House,21,REP,Stefanik,3
+Jefferson,Clayton 3,U.S. House,21,CON,Stefanik,3
+Jefferson,Clayton 3,U.S. House,21,GREEN,Kahn,3
+Jefferson,Clayton 3,U.S. House,21,WF,Cobb,3
+Jefferson,Clayton 3,U.S. House,21,IND,Stefanik,3
+Jefferson,Clayton 3,U.S. House,21,WE,Cobb,3
+Jefferson,Clayton 3,U.S. House,21,REF,Stefanik,3
+Jefferson,Clayton 3,U.S. House,21,,Write-ins,3
+Jefferson,Ellisburg 1,U.S. House,21,DEM,Cobb,0
+Jefferson,Ellisburg 1,U.S. House,21,REP,Stefanik,0
+Jefferson,Ellisburg 1,U.S. House,21,CON,Stefanik,0
+Jefferson,Ellisburg 1,U.S. House,21,GREEN,Kahn,0
+Jefferson,Ellisburg 1,U.S. House,21,WF,Cobb,0
+Jefferson,Ellisburg 1,U.S. House,21,IND,Stefanik,0
+Jefferson,Ellisburg 1,U.S. House,21,WE,Cobb,0
+Jefferson,Ellisburg 1,U.S. House,21,REF,Stefanik,0
+Jefferson,Ellisburg 1,U.S. House,21,,Write-ins,0
+Jefferson,Elllisburg 2,U.S. House,21,DEM,Cobb,0
+Jefferson,Elllisburg 2,U.S. House,21,REP,Stefanik,0
+Jefferson,Elllisburg 2,U.S. House,21,CON,Stefanik,0
+Jefferson,Elllisburg 2,U.S. House,21,GREEN,Kahn,0
+Jefferson,Elllisburg 2,U.S. House,21,WF,Cobb,0
+Jefferson,Elllisburg 2,U.S. House,21,IND,Stefanik,0
+Jefferson,Elllisburg 2,U.S. House,21,WE,Cobb,0
+Jefferson,Elllisburg 2,U.S. House,21,REF,Stefanik,0
+Jefferson,Elllisburg 2,U.S. House,21,,Write-ins,0
+Jefferson,Ellisburg 3,U.S. House,21,DEM,Cobb,0
+Jefferson,Ellisburg 3,U.S. House,21,REP,Stefanik,0
+Jefferson,Ellisburg 3,U.S. House,21,CON,Stefanik,0
+Jefferson,Ellisburg 3,U.S. House,21,GREEN,Kahn,0
+Jefferson,Ellisburg 3,U.S. House,21,WF,Cobb,0
+Jefferson,Ellisburg 3,U.S. House,21,IND,Stefanik,0
+Jefferson,Ellisburg 3,U.S. House,21,WE,Cobb,0
+Jefferson,Ellisburg 3,U.S. House,21,REF,Stefanik,0
+Jefferson,Ellisburg 3,U.S. House,21,,Write-ins,0
+Jefferson,Ellisburg 4,U.S. House,21,DEM,Cobb,1
+Jefferson,Ellisburg 4,U.S. House,21,REP,Stefanik,1
+Jefferson,Ellisburg 4,U.S. House,21,CON,Stefanik,1
+Jefferson,Ellisburg 4,U.S. House,21,GREEN,Kahn,1
+Jefferson,Ellisburg 4,U.S. House,21,WF,Cobb,1
+Jefferson,Ellisburg 4,U.S. House,21,IND,Stefanik,1
+Jefferson,Ellisburg 4,U.S. House,21,WE,Cobb,1
+Jefferson,Ellisburg 4,U.S. House,21,REF,Stefanik,1
+Jefferson,Ellisburg 4,U.S. House,21,,Write-ins,1
+Jefferson,Henderson 1,U.S. House,21,DEM,Cobb,3
+Jefferson,Henderson 1,U.S. House,21,REP,Stefanik,3
+Jefferson,Henderson 1,U.S. House,21,CON,Stefanik,3
+Jefferson,Henderson 1,U.S. House,21,GREEN,Kahn,3
+Jefferson,Henderson 1,U.S. House,21,WF,Cobb,3
+Jefferson,Henderson 1,U.S. House,21,IND,Stefanik,3
+Jefferson,Henderson 1,U.S. House,21,WE,Cobb,3
+Jefferson,Henderson 1,U.S. House,21,REF,Stefanik,3
+Jefferson,Henderson 1,U.S. House,21,,Write-ins,3
+Jefferson,Hounsfield 1,U.S. House,21,DEM,Cobb,2
+Jefferson,Hounsfield 1,U.S. House,21,REP,Stefanik,2
+Jefferson,Hounsfield 1,U.S. House,21,CON,Stefanik,2
+Jefferson,Hounsfield 1,U.S. House,21,GREEN,Kahn,2
+Jefferson,Hounsfield 1,U.S. House,21,WF,Cobb,2
+Jefferson,Hounsfield 1,U.S. House,21,IND,Stefanik,2
+Jefferson,Hounsfield 1,U.S. House,21,WE,Cobb,2
+Jefferson,Hounsfield 1,U.S. House,21,REF,Stefanik,2
+Jefferson,Hounsfield 1,U.S. House,21,,Write-ins,2
+Jefferson,Hounsfield 2,U.S. House,21,DEM,Cobb,0
+Jefferson,Hounsfield 2,U.S. House,21,REP,Stefanik,0
+Jefferson,Hounsfield 2,U.S. House,21,CON,Stefanik,0
+Jefferson,Hounsfield 2,U.S. House,21,GREEN,Kahn,0
+Jefferson,Hounsfield 2,U.S. House,21,WF,Cobb,0
+Jefferson,Hounsfield 2,U.S. House,21,IND,Stefanik,0
+Jefferson,Hounsfield 2,U.S. House,21,WE,Cobb,0
+Jefferson,Hounsfield 2,U.S. House,21,REF,Stefanik,0
+Jefferson,Hounsfield 2,U.S. House,21,,Write-ins,0
+Jefferson,LeRay 1,U.S. House,21,DEM,Cobb,1
+Jefferson,LeRay 1,U.S. House,21,REP,Stefanik,1
+Jefferson,LeRay 1,U.S. House,21,CON,Stefanik,1
+Jefferson,LeRay 1,U.S. House,21,GREEN,Kahn,1
+Jefferson,LeRay 1,U.S. House,21,WF,Cobb,1
+Jefferson,LeRay 1,U.S. House,21,IND,Stefanik,1
+Jefferson,LeRay 1,U.S. House,21,WE,Cobb,1
+Jefferson,LeRay 1,U.S. House,21,REF,Stefanik,1
+Jefferson,LeRay 1,U.S. House,21,,Write-ins,1
+Jefferson,LeRay 2,U.S. House,21,DEM,Cobb,0
+Jefferson,LeRay 2,U.S. House,21,REP,Stefanik,0
+Jefferson,LeRay 2,U.S. House,21,CON,Stefanik,0
+Jefferson,LeRay 2,U.S. House,21,GREEN,Kahn,0
+Jefferson,LeRay 2,U.S. House,21,WF,Cobb,0
+Jefferson,LeRay 2,U.S. House,21,IND,Stefanik,0
+Jefferson,LeRay 2,U.S. House,21,WE,Cobb,0
+Jefferson,LeRay 2,U.S. House,21,REF,Stefanik,0
+Jefferson,LeRay 2,U.S. House,21,,Write-ins,0
+Jefferson,LeRay 3,U.S. House,21,DEM,Cobb,0
+Jefferson,LeRay 3,U.S. House,21,REP,Stefanik,0
+Jefferson,LeRay 3,U.S. House,21,CON,Stefanik,0
+Jefferson,LeRay 3,U.S. House,21,GREEN,Kahn,0
+Jefferson,LeRay 3,U.S. House,21,WF,Cobb,0
+Jefferson,LeRay 3,U.S. House,21,IND,Stefanik,0
+Jefferson,LeRay 3,U.S. House,21,WE,Cobb,0
+Jefferson,LeRay 3,U.S. House,21,REF,Stefanik,0
+Jefferson,LeRay 3,U.S. House,21,,Write-ins,0
+Jefferson,LeRay 4,U.S. House,21,DEM,Cobb,0
+Jefferson,LeRay 4,U.S. House,21,REP,Stefanik,0
+Jefferson,LeRay 4,U.S. House,21,CON,Stefanik,0
+Jefferson,LeRay 4,U.S. House,21,GREEN,Kahn,0
+Jefferson,LeRay 4,U.S. House,21,WF,Cobb,0
+Jefferson,LeRay 4,U.S. House,21,IND,Stefanik,0
+Jefferson,LeRay 4,U.S. House,21,WE,Cobb,0
+Jefferson,LeRay 4,U.S. House,21,REF,Stefanik,0
+Jefferson,LeRay 4,U.S. House,21,,Write-ins,0
+Jefferson,LeRay 5,U.S. House,21,DEM,Cobb,0
+Jefferson,LeRay 5,U.S. House,21,REP,Stefanik,0
+Jefferson,LeRay 5,U.S. House,21,CON,Stefanik,0
+Jefferson,LeRay 5,U.S. House,21,GREEN,Kahn,0
+Jefferson,LeRay 5,U.S. House,21,WF,Cobb,0
+Jefferson,LeRay 5,U.S. House,21,IND,Stefanik,0
+Jefferson,LeRay 5,U.S. House,21,WE,Cobb,0
+Jefferson,LeRay 5,U.S. House,21,REF,Stefanik,0
+Jefferson,LeRay 5,U.S. House,21,,Write-ins,0
+Jefferson,LeRay 6,U.S. House,21,DEM,Cobb,1
+Jefferson,LeRay 6,U.S. House,21,REP,Stefanik,1
+Jefferson,LeRay 6,U.S. House,21,CON,Stefanik,1
+Jefferson,LeRay 6,U.S. House,21,GREEN,Kahn,1
+Jefferson,LeRay 6,U.S. House,21,WF,Cobb,1
+Jefferson,LeRay 6,U.S. House,21,IND,Stefanik,1
+Jefferson,LeRay 6,U.S. House,21,WE,Cobb,1
+Jefferson,LeRay 6,U.S. House,21,REF,Stefanik,1
+Jefferson,LeRay 6,U.S. House,21,,Write-ins,1
+Jefferson,LeRay 7,U.S. House,21,DEM,Cobb,0
+Jefferson,LeRay 7,U.S. House,21,REP,Stefanik,0
+Jefferson,LeRay 7,U.S. House,21,CON,Stefanik,0
+Jefferson,LeRay 7,U.S. House,21,GREEN,Kahn,0
+Jefferson,LeRay 7,U.S. House,21,WF,Cobb,0
+Jefferson,LeRay 7,U.S. House,21,IND,Stefanik,0
+Jefferson,LeRay 7,U.S. House,21,WE,Cobb,0
+Jefferson,LeRay 7,U.S. House,21,REF,Stefanik,0
+Jefferson,LeRay 7,U.S. House,21,,Write-ins,0
+Jefferson,LeRay 8,U.S. House,21,DEM,Cobb,4
+Jefferson,LeRay 8,U.S. House,21,REP,Stefanik,4
+Jefferson,LeRay 8,U.S. House,21,CON,Stefanik,4
+Jefferson,LeRay 8,U.S. House,21,GREEN,Kahn,4
+Jefferson,LeRay 8,U.S. House,21,WF,Cobb,4
+Jefferson,LeRay 8,U.S. House,21,IND,Stefanik,4
+Jefferson,LeRay 8,U.S. House,21,WE,Cobb,4
+Jefferson,LeRay 8,U.S. House,21,REF,Stefanik,4
+Jefferson,LeRay 8,U.S. House,21,,Write-ins,4
+Jefferson,Lorraine 1,U.S. House,21,DEM,Cobb,0
+Jefferson,Lorraine 1,U.S. House,21,REP,Stefanik,0
+Jefferson,Lorraine 1,U.S. House,21,CON,Stefanik,0
+Jefferson,Lorraine 1,U.S. House,21,GREEN,Kahn,0
+Jefferson,Lorraine 1,U.S. House,21,WF,Cobb,0
+Jefferson,Lorraine 1,U.S. House,21,IND,Stefanik,0
+Jefferson,Lorraine 1,U.S. House,21,WE,Cobb,0
+Jefferson,Lorraine 1,U.S. House,21,REF,Stefanik,0
+Jefferson,Lorraine 1,U.S. House,21,,Write-ins,0
+Jefferson,Lyme 1,U.S. House,21,DEM,Cobb,2
+Jefferson,Lyme 1,U.S. House,21,REP,Stefanik,2
+Jefferson,Lyme 1,U.S. House,21,CON,Stefanik,2
+Jefferson,Lyme 1,U.S. House,21,GREEN,Kahn,2
+Jefferson,Lyme 1,U.S. House,21,WF,Cobb,2
+Jefferson,Lyme 1,U.S. House,21,IND,Stefanik,2
+Jefferson,Lyme 1,U.S. House,21,WE,Cobb,2
+Jefferson,Lyme 1,U.S. House,21,REF,Stefanik,2
+Jefferson,Lyme 1,U.S. House,21,,Write-ins,2
+Jefferson,Lyme 2,U.S. House,21,DEM,Cobb,0
+Jefferson,Lyme 2,U.S. House,21,REP,Stefanik,0
+Jefferson,Lyme 2,U.S. House,21,CON,Stefanik,0
+Jefferson,Lyme 2,U.S. House,21,GREEN,Kahn,0
+Jefferson,Lyme 2,U.S. House,21,WF,Cobb,0
+Jefferson,Lyme 2,U.S. House,21,IND,Stefanik,0
+Jefferson,Lyme 2,U.S. House,21,WE,Cobb,0
+Jefferson,Lyme 2,U.S. House,21,REF,Stefanik,0
+Jefferson,Lyme 2,U.S. House,21,,Write-ins,0
+Jefferson,Lyme 3,U.S. House,21,DEM,Cobb,0
+Jefferson,Lyme 3,U.S. House,21,REP,Stefanik,0
+Jefferson,Lyme 3,U.S. House,21,CON,Stefanik,0
+Jefferson,Lyme 3,U.S. House,21,GREEN,Kahn,0
+Jefferson,Lyme 3,U.S. House,21,WF,Cobb,0
+Jefferson,Lyme 3,U.S. House,21,IND,Stefanik,0
+Jefferson,Lyme 3,U.S. House,21,WE,Cobb,0
+Jefferson,Lyme 3,U.S. House,21,REF,Stefanik,0
+Jefferson,Lyme 3,U.S. House,21,,Write-ins,0
+Jefferson,Orleans 1,U.S. House,21,DEM,Cobb,2
+Jefferson,Orleans 1,U.S. House,21,REP,Stefanik,2
+Jefferson,Orleans 1,U.S. House,21,CON,Stefanik,2
+Jefferson,Orleans 1,U.S. House,21,GREEN,Kahn,2
+Jefferson,Orleans 1,U.S. House,21,WF,Cobb,2
+Jefferson,Orleans 1,U.S. House,21,IND,Stefanik,2
+Jefferson,Orleans 1,U.S. House,21,WE,Cobb,2
+Jefferson,Orleans 1,U.S. House,21,REF,Stefanik,2
+Jefferson,Orleans 1,U.S. House,21,,Write-ins,2
+Jefferson,Orleans 2,U.S. House,21,DEM,Cobb,1
+Jefferson,Orleans 2,U.S. House,21,REP,Stefanik,1
+Jefferson,Orleans 2,U.S. House,21,CON,Stefanik,1
+Jefferson,Orleans 2,U.S. House,21,GREEN,Kahn,1
+Jefferson,Orleans 2,U.S. House,21,WF,Cobb,1
+Jefferson,Orleans 2,U.S. House,21,IND,Stefanik,1
+Jefferson,Orleans 2,U.S. House,21,WE,Cobb,1
+Jefferson,Orleans 2,U.S. House,21,REF,Stefanik,1
+Jefferson,Orleans 2,U.S. House,21,,Write-ins,1
+Jefferson,Pamelia 1,U.S. House,21,DEM,Cobb,2
+Jefferson,Pamelia 1,U.S. House,21,REP,Stefanik,2
+Jefferson,Pamelia 1,U.S. House,21,CON,Stefanik,2
+Jefferson,Pamelia 1,U.S. House,21,GREEN,Kahn,2
+Jefferson,Pamelia 1,U.S. House,21,WF,Cobb,2
+Jefferson,Pamelia 1,U.S. House,21,IND,Stefanik,2
+Jefferson,Pamelia 1,U.S. House,21,WE,Cobb,2
+Jefferson,Pamelia 1,U.S. House,21,REF,Stefanik,2
+Jefferson,Pamelia 1,U.S. House,21,,Write-ins,2
+Jefferson,Pamelia 2,U.S. House,21,DEM,Cobb,3
+Jefferson,Pamelia 2,U.S. House,21,REP,Stefanik,3
+Jefferson,Pamelia 2,U.S. House,21,CON,Stefanik,3
+Jefferson,Pamelia 2,U.S. House,21,GREEN,Kahn,3
+Jefferson,Pamelia 2,U.S. House,21,WF,Cobb,3
+Jefferson,Pamelia 2,U.S. House,21,IND,Stefanik,3
+Jefferson,Pamelia 2,U.S. House,21,WE,Cobb,3
+Jefferson,Pamelia 2,U.S. House,21,REF,Stefanik,3
+Jefferson,Pamelia 2,U.S. House,21,,Write-ins,3
+Jefferson,Philadelphia 1,U.S. House,21,DEM,Cobb,2
+Jefferson,Philadelphia 1,U.S. House,21,REP,Stefanik,2
+Jefferson,Philadelphia 1,U.S. House,21,CON,Stefanik,2
+Jefferson,Philadelphia 1,U.S. House,21,GREEN,Kahn,2
+Jefferson,Philadelphia 1,U.S. House,21,WF,Cobb,2
+Jefferson,Philadelphia 1,U.S. House,21,IND,Stefanik,2
+Jefferson,Philadelphia 1,U.S. House,21,WE,Cobb,2
+Jefferson,Philadelphia 1,U.S. House,21,REF,Stefanik,2
+Jefferson,Philadelphia 1,U.S. House,21,,Write-ins,2
+Jefferson,Philadelphia 2,U.S. House,21,DEM,Cobb,2
+Jefferson,Philadelphia 2,U.S. House,21,REP,Stefanik,2
+Jefferson,Philadelphia 2,U.S. House,21,CON,Stefanik,2
+Jefferson,Philadelphia 2,U.S. House,21,GREEN,Kahn,2
+Jefferson,Philadelphia 2,U.S. House,21,WF,Cobb,2
+Jefferson,Philadelphia 2,U.S. House,21,IND,Stefanik,2
+Jefferson,Philadelphia 2,U.S. House,21,WE,Cobb,2
+Jefferson,Philadelphia 2,U.S. House,21,REF,Stefanik,2
+Jefferson,Philadelphia 2,U.S. House,21,,Write-ins,2
+Jefferson,Rodman 1,U.S. House,21,DEM,Cobb,2
+Jefferson,Rodman 1,U.S. House,21,REP,Stefanik,2
+Jefferson,Rodman 1,U.S. House,21,CON,Stefanik,2
+Jefferson,Rodman 1,U.S. House,21,GREEN,Kahn,2
+Jefferson,Rodman 1,U.S. House,21,WF,Cobb,2
+Jefferson,Rodman 1,U.S. House,21,IND,Stefanik,2
+Jefferson,Rodman 1,U.S. House,21,WE,Cobb,2
+Jefferson,Rodman 1,U.S. House,21,REF,Stefanik,2
+Jefferson,Rodman 1,U.S. House,21,,Write-ins,2
+Jefferson,Rutland 1,U.S. House,21,DEM,Cobb,2
+Jefferson,Rutland 1,U.S. House,21,REP,Stefanik,2
+Jefferson,Rutland 1,U.S. House,21,CON,Stefanik,2
+Jefferson,Rutland 1,U.S. House,21,GREEN,Kahn,2
+Jefferson,Rutland 1,U.S. House,21,WF,Cobb,2
+Jefferson,Rutland 1,U.S. House,21,IND,Stefanik,2
+Jefferson,Rutland 1,U.S. House,21,WE,Cobb,2
+Jefferson,Rutland 1,U.S. House,21,REF,Stefanik,2
+Jefferson,Rutland 1,U.S. House,21,,Write-ins,2
+Jefferson,Rutland 2,U.S. House,21,DEM,Cobb,2
+Jefferson,Rutland 2,U.S. House,21,REP,Stefanik,2
+Jefferson,Rutland 2,U.S. House,21,CON,Stefanik,2
+Jefferson,Rutland 2,U.S. House,21,GREEN,Kahn,2
+Jefferson,Rutland 2,U.S. House,21,WF,Cobb,2
+Jefferson,Rutland 2,U.S. House,21,IND,Stefanik,2
+Jefferson,Rutland 2,U.S. House,21,WE,Cobb,2
+Jefferson,Rutland 2,U.S. House,21,REF,Stefanik,2
+Jefferson,Rutland 2,U.S. House,21,,Write-ins,2
+Jefferson,Rutland 3,U.S. House,21,DEM,Cobb,1
+Jefferson,Rutland 3,U.S. House,21,REP,Stefanik,1
+Jefferson,Rutland 3,U.S. House,21,CON,Stefanik,1
+Jefferson,Rutland 3,U.S. House,21,GREEN,Kahn,1
+Jefferson,Rutland 3,U.S. House,21,WF,Cobb,1
+Jefferson,Rutland 3,U.S. House,21,IND,Stefanik,1
+Jefferson,Rutland 3,U.S. House,21,WE,Cobb,1
+Jefferson,Rutland 3,U.S. House,21,REF,Stefanik,1
+Jefferson,Rutland 3,U.S. House,21,,Write-ins,1
+Jefferson,Theresa 1,U.S. House,21,DEM,Cobb,2
+Jefferson,Theresa 1,U.S. House,21,REP,Stefanik,2
+Jefferson,Theresa 1,U.S. House,21,CON,Stefanik,2
+Jefferson,Theresa 1,U.S. House,21,GREEN,Kahn,2
+Jefferson,Theresa 1,U.S. House,21,WF,Cobb,2
+Jefferson,Theresa 1,U.S. House,21,IND,Stefanik,2
+Jefferson,Theresa 1,U.S. House,21,WE,Cobb,2
+Jefferson,Theresa 1,U.S. House,21,REF,Stefanik,2
+Jefferson,Theresa 1,U.S. House,21,,Write-ins,2
+Jefferson,Watertown 1,U.S. House,21,DEM,Cobb,2
+Jefferson,Watertown 1,U.S. House,21,REP,Stefanik,2
+Jefferson,Watertown 1,U.S. House,21,CON,Stefanik,2
+Jefferson,Watertown 1,U.S. House,21,GREEN,Kahn,2
+Jefferson,Watertown 1,U.S. House,21,WF,Cobb,2
+Jefferson,Watertown 1,U.S. House,21,IND,Stefanik,2
+Jefferson,Watertown 1,U.S. House,21,WE,Cobb,2
+Jefferson,Watertown 1,U.S. House,21,REF,Stefanik,2
+Jefferson,Watertown 1,U.S. House,21,,Write-ins,2
+Jefferson,Watertown 2,U.S. House,21,DEM,Cobb,1
+Jefferson,Watertown 2,U.S. House,21,REP,Stefanik,1
+Jefferson,Watertown 2,U.S. House,21,CON,Stefanik,1
+Jefferson,Watertown 2,U.S. House,21,GREEN,Kahn,1
+Jefferson,Watertown 2,U.S. House,21,WF,Cobb,1
+Jefferson,Watertown 2,U.S. House,21,IND,Stefanik,1
+Jefferson,Watertown 2,U.S. House,21,WE,Cobb,1
+Jefferson,Watertown 2,U.S. House,21,REF,Stefanik,1
+Jefferson,Watertown 2,U.S. House,21,,Write-ins,1
+Jefferson,Wilna 1,U.S. House,21,DEM,Cobb,3
+Jefferson,Wilna 1,U.S. House,21,REP,Stefanik,3
+Jefferson,Wilna 1,U.S. House,21,CON,Stefanik,3
+Jefferson,Wilna 1,U.S. House,21,GREEN,Kahn,3
+Jefferson,Wilna 1,U.S. House,21,WF,Cobb,3
+Jefferson,Wilna 1,U.S. House,21,IND,Stefanik,3
+Jefferson,Wilna 1,U.S. House,21,WE,Cobb,3
+Jefferson,Wilna 1,U.S. House,21,REF,Stefanik,3
+Jefferson,Wilna 1,U.S. House,21,,Write-ins,3
+Jefferson,Wilna 2,U.S. House,21,DEM,Cobb,0
+Jefferson,Wilna 2,U.S. House,21,REP,Stefanik,0
+Jefferson,Wilna 2,U.S. House,21,CON,Stefanik,0
+Jefferson,Wilna 2,U.S. House,21,GREEN,Kahn,0
+Jefferson,Wilna 2,U.S. House,21,WF,Cobb,0
+Jefferson,Wilna 2,U.S. House,21,IND,Stefanik,0
+Jefferson,Wilna 2,U.S. House,21,WE,Cobb,0
+Jefferson,Wilna 2,U.S. House,21,REF,Stefanik,0
+Jefferson,Wilna 2,U.S. House,21,,Write-ins,0
+Jefferson,Wilna 3,U.S. House,21,DEM,Cobb,0
+Jefferson,Wilna 3,U.S. House,21,REP,Stefanik,0
+Jefferson,Wilna 3,U.S. House,21,CON,Stefanik,0
+Jefferson,Wilna 3,U.S. House,21,GREEN,Kahn,0
+Jefferson,Wilna 3,U.S. House,21,WF,Cobb,0
+Jefferson,Wilna 3,U.S. House,21,IND,Stefanik,0
+Jefferson,Wilna 3,U.S. House,21,WE,Cobb,0
+Jefferson,Wilna 3,U.S. House,21,REF,Stefanik,0
+Jefferson,Wilna 3,U.S. House,21,,Write-ins,0
+Jefferson,Wilna 4,U.S. House,21,DEM,Cobb,2
+Jefferson,Wilna 4,U.S. House,21,REP,Stefanik,2
+Jefferson,Wilna 4,U.S. House,21,CON,Stefanik,2
+Jefferson,Wilna 4,U.S. House,21,GREEN,Kahn,2
+Jefferson,Wilna 4,U.S. House,21,WF,Cobb,2
+Jefferson,Wilna 4,U.S. House,21,IND,Stefanik,2
+Jefferson,Wilna 4,U.S. House,21,WE,Cobb,2
+Jefferson,Wilna 4,U.S. House,21,REF,Stefanik,2
+Jefferson,Wilna 4,U.S. House,21,,Write-ins,2
+Jefferson,Wilna 5,U.S. House,21,DEM,Cobb,1
+Jefferson,Wilna 5,U.S. House,21,REP,Stefanik,1
+Jefferson,Wilna 5,U.S. House,21,CON,Stefanik,1
+Jefferson,Wilna 5,U.S. House,21,GREEN,Kahn,1
+Jefferson,Wilna 5,U.S. House,21,WF,Cobb,1
+Jefferson,Wilna 5,U.S. House,21,IND,Stefanik,1
+Jefferson,Wilna 5,U.S. House,21,WE,Cobb,1
+Jefferson,Wilna 5,U.S. House,21,REF,Stefanik,1
+Jefferson,Wilna 5,U.S. House,21,,Write-ins,1
+Jefferson,Worth 1,U.S. House,21,DEM,Cobb,1
+Jefferson,Worth 1,U.S. House,21,REP,Stefanik,1
+Jefferson,Worth 1,U.S. House,21,CON,Stefanik,1
+Jefferson,Worth 1,U.S. House,21,GREEN,Kahn,1
+Jefferson,Worth 1,U.S. House,21,WF,Cobb,1
+Jefferson,Worth 1,U.S. House,21,IND,Stefanik,1
+Jefferson,Worth 1,U.S. House,21,WE,Cobb,1
+Jefferson,Worth 1,U.S. House,21,REF,Stefanik,1
+Jefferson,Worth 1,U.S. House,21,,Write-ins,1

--- a/2018/20181106__ny__general__jefferson__precinct.csv
+++ b/2018/20181106__ny__general__jefferson__precinct.csv
@@ -2310,1470 +2310,1398 @@ Jefferson,Worth 1,Attorney General,,IND,James,1
 Jefferson,Worth 1,Attorney General,,REF,Sliwa,1
 Jefferson,Worth 1,Attorney General,,LIB,Garvey,1
 Jefferson,Worth 1,Attorney General,,,Write-ins,1
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
-,,,,,,
 Jefferson,Adams 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Adams 1,Registered Voters,,,,978
+Jefferson,Adams 1,Ballots Cast,,,,507
 Jefferson,Adams 1,U.S. Senate,,REP,Farley,0
+Jefferson,Adams 1,Registered Voters,,,,978
+Jefferson,Adams 1,Ballots Cast,,,,507
 Jefferson,Adams 1,U.S. Senate,,CON,Farley,0
+Jefferson,Adams 1,Registered Voters,,,,978
+Jefferson,Adams 1,Ballots Cast,,,,507
 Jefferson,Adams 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Adams 1,Registered Voters,,,,978
+Jefferson,Adams 1,Ballots Cast,,,,507
 Jefferson,Adams 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Adams 1,Registered Voters,,,,978
+Jefferson,Adams 1,Ballots Cast,,,,507
 Jefferson,Adams 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Adams 1,Registered Voters,,,,978
+Jefferson,Adams 1,Ballots Cast,,,,507
 Jefferson,Adams 1,U.S. Senate,,REF,Farley,0
+Jefferson,Adams 1,Registered Voters,,,,978
+Jefferson,Adams 1,Ballots Cast,,,,507
 Jefferson,Adams 1,U.S. Senate,,,Write-ins,0
+Jefferson,Adams 1,Registered Voters,,,,978
+Jefferson,Adams 1,Ballots Cast,,,,507
 Jefferson,Adams 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Adams 2,Registered Voters,,,,643
+Jefferson,Adams 2,Ballots Cast,,,,371
 Jefferson,Adams 2,U.S. Senate,,REP,Farley,0
+Jefferson,Adams 2,Registered Voters,,,,643
+Jefferson,Adams 2,Ballots Cast,,,,371
 Jefferson,Adams 2,U.S. Senate,,CON,Farley,0
+Jefferson,Adams 2,Registered Voters,,,,643
+Jefferson,Adams 2,Ballots Cast,,,,371
 Jefferson,Adams 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Adams 2,Registered Voters,,,,643
+Jefferson,Adams 2,Ballots Cast,,,,371
 Jefferson,Adams 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Adams 2,Registered Voters,,,,643
+Jefferson,Adams 2,Ballots Cast,,,,371
 Jefferson,Adams 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Adams 2,Registered Voters,,,,643
+Jefferson,Adams 2,Ballots Cast,,,,371
 Jefferson,Adams 2,U.S. Senate,,REF,Farley,0
+Jefferson,Adams 2,Registered Voters,,,,643
+Jefferson,Adams 2,Ballots Cast,,,,371
 Jefferson,Adams 2,U.S. Senate,,,Write-ins,0
+Jefferson,Adams 2,Registered Voters,,,,643
+Jefferson,Adams 2,Ballots Cast,,,,371
 Jefferson,Adams 3,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Adams 3,Registered Voters,,,,1385
+Jefferson,Adams 3,Ballots Cast,,,,761
 Jefferson,Adams 3,U.S. Senate,,REP,Farley,0
+Jefferson,Adams 3,Registered Voters,,,,1385
+Jefferson,Adams 3,Ballots Cast,,,,761
 Jefferson,Adams 3,U.S. Senate,,CON,Farley,0
+Jefferson,Adams 3,Registered Voters,,,,1385
+Jefferson,Adams 3,Ballots Cast,,,,761
 Jefferson,Adams 3,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Adams 3,Registered Voters,,,,1385
+Jefferson,Adams 3,Ballots Cast,,,,761
 Jefferson,Adams 3,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Adams 3,Registered Voters,,,,1385
+Jefferson,Adams 3,Ballots Cast,,,,761
 Jefferson,Adams 3,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Adams 3,Registered Voters,,,,1385
+Jefferson,Adams 3,Ballots Cast,,,,761
 Jefferson,Adams 3,U.S. Senate,,REF,Farley,0
+Jefferson,Adams 3,Registered Voters,,,,1385
+Jefferson,Adams 3,Ballots Cast,,,,761
 Jefferson,Adams 3,U.S. Senate,,,Write-ins,0
+Jefferson,Adams 3,Registered Voters,,,,1385
+Jefferson,Adams 3,Ballots Cast,,,,761
 Jefferson,Alexandria 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Alexandria 1,Registered Voters,,,,655
+Jefferson,Alexandria 1,Ballots Cast,,,,366
 Jefferson,Alexandria 1,U.S. Senate,,REP,Farley,0
+Jefferson,Alexandria 1,Registered Voters,,,,655
+Jefferson,Alexandria 1,Ballots Cast,,,,366
 Jefferson,Alexandria 1,U.S. Senate,,CON,Farley,0
+Jefferson,Alexandria 1,Registered Voters,,,,655
+Jefferson,Alexandria 1,Ballots Cast,,,,366
 Jefferson,Alexandria 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Alexandria 1,Registered Voters,,,,655
+Jefferson,Alexandria 1,Ballots Cast,,,,366
 Jefferson,Alexandria 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Alexandria 1,Registered Voters,,,,655
+Jefferson,Alexandria 1,Ballots Cast,,,,366
 Jefferson,Alexandria 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Alexandria 1,Registered Voters,,,,655
+Jefferson,Alexandria 1,Ballots Cast,,,,366
 Jefferson,Alexandria 1,U.S. Senate,,REF,Farley,0
+Jefferson,Alexandria 1,Registered Voters,,,,655
+Jefferson,Alexandria 1,Ballots Cast,,,,366
 Jefferson,Alexandria 1,U.S. Senate,,,Write-ins,0
+Jefferson,Alexandria 1,Registered Voters,,,,655
+Jefferson,Alexandria 1,Ballots Cast,,,,366
 Jefferson,Alexandria 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Alexandria 2,Registered Voters,,,,834
+Jefferson,Alexandria 2,Ballots Cast,,,,526
 Jefferson,Alexandria 2,U.S. Senate,,REP,Farley,0
+Jefferson,Alexandria 2,Registered Voters,,,,834
+Jefferson,Alexandria 2,Ballots Cast,,,,526
 Jefferson,Alexandria 2,U.S. Senate,,CON,Farley,0
+Jefferson,Alexandria 2,Registered Voters,,,,834
+Jefferson,Alexandria 2,Ballots Cast,,,,526
 Jefferson,Alexandria 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Alexandria 2,Registered Voters,,,,834
+Jefferson,Alexandria 2,Ballots Cast,,,,526
 Jefferson,Alexandria 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Alexandria 2,Registered Voters,,,,834
+Jefferson,Alexandria 2,Ballots Cast,,,,526
 Jefferson,Alexandria 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Alexandria 2,Registered Voters,,,,834
+Jefferson,Alexandria 2,Ballots Cast,,,,526
 Jefferson,Alexandria 2,U.S. Senate,,REF,Farley,0
+Jefferson,Alexandria 2,Registered Voters,,,,834
+Jefferson,Alexandria 2,Ballots Cast,,,,526
 Jefferson,Alexandria 2,U.S. Senate,,,Write-ins,0
+Jefferson,Alexandria 2,Registered Voters,,,,834
+Jefferson,Alexandria 2,Ballots Cast,,,,526
 Jefferson,Alexandria 3,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Alexandria 3,Registered Voters,,,,1235
+Jefferson,Alexandria 3,Ballots Cast,,,,685
 Jefferson,Alexandria 3,U.S. Senate,,REP,Farley,0
+Jefferson,Alexandria 3,Registered Voters,,,,1235
+Jefferson,Alexandria 3,Ballots Cast,,,,685
 Jefferson,Alexandria 3,U.S. Senate,,CON,Farley,0
+Jefferson,Alexandria 3,Registered Voters,,,,1235
+Jefferson,Alexandria 3,Ballots Cast,,,,685
 Jefferson,Alexandria 3,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Alexandria 3,Registered Voters,,,,1235
+Jefferson,Alexandria 3,Ballots Cast,,,,685
 Jefferson,Alexandria 3,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Alexandria 3,Registered Voters,,,,1235
+Jefferson,Alexandria 3,Ballots Cast,,,,685
 Jefferson,Alexandria 3,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Alexandria 3,Registered Voters,,,,1235
+Jefferson,Alexandria 3,Ballots Cast,,,,685
 Jefferson,Alexandria 3,U.S. Senate,,REF,Farley,0
+Jefferson,Alexandria 3,Registered Voters,,,,1235
+Jefferson,Alexandria 3,Ballots Cast,,,,685
 Jefferson,Alexandria 3,U.S. Senate,,,Write-ins,0
+Jefferson,Alexandria 3,Registered Voters,,,,1235
+Jefferson,Alexandria 3,Ballots Cast,,,,685
 Jefferson,Antwerp 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Antwerp 1,Registered Voters,,,,358
+Jefferson,Antwerp 1,Ballots Cast,,,,180
 Jefferson,Antwerp 1,U.S. Senate,,REP,Farley,0
+Jefferson,Antwerp 1,Registered Voters,,,,358
+Jefferson,Antwerp 1,Ballots Cast,,,,180
 Jefferson,Antwerp 1,U.S. Senate,,CON,Farley,0
+Jefferson,Antwerp 1,Registered Voters,,,,358
+Jefferson,Antwerp 1,Ballots Cast,,,,180
 Jefferson,Antwerp 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Antwerp 1,Registered Voters,,,,358
+Jefferson,Antwerp 1,Ballots Cast,,,,180
 Jefferson,Antwerp 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Antwerp 1,Registered Voters,,,,358
+Jefferson,Antwerp 1,Ballots Cast,,,,180
 Jefferson,Antwerp 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Antwerp 1,Registered Voters,,,,358
+Jefferson,Antwerp 1,Ballots Cast,,,,180
 Jefferson,Antwerp 1,U.S. Senate,,REF,Farley,0
+Jefferson,Antwerp 1,Registered Voters,,,,358
+Jefferson,Antwerp 1,Ballots Cast,,,,180
 Jefferson,Antwerp 1,U.S. Senate,,,Write-ins,0
+Jefferson,Antwerp 1,Registered Voters,,,,358
+Jefferson,Antwerp 1,Ballots Cast,,,,180
 Jefferson,Antwerp 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Antwerp 2,Registered Voters,,,,683
+Jefferson,Antwerp 2,Ballots Cast,,,,363
 Jefferson,Antwerp 2,U.S. Senate,,REP,Farley,0
+Jefferson,Antwerp 2,Registered Voters,,,,683
+Jefferson,Antwerp 2,Ballots Cast,,,,363
 Jefferson,Antwerp 2,U.S. Senate,,CON,Farley,0
+Jefferson,Antwerp 2,Registered Voters,,,,683
+Jefferson,Antwerp 2,Ballots Cast,,,,363
 Jefferson,Antwerp 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Antwerp 2,Registered Voters,,,,683
+Jefferson,Antwerp 2,Ballots Cast,,,,363
 Jefferson,Antwerp 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Antwerp 2,Registered Voters,,,,683
+Jefferson,Antwerp 2,Ballots Cast,,,,363
 Jefferson,Antwerp 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Antwerp 2,Registered Voters,,,,683
+Jefferson,Antwerp 2,Ballots Cast,,,,363
 Jefferson,Antwerp 2,U.S. Senate,,REF,Farley,0
+Jefferson,Antwerp 2,Registered Voters,,,,683
+Jefferson,Antwerp 2,Ballots Cast,,,,363
 Jefferson,Antwerp 2,U.S. Senate,,,Write-ins,0
+Jefferson,Antwerp 2,Registered Voters,,,,683
+Jefferson,Antwerp 2,Ballots Cast,,,,363
 Jefferson,Brownville 1,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,Brownville 1,Registered Voters,,,,782
+Jefferson,Brownville 1,Ballots Cast,,,,405
 Jefferson,Brownville 1,U.S. Senate,,REP,Farley,1
+Jefferson,Brownville 1,Registered Voters,,,,782
+Jefferson,Brownville 1,Ballots Cast,,,,405
 Jefferson,Brownville 1,U.S. Senate,,CON,Farley,1
+Jefferson,Brownville 1,Registered Voters,,,,782
+Jefferson,Brownville 1,Ballots Cast,,,,405
 Jefferson,Brownville 1,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,Brownville 1,Registered Voters,,,,782
+Jefferson,Brownville 1,Ballots Cast,,,,405
 Jefferson,Brownville 1,U.S. Senate,,IND,Gillibrand,1
+Jefferson,Brownville 1,Registered Voters,,,,782
+Jefferson,Brownville 1,Ballots Cast,,,,405
 Jefferson,Brownville 1,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,Brownville 1,Registered Voters,,,,782
+Jefferson,Brownville 1,Ballots Cast,,,,405
 Jefferson,Brownville 1,U.S. Senate,,REF,Farley,1
+Jefferson,Brownville 1,Registered Voters,,,,782
+Jefferson,Brownville 1,Ballots Cast,,,,405
 Jefferson,Brownville 1,U.S. Senate,,,Write-ins,1
+Jefferson,Brownville 1,Registered Voters,,,,782
+Jefferson,Brownville 1,Ballots Cast,,,,405
 Jefferson,Brownville 2,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,Brownville 2,Registered Voters,,,,609
+Jefferson,Brownville 2,Ballots Cast,,,,333
 Jefferson,Brownville 2,U.S. Senate,,REP,Farley,1
+Jefferson,Brownville 2,Registered Voters,,,,609
+Jefferson,Brownville 2,Ballots Cast,,,,333
 Jefferson,Brownville 2,U.S. Senate,,CON,Farley,1
+Jefferson,Brownville 2,Registered Voters,,,,609
+Jefferson,Brownville 2,Ballots Cast,,,,333
 Jefferson,Brownville 2,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,Brownville 2,Registered Voters,,,,609
+Jefferson,Brownville 2,Ballots Cast,,,,333
 Jefferson,Brownville 2,U.S. Senate,,IND,Gillibrand,1
+Jefferson,Brownville 2,Registered Voters,,,,609
+Jefferson,Brownville 2,Ballots Cast,,,,333
 Jefferson,Brownville 2,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,Brownville 2,Registered Voters,,,,609
+Jefferson,Brownville 2,Ballots Cast,,,,333
 Jefferson,Brownville 2,U.S. Senate,,REF,Farley,1
+Jefferson,Brownville 2,Registered Voters,,,,609
+Jefferson,Brownville 2,Ballots Cast,,,,333
 Jefferson,Brownville 2,U.S. Senate,,,Write-ins,1
+Jefferson,Brownville 2,Registered Voters,,,,609
+Jefferson,Brownville 2,Ballots Cast,,,,333
 Jefferson,Brownville 3,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Brownville 3,Registered Voters,,,,944
+Jefferson,Brownville 3,Ballots Cast,,,,478
 Jefferson,Brownville 3,U.S. Senate,,REP,Farley,0
+Jefferson,Brownville 3,Registered Voters,,,,944
+Jefferson,Brownville 3,Ballots Cast,,,,478
 Jefferson,Brownville 3,U.S. Senate,,CON,Farley,0
+Jefferson,Brownville 3,Registered Voters,,,,944
+Jefferson,Brownville 3,Ballots Cast,,,,478
 Jefferson,Brownville 3,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Brownville 3,Registered Voters,,,,944
+Jefferson,Brownville 3,Ballots Cast,,,,478
 Jefferson,Brownville 3,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Brownville 3,Registered Voters,,,,944
+Jefferson,Brownville 3,Ballots Cast,,,,478
 Jefferson,Brownville 3,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Brownville 3,Registered Voters,,,,944
+Jefferson,Brownville 3,Ballots Cast,,,,478
 Jefferson,Brownville 3,U.S. Senate,,REF,Farley,0
+Jefferson,Brownville 3,Registered Voters,,,,944
+Jefferson,Brownville 3,Ballots Cast,,,,478
 Jefferson,Brownville 3,U.S. Senate,,,Write-ins,0
+Jefferson,Brownville 3,Registered Voters,,,,944
+Jefferson,Brownville 3,Ballots Cast,,,,478
 Jefferson,Brownville 4,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Brownville 4,Registered Voters,,,,565
+Jefferson,Brownville 4,Ballots Cast,,,,325
 Jefferson,Brownville 4,U.S. Senate,,REP,Farley,0
+Jefferson,Brownville 4,Registered Voters,,,,565
+Jefferson,Brownville 4,Ballots Cast,,,,325
 Jefferson,Brownville 4,U.S. Senate,,CON,Farley,0
+Jefferson,Brownville 4,Registered Voters,,,,565
+Jefferson,Brownville 4,Ballots Cast,,,,325
 Jefferson,Brownville 4,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Brownville 4,Registered Voters,,,,565
+Jefferson,Brownville 4,Ballots Cast,,,,325
 Jefferson,Brownville 4,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Brownville 4,Registered Voters,,,,565
+Jefferson,Brownville 4,Ballots Cast,,,,325
 Jefferson,Brownville 4,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Brownville 4,Registered Voters,,,,565
+Jefferson,Brownville 4,Ballots Cast,,,,325
 Jefferson,Brownville 4,U.S. Senate,,REF,Farley,0
+Jefferson,Brownville 4,Registered Voters,,,,565
+Jefferson,Brownville 4,Ballots Cast,,,,325
 Jefferson,Brownville 4,U.S. Senate,,,Write-ins,0
+Jefferson,Brownville 4,Registered Voters,,,,565
+Jefferson,Brownville 4,Ballots Cast,,,,325
 Jefferson,Brownville 5,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Brownville 5,Registered Voters,,,,883
+Jefferson,Brownville 5,Ballots Cast,,,,520
 Jefferson,Brownville 5,U.S. Senate,,REP,Farley,0
+Jefferson,Brownville 5,Registered Voters,,,,883
+Jefferson,Brownville 5,Ballots Cast,,,,520
 Jefferson,Brownville 5,U.S. Senate,,CON,Farley,0
+Jefferson,Brownville 5,Registered Voters,,,,883
+Jefferson,Brownville 5,Ballots Cast,,,,520
 Jefferson,Brownville 5,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Brownville 5,Registered Voters,,,,883
+Jefferson,Brownville 5,Ballots Cast,,,,520
 Jefferson,Brownville 5,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Brownville 5,Registered Voters,,,,883
+Jefferson,Brownville 5,Ballots Cast,,,,520
 Jefferson,Brownville 5,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Brownville 5,Registered Voters,,,,883
+Jefferson,Brownville 5,Ballots Cast,,,,520
 Jefferson,Brownville 5,U.S. Senate,,REF,Farley,0
+Jefferson,Brownville 5,Registered Voters,,,,883
+Jefferson,Brownville 5,Ballots Cast,,,,520
 Jefferson,Brownville 5,U.S. Senate,,,Write-ins,0
+Jefferson,Brownville 5,Registered Voters,,,,883
+Jefferson,Brownville 5,Ballots Cast,,,,520
 Jefferson,Cape Vincent 1,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,Cape Vincent 1,Registered Voters,,,,574
+Jefferson,Cape Vincent 1,Ballots Cast,,,,379
 Jefferson,Cape Vincent 1,U.S. Senate,,REP,Farley,1
+Jefferson,Cape Vincent 1,Registered Voters,,,,574
+Jefferson,Cape Vincent 1,Ballots Cast,,,,379
 Jefferson,Cape Vincent 1,U.S. Senate,,CON,Farley,1
+Jefferson,Cape Vincent 1,Registered Voters,,,,574
+Jefferson,Cape Vincent 1,Ballots Cast,,,,379
 Jefferson,Cape Vincent 1,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,Cape Vincent 1,Registered Voters,,,,574
+Jefferson,Cape Vincent 1,Ballots Cast,,,,379
 Jefferson,Cape Vincent 1,U.S. Senate,,IND,Gillibrand,1
+Jefferson,Cape Vincent 1,Registered Voters,,,,574
+Jefferson,Cape Vincent 1,Ballots Cast,,,,379
 Jefferson,Cape Vincent 1,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,Cape Vincent 1,Registered Voters,,,,574
+Jefferson,Cape Vincent 1,Ballots Cast,,,,379
 Jefferson,Cape Vincent 1,U.S. Senate,,REF,Farley,1
+Jefferson,Cape Vincent 1,Registered Voters,,,,574
+Jefferson,Cape Vincent 1,Ballots Cast,,,,379
 Jefferson,Cape Vincent 1,U.S. Senate,,,Write-ins,1
+Jefferson,Cape Vincent 1,Registered Voters,,,,574
+Jefferson,Cape Vincent 1,Ballots Cast,,,,379
 Jefferson,Cape Vincent 2,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,Cape Vincent 2,Registered Voters,,,,1266
+Jefferson,Cape Vincent 2,Ballots Cast,,,,724
 Jefferson,Cape Vincent 2,U.S. Senate,,REP,Farley,1
+Jefferson,Cape Vincent 2,Registered Voters,,,,1266
+Jefferson,Cape Vincent 2,Ballots Cast,,,,724
 Jefferson,Cape Vincent 2,U.S. Senate,,CON,Farley,1
+Jefferson,Cape Vincent 2,Registered Voters,,,,1266
+Jefferson,Cape Vincent 2,Ballots Cast,,,,724
 Jefferson,Cape Vincent 2,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,Cape Vincent 2,Registered Voters,,,,1266
+Jefferson,Cape Vincent 2,Ballots Cast,,,,724
 Jefferson,Cape Vincent 2,U.S. Senate,,IND,Gillibrand,1
+Jefferson,Cape Vincent 2,Registered Voters,,,,1266
+Jefferson,Cape Vincent 2,Ballots Cast,,,,724
 Jefferson,Cape Vincent 2,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,Cape Vincent 2,Registered Voters,,,,1266
+Jefferson,Cape Vincent 2,Ballots Cast,,,,724
 Jefferson,Cape Vincent 2,U.S. Senate,,REF,Farley,1
+Jefferson,Cape Vincent 2,Registered Voters,,,,1266
+Jefferson,Cape Vincent 2,Ballots Cast,,,,724
 Jefferson,Cape Vincent 2,U.S. Senate,,,Write-ins,1
+Jefferson,Cape Vincent 2,Registered Voters,,,,1266
+Jefferson,Cape Vincent 2,Ballots Cast,,,,724
 Jefferson,Champion 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Champion 1,Registered Voters,,,,1448
+Jefferson,Champion 1,Ballots Cast,,,,781
 Jefferson,Champion 1,U.S. Senate,,REP,Farley,0
+Jefferson,Champion 1,Registered Voters,,,,1448
+Jefferson,Champion 1,Ballots Cast,,,,781
 Jefferson,Champion 1,U.S. Senate,,CON,Farley,0
+Jefferson,Champion 1,Registered Voters,,,,1448
+Jefferson,Champion 1,Ballots Cast,,,,781
 Jefferson,Champion 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Champion 1,Registered Voters,,,,1448
+Jefferson,Champion 1,Ballots Cast,,,,781
 Jefferson,Champion 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Champion 1,Registered Voters,,,,1448
+Jefferson,Champion 1,Ballots Cast,,,,781
 Jefferson,Champion 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Champion 1,Registered Voters,,,,1448
+Jefferson,Champion 1,Ballots Cast,,,,781
 Jefferson,Champion 1,U.S. Senate,,REF,Farley,0
+Jefferson,Champion 1,Registered Voters,,,,1448
+Jefferson,Champion 1,Ballots Cast,,,,781
 Jefferson,Champion 1,U.S. Senate,,,Write-ins,0
+Jefferson,Champion 1,Registered Voters,,,,1448
+Jefferson,Champion 1,Ballots Cast,,,,781
 Jefferson,Champion 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Champion 2,Registered Voters,,,,824
+Jefferson,Champion 2,Ballots Cast,,,,415
 Jefferson,Champion 2,U.S. Senate,,REP,Farley,0
+Jefferson,Champion 2,Registered Voters,,,,824
+Jefferson,Champion 2,Ballots Cast,,,,415
 Jefferson,Champion 2,U.S. Senate,,CON,Farley,0
+Jefferson,Champion 2,Registered Voters,,,,824
+Jefferson,Champion 2,Ballots Cast,,,,415
 Jefferson,Champion 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Champion 2,Registered Voters,,,,824
+Jefferson,Champion 2,Ballots Cast,,,,415
 Jefferson,Champion 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Champion 2,Registered Voters,,,,824
+Jefferson,Champion 2,Ballots Cast,,,,415
 Jefferson,Champion 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Champion 2,Registered Voters,,,,824
+Jefferson,Champion 2,Ballots Cast,,,,415
 Jefferson,Champion 2,U.S. Senate,,REF,Farley,0
+Jefferson,Champion 2,Registered Voters,,,,824
+Jefferson,Champion 2,Ballots Cast,,,,415
 Jefferson,Champion 2,U.S. Senate,,,Write-ins,0
+Jefferson,Champion 2,Registered Voters,,,,824
+Jefferson,Champion 2,Ballots Cast,,,,415
 Jefferson,Clayton 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Clayton 1,Registered Voters,,,,758
+Jefferson,Clayton 1,Ballots Cast,,,,443
 Jefferson,Clayton 1,U.S. Senate,,REP,Farley,0
+Jefferson,Clayton 1,Registered Voters,,,,758
+Jefferson,Clayton 1,Ballots Cast,,,,443
 Jefferson,Clayton 1,U.S. Senate,,CON,Farley,0
+Jefferson,Clayton 1,Registered Voters,,,,758
+Jefferson,Clayton 1,Ballots Cast,,,,443
 Jefferson,Clayton 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Clayton 1,Registered Voters,,,,758
+Jefferson,Clayton 1,Ballots Cast,,,,443
 Jefferson,Clayton 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Clayton 1,Registered Voters,,,,758
+Jefferson,Clayton 1,Ballots Cast,,,,443
 Jefferson,Clayton 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Clayton 1,Registered Voters,,,,758
+Jefferson,Clayton 1,Ballots Cast,,,,443
 Jefferson,Clayton 1,U.S. Senate,,REF,Farley,0
+Jefferson,Clayton 1,Registered Voters,,,,758
+Jefferson,Clayton 1,Ballots Cast,,,,443
 Jefferson,Clayton 1,U.S. Senate,,,Write-ins,0
+Jefferson,Clayton 1,Registered Voters,,,,758
+Jefferson,Clayton 1,Ballots Cast,,,,443
 Jefferson,Clayton 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Clayton 2,Registered Voters,,,,1109
+Jefferson,Clayton 2,Ballots Cast,,,,668
 Jefferson,Clayton 2,U.S. Senate,,REP,Farley,0
+Jefferson,Clayton 2,Registered Voters,,,,1109
+Jefferson,Clayton 2,Ballots Cast,,,,668
 Jefferson,Clayton 2,U.S. Senate,,CON,Farley,0
+Jefferson,Clayton 2,Registered Voters,,,,1109
+Jefferson,Clayton 2,Ballots Cast,,,,668
 Jefferson,Clayton 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Clayton 2,Registered Voters,,,,1109
+Jefferson,Clayton 2,Ballots Cast,,,,668
 Jefferson,Clayton 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Clayton 2,Registered Voters,,,,1109
+Jefferson,Clayton 2,Ballots Cast,,,,668
 Jefferson,Clayton 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Clayton 2,Registered Voters,,,,1109
+Jefferson,Clayton 2,Ballots Cast,,,,668
 Jefferson,Clayton 2,U.S. Senate,,REF,Farley,0
+Jefferson,Clayton 2,Registered Voters,,,,1109
+Jefferson,Clayton 2,Ballots Cast,,,,668
 Jefferson,Clayton 2,U.S. Senate,,,Write-ins,0
+Jefferson,Clayton 2,Registered Voters,,,,1109
+Jefferson,Clayton 2,Ballots Cast,,,,668
 Jefferson,Clayton 3,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Clayton 3,Registered Voters,,,,1318
+Jefferson,Clayton 3,Ballots Cast,,,,803
 Jefferson,Clayton 3,U.S. Senate,,REP,Farley,0
+Jefferson,Clayton 3,Registered Voters,,,,1318
+Jefferson,Clayton 3,Ballots Cast,,,,803
 Jefferson,Clayton 3,U.S. Senate,,CON,Farley,0
+Jefferson,Clayton 3,Registered Voters,,,,1318
+Jefferson,Clayton 3,Ballots Cast,,,,803
 Jefferson,Clayton 3,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Clayton 3,Registered Voters,,,,1318
+Jefferson,Clayton 3,Ballots Cast,,,,803
 Jefferson,Clayton 3,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Clayton 3,Registered Voters,,,,1318
+Jefferson,Clayton 3,Ballots Cast,,,,803
 Jefferson,Clayton 3,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Clayton 3,Registered Voters,,,,1318
+Jefferson,Clayton 3,Ballots Cast,,,,803
 Jefferson,Clayton 3,U.S. Senate,,REF,Farley,0
+Jefferson,Clayton 3,Registered Voters,,,,1318
+Jefferson,Clayton 3,Ballots Cast,,,,803
 Jefferson,Clayton 3,U.S. Senate,,,Write-ins,0
+Jefferson,Clayton 3,Registered Voters,,,,1318
+Jefferson,Clayton 3,Ballots Cast,,,,803
 Jefferson,Ellisburg 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Ellisburg 1,Registered Voters,,,,216
+Jefferson,Ellisburg 1,Ballots Cast,,,,137
 Jefferson,Ellisburg 1,U.S. Senate,,REP,Farley,0
+Jefferson,Ellisburg 1,Registered Voters,,,,216
+Jefferson,Ellisburg 1,Ballots Cast,,,,137
 Jefferson,Ellisburg 1,U.S. Senate,,CON,Farley,0
+Jefferson,Ellisburg 1,Registered Voters,,,,216
+Jefferson,Ellisburg 1,Ballots Cast,,,,137
 Jefferson,Ellisburg 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Ellisburg 1,Registered Voters,,,,216
+Jefferson,Ellisburg 1,Ballots Cast,,,,137
 Jefferson,Ellisburg 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Ellisburg 1,Registered Voters,,,,216
+Jefferson,Ellisburg 1,Ballots Cast,,,,137
 Jefferson,Ellisburg 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Ellisburg 1,Registered Voters,,,,216
+Jefferson,Ellisburg 1,Ballots Cast,,,,137
 Jefferson,Ellisburg 1,U.S. Senate,,REF,Farley,0
+Jefferson,Ellisburg 1,Registered Voters,,,,216
+Jefferson,Ellisburg 1,Ballots Cast,,,,137
 Jefferson,Ellisburg 1,U.S. Senate,,,Write-ins,0
+Jefferson,Ellisburg 1,Registered Voters,,,,216
+Jefferson,Ellisburg 1,Ballots Cast,,,,137
 Jefferson,Elllisburg 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Elllisburg 2,Registered Voters,,,,716
+Jefferson,Elllisburg 2,Ballots Cast,,,,393
 Jefferson,Elllisburg 2,U.S. Senate,,REP,Farley,0
+Jefferson,Elllisburg 2,Registered Voters,,,,716
+Jefferson,Elllisburg 2,Ballots Cast,,,,393
 Jefferson,Elllisburg 2,U.S. Senate,,CON,Farley,0
+Jefferson,Elllisburg 2,Registered Voters,,,,716
+Jefferson,Elllisburg 2,Ballots Cast,,,,393
 Jefferson,Elllisburg 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Elllisburg 2,Registered Voters,,,,716
+Jefferson,Elllisburg 2,Ballots Cast,,,,393
 Jefferson,Elllisburg 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Elllisburg 2,Registered Voters,,,,716
+Jefferson,Elllisburg 2,Ballots Cast,,,,393
 Jefferson,Elllisburg 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Elllisburg 2,Registered Voters,,,,716
+Jefferson,Elllisburg 2,Ballots Cast,,,,393
 Jefferson,Elllisburg 2,U.S. Senate,,REF,Farley,0
+Jefferson,Elllisburg 2,Registered Voters,,,,716
+Jefferson,Elllisburg 2,Ballots Cast,,,,393
 Jefferson,Elllisburg 2,U.S. Senate,,,Write-ins,0
+Jefferson,Elllisburg 2,Registered Voters,,,,716
+Jefferson,Elllisburg 2,Ballots Cast,,,,393
 Jefferson,Ellisburg 3,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Ellisburg 3,Registered Voters,,,,147
+Jefferson,Ellisburg 3,Ballots Cast,,,,87
 Jefferson,Ellisburg 3,U.S. Senate,,REP,Farley,0
+Jefferson,Ellisburg 3,Registered Voters,,,,147
+Jefferson,Ellisburg 3,Ballots Cast,,,,87
 Jefferson,Ellisburg 3,U.S. Senate,,CON,Farley,0
+Jefferson,Ellisburg 3,Registered Voters,,,,147
+Jefferson,Ellisburg 3,Ballots Cast,,,,87
 Jefferson,Ellisburg 3,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Ellisburg 3,Registered Voters,,,,147
+Jefferson,Ellisburg 3,Ballots Cast,,,,87
 Jefferson,Ellisburg 3,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Ellisburg 3,Registered Voters,,,,147
+Jefferson,Ellisburg 3,Ballots Cast,,,,87
 Jefferson,Ellisburg 3,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Ellisburg 3,Registered Voters,,,,147
+Jefferson,Ellisburg 3,Ballots Cast,,,,87
 Jefferson,Ellisburg 3,U.S. Senate,,REF,Farley,0
+Jefferson,Ellisburg 3,Registered Voters,,,,147
+Jefferson,Ellisburg 3,Ballots Cast,,,,87
 Jefferson,Ellisburg 3,U.S. Senate,,,Write-ins,0
+Jefferson,Ellisburg 3,Registered Voters,,,,147
+Jefferson,Ellisburg 3,Ballots Cast,,,,87
 Jefferson,Ellisburg 4,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Ellisburg 4,Registered Voters,,,,941
+Jefferson,Ellisburg 4,Ballots Cast,,,,500
 Jefferson,Ellisburg 4,U.S. Senate,,REP,Farley,0
+Jefferson,Ellisburg 4,Registered Voters,,,,941
+Jefferson,Ellisburg 4,Ballots Cast,,,,500
 Jefferson,Ellisburg 4,U.S. Senate,,CON,Farley,0
+Jefferson,Ellisburg 4,Registered Voters,,,,941
+Jefferson,Ellisburg 4,Ballots Cast,,,,500
 Jefferson,Ellisburg 4,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Ellisburg 4,Registered Voters,,,,941
+Jefferson,Ellisburg 4,Ballots Cast,,,,500
 Jefferson,Ellisburg 4,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Ellisburg 4,Registered Voters,,,,941
+Jefferson,Ellisburg 4,Ballots Cast,,,,500
 Jefferson,Ellisburg 4,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Ellisburg 4,Registered Voters,,,,941
+Jefferson,Ellisburg 4,Ballots Cast,,,,500
 Jefferson,Ellisburg 4,U.S. Senate,,REF,Farley,0
+Jefferson,Ellisburg 4,Registered Voters,,,,941
+Jefferson,Ellisburg 4,Ballots Cast,,,,500
 Jefferson,Ellisburg 4,U.S. Senate,,,Write-ins,0
+Jefferson,Ellisburg 4,Registered Voters,,,,941
+Jefferson,Ellisburg 4,Ballots Cast,,,,500
 Jefferson,Henderson 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Henderson 1,Registered Voters,,,,1097
+Jefferson,Henderson 1,Ballots Cast,,,,657
 Jefferson,Henderson 1,U.S. Senate,,REP,Farley,0
+Jefferson,Henderson 1,Registered Voters,,,,1097
+Jefferson,Henderson 1,Ballots Cast,,,,657
 Jefferson,Henderson 1,U.S. Senate,,CON,Farley,0
+Jefferson,Henderson 1,Registered Voters,,,,1097
+Jefferson,Henderson 1,Ballots Cast,,,,657
 Jefferson,Henderson 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Henderson 1,Registered Voters,,,,1097
+Jefferson,Henderson 1,Ballots Cast,,,,657
 Jefferson,Henderson 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Henderson 1,Registered Voters,,,,1097
+Jefferson,Henderson 1,Ballots Cast,,,,657
 Jefferson,Henderson 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Henderson 1,Registered Voters,,,,1097
+Jefferson,Henderson 1,Ballots Cast,,,,657
 Jefferson,Henderson 1,U.S. Senate,,REF,Farley,0
+Jefferson,Henderson 1,Registered Voters,,,,1097
+Jefferson,Henderson 1,Ballots Cast,,,,657
 Jefferson,Henderson 1,U.S. Senate,,,Write-ins,0
+Jefferson,Henderson 1,Registered Voters,,,,1097
+Jefferson,Henderson 1,Ballots Cast,,,,657
 Jefferson,Hounsfield 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Hounsfield 1,Registered Voters,,,,903
+Jefferson,Hounsfield 1,Ballots Cast,,,,542
 Jefferson,Hounsfield 1,U.S. Senate,,REP,Farley,0
+Jefferson,Hounsfield 1,Registered Voters,,,,903
+Jefferson,Hounsfield 1,Ballots Cast,,,,542
 Jefferson,Hounsfield 1,U.S. Senate,,CON,Farley,0
+Jefferson,Hounsfield 1,Registered Voters,,,,903
+Jefferson,Hounsfield 1,Ballots Cast,,,,542
 Jefferson,Hounsfield 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Hounsfield 1,Registered Voters,,,,903
+Jefferson,Hounsfield 1,Ballots Cast,,,,542
 Jefferson,Hounsfield 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Hounsfield 1,Registered Voters,,,,903
+Jefferson,Hounsfield 1,Ballots Cast,,,,542
 Jefferson,Hounsfield 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Hounsfield 1,Registered Voters,,,,903
+Jefferson,Hounsfield 1,Ballots Cast,,,,542
 Jefferson,Hounsfield 1,U.S. Senate,,REF,Farley,0
+Jefferson,Hounsfield 1,Registered Voters,,,,903
+Jefferson,Hounsfield 1,Ballots Cast,,,,542
 Jefferson,Hounsfield 1,U.S. Senate,,,Write-ins,0
+Jefferson,Hounsfield 1,Registered Voters,,,,903
+Jefferson,Hounsfield 1,Ballots Cast,,,,542
 Jefferson,Hounsfield 2,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,Hounsfield 2,Registered Voters,,,,1330
+Jefferson,Hounsfield 2,Ballots Cast,,,,750
 Jefferson,Hounsfield 2,U.S. Senate,,REP,Farley,1
+Jefferson,Hounsfield 2,Registered Voters,,,,1330
+Jefferson,Hounsfield 2,Ballots Cast,,,,750
 Jefferson,Hounsfield 2,U.S. Senate,,CON,Farley,1
+Jefferson,Hounsfield 2,Registered Voters,,,,1330
+Jefferson,Hounsfield 2,Ballots Cast,,,,750
 Jefferson,Hounsfield 2,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,Hounsfield 2,Registered Voters,,,,1330
+Jefferson,Hounsfield 2,Ballots Cast,,,,750
 Jefferson,Hounsfield 2,U.S. Senate,,IND,Gillibrand,1
+Jefferson,Hounsfield 2,Registered Voters,,,,1330
+Jefferson,Hounsfield 2,Ballots Cast,,,,750
 Jefferson,Hounsfield 2,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,Hounsfield 2,Registered Voters,,,,1330
+Jefferson,Hounsfield 2,Ballots Cast,,,,750
 Jefferson,Hounsfield 2,U.S. Senate,,REF,Farley,1
+Jefferson,Hounsfield 2,Registered Voters,,,,1330
+Jefferson,Hounsfield 2,Ballots Cast,,,,750
 Jefferson,Hounsfield 2,U.S. Senate,,,Write-ins,1
+Jefferson,Hounsfield 2,Registered Voters,,,,1330
+Jefferson,Hounsfield 2,Ballots Cast,,,,750
 Jefferson,LeRay 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,LeRay 1,Registered Voters,,,,379
+Jefferson,LeRay 1,Ballots Cast,,,,201
 Jefferson,LeRay 1,U.S. Senate,,REP,Farley,0
+Jefferson,LeRay 1,Registered Voters,,,,379
+Jefferson,LeRay 1,Ballots Cast,,,,201
 Jefferson,LeRay 1,U.S. Senate,,CON,Farley,0
+Jefferson,LeRay 1,Registered Voters,,,,379
+Jefferson,LeRay 1,Ballots Cast,,,,201
 Jefferson,LeRay 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,LeRay 1,Registered Voters,,,,379
+Jefferson,LeRay 1,Ballots Cast,,,,201
 Jefferson,LeRay 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,LeRay 1,Registered Voters,,,,379
+Jefferson,LeRay 1,Ballots Cast,,,,201
 Jefferson,LeRay 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,LeRay 1,Registered Voters,,,,379
+Jefferson,LeRay 1,Ballots Cast,,,,201
 Jefferson,LeRay 1,U.S. Senate,,REF,Farley,0
+Jefferson,LeRay 1,Registered Voters,,,,379
+Jefferson,LeRay 1,Ballots Cast,,,,201
 Jefferson,LeRay 1,U.S. Senate,,,Write-ins,0
+Jefferson,LeRay 1,Registered Voters,,,,379
+Jefferson,LeRay 1,Ballots Cast,,,,201
 Jefferson,LeRay 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,LeRay 2,Registered Voters,,,,212
+Jefferson,LeRay 2,Ballots Cast,,,,101
 Jefferson,LeRay 2,U.S. Senate,,REP,Farley,0
+Jefferson,LeRay 2,Registered Voters,,,,212
+Jefferson,LeRay 2,Ballots Cast,,,,101
 Jefferson,LeRay 2,U.S. Senate,,CON,Farley,0
+Jefferson,LeRay 2,Registered Voters,,,,212
+Jefferson,LeRay 2,Ballots Cast,,,,101
 Jefferson,LeRay 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,LeRay 2,Registered Voters,,,,212
+Jefferson,LeRay 2,Ballots Cast,,,,101
 Jefferson,LeRay 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,LeRay 2,Registered Voters,,,,212
+Jefferson,LeRay 2,Ballots Cast,,,,101
 Jefferson,LeRay 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,LeRay 2,Registered Voters,,,,212
+Jefferson,LeRay 2,Ballots Cast,,,,101
 Jefferson,LeRay 2,U.S. Senate,,REF,Farley,0
+Jefferson,LeRay 2,Registered Voters,,,,212
+Jefferson,LeRay 2,Ballots Cast,,,,101
 Jefferson,LeRay 2,U.S. Senate,,,Write-ins,0
+Jefferson,LeRay 2,Registered Voters,,,,212
+Jefferson,LeRay 2,Ballots Cast,,,,101
 Jefferson,LeRay 3,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,LeRay 3,Registered Voters,,,,305
+Jefferson,LeRay 3,Ballots Cast,,,,162
 Jefferson,LeRay 3,U.S. Senate,,REP,Farley,0
+Jefferson,LeRay 3,Registered Voters,,,,305
+Jefferson,LeRay 3,Ballots Cast,,,,162
 Jefferson,LeRay 3,U.S. Senate,,CON,Farley,0
+Jefferson,LeRay 3,Registered Voters,,,,305
+Jefferson,LeRay 3,Ballots Cast,,,,162
 Jefferson,LeRay 3,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,LeRay 3,Registered Voters,,,,305
+Jefferson,LeRay 3,Ballots Cast,,,,162
 Jefferson,LeRay 3,U.S. Senate,,IND,Gillibrand,0
+Jefferson,LeRay 3,Registered Voters,,,,305
+Jefferson,LeRay 3,Ballots Cast,,,,162
 Jefferson,LeRay 3,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,LeRay 3,Registered Voters,,,,305
+Jefferson,LeRay 3,Ballots Cast,,,,162
 Jefferson,LeRay 3,U.S. Senate,,REF,Farley,0
+Jefferson,LeRay 3,Registered Voters,,,,305
+Jefferson,LeRay 3,Ballots Cast,,,,162
 Jefferson,LeRay 3,U.S. Senate,,,Write-ins,0
+Jefferson,LeRay 3,Registered Voters,,,,305
+Jefferson,LeRay 3,Ballots Cast,,,,162
 Jefferson,LeRay 4,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,LeRay 4,Registered Voters,,,,1497
+Jefferson,LeRay 4,Ballots Cast,,,,488
 Jefferson,LeRay 4,U.S. Senate,,REP,Farley,1
+Jefferson,LeRay 4,Registered Voters,,,,1497
+Jefferson,LeRay 4,Ballots Cast,,,,488
 Jefferson,LeRay 4,U.S. Senate,,CON,Farley,1
+Jefferson,LeRay 4,Registered Voters,,,,1497
+Jefferson,LeRay 4,Ballots Cast,,,,488
 Jefferson,LeRay 4,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,LeRay 4,Registered Voters,,,,1497
+Jefferson,LeRay 4,Ballots Cast,,,,488
 Jefferson,LeRay 4,U.S. Senate,,IND,Gillibrand,1
+Jefferson,LeRay 4,Registered Voters,,,,1497
+Jefferson,LeRay 4,Ballots Cast,,,,488
 Jefferson,LeRay 4,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,LeRay 4,Registered Voters,,,,1497
+Jefferson,LeRay 4,Ballots Cast,,,,488
 Jefferson,LeRay 4,U.S. Senate,,REF,Farley,1
+Jefferson,LeRay 4,Registered Voters,,,,1497
+Jefferson,LeRay 4,Ballots Cast,,,,488
 Jefferson,LeRay 4,U.S. Senate,,,Write-ins,1
+Jefferson,LeRay 4,Registered Voters,,,,1497
+Jefferson,LeRay 4,Ballots Cast,,,,488
 Jefferson,LeRay 5,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,LeRay 5,Registered Voters,,,,419
+Jefferson,LeRay 5,Ballots Cast,,,,237
 Jefferson,LeRay 5,U.S. Senate,,REP,Farley,1
+Jefferson,LeRay 5,Registered Voters,,,,419
+Jefferson,LeRay 5,Ballots Cast,,,,237
 Jefferson,LeRay 5,U.S. Senate,,CON,Farley,1
+Jefferson,LeRay 5,Registered Voters,,,,419
+Jefferson,LeRay 5,Ballots Cast,,,,237
 Jefferson,LeRay 5,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,LeRay 5,Registered Voters,,,,419
+Jefferson,LeRay 5,Ballots Cast,,,,237
 Jefferson,LeRay 5,U.S. Senate,,IND,Gillibrand,1
+Jefferson,LeRay 5,Registered Voters,,,,419
+Jefferson,LeRay 5,Ballots Cast,,,,237
 Jefferson,LeRay 5,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,LeRay 5,Registered Voters,,,,419
+Jefferson,LeRay 5,Ballots Cast,,,,237
 Jefferson,LeRay 5,U.S. Senate,,REF,Farley,1
+Jefferson,LeRay 5,Registered Voters,,,,419
+Jefferson,LeRay 5,Ballots Cast,,,,237
 Jefferson,LeRay 5,U.S. Senate,,,Write-ins,1
+Jefferson,LeRay 5,Registered Voters,,,,419
+Jefferson,LeRay 5,Ballots Cast,,,,237
 Jefferson,LeRay 6,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,LeRay 6,Registered Voters,,,,280
+Jefferson,LeRay 6,Ballots Cast,,,,110
 Jefferson,LeRay 6,U.S. Senate,,REP,Farley,0
+Jefferson,LeRay 6,Registered Voters,,,,280
+Jefferson,LeRay 6,Ballots Cast,,,,110
 Jefferson,LeRay 6,U.S. Senate,,CON,Farley,0
+Jefferson,LeRay 6,Registered Voters,,,,280
+Jefferson,LeRay 6,Ballots Cast,,,,110
 Jefferson,LeRay 6,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,LeRay 6,Registered Voters,,,,280
+Jefferson,LeRay 6,Ballots Cast,,,,110
 Jefferson,LeRay 6,U.S. Senate,,IND,Gillibrand,0
+Jefferson,LeRay 6,Registered Voters,,,,280
+Jefferson,LeRay 6,Ballots Cast,,,,110
 Jefferson,LeRay 6,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,LeRay 6,Registered Voters,,,,280
+Jefferson,LeRay 6,Ballots Cast,,,,110
 Jefferson,LeRay 6,U.S. Senate,,REF,Farley,0
+Jefferson,LeRay 6,Registered Voters,,,,280
+Jefferson,LeRay 6,Ballots Cast,,,,110
 Jefferson,LeRay 6,U.S. Senate,,,Write-ins,0
+Jefferson,LeRay 6,Registered Voters,,,,280
+Jefferson,LeRay 6,Ballots Cast,,,,110
 Jefferson,LeRay 7,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,LeRay 7,Registered Voters,,,,258
+Jefferson,LeRay 7,Ballots Cast,,,,61
 Jefferson,LeRay 7,U.S. Senate,,REP,Farley,0
+Jefferson,LeRay 7,Registered Voters,,,,258
+Jefferson,LeRay 7,Ballots Cast,,,,61
 Jefferson,LeRay 7,U.S. Senate,,CON,Farley,0
+Jefferson,LeRay 7,Registered Voters,,,,258
+Jefferson,LeRay 7,Ballots Cast,,,,61
 Jefferson,LeRay 7,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,LeRay 7,Registered Voters,,,,258
+Jefferson,LeRay 7,Ballots Cast,,,,61
 Jefferson,LeRay 7,U.S. Senate,,IND,Gillibrand,0
+Jefferson,LeRay 7,Registered Voters,,,,258
+Jefferson,LeRay 7,Ballots Cast,,,,61
 Jefferson,LeRay 7,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,LeRay 7,Registered Voters,,,,258
+Jefferson,LeRay 7,Ballots Cast,,,,61
 Jefferson,LeRay 7,U.S. Senate,,REF,Farley,0
+Jefferson,LeRay 7,Registered Voters,,,,258
+Jefferson,LeRay 7,Ballots Cast,,,,61
 Jefferson,LeRay 7,U.S. Senate,,,Write-ins,0
+Jefferson,LeRay 7,Registered Voters,,,,258
+Jefferson,LeRay 7,Ballots Cast,,,,61
 Jefferson,LeRay 8,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,LeRay 8,Registered Voters,,,,1190
+Jefferson,LeRay 8,Ballots Cast,,,,377
 Jefferson,LeRay 8,U.S. Senate,,REP,Farley,0
+Jefferson,LeRay 8,Registered Voters,,,,1190
+Jefferson,LeRay 8,Ballots Cast,,,,377
 Jefferson,LeRay 8,U.S. Senate,,CON,Farley,0
+Jefferson,LeRay 8,Registered Voters,,,,1190
+Jefferson,LeRay 8,Ballots Cast,,,,377
 Jefferson,LeRay 8,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,LeRay 8,Registered Voters,,,,1190
+Jefferson,LeRay 8,Ballots Cast,,,,377
 Jefferson,LeRay 8,U.S. Senate,,IND,Gillibrand,0
+Jefferson,LeRay 8,Registered Voters,,,,1190
+Jefferson,LeRay 8,Ballots Cast,,,,377
 Jefferson,LeRay 8,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,LeRay 8,Registered Voters,,,,1190
+Jefferson,LeRay 8,Ballots Cast,,,,377
 Jefferson,LeRay 8,U.S. Senate,,REF,Farley,0
+Jefferson,LeRay 8,Registered Voters,,,,1190
+Jefferson,LeRay 8,Ballots Cast,,,,377
 Jefferson,LeRay 8,U.S. Senate,,,Write-ins,0
+Jefferson,LeRay 8,Registered Voters,,,,1190
+Jefferson,LeRay 8,Ballots Cast,,,,377
 Jefferson,Lorraine 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Lorraine 1,Registered Voters,,,,603
+Jefferson,Lorraine 1,Ballots Cast,,,,343
 Jefferson,Lorraine 1,U.S. Senate,,REP,Farley,0
+Jefferson,Lorraine 1,Registered Voters,,,,603
+Jefferson,Lorraine 1,Ballots Cast,,,,343
 Jefferson,Lorraine 1,U.S. Senate,,CON,Farley,0
+Jefferson,Lorraine 1,Registered Voters,,,,603
+Jefferson,Lorraine 1,Ballots Cast,,,,343
 Jefferson,Lorraine 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Lorraine 1,Registered Voters,,,,603
+Jefferson,Lorraine 1,Ballots Cast,,,,343
 Jefferson,Lorraine 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Lorraine 1,Registered Voters,,,,603
+Jefferson,Lorraine 1,Ballots Cast,,,,343
 Jefferson,Lorraine 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Lorraine 1,Registered Voters,,,,603
+Jefferson,Lorraine 1,Ballots Cast,,,,343
 Jefferson,Lorraine 1,U.S. Senate,,REF,Farley,0
+Jefferson,Lorraine 1,Registered Voters,,,,603
+Jefferson,Lorraine 1,Ballots Cast,,,,343
 Jefferson,Lorraine 1,U.S. Senate,,,Write-ins,0
+Jefferson,Lorraine 1,Registered Voters,,,,603
+Jefferson,Lorraine 1,Ballots Cast,,,,343
 Jefferson,Lyme 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Lyme 1,Registered Voters,,,,582
+Jefferson,Lyme 1,Ballots Cast,,,,353
 Jefferson,Lyme 1,U.S. Senate,,REP,Farley,0
+Jefferson,Lyme 1,Registered Voters,,,,582
+Jefferson,Lyme 1,Ballots Cast,,,,353
 Jefferson,Lyme 1,U.S. Senate,,CON,Farley,0
+Jefferson,Lyme 1,Registered Voters,,,,582
+Jefferson,Lyme 1,Ballots Cast,,,,353
 Jefferson,Lyme 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Lyme 1,Registered Voters,,,,582
+Jefferson,Lyme 1,Ballots Cast,,,,353
 Jefferson,Lyme 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Lyme 1,Registered Voters,,,,582
+Jefferson,Lyme 1,Ballots Cast,,,,353
 Jefferson,Lyme 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Lyme 1,Registered Voters,,,,582
+Jefferson,Lyme 1,Ballots Cast,,,,353
 Jefferson,Lyme 1,U.S. Senate,,REF,Farley,0
+Jefferson,Lyme 1,Registered Voters,,,,582
+Jefferson,Lyme 1,Ballots Cast,,,,353
 Jefferson,Lyme 1,U.S. Senate,,,Write-ins,0
+Jefferson,Lyme 1,Registered Voters,,,,582
+Jefferson,Lyme 1,Ballots Cast,,,,353
 Jefferson,Lyme 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Lyme 2,Registered Voters,,,,724
+Jefferson,Lyme 2,Ballots Cast,,,,460
 Jefferson,Lyme 2,U.S. Senate,,REP,Farley,0
+Jefferson,Lyme 2,Registered Voters,,,,724
+Jefferson,Lyme 2,Ballots Cast,,,,460
 Jefferson,Lyme 2,U.S. Senate,,CON,Farley,0
+Jefferson,Lyme 2,Registered Voters,,,,724
+Jefferson,Lyme 2,Ballots Cast,,,,460
 Jefferson,Lyme 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Lyme 2,Registered Voters,,,,724
+Jefferson,Lyme 2,Ballots Cast,,,,460
 Jefferson,Lyme 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Lyme 2,Registered Voters,,,,724
+Jefferson,Lyme 2,Ballots Cast,,,,460
 Jefferson,Lyme 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Lyme 2,Registered Voters,,,,724
+Jefferson,Lyme 2,Ballots Cast,,,,460
 Jefferson,Lyme 2,U.S. Senate,,REF,Farley,0
+Jefferson,Lyme 2,Registered Voters,,,,724
+Jefferson,Lyme 2,Ballots Cast,,,,460
 Jefferson,Lyme 2,U.S. Senate,,,Write-ins,0
+Jefferson,Lyme 2,Registered Voters,,,,724
+Jefferson,Lyme 2,Ballots Cast,,,,460
 Jefferson,Lyme 3,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Lyme 3,Registered Voters,,,,425
+Jefferson,Lyme 3,Ballots Cast,,,,245
 Jefferson,Lyme 3,U.S. Senate,,REP,Farley,0
+Jefferson,Lyme 3,Registered Voters,,,,425
+Jefferson,Lyme 3,Ballots Cast,,,,245
 Jefferson,Lyme 3,U.S. Senate,,CON,Farley,0
+Jefferson,Lyme 3,Registered Voters,,,,425
+Jefferson,Lyme 3,Ballots Cast,,,,245
 Jefferson,Lyme 3,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Lyme 3,Registered Voters,,,,425
+Jefferson,Lyme 3,Ballots Cast,,,,245
 Jefferson,Lyme 3,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Lyme 3,Registered Voters,,,,425
+Jefferson,Lyme 3,Ballots Cast,,,,245
 Jefferson,Lyme 3,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Lyme 3,Registered Voters,,,,425
+Jefferson,Lyme 3,Ballots Cast,,,,245
 Jefferson,Lyme 3,U.S. Senate,,REF,Farley,0
+Jefferson,Lyme 3,Registered Voters,,,,425
+Jefferson,Lyme 3,Ballots Cast,,,,245
 Jefferson,Lyme 3,U.S. Senate,,,Write-ins,0
+Jefferson,Lyme 3,Registered Voters,,,,425
+Jefferson,Lyme 3,Ballots Cast,,,,245
 Jefferson,Orleans 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Orleans 1,Registered Voters,,,,1107
+Jefferson,Orleans 1,Ballots Cast,,,,593
 Jefferson,Orleans 1,U.S. Senate,,REP,Farley,0
+Jefferson,Orleans 1,Registered Voters,,,,1107
+Jefferson,Orleans 1,Ballots Cast,,,,593
 Jefferson,Orleans 1,U.S. Senate,,CON,Farley,0
+Jefferson,Orleans 1,Registered Voters,,,,1107
+Jefferson,Orleans 1,Ballots Cast,,,,593
 Jefferson,Orleans 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Orleans 1,Registered Voters,,,,1107
+Jefferson,Orleans 1,Ballots Cast,,,,593
 Jefferson,Orleans 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Orleans 1,Registered Voters,,,,1107
+Jefferson,Orleans 1,Ballots Cast,,,,593
 Jefferson,Orleans 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Orleans 1,Registered Voters,,,,1107
+Jefferson,Orleans 1,Ballots Cast,,,,593
 Jefferson,Orleans 1,U.S. Senate,,REF,Farley,0
+Jefferson,Orleans 1,Registered Voters,,,,1107
+Jefferson,Orleans 1,Ballots Cast,,,,593
 Jefferson,Orleans 1,U.S. Senate,,,Write-ins,0
+Jefferson,Orleans 1,Registered Voters,,,,1107
+Jefferson,Orleans 1,Ballots Cast,,,,593
 Jefferson,Orleans 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Orleans 2,Registered Voters,,,,643
+Jefferson,Orleans 2,Ballots Cast,,,,401
 Jefferson,Orleans 2,U.S. Senate,,REP,Farley,0
+Jefferson,Orleans 2,Registered Voters,,,,643
+Jefferson,Orleans 2,Ballots Cast,,,,401
 Jefferson,Orleans 2,U.S. Senate,,CON,Farley,0
+Jefferson,Orleans 2,Registered Voters,,,,643
+Jefferson,Orleans 2,Ballots Cast,,,,401
 Jefferson,Orleans 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Orleans 2,Registered Voters,,,,643
+Jefferson,Orleans 2,Ballots Cast,,,,401
 Jefferson,Orleans 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Orleans 2,Registered Voters,,,,643
+Jefferson,Orleans 2,Ballots Cast,,,,401
 Jefferson,Orleans 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Orleans 2,Registered Voters,,,,643
+Jefferson,Orleans 2,Ballots Cast,,,,401
 Jefferson,Orleans 2,U.S. Senate,,REF,Farley,0
+Jefferson,Orleans 2,Registered Voters,,,,643
+Jefferson,Orleans 2,Ballots Cast,,,,401
 Jefferson,Orleans 2,U.S. Senate,,,Write-ins,0
+Jefferson,Orleans 2,Registered Voters,,,,643
+Jefferson,Orleans 2,Ballots Cast,,,,401
 Jefferson,Pamelia 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Pamelia 1,Registered Voters,,,,963
+Jefferson,Pamelia 1,Ballots Cast,,,,513
 Jefferson,Pamelia 1,U.S. Senate,,REP,Farley,0
+Jefferson,Pamelia 1,Registered Voters,,,,963
+Jefferson,Pamelia 1,Ballots Cast,,,,513
 Jefferson,Pamelia 1,U.S. Senate,,CON,Farley,0
+Jefferson,Pamelia 1,Registered Voters,,,,963
+Jefferson,Pamelia 1,Ballots Cast,,,,513
 Jefferson,Pamelia 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Pamelia 1,Registered Voters,,,,963
+Jefferson,Pamelia 1,Ballots Cast,,,,513
 Jefferson,Pamelia 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Pamelia 1,Registered Voters,,,,963
+Jefferson,Pamelia 1,Ballots Cast,,,,513
 Jefferson,Pamelia 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Pamelia 1,Registered Voters,,,,963
+Jefferson,Pamelia 1,Ballots Cast,,,,513
 Jefferson,Pamelia 1,U.S. Senate,,REF,Farley,0
+Jefferson,Pamelia 1,Registered Voters,,,,963
+Jefferson,Pamelia 1,Ballots Cast,,,,513
 Jefferson,Pamelia 1,U.S. Senate,,,Write-ins,0
+Jefferson,Pamelia 1,Registered Voters,,,,963
+Jefferson,Pamelia 1,Ballots Cast,,,,513
 Jefferson,Pamelia 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Pamelia 2,Registered Voters,,,,983
+Jefferson,Pamelia 2,Ballots Cast,,,,510
 Jefferson,Pamelia 2,U.S. Senate,,REP,Farley,0
+Jefferson,Pamelia 2,Registered Voters,,,,983
+Jefferson,Pamelia 2,Ballots Cast,,,,510
 Jefferson,Pamelia 2,U.S. Senate,,CON,Farley,0
+Jefferson,Pamelia 2,Registered Voters,,,,983
+Jefferson,Pamelia 2,Ballots Cast,,,,510
 Jefferson,Pamelia 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Pamelia 2,Registered Voters,,,,983
+Jefferson,Pamelia 2,Ballots Cast,,,,510
 Jefferson,Pamelia 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Pamelia 2,Registered Voters,,,,983
+Jefferson,Pamelia 2,Ballots Cast,,,,510
 Jefferson,Pamelia 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Pamelia 2,Registered Voters,,,,983
+Jefferson,Pamelia 2,Ballots Cast,,,,510
 Jefferson,Pamelia 2,U.S. Senate,,REF,Farley,0
+Jefferson,Pamelia 2,Registered Voters,,,,983
+Jefferson,Pamelia 2,Ballots Cast,,,,510
 Jefferson,Pamelia 2,U.S. Senate,,,Write-ins,0
+Jefferson,Pamelia 2,Registered Voters,,,,983
+Jefferson,Pamelia 2,Ballots Cast,,,,510
 Jefferson,Philadelphia 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Philadelphia 1,Registered Voters,,,,509
+Jefferson,Philadelphia 1,Ballots Cast,,,,248
 Jefferson,Philadelphia 1,U.S. Senate,,REP,Farley,0
+Jefferson,Philadelphia 1,Registered Voters,,,,509
+Jefferson,Philadelphia 1,Ballots Cast,,,,248
 Jefferson,Philadelphia 1,U.S. Senate,,CON,Farley,0
+Jefferson,Philadelphia 1,Registered Voters,,,,509
+Jefferson,Philadelphia 1,Ballots Cast,,,,248
 Jefferson,Philadelphia 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Philadelphia 1,Registered Voters,,,,509
+Jefferson,Philadelphia 1,Ballots Cast,,,,248
 Jefferson,Philadelphia 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Philadelphia 1,Registered Voters,,,,509
+Jefferson,Philadelphia 1,Ballots Cast,,,,248
 Jefferson,Philadelphia 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Philadelphia 1,Registered Voters,,,,509
+Jefferson,Philadelphia 1,Ballots Cast,,,,248
 Jefferson,Philadelphia 1,U.S. Senate,,REF,Farley,0
+Jefferson,Philadelphia 1,Registered Voters,,,,509
+Jefferson,Philadelphia 1,Ballots Cast,,,,248
 Jefferson,Philadelphia 1,U.S. Senate,,,Write-ins,0
+Jefferson,Philadelphia 1,Registered Voters,,,,509
+Jefferson,Philadelphia 1,Ballots Cast,,,,248
 Jefferson,Philadelphia 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Philadelphia 2,Registered Voters,,,,477
+Jefferson,Philadelphia 2,Ballots Cast,,,,264
 Jefferson,Philadelphia 2,U.S. Senate,,REP,Farley,0
+Jefferson,Philadelphia 2,Registered Voters,,,,477
+Jefferson,Philadelphia 2,Ballots Cast,,,,264
 Jefferson,Philadelphia 2,U.S. Senate,,CON,Farley,0
+Jefferson,Philadelphia 2,Registered Voters,,,,477
+Jefferson,Philadelphia 2,Ballots Cast,,,,264
 Jefferson,Philadelphia 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Philadelphia 2,Registered Voters,,,,477
+Jefferson,Philadelphia 2,Ballots Cast,,,,264
 Jefferson,Philadelphia 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Philadelphia 2,Registered Voters,,,,477
+Jefferson,Philadelphia 2,Ballots Cast,,,,264
 Jefferson,Philadelphia 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Philadelphia 2,Registered Voters,,,,477
+Jefferson,Philadelphia 2,Ballots Cast,,,,264
 Jefferson,Philadelphia 2,U.S. Senate,,REF,Farley,0
+Jefferson,Philadelphia 2,Registered Voters,,,,477
+Jefferson,Philadelphia 2,Ballots Cast,,,,264
 Jefferson,Philadelphia 2,U.S. Senate,,,Write-ins,0
+Jefferson,Philadelphia 2,Registered Voters,,,,477
+Jefferson,Philadelphia 2,Ballots Cast,,,,264
 Jefferson,Rodman 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Rodman 1,Registered Voters,,,,828
+Jefferson,Rodman 1,Ballots Cast,,,,452
 Jefferson,Rodman 1,U.S. Senate,,REP,Farley,0
+Jefferson,Rodman 1,Registered Voters,,,,828
+Jefferson,Rodman 1,Ballots Cast,,,,452
 Jefferson,Rodman 1,U.S. Senate,,CON,Farley,0
+Jefferson,Rodman 1,Registered Voters,,,,828
+Jefferson,Rodman 1,Ballots Cast,,,,452
 Jefferson,Rodman 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Rodman 1,Registered Voters,,,,828
+Jefferson,Rodman 1,Ballots Cast,,,,452
 Jefferson,Rodman 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Rodman 1,Registered Voters,,,,828
+Jefferson,Rodman 1,Ballots Cast,,,,452
 Jefferson,Rodman 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Rodman 1,Registered Voters,,,,828
+Jefferson,Rodman 1,Ballots Cast,,,,452
 Jefferson,Rodman 1,U.S. Senate,,REF,Farley,0
+Jefferson,Rodman 1,Registered Voters,,,,828
+Jefferson,Rodman 1,Ballots Cast,,,,452
 Jefferson,Rodman 1,U.S. Senate,,,Write-ins,0
+Jefferson,Rodman 1,Registered Voters,,,,828
+Jefferson,Rodman 1,Ballots Cast,,,,452
 Jefferson,Rutland 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Rutland 1,Registered Voters,,,,735
+Jefferson,Rutland 1,Ballots Cast,,,,410
 Jefferson,Rutland 1,U.S. Senate,,REP,Farley,0
+Jefferson,Rutland 1,Registered Voters,,,,735
+Jefferson,Rutland 1,Ballots Cast,,,,410
 Jefferson,Rutland 1,U.S. Senate,,CON,Farley,0
+Jefferson,Rutland 1,Registered Voters,,,,735
+Jefferson,Rutland 1,Ballots Cast,,,,410
 Jefferson,Rutland 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Rutland 1,Registered Voters,,,,735
+Jefferson,Rutland 1,Ballots Cast,,,,410
 Jefferson,Rutland 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Rutland 1,Registered Voters,,,,735
+Jefferson,Rutland 1,Ballots Cast,,,,410
 Jefferson,Rutland 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Rutland 1,Registered Voters,,,,735
+Jefferson,Rutland 1,Ballots Cast,,,,410
 Jefferson,Rutland 1,U.S. Senate,,REF,Farley,0
+Jefferson,Rutland 1,Registered Voters,,,,735
+Jefferson,Rutland 1,Ballots Cast,,,,410
 Jefferson,Rutland 1,U.S. Senate,,,Write-ins,0
+Jefferson,Rutland 1,Registered Voters,,,,735
+Jefferson,Rutland 1,Ballots Cast,,,,410
 Jefferson,Rutland 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Rutland 2,Registered Voters,,,,678
+Jefferson,Rutland 2,Ballots Cast,,,,314
 Jefferson,Rutland 2,U.S. Senate,,REP,Farley,0
+Jefferson,Rutland 2,Registered Voters,,,,678
+Jefferson,Rutland 2,Ballots Cast,,,,314
 Jefferson,Rutland 2,U.S. Senate,,CON,Farley,0
+Jefferson,Rutland 2,Registered Voters,,,,678
+Jefferson,Rutland 2,Ballots Cast,,,,314
 Jefferson,Rutland 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Rutland 2,Registered Voters,,,,678
+Jefferson,Rutland 2,Ballots Cast,,,,314
 Jefferson,Rutland 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Rutland 2,Registered Voters,,,,678
+Jefferson,Rutland 2,Ballots Cast,,,,314
 Jefferson,Rutland 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Rutland 2,Registered Voters,,,,678
+Jefferson,Rutland 2,Ballots Cast,,,,314
 Jefferson,Rutland 2,U.S. Senate,,REF,Farley,0
+Jefferson,Rutland 2,Registered Voters,,,,678
+Jefferson,Rutland 2,Ballots Cast,,,,314
 Jefferson,Rutland 2,U.S. Senate,,,Write-ins,0
+Jefferson,Rutland 2,Registered Voters,,,,678
+Jefferson,Rutland 2,Ballots Cast,,,,314
 Jefferson,Rutland 3,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,Rutland 3,Registered Voters,,,,229
+Jefferson,Rutland 3,Ballots Cast,,,,116
 Jefferson,Rutland 3,U.S. Senate,,REP,Farley,1
+Jefferson,Rutland 3,Registered Voters,,,,229
+Jefferson,Rutland 3,Ballots Cast,,,,116
 Jefferson,Rutland 3,U.S. Senate,,CON,Farley,1
+Jefferson,Rutland 3,Registered Voters,,,,229
+Jefferson,Rutland 3,Ballots Cast,,,,116
 Jefferson,Rutland 3,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,Rutland 3,Registered Voters,,,,229
+Jefferson,Rutland 3,Ballots Cast,,,,116
 Jefferson,Rutland 3,U.S. Senate,,IND,Gillibrand,1
+Jefferson,Rutland 3,Registered Voters,,,,229
+Jefferson,Rutland 3,Ballots Cast,,,,116
 Jefferson,Rutland 3,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,Rutland 3,Registered Voters,,,,229
+Jefferson,Rutland 3,Ballots Cast,,,,116
 Jefferson,Rutland 3,U.S. Senate,,REF,Farley,1
+Jefferson,Rutland 3,Registered Voters,,,,229
+Jefferson,Rutland 3,Ballots Cast,,,,116
 Jefferson,Rutland 3,U.S. Senate,,,Write-ins,1
+Jefferson,Rutland 3,Registered Voters,,,,229
+Jefferson,Rutland 3,Ballots Cast,,,,116
 Jefferson,Theresa 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Theresa 1,Registered Voters,,,,1592
+Jefferson,Theresa 1,Ballots Cast,,,,841
 Jefferson,Theresa 1,U.S. Senate,,REP,Farley,0
+Jefferson,Theresa 1,Registered Voters,,,,1592
+Jefferson,Theresa 1,Ballots Cast,,,,841
 Jefferson,Theresa 1,U.S. Senate,,CON,Farley,0
+Jefferson,Theresa 1,Registered Voters,,,,1592
+Jefferson,Theresa 1,Ballots Cast,,,,841
 Jefferson,Theresa 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Theresa 1,Registered Voters,,,,1592
+Jefferson,Theresa 1,Ballots Cast,,,,841
 Jefferson,Theresa 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Theresa 1,Registered Voters,,,,1592
+Jefferson,Theresa 1,Ballots Cast,,,,841
 Jefferson,Theresa 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Theresa 1,Registered Voters,,,,1592
+Jefferson,Theresa 1,Ballots Cast,,,,841
 Jefferson,Theresa 1,U.S. Senate,,REF,Farley,0
+Jefferson,Theresa 1,Registered Voters,,,,1592
+Jefferson,Theresa 1,Ballots Cast,,,,841
 Jefferson,Theresa 1,U.S. Senate,,,Write-ins,0
+Jefferson,Theresa 1,Registered Voters,,,,1592
+Jefferson,Theresa 1,Ballots Cast,,,,841
 Jefferson,Watertown 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Watertown 1,Registered Voters,,,,1670
+Jefferson,Watertown 1,Ballots Cast,,,,835
 Jefferson,Watertown 1,U.S. Senate,,REP,Farley,0
+Jefferson,Watertown 1,Registered Voters,,,,1670
+Jefferson,Watertown 1,Ballots Cast,,,,835
 Jefferson,Watertown 1,U.S. Senate,,CON,Farley,0
+Jefferson,Watertown 1,Registered Voters,,,,1670
+Jefferson,Watertown 1,Ballots Cast,,,,835
 Jefferson,Watertown 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Watertown 1,Registered Voters,,,,1670
+Jefferson,Watertown 1,Ballots Cast,,,,835
 Jefferson,Watertown 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Watertown 1,Registered Voters,,,,1670
+Jefferson,Watertown 1,Ballots Cast,,,,835
 Jefferson,Watertown 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Watertown 1,Registered Voters,,,,1670
+Jefferson,Watertown 1,Ballots Cast,,,,835
 Jefferson,Watertown 1,U.S. Senate,,REF,Farley,0
+Jefferson,Watertown 1,Registered Voters,,,,1670
+Jefferson,Watertown 1,Ballots Cast,,,,835
 Jefferson,Watertown 1,U.S. Senate,,,Write-ins,0
+Jefferson,Watertown 1,Registered Voters,,,,1670
+Jefferson,Watertown 1,Ballots Cast,,,,835
 Jefferson,Watertown 2,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,Watertown 2,Registered Voters,,,,1441
+Jefferson,Watertown 2,Ballots Cast,,,,793
 Jefferson,Watertown 2,U.S. Senate,,REP,Farley,1
+Jefferson,Watertown 2,Registered Voters,,,,1441
+Jefferson,Watertown 2,Ballots Cast,,,,793
 Jefferson,Watertown 2,U.S. Senate,,CON,Farley,1
+Jefferson,Watertown 2,Registered Voters,,,,1441
+Jefferson,Watertown 2,Ballots Cast,,,,793
 Jefferson,Watertown 2,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,Watertown 2,Registered Voters,,,,1441
+Jefferson,Watertown 2,Ballots Cast,,,,793
 Jefferson,Watertown 2,U.S. Senate,,IND,Gillibrand,1
+Jefferson,Watertown 2,Registered Voters,,,,1441
+Jefferson,Watertown 2,Ballots Cast,,,,793
 Jefferson,Watertown 2,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,Watertown 2,Registered Voters,,,,1441
+Jefferson,Watertown 2,Ballots Cast,,,,793
 Jefferson,Watertown 2,U.S. Senate,,REF,Farley,1
+Jefferson,Watertown 2,Registered Voters,,,,1441
+Jefferson,Watertown 2,Ballots Cast,,,,793
 Jefferson,Watertown 2,U.S. Senate,,,Write-ins,1
+Jefferson,Watertown 2,Registered Voters,,,,1441
+Jefferson,Watertown 2,Ballots Cast,,,,793
 Jefferson,Wilna 1,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,Wilna 1,Registered Voters,,,,1393
+Jefferson,Wilna 1,Ballots Cast,,,,625
 Jefferson,Wilna 1,U.S. Senate,,REP,Farley,1
+Jefferson,Wilna 1,Registered Voters,,,,1393
+Jefferson,Wilna 1,Ballots Cast,,,,625
 Jefferson,Wilna 1,U.S. Senate,,CON,Farley,1
+Jefferson,Wilna 1,Registered Voters,,,,1393
+Jefferson,Wilna 1,Ballots Cast,,,,625
 Jefferson,Wilna 1,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,Wilna 1,Registered Voters,,,,1393
+Jefferson,Wilna 1,Ballots Cast,,,,625
 Jefferson,Wilna 1,U.S. Senate,,IND,Gillibrand,1
+Jefferson,Wilna 1,Registered Voters,,,,1393
+Jefferson,Wilna 1,Ballots Cast,,,,625
 Jefferson,Wilna 1,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,Wilna 1,Registered Voters,,,,1393
+Jefferson,Wilna 1,Ballots Cast,,,,625
 Jefferson,Wilna 1,U.S. Senate,,REF,Farley,1
+Jefferson,Wilna 1,Registered Voters,,,,1393
+Jefferson,Wilna 1,Ballots Cast,,,,625
 Jefferson,Wilna 1,U.S. Senate,,,Write-ins,1
+Jefferson,Wilna 1,Registered Voters,,,,1393
+Jefferson,Wilna 1,Ballots Cast,,,,625
 Jefferson,Wilna 2,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Wilna 2,Registered Voters,,,,53
+Jefferson,Wilna 2,Ballots Cast,,,,20
 Jefferson,Wilna 2,U.S. Senate,,REP,Farley,0
+Jefferson,Wilna 2,Registered Voters,,,,53
+Jefferson,Wilna 2,Ballots Cast,,,,20
 Jefferson,Wilna 2,U.S. Senate,,CON,Farley,0
+Jefferson,Wilna 2,Registered Voters,,,,53
+Jefferson,Wilna 2,Ballots Cast,,,,20
 Jefferson,Wilna 2,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Wilna 2,Registered Voters,,,,53
+Jefferson,Wilna 2,Ballots Cast,,,,20
 Jefferson,Wilna 2,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Wilna 2,Registered Voters,,,,53
+Jefferson,Wilna 2,Ballots Cast,,,,20
 Jefferson,Wilna 2,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Wilna 2,Registered Voters,,,,53
+Jefferson,Wilna 2,Ballots Cast,,,,20
 Jefferson,Wilna 2,U.S. Senate,,REF,Farley,0
+Jefferson,Wilna 2,Registered Voters,,,,53
+Jefferson,Wilna 2,Ballots Cast,,,,20
 Jefferson,Wilna 2,U.S. Senate,,,Write-ins,0
+Jefferson,Wilna 2,Registered Voters,,,,53
+Jefferson,Wilna 2,Ballots Cast,,,,20
 Jefferson,Wilna 3,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Wilna 3,Registered Voters,,,,131
+Jefferson,Wilna 3,Ballots Cast,,,,67
 Jefferson,Wilna 3,U.S. Senate,,REP,Farley,0
+Jefferson,Wilna 3,Registered Voters,,,,131
+Jefferson,Wilna 3,Ballots Cast,,,,67
 Jefferson,Wilna 3,U.S. Senate,,CON,Farley,0
+Jefferson,Wilna 3,Registered Voters,,,,131
+Jefferson,Wilna 3,Ballots Cast,,,,67
 Jefferson,Wilna 3,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Wilna 3,Registered Voters,,,,131
+Jefferson,Wilna 3,Ballots Cast,,,,67
 Jefferson,Wilna 3,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Wilna 3,Registered Voters,,,,131
+Jefferson,Wilna 3,Ballots Cast,,,,67
 Jefferson,Wilna 3,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Wilna 3,Registered Voters,,,,131
+Jefferson,Wilna 3,Ballots Cast,,,,67
 Jefferson,Wilna 3,U.S. Senate,,REF,Farley,0
+Jefferson,Wilna 3,Registered Voters,,,,131
+Jefferson,Wilna 3,Ballots Cast,,,,67
 Jefferson,Wilna 3,U.S. Senate,,,Write-ins,0
+Jefferson,Wilna 3,Registered Voters,,,,131
+Jefferson,Wilna 3,Ballots Cast,,,,67
 Jefferson,Wilna 4,U.S. Senate,,DEM,Gillibrand,1
+Jefferson,Wilna 4,Registered Voters,,,,323
+Jefferson,Wilna 4,Ballots Cast,,,,177
 Jefferson,Wilna 4,U.S. Senate,,REP,Farley,1
+Jefferson,Wilna 4,Registered Voters,,,,323
+Jefferson,Wilna 4,Ballots Cast,,,,177
 Jefferson,Wilna 4,U.S. Senate,,CON,Farley,1
+Jefferson,Wilna 4,Registered Voters,,,,323
+Jefferson,Wilna 4,Ballots Cast,,,,177
 Jefferson,Wilna 4,U.S. Senate,,WFP,Gillibrand,1
+Jefferson,Wilna 4,Registered Voters,,,,323
+Jefferson,Wilna 4,Ballots Cast,,,,177
 Jefferson,Wilna 4,U.S. Senate,,IND,Gillibrand,1
+Jefferson,Wilna 4,Registered Voters,,,,323
+Jefferson,Wilna 4,Ballots Cast,,,,177
 Jefferson,Wilna 4,U.S. Senate,,WEP,Gillibrand,1
+Jefferson,Wilna 4,Registered Voters,,,,323
+Jefferson,Wilna 4,Ballots Cast,,,,177
 Jefferson,Wilna 4,U.S. Senate,,REF,Farley,1
+Jefferson,Wilna 4,Registered Voters,,,,323
+Jefferson,Wilna 4,Ballots Cast,,,,177
 Jefferson,Wilna 4,U.S. Senate,,,Write-ins,1
+Jefferson,Wilna 4,Registered Voters,,,,323
+Jefferson,Wilna 4,Ballots Cast,,,,177
 Jefferson,Wilna 5,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Wilna 5,Registered Voters,,,,818
+Jefferson,Wilna 5,Ballots Cast,,,,374
 Jefferson,Wilna 5,U.S. Senate,,REP,Farley,0
+Jefferson,Wilna 5,Registered Voters,,,,818
+Jefferson,Wilna 5,Ballots Cast,,,,374
 Jefferson,Wilna 5,U.S. Senate,,CON,Farley,0
+Jefferson,Wilna 5,Registered Voters,,,,818
+Jefferson,Wilna 5,Ballots Cast,,,,374
 Jefferson,Wilna 5,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Wilna 5,Registered Voters,,,,818
+Jefferson,Wilna 5,Ballots Cast,,,,374
 Jefferson,Wilna 5,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Wilna 5,Registered Voters,,,,818
+Jefferson,Wilna 5,Ballots Cast,,,,374
 Jefferson,Wilna 5,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Wilna 5,Registered Voters,,,,818
+Jefferson,Wilna 5,Ballots Cast,,,,374
 Jefferson,Wilna 5,U.S. Senate,,REF,Farley,0
+Jefferson,Wilna 5,Registered Voters,,,,818
+Jefferson,Wilna 5,Ballots Cast,,,,374
 Jefferson,Wilna 5,U.S. Senate,,,Write-ins,0
+Jefferson,Wilna 5,Registered Voters,,,,818
+Jefferson,Wilna 5,Ballots Cast,,,,374
 Jefferson,Worth 1,U.S. Senate,,DEM,Gillibrand,0
+Jefferson,Worth 1,Registered Voters,,,,172
+Jefferson,Worth 1,Ballots Cast,,,,98
 Jefferson,Worth 1,U.S. Senate,,REP,Farley,0
+Jefferson,Worth 1,Registered Voters,,,,172
+Jefferson,Worth 1,Ballots Cast,,,,98
 Jefferson,Worth 1,U.S. Senate,,CON,Farley,0
+Jefferson,Worth 1,Registered Voters,,,,172
+Jefferson,Worth 1,Ballots Cast,,,,98
 Jefferson,Worth 1,U.S. Senate,,WFP,Gillibrand,0
+Jefferson,Worth 1,Registered Voters,,,,172
+Jefferson,Worth 1,Ballots Cast,,,,98
 Jefferson,Worth 1,U.S. Senate,,IND,Gillibrand,0
+Jefferson,Worth 1,Registered Voters,,,,172
+Jefferson,Worth 1,Ballots Cast,,,,98
 Jefferson,Worth 1,U.S. Senate,,WEP,Gillibrand,0
+Jefferson,Worth 1,Registered Voters,,,,172
+Jefferson,Worth 1,Ballots Cast,,,,98
 Jefferson,Worth 1,U.S. Senate,,REF,Farley,0
+Jefferson,Worth 1,Registered Voters,,,,172
+Jefferson,Worth 1,Ballots Cast,,,,98
 Jefferson,Worth 1,U.S. Senate,,,Write-ins,0
+Jefferson,Worth 1,Registered Voters,,,,172
+Jefferson,Worth 1,Ballots Cast,,,,98
 Jefferson,Adams 1,U.S. House,21,DEM,Cobb,1
 Jefferson,Adams 1,U.S. House,21,REP,Stefanik,1
 Jefferson,Adams 1,U.S. House,21,CON,Stefanik,1
@@ -4296,3 +4224,488 @@ Jefferson,Worth 1,U.S. House,21,IND,Stefanik,1
 Jefferson,Worth 1,U.S. House,21,WE,Cobb,1
 Jefferson,Worth 1,U.S. House,21,REF,Stefanik,1
 Jefferson,Worth 1,U.S. House,21,,Write-ins,1
+Jefferson,Adams 1,State Senate,48,REP,Ritchie,449
+Jefferson,Adams 1,State Senate,48,CON,Ritchie,449
+Jefferson,Adams 1,State Senate,48,IND,Ritchie,449
+Jefferson,Adams 1,State Senate,48,,Write-ins,449
+Jefferson,Adams 2,State Senate,48,REP,Ritchie,323
+Jefferson,Adams 2,State Senate,48,CON,Ritchie,323
+Jefferson,Adams 2,State Senate,48,IND,Ritchie,323
+Jefferson,Adams 2,State Senate,48,,Write-ins,323
+Jefferson,Adams 3,State Senate,48,REP,Ritchie,671
+Jefferson,Adams 3,State Senate,48,CON,Ritchie,671
+Jefferson,Adams 3,State Senate,48,IND,Ritchie,671
+Jefferson,Adams 3,State Senate,48,,Write-ins,671
+Jefferson,Alexandria 1,State Senate,48,REP,Ritchie,298
+Jefferson,Alexandria 1,State Senate,48,CON,Ritchie,298
+Jefferson,Alexandria 1,State Senate,48,IND,Ritchie,298
+Jefferson,Alexandria 1,State Senate,48,,Write-ins,298
+Jefferson,Alexandria 2,State Senate,48,REP,Ritchie,437
+Jefferson,Alexandria 2,State Senate,48,CON,Ritchie,437
+Jefferson,Alexandria 2,State Senate,48,IND,Ritchie,437
+Jefferson,Alexandria 2,State Senate,48,,Write-ins,437
+Jefferson,Alexandria 3,State Senate,48,REP,Ritchie,611
+Jefferson,Alexandria 3,State Senate,48,CON,Ritchie,611
+Jefferson,Alexandria 3,State Senate,48,IND,Ritchie,611
+Jefferson,Alexandria 3,State Senate,48,,Write-ins,611
+Jefferson,Antwerp 1,State Senate,48,REP,Ritchie,153
+Jefferson,Antwerp 1,State Senate,48,CON,Ritchie,153
+Jefferson,Antwerp 1,State Senate,48,IND,Ritchie,153
+Jefferson,Antwerp 1,State Senate,48,,Write-ins,153
+Jefferson,Antwerp 2,State Senate,48,REP,Ritchie,322
+Jefferson,Antwerp 2,State Senate,48,CON,Ritchie,322
+Jefferson,Antwerp 2,State Senate,48,IND,Ritchie,322
+Jefferson,Antwerp 2,State Senate,48,,Write-ins,322
+Jefferson,Brownville 1,State Senate,48,REP,Ritchie,369
+Jefferson,Brownville 1,State Senate,48,CON,Ritchie,369
+Jefferson,Brownville 1,State Senate,48,IND,Ritchie,369
+Jefferson,Brownville 1,State Senate,48,,Write-ins,369
+Jefferson,Brownville 2,State Senate,48,REP,Ritchie,287
+Jefferson,Brownville 2,State Senate,48,CON,Ritchie,287
+Jefferson,Brownville 2,State Senate,48,IND,Ritchie,287
+Jefferson,Brownville 2,State Senate,48,,Write-ins,287
+Jefferson,Brownville 3,State Senate,48,REP,Ritchie,409
+Jefferson,Brownville 3,State Senate,48,CON,Ritchie,409
+Jefferson,Brownville 3,State Senate,48,IND,Ritchie,409
+Jefferson,Brownville 3,State Senate,48,,Write-ins,409
+Jefferson,Brownville 4,State Senate,48,REP,Ritchie,279
+Jefferson,Brownville 4,State Senate,48,CON,Ritchie,279
+Jefferson,Brownville 4,State Senate,48,IND,Ritchie,279
+Jefferson,Brownville 4,State Senate,48,,Write-ins,279
+Jefferson,Brownville 5,State Senate,48,REP,Ritchie,424
+Jefferson,Brownville 5,State Senate,48,CON,Ritchie,424
+Jefferson,Brownville 5,State Senate,48,IND,Ritchie,424
+Jefferson,Brownville 5,State Senate,48,,Write-ins,424
+Jefferson,Cape Vincent 1,State Senate,48,REP,Ritchie,302
+Jefferson,Cape Vincent 1,State Senate,48,CON,Ritchie,302
+Jefferson,Cape Vincent 1,State Senate,48,IND,Ritchie,302
+Jefferson,Cape Vincent 1,State Senate,48,,Write-ins,302
+Jefferson,Cape Vincent 2,State Senate,48,REP,Ritchie,571
+Jefferson,Cape Vincent 2,State Senate,48,CON,Ritchie,571
+Jefferson,Cape Vincent 2,State Senate,48,IND,Ritchie,571
+Jefferson,Cape Vincent 2,State Senate,48,,Write-ins,571
+Jefferson,Champion 1,State Senate,48,REP,Ritchie,675
+Jefferson,Champion 1,State Senate,48,CON,Ritchie,675
+Jefferson,Champion 1,State Senate,48,IND,Ritchie,675
+Jefferson,Champion 1,State Senate,48,,Write-ins,675
+Jefferson,Champion 2,State Senate,48,REP,Ritchie,383
+Jefferson,Champion 2,State Senate,48,CON,Ritchie,383
+Jefferson,Champion 2,State Senate,48,IND,Ritchie,383
+Jefferson,Champion 2,State Senate,48,,Write-ins,383
+Jefferson,Clayton 1,State Senate,48,REP,Ritchie,397
+Jefferson,Clayton 1,State Senate,48,CON,Ritchie,397
+Jefferson,Clayton 1,State Senate,48,IND,Ritchie,397
+Jefferson,Clayton 1,State Senate,48,,Write-ins,397
+Jefferson,Clayton 2,State Senate,48,REP,Ritchie,535
+Jefferson,Clayton 2,State Senate,48,CON,Ritchie,535
+Jefferson,Clayton 2,State Senate,48,IND,Ritchie,535
+Jefferson,Clayton 2,State Senate,48,,Write-ins,535
+Jefferson,Clayton 3,State Senate,48,REP,Ritchie,668
+Jefferson,Clayton 3,State Senate,48,CON,Ritchie,668
+Jefferson,Clayton 3,State Senate,48,IND,Ritchie,668
+Jefferson,Clayton 3,State Senate,48,,Write-ins,668
+Jefferson,Ellisburg 1,State Senate,48,REP,Ritchie,114
+Jefferson,Ellisburg 1,State Senate,48,CON,Ritchie,114
+Jefferson,Ellisburg 1,State Senate,48,IND,Ritchie,114
+Jefferson,Ellisburg 1,State Senate,48,,Write-ins,114
+Jefferson,Elllisburg 2,State Senate,48,REP,Ritchie,354
+Jefferson,Elllisburg 2,State Senate,48,CON,Ritchie,354
+Jefferson,Elllisburg 2,State Senate,48,IND,Ritchie,354
+Jefferson,Elllisburg 2,State Senate,48,,Write-ins,354
+Jefferson,Ellisburg 3,State Senate,48,REP,Ritchie,78
+Jefferson,Ellisburg 3,State Senate,48,CON,Ritchie,78
+Jefferson,Ellisburg 3,State Senate,48,IND,Ritchie,78
+Jefferson,Ellisburg 3,State Senate,48,,Write-ins,78
+Jefferson,Ellisburg 4,State Senate,48,REP,Ritchie,444
+Jefferson,Ellisburg 4,State Senate,48,CON,Ritchie,444
+Jefferson,Ellisburg 4,State Senate,48,IND,Ritchie,444
+Jefferson,Ellisburg 4,State Senate,48,,Write-ins,444
+Jefferson,Henderson 1,State Senate,48,REP,Ritchie,543
+Jefferson,Henderson 1,State Senate,48,CON,Ritchie,543
+Jefferson,Henderson 1,State Senate,48,IND,Ritchie,543
+Jefferson,Henderson 1,State Senate,48,,Write-ins,543
+Jefferson,Hounsfield 1,State Senate,48,REP,Ritchie,408
+Jefferson,Hounsfield 1,State Senate,48,CON,Ritchie,408
+Jefferson,Hounsfield 1,State Senate,48,IND,Ritchie,408
+Jefferson,Hounsfield 1,State Senate,48,,Write-ins,408
+Jefferson,Hounsfield 2,State Senate,48,REP,Ritchie,681
+Jefferson,Hounsfield 2,State Senate,48,CON,Ritchie,681
+Jefferson,Hounsfield 2,State Senate,48,IND,Ritchie,681
+Jefferson,Hounsfield 2,State Senate,48,,Write-ins,681
+Jefferson,LeRay 1,State Senate,48,REP,Ritchie,173
+Jefferson,LeRay 1,State Senate,48,CON,Ritchie,173
+Jefferson,LeRay 1,State Senate,48,IND,Ritchie,173
+Jefferson,LeRay 1,State Senate,48,,Write-ins,173
+Jefferson,LeRay 2,State Senate,48,REP,Ritchie,95
+Jefferson,LeRay 2,State Senate,48,CON,Ritchie,95
+Jefferson,LeRay 2,State Senate,48,IND,Ritchie,95
+Jefferson,LeRay 2,State Senate,48,,Write-ins,95
+Jefferson,LeRay 3,State Senate,48,REP,Ritchie,142
+Jefferson,LeRay 3,State Senate,48,CON,Ritchie,142
+Jefferson,LeRay 3,State Senate,48,IND,Ritchie,142
+Jefferson,LeRay 3,State Senate,48,,Write-ins,142
+Jefferson,LeRay 4,State Senate,48,REP,Ritchie,399
+Jefferson,LeRay 4,State Senate,48,CON,Ritchie,399
+Jefferson,LeRay 4,State Senate,48,IND,Ritchie,399
+Jefferson,LeRay 4,State Senate,48,,Write-ins,399
+Jefferson,LeRay 5,State Senate,48,REP,Ritchie,204
+Jefferson,LeRay 5,State Senate,48,CON,Ritchie,204
+Jefferson,LeRay 5,State Senate,48,IND,Ritchie,204
+Jefferson,LeRay 5,State Senate,48,,Write-ins,204
+Jefferson,LeRay 6,State Senate,48,REP,Ritchie,98
+Jefferson,LeRay 6,State Senate,48,CON,Ritchie,98
+Jefferson,LeRay 6,State Senate,48,IND,Ritchie,98
+Jefferson,LeRay 6,State Senate,48,,Write-ins,98
+Jefferson,LeRay 7,State Senate,48,REP,Ritchie,48
+Jefferson,LeRay 7,State Senate,48,CON,Ritchie,48
+Jefferson,LeRay 7,State Senate,48,IND,Ritchie,48
+Jefferson,LeRay 7,State Senate,48,,Write-ins,48
+Jefferson,LeRay 8,State Senate,48,REP,Ritchie,299
+Jefferson,LeRay 8,State Senate,48,CON,Ritchie,299
+Jefferson,LeRay 8,State Senate,48,IND,Ritchie,299
+Jefferson,LeRay 8,State Senate,48,,Write-ins,299
+Jefferson,Lorraine 1,State Senate,48,REP,Ritchie,310
+Jefferson,Lorraine 1,State Senate,48,CON,Ritchie,310
+Jefferson,Lorraine 1,State Senate,48,IND,Ritchie,310
+Jefferson,Lorraine 1,State Senate,48,,Write-ins,310
+Jefferson,Lyme 1,State Senate,48,REP,Ritchie,291
+Jefferson,Lyme 1,State Senate,48,CON,Ritchie,291
+Jefferson,Lyme 1,State Senate,48,IND,Ritchie,291
+Jefferson,Lyme 1,State Senate,48,,Write-ins,291
+Jefferson,Lyme 2,State Senate,48,REP,Ritchie,375
+Jefferson,Lyme 2,State Senate,48,CON,Ritchie,375
+Jefferson,Lyme 2,State Senate,48,IND,Ritchie,375
+Jefferson,Lyme 2,State Senate,48,,Write-ins,375
+Jefferson,Lyme 3,State Senate,48,REP,Ritchie,213
+Jefferson,Lyme 3,State Senate,48,CON,Ritchie,213
+Jefferson,Lyme 3,State Senate,48,IND,Ritchie,213
+Jefferson,Lyme 3,State Senate,48,,Write-ins,213
+Jefferson,Orleans 1,State Senate,48,REP,Ritchie,533
+Jefferson,Orleans 1,State Senate,48,CON,Ritchie,533
+Jefferson,Orleans 1,State Senate,48,IND,Ritchie,533
+Jefferson,Orleans 1,State Senate,48,,Write-ins,533
+Jefferson,Orleans 2,State Senate,48,REP,Ritchie,324
+Jefferson,Orleans 2,State Senate,48,CON,Ritchie,324
+Jefferson,Orleans 2,State Senate,48,IND,Ritchie,324
+Jefferson,Orleans 2,State Senate,48,,Write-ins,324
+Jefferson,Pamelia 1,State Senate,48,REP,Ritchie,456
+Jefferson,Pamelia 1,State Senate,48,CON,Ritchie,456
+Jefferson,Pamelia 1,State Senate,48,IND,Ritchie,456
+Jefferson,Pamelia 1,State Senate,48,,Write-ins,456
+Jefferson,Pamelia 2,State Senate,48,REP,Ritchie,422
+Jefferson,Pamelia 2,State Senate,48,CON,Ritchie,422
+Jefferson,Pamelia 2,State Senate,48,IND,Ritchie,422
+Jefferson,Pamelia 2,State Senate,48,,Write-ins,422
+Jefferson,Philadelphia 1,State Senate,48,REP,Ritchie,208
+Jefferson,Philadelphia 1,State Senate,48,CON,Ritchie,208
+Jefferson,Philadelphia 1,State Senate,48,IND,Ritchie,208
+Jefferson,Philadelphia 1,State Senate,48,,Write-ins,208
+Jefferson,Philadelphia 2,State Senate,48,REP,Ritchie,224
+Jefferson,Philadelphia 2,State Senate,48,CON,Ritchie,224
+Jefferson,Philadelphia 2,State Senate,48,IND,Ritchie,224
+Jefferson,Philadelphia 2,State Senate,48,,Write-ins,224
+Jefferson,Rodman 1,State Senate,48,REP,Ritchie,408
+Jefferson,Rodman 1,State Senate,48,CON,Ritchie,408
+Jefferson,Rodman 1,State Senate,48,IND,Ritchie,408
+Jefferson,Rodman 1,State Senate,48,,Write-ins,408
+Jefferson,Rutland 1,State Senate,48,REP,Ritchie,384
+Jefferson,Rutland 1,State Senate,48,CON,Ritchie,384
+Jefferson,Rutland 1,State Senate,48,IND,Ritchie,384
+Jefferson,Rutland 1,State Senate,48,,Write-ins,384
+Jefferson,Rutland 2,State Senate,48,REP,Ritchie,305
+Jefferson,Rutland 2,State Senate,48,CON,Ritchie,305
+Jefferson,Rutland 2,State Senate,48,IND,Ritchie,305
+Jefferson,Rutland 2,State Senate,48,,Write-ins,305
+Jefferson,Rutland 3,State Senate,48,REP,Ritchie,100
+Jefferson,Rutland 3,State Senate,48,CON,Ritchie,100
+Jefferson,Rutland 3,State Senate,48,IND,Ritchie,100
+Jefferson,Rutland 3,State Senate,48,,Write-ins,100
+Jefferson,Theresa 1,State Senate,48,REP,Ritchie,701
+Jefferson,Theresa 1,State Senate,48,CON,Ritchie,701
+Jefferson,Theresa 1,State Senate,48,IND,Ritchie,701
+Jefferson,Theresa 1,State Senate,48,,Write-ins,701
+Jefferson,Watertown 1,State Senate,48,REP,Ritchie,687
+Jefferson,Watertown 1,State Senate,48,CON,Ritchie,687
+Jefferson,Watertown 1,State Senate,48,IND,Ritchie,687
+Jefferson,Watertown 1,State Senate,48,,Write-ins,687
+Jefferson,Watertown 2,State Senate,48,REP,Ritchie,712
+Jefferson,Watertown 2,State Senate,48,CON,Ritchie,712
+Jefferson,Watertown 2,State Senate,48,IND,Ritchie,712
+Jefferson,Watertown 2,State Senate,48,,Write-ins,712
+Jefferson,Wilna 1,State Senate,48,REP,Ritchie,532
+Jefferson,Wilna 1,State Senate,48,CON,Ritchie,532
+Jefferson,Wilna 1,State Senate,48,IND,Ritchie,532
+Jefferson,Wilna 1,State Senate,48,,Write-ins,532
+Jefferson,Wilna 2,State Senate,48,REP,Ritchie,14
+Jefferson,Wilna 2,State Senate,48,CON,Ritchie,14
+Jefferson,Wilna 2,State Senate,48,IND,Ritchie,14
+Jefferson,Wilna 2,State Senate,48,,Write-ins,14
+Jefferson,Wilna 3,State Senate,48,REP,Ritchie,56
+Jefferson,Wilna 3,State Senate,48,CON,Ritchie,56
+Jefferson,Wilna 3,State Senate,48,IND,Ritchie,56
+Jefferson,Wilna 3,State Senate,48,,Write-ins,56
+Jefferson,Wilna 4,State Senate,48,REP,Ritchie,160
+Jefferson,Wilna 4,State Senate,48,CON,Ritchie,160
+Jefferson,Wilna 4,State Senate,48,IND,Ritchie,160
+Jefferson,Wilna 4,State Senate,48,,Write-ins,160
+Jefferson,Wilna 5,State Senate,48,REP,Ritchie,328
+Jefferson,Wilna 5,State Senate,48,CON,Ritchie,328
+Jefferson,Wilna 5,State Senate,48,IND,Ritchie,328
+Jefferson,Wilna 5,State Senate,48,,Write-ins,328
+Jefferson,Worth 1,State Senate,48,REP,Ritchie,93
+Jefferson,Worth 1,State Senate,48,CON,Ritchie,93
+Jefferson,Worth 1,State Senate,48,IND,Ritchie,93
+Jefferson,Worth 1,State Senate,48,,Write-ins,93
+Jefferson,Alexandria 1,State Assembly,116,DEM,Jenne,13
+Jefferson,Alexandria 1,State Assembly,116,REP,Walczyk,13
+Jefferson,Alexandria 1,State Assembly,116,CON,Walczyk,13
+Jefferson,Alexandria 1,State Assembly,116,WF,Walczyk,13
+Jefferson,Alexandria 1,State Assembly,116,IND,Walczyk,13
+Jefferson,Alexandria 1,State Assembly,116,REF,Walczyk,13
+Jefferson,Alexandria 1,State Assembly,116,,Write-ins,13
+Jefferson,Alexandria 2,State Assembly,116,DEM,Jenne,10
+Jefferson,Alexandria 2,State Assembly,116,REP,Walczyk,10
+Jefferson,Alexandria 2,State Assembly,116,CON,Walczyk,10
+Jefferson,Alexandria 2,State Assembly,116,WF,Walczyk,10
+Jefferson,Alexandria 2,State Assembly,116,IND,Walczyk,10
+Jefferson,Alexandria 2,State Assembly,116,REF,Walczyk,10
+Jefferson,Alexandria 2,State Assembly,116,,Write-ins,10
+Jefferson,Alexandria 3,State Assembly,116,DEM,Jenne,10
+Jefferson,Alexandria 3,State Assembly,116,REP,Walczyk,10
+Jefferson,Alexandria 3,State Assembly,116,CON,Walczyk,10
+Jefferson,Alexandria 3,State Assembly,116,WF,Walczyk,10
+Jefferson,Alexandria 3,State Assembly,116,IND,Walczyk,10
+Jefferson,Alexandria 3,State Assembly,116,REF,Walczyk,10
+Jefferson,Alexandria 3,State Assembly,116,,Write-ins,10
+Jefferson,Antwerp 1,State Assembly,116,DEM,Jenne,4
+Jefferson,Antwerp 1,State Assembly,116,REP,Walczyk,4
+Jefferson,Antwerp 1,State Assembly,116,CON,Walczyk,4
+Jefferson,Antwerp 1,State Assembly,116,WF,Walczyk,4
+Jefferson,Antwerp 1,State Assembly,116,IND,Walczyk,4
+Jefferson,Antwerp 1,State Assembly,116,REF,Walczyk,4
+Jefferson,Antwerp 1,State Assembly,116,,Write-ins,4
+Jefferson,Antwerp 2,State Assembly,116,DEM,Jenne,4
+Jefferson,Antwerp 2,State Assembly,116,REP,Walczyk,4
+Jefferson,Antwerp 2,State Assembly,116,CON,Walczyk,4
+Jefferson,Antwerp 2,State Assembly,116,WF,Walczyk,4
+Jefferson,Antwerp 2,State Assembly,116,IND,Walczyk,4
+Jefferson,Antwerp 2,State Assembly,116,REF,Walczyk,4
+Jefferson,Antwerp 2,State Assembly,116,,Write-ins,4
+Jefferson,Brownville 1,State Assembly,116,DEM,Jenne,5
+Jefferson,Brownville 1,State Assembly,116,REP,Walczyk,5
+Jefferson,Brownville 1,State Assembly,116,CON,Walczyk,5
+Jefferson,Brownville 1,State Assembly,116,WF,Walczyk,5
+Jefferson,Brownville 1,State Assembly,116,IND,Walczyk,5
+Jefferson,Brownville 1,State Assembly,116,REF,Walczyk,5
+Jefferson,Brownville 1,State Assembly,116,,Write-ins,5
+Jefferson,Brownville 2,State Assembly,116,DEM,Jenne,5
+Jefferson,Brownville 2,State Assembly,116,REP,Walczyk,5
+Jefferson,Brownville 2,State Assembly,116,CON,Walczyk,5
+Jefferson,Brownville 2,State Assembly,116,WF,Walczyk,5
+Jefferson,Brownville 2,State Assembly,116,IND,Walczyk,5
+Jefferson,Brownville 2,State Assembly,116,REF,Walczyk,5
+Jefferson,Brownville 2,State Assembly,116,,Write-ins,5
+Jefferson,Brownville 3,State Assembly,116,DEM,Jenne,9
+Jefferson,Brownville 3,State Assembly,116,REP,Walczyk,9
+Jefferson,Brownville 3,State Assembly,116,CON,Walczyk,9
+Jefferson,Brownville 3,State Assembly,116,WF,Walczyk,9
+Jefferson,Brownville 3,State Assembly,116,IND,Walczyk,9
+Jefferson,Brownville 3,State Assembly,116,REF,Walczyk,9
+Jefferson,Brownville 3,State Assembly,116,,Write-ins,9
+Jefferson,Brownville 4,State Assembly,116,DEM,Jenne,7
+Jefferson,Brownville 4,State Assembly,116,REP,Walczyk,7
+Jefferson,Brownville 4,State Assembly,116,CON,Walczyk,7
+Jefferson,Brownville 4,State Assembly,116,WF,Walczyk,7
+Jefferson,Brownville 4,State Assembly,116,IND,Walczyk,7
+Jefferson,Brownville 4,State Assembly,116,REF,Walczyk,7
+Jefferson,Brownville 4,State Assembly,116,,Write-ins,7
+Jefferson,Brownville 5,State Assembly,116,DEM,Jenne,8
+Jefferson,Brownville 5,State Assembly,116,REP,Walczyk,8
+Jefferson,Brownville 5,State Assembly,116,CON,Walczyk,8
+Jefferson,Brownville 5,State Assembly,116,WF,Walczyk,8
+Jefferson,Brownville 5,State Assembly,116,IND,Walczyk,8
+Jefferson,Brownville 5,State Assembly,116,REF,Walczyk,8
+Jefferson,Brownville 5,State Assembly,116,,Write-ins,8
+Jefferson,Cape Vincent 1,State Assembly,116,DEM,Jenne,8
+Jefferson,Cape Vincent 1,State Assembly,116,REP,Walczyk,8
+Jefferson,Cape Vincent 1,State Assembly,116,CON,Walczyk,8
+Jefferson,Cape Vincent 1,State Assembly,116,WF,Walczyk,8
+Jefferson,Cape Vincent 1,State Assembly,116,IND,Walczyk,8
+Jefferson,Cape Vincent 1,State Assembly,116,REF,Walczyk,8
+Jefferson,Cape Vincent 1,State Assembly,116,,Write-ins,8
+Jefferson,Cape Vincent 2,State Assembly,116,DEM,Jenne,12
+Jefferson,Cape Vincent 2,State Assembly,116,REP,Walczyk,12
+Jefferson,Cape Vincent 2,State Assembly,116,CON,Walczyk,12
+Jefferson,Cape Vincent 2,State Assembly,116,WF,Walczyk,12
+Jefferson,Cape Vincent 2,State Assembly,116,IND,Walczyk,12
+Jefferson,Cape Vincent 2,State Assembly,116,REF,Walczyk,12
+Jefferson,Cape Vincent 2,State Assembly,116,,Write-ins,12
+Jefferson,Clayton 1,State Assembly,116,DEM,Jenne,8
+Jefferson,Clayton 1,State Assembly,116,REP,Walczyk,8
+Jefferson,Clayton 1,State Assembly,116,CON,Walczyk,8
+Jefferson,Clayton 1,State Assembly,116,WF,Walczyk,8
+Jefferson,Clayton 1,State Assembly,116,IND,Walczyk,8
+Jefferson,Clayton 1,State Assembly,116,REF,Walczyk,8
+Jefferson,Clayton 1,State Assembly,116,,Write-ins,8
+Jefferson,Clayton 2,State Assembly,116,DEM,Jenne,4
+Jefferson,Clayton 2,State Assembly,116,REP,Walczyk,4
+Jefferson,Clayton 2,State Assembly,116,CON,Walczyk,4
+Jefferson,Clayton 2,State Assembly,116,WF,Walczyk,4
+Jefferson,Clayton 2,State Assembly,116,IND,Walczyk,4
+Jefferson,Clayton 2,State Assembly,116,REF,Walczyk,4
+Jefferson,Clayton 2,State Assembly,116,,Write-ins,4
+Jefferson,Clayton 3,State Assembly,116,DEM,Jenne,5
+Jefferson,Clayton 3,State Assembly,116,REP,Walczyk,5
+Jefferson,Clayton 3,State Assembly,116,CON,Walczyk,5
+Jefferson,Clayton 3,State Assembly,116,WF,Walczyk,5
+Jefferson,Clayton 3,State Assembly,116,IND,Walczyk,5
+Jefferson,Clayton 3,State Assembly,116,REF,Walczyk,5
+Jefferson,Clayton 3,State Assembly,116,,Write-ins,5
+Jefferson,Hounsfield 1,State Assembly,116,DEM,Jenne,12
+Jefferson,Hounsfield 1,State Assembly,116,REP,Walczyk,12
+Jefferson,Hounsfield 1,State Assembly,116,CON,Walczyk,12
+Jefferson,Hounsfield 1,State Assembly,116,WF,Walczyk,12
+Jefferson,Hounsfield 1,State Assembly,116,IND,Walczyk,12
+Jefferson,Hounsfield 1,State Assembly,116,REF,Walczyk,12
+Jefferson,Hounsfield 1,State Assembly,116,,Write-ins,12
+Jefferson,Hounsfield 2,State Assembly,116,DEM,Jenne,9
+Jefferson,Hounsfield 2,State Assembly,116,REP,Walczyk,9
+Jefferson,Hounsfield 2,State Assembly,116,CON,Walczyk,9
+Jefferson,Hounsfield 2,State Assembly,116,WF,Walczyk,9
+Jefferson,Hounsfield 2,State Assembly,116,IND,Walczyk,9
+Jefferson,Hounsfield 2,State Assembly,116,REF,Walczyk,9
+Jefferson,Hounsfield 2,State Assembly,116,,Write-ins,9
+Jefferson,Lyme 1,State Assembly,116,DEM,Jenne,11
+Jefferson,Lyme 1,State Assembly,116,REP,Walczyk,11
+Jefferson,Lyme 1,State Assembly,116,CON,Walczyk,11
+Jefferson,Lyme 1,State Assembly,116,WF,Walczyk,11
+Jefferson,Lyme 1,State Assembly,116,IND,Walczyk,11
+Jefferson,Lyme 1,State Assembly,116,REF,Walczyk,11
+Jefferson,Lyme 1,State Assembly,116,,Write-ins,11
+Jefferson,Lyme 2,State Assembly,116,DEM,Jenne,5
+Jefferson,Lyme 2,State Assembly,116,REP,Walczyk,5
+Jefferson,Lyme 2,State Assembly,116,CON,Walczyk,5
+Jefferson,Lyme 2,State Assembly,116,WF,Walczyk,5
+Jefferson,Lyme 2,State Assembly,116,IND,Walczyk,5
+Jefferson,Lyme 2,State Assembly,116,REF,Walczyk,5
+Jefferson,Lyme 2,State Assembly,116,,Write-ins,5
+Jefferson,Lyme 3,State Assembly,116,DEM,Jenne,4
+Jefferson,Lyme 3,State Assembly,116,REP,Walczyk,4
+Jefferson,Lyme 3,State Assembly,116,CON,Walczyk,4
+Jefferson,Lyme 3,State Assembly,116,WF,Walczyk,4
+Jefferson,Lyme 3,State Assembly,116,IND,Walczyk,4
+Jefferson,Lyme 3,State Assembly,116,REF,Walczyk,4
+Jefferson,Lyme 3,State Assembly,116,,Write-ins,4
+Jefferson,Orleans 1,State Assembly,116,DEM,Jenne,7
+Jefferson,Orleans 1,State Assembly,116,REP,Walczyk,7
+Jefferson,Orleans 1,State Assembly,116,CON,Walczyk,7
+Jefferson,Orleans 1,State Assembly,116,WF,Walczyk,7
+Jefferson,Orleans 1,State Assembly,116,IND,Walczyk,7
+Jefferson,Orleans 1,State Assembly,116,REF,Walczyk,7
+Jefferson,Orleans 1,State Assembly,116,,Write-ins,7
+Jefferson,Orleans 2,State Assembly,116,DEM,Jenne,9
+Jefferson,Orleans 2,State Assembly,116,REP,Walczyk,9
+Jefferson,Orleans 2,State Assembly,116,CON,Walczyk,9
+Jefferson,Orleans 2,State Assembly,116,WF,Walczyk,9
+Jefferson,Orleans 2,State Assembly,116,IND,Walczyk,9
+Jefferson,Orleans 2,State Assembly,116,REF,Walczyk,9
+Jefferson,Orleans 2,State Assembly,116,,Write-ins,9
+Jefferson,Pamelia 1,State Assembly,116,DEM,Jenne,9
+Jefferson,Pamelia 1,State Assembly,116,REP,Walczyk,9
+Jefferson,Pamelia 1,State Assembly,116,CON,Walczyk,9
+Jefferson,Pamelia 1,State Assembly,116,WF,Walczyk,9
+Jefferson,Pamelia 1,State Assembly,116,IND,Walczyk,9
+Jefferson,Pamelia 1,State Assembly,116,REF,Walczyk,9
+Jefferson,Pamelia 1,State Assembly,116,,Write-ins,9
+Jefferson,Pamelia 2,State Assembly,116,DEM,Jenne,6
+Jefferson,Pamelia 2,State Assembly,116,REP,Walczyk,6
+Jefferson,Pamelia 2,State Assembly,116,CON,Walczyk,6
+Jefferson,Pamelia 2,State Assembly,116,WF,Walczyk,6
+Jefferson,Pamelia 2,State Assembly,116,IND,Walczyk,6
+Jefferson,Pamelia 2,State Assembly,116,REF,Walczyk,6
+Jefferson,Pamelia 2,State Assembly,116,,Write-ins,6
+Jefferson,Philadelphia 1,State Assembly,116,DEM,Jenne,6
+Jefferson,Philadelphia 1,State Assembly,116,REP,Walczyk,6
+Jefferson,Philadelphia 1,State Assembly,116,CON,Walczyk,6
+Jefferson,Philadelphia 1,State Assembly,116,WF,Walczyk,6
+Jefferson,Philadelphia 1,State Assembly,116,IND,Walczyk,6
+Jefferson,Philadelphia 1,State Assembly,116,REF,Walczyk,6
+Jefferson,Philadelphia 1,State Assembly,116,,Write-ins,6
+Jefferson,Philadelphia 2,State Assembly,116,DEM,Jenne,5
+Jefferson,Philadelphia 2,State Assembly,116,REP,Walczyk,5
+Jefferson,Philadelphia 2,State Assembly,116,CON,Walczyk,5
+Jefferson,Philadelphia 2,State Assembly,116,WF,Walczyk,5
+Jefferson,Philadelphia 2,State Assembly,116,IND,Walczyk,5
+Jefferson,Philadelphia 2,State Assembly,116,REF,Walczyk,5
+Jefferson,Philadelphia 2,State Assembly,116,,Write-ins,5
+Jefferson,Theresa 1,State Assembly,116,DEM,Jenne,11
+Jefferson,Theresa 1,State Assembly,116,REP,Walczyk,11
+Jefferson,Theresa 1,State Assembly,116,CON,Walczyk,11
+Jefferson,Theresa 1,State Assembly,116,WF,Walczyk,11
+Jefferson,Theresa 1,State Assembly,116,IND,Walczyk,11
+Jefferson,Theresa 1,State Assembly,116,REF,Walczyk,11
+Jefferson,Theresa 1,State Assembly,116,,Write-ins,11
+Jefferson,LeRay 6,State Assembly,117,REP,Blankenbush,94
+Jefferson,LeRay 6,State Assembly,117,CON,Blankenbush,94
+Jefferson,LeRay 6,State Assembly,117,IND,Blankenbush,94
+Jefferson,LeRay 6,State Assembly,117,,Write-ins,94
+Jefferson,LeRay 7,State Assembly,117,REP,Blankenbush,48
+Jefferson,LeRay 7,State Assembly,117,CON,Blankenbush,48
+Jefferson,LeRay 7,State Assembly,117,IND,Blankenbush,48
+Jefferson,LeRay 7,State Assembly,117,,Write-ins,48
+Jefferson,LeRay 8,State Assembly,117,REP,Blankenbush,292
+Jefferson,LeRay 8,State Assembly,117,CON,Blankenbush,292
+Jefferson,LeRay 8,State Assembly,117,IND,Blankenbush,292
+Jefferson,LeRay 8,State Assembly,117,,Write-ins,292
+Jefferson,Lorraine 1,State Assembly,117,REP,Blankenbush,304
+Jefferson,Lorraine 1,State Assembly,117,CON,Blankenbush,304
+Jefferson,Lorraine 1,State Assembly,117,IND,Blankenbush,304
+Jefferson,Lorraine 1,State Assembly,117,,Write-ins,304
+Jefferson,Rodman 1,State Assembly,117,REP,Blankenbush,402
+Jefferson,Rodman 1,State Assembly,117,CON,Blankenbush,402
+Jefferson,Rodman 1,State Assembly,117,IND,Blankenbush,402
+Jefferson,Rodman 1,State Assembly,117,,Write-ins,402
+Jefferson,Rutland 1,State Assembly,117,REP,Blankenbush,379
+Jefferson,Rutland 1,State Assembly,117,CON,Blankenbush,379
+Jefferson,Rutland 1,State Assembly,117,IND,Blankenbush,379
+Jefferson,Rutland 1,State Assembly,117,,Write-ins,379
+Jefferson,Rutland 2,State Assembly,117,REP,Blankenbush,294
+Jefferson,Rutland 2,State Assembly,117,CON,Blankenbush,294
+Jefferson,Rutland 2,State Assembly,117,IND,Blankenbush,294
+Jefferson,Rutland 2,State Assembly,117,,Write-ins,294
+Jefferson,Rutland 3,State Assembly,117,REP,Blankenbush,100
+Jefferson,Rutland 3,State Assembly,117,CON,Blankenbush,100
+Jefferson,Rutland 3,State Assembly,117,IND,Blankenbush,100
+Jefferson,Rutland 3,State Assembly,117,,Write-ins,100
+Jefferson,Watertown 1,State Assembly,117,REP,Blankenbush,671
+Jefferson,Watertown 1,State Assembly,117,CON,Blankenbush,671
+Jefferson,Watertown 1,State Assembly,117,IND,Blankenbush,671
+Jefferson,Watertown 1,State Assembly,117,,Write-ins,671
+Jefferson,Watertown 2,State Assembly,117,REP,Blankenbush,695
+Jefferson,Watertown 2,State Assembly,117,CON,Blankenbush,695
+Jefferson,Watertown 2,State Assembly,117,IND,Blankenbush,695
+Jefferson,Watertown 2,State Assembly,117,,Write-ins,695
+Jefferson,Wilna 1,State Assembly,117,REP,Blankenbush,516
+Jefferson,Wilna 1,State Assembly,117,CON,Blankenbush,516
+Jefferson,Wilna 1,State Assembly,117,IND,Blankenbush,516
+Jefferson,Wilna 1,State Assembly,117,,Write-ins,516
+Jefferson,Wilna 2,State Assembly,117,REP,Blankenbush,14
+Jefferson,Wilna 2,State Assembly,117,CON,Blankenbush,14
+Jefferson,Wilna 2,State Assembly,117,IND,Blankenbush,14
+Jefferson,Wilna 2,State Assembly,117,,Write-ins,14
+Jefferson,Wilna 3,State Assembly,117,REP,Blankenbush,56
+Jefferson,Wilna 3,State Assembly,117,CON,Blankenbush,56
+Jefferson,Wilna 3,State Assembly,117,IND,Blankenbush,56
+Jefferson,Wilna 3,State Assembly,117,,Write-ins,56
+Jefferson,Wilna 4,State Assembly,117,REP,Blankenbush,159
+Jefferson,Wilna 4,State Assembly,117,CON,Blankenbush,159
+Jefferson,Wilna 4,State Assembly,117,IND,Blankenbush,159
+Jefferson,Wilna 4,State Assembly,117,,Write-ins,159
+Jefferson,Wilna 5,State Assembly,117,REP,Blankenbush,325
+Jefferson,Wilna 5,State Assembly,117,CON,Blankenbush,325
+Jefferson,Wilna 5,State Assembly,117,IND,Blankenbush,325
+Jefferson,Wilna 5,State Assembly,117,,Write-ins,325
+Jefferson,Worth 1,State Assembly,117,REP,Blankenbush,85
+Jefferson,Worth 1,State Assembly,117,CON,Blankenbush,85
+Jefferson,Worth 1,State Assembly,117,IND,Blankenbush,85
+Jefferson,Worth 1,State Assembly,117,,Write-ins,85


### PR DESCRIPTION
Here are 2018 general election results from Jefferson County, NY. They are [sourced from this Google spreadsheet](https://docs.google.com/spreadsheets/d/18ZiVIKiBh-iahG4I_Ildlkc3u46OlBOyp6hDtjE89oo/edit#gid=376624947) found on the Jefferson Co [BOE website](https://co.jefferson.ny.us/departments/Elections/election-results-2010-present) and generated with [this script](https://github.com/jeremiak/open-elections-utils/tree/master/ny/2018/jefferson-general).

They are mostly complete though I have some questions about how to represent the `Registered Voters` and the `Ballots Cast` offices, which are included in each sheet of the source data.

1. When the office is `Registered Voters` should the `party` and `candidate` values be blank? And should the `votes` column represent the number of voters?

2. When the office is `Ballots Cast`, which race should I refer to? Though each precinct has the same number or registered voters across races, they do not necessarily have matching counts of total ballots cast. Do you have a method for determining which race to use for this number?

Thanks!