### PR TITLE
update putnam county precinct results

### DIFF
--- a/2020/20201103__ny__general__putnam__precinct.csv
+++ b/2020/20201103__ny__general__putnam__precinct.csv
@@ -171,12 +171,12 @@ Putnam,SE 12,Registered Voters,,,,631
 Putnam,SE 13,Registered Voters,,,,659
 Putnam,SE 14,Registered Voters,,,,991
 Putnam,SE 15,Registered Voters,,,,699
-Putnam,CA 01,President,,Joseph R. Biden,DEM,166
-Putnam,CA 02,President,,Joseph R. Biden,DEM,369
+Putnam,CA 01,President,,Joseph R. Biden,DEM,167
+Putnam,CA 02,President,,Joseph R. Biden,DEM,370
 Putnam,CA 03,President,,Joseph R. Biden,DEM,339
 Putnam,CA 04,President,,Joseph R. Biden,DEM,178
 Putnam,CA 05,President,,Joseph R. Biden,DEM,219
-Putnam,CA 06,President,,Joseph R. Biden,DEM,201
+Putnam,CA 06,President,,Joseph R. Biden,DEM,202
 Putnam,CA 07,President,,Joseph R. Biden,DEM,295
 Putnam,CA 08,President,,Joseph R. Biden,DEM,299
 Putnam,CA 09,President,,Joseph R. Biden,DEM,129
@@ -194,11 +194,11 @@ Putnam,CA 20,President,,Joseph R. Biden,DEM,279
 Putnam,CA 21,President,,Joseph R. Biden,DEM,137
 Putnam,CA 22,President,,Joseph R. Biden,DEM,233
 Putnam,CA 23,President,,Joseph R. Biden,DEM,213
-Putnam,CA 24,President,,Joseph R. Biden,DEM,242
+Putnam,CA 24,President,,Joseph R. Biden,DEM,243
 Putnam,CA 25,President,,Joseph R. Biden,DEM,244
 Putnam,CA 26,President,,Joseph R. Biden,DEM,164
 Putnam,CA 27,President,,Joseph R. Biden,DEM,161
-Putnam,CA 28,President,,Joseph R. Biden,DEM,235
+Putnam,CA 28,President,,Joseph R. Biden,DEM,236
 Putnam,CA 29,President,,Joseph R. Biden,DEM,458
 Putnam,CA 30,President,,Joseph R. Biden,DEM,199
 Putnam,KE 01,President,,Joseph R. Biden,DEM,350
@@ -214,7 +214,7 @@ Putnam,KE 10,President,,Joseph R. Biden,DEM,241
 Putnam,KE 11,President,,Joseph R. Biden,DEM,252
 Putnam,KE 12,President,,Joseph R. Biden,DEM,158
 Putnam,PA 01,President,,Joseph R. Biden,DEM,303
-Putnam,PA 02,President,,Joseph R. Biden,DEM,310
+Putnam,PA 02,President,,Joseph R. Biden,DEM,311
 Putnam,PA 03,President,,Joseph R. Biden,DEM,419
 Putnam,PA 04,President,,Joseph R. Biden,DEM,243
 Putnam,PA 05,President,,Joseph R. Biden,DEM,249
@@ -257,7 +257,7 @@ Putnam,SE 12,President,,Joseph R. Biden,DEM,207
 Putnam,SE 13,President,,Joseph R. Biden,DEM,218
 Putnam,SE 14,President,,Joseph R. Biden,DEM,365
 Putnam,SE 15,President,,Joseph R. Biden,DEM,286
-Putnam,CA 01,President,,Donald J. Trump,REP,195
+Putnam,CA 01,President,,Donald J. Trump,REP,196
 Putnam,CA 02,President,,Donald J. Trump,REP,475
 Putnam,CA 03,President,,Donald J. Trump,REP,443
 Putnam,CA 04,President,,Donald J. Trump,REP,273
@@ -278,7 +278,7 @@ Putnam,CA 18,President,,Donald J. Trump,REP,387
 Putnam,CA 19,President,,Donald J. Trump,REP,450
 Putnam,CA 20,President,,Donald J. Trump,REP,420
 Putnam,CA 21,President,,Donald J. Trump,REP,308
-Putnam,CA 22,President,,Donald J. Trump,REP,398
+Putnam,CA 22,President,,Donald J. Trump,REP,399
 Putnam,CA 23,President,,Donald J. Trump,REP,317
 Putnam,CA 24,President,,Donald J. Trump,REP,336
 Putnam,CA 25,President,,Donald J. Trump,REP,358
@@ -286,7 +286,7 @@ Putnam,CA 26,President,,Donald J. Trump,REP,322
 Putnam,CA 27,President,,Donald J. Trump,REP,268
 Putnam,CA 28,President,,Donald J. Trump,REP,356
 Putnam,CA 29,President,,Donald J. Trump,REP,592
-Putnam,CA 30,President,,Donald J. Trump,REP,263
+Putnam,CA 30,President,,Donald J. Trump,REP,264
 Putnam,KE 01,President,,Donald J. Trump,REP,334
 Putnam,KE 02,President,,Donald J. Trump,REP,175
 Putnam,KE 03,President,,Donald J. Trump,REP,308
@@ -299,7 +299,7 @@ Putnam,KE 09,President,,Donald J. Trump,REP,230
 Putnam,KE 10,President,,Donald J. Trump,REP,316
 Putnam,KE 11,President,,Donald J. Trump,REP,315
 Putnam,KE 12,President,,Donald J. Trump,REP,224
-Putnam,PA 01,President,,Donald J. Trump,REP,375
+Putnam,PA 01,President,,Donald J. Trump,REP,377
 Putnam,PA 02,President,,Donald J. Trump,REP,413
 Putnam,PA 03,President,,Donald J. Trump,REP,444
 Putnam,PA 04,President,,Donald J. Trump,REP,263
@@ -337,7 +337,7 @@ Putnam,SE 06,President,,Donald J. Trump,REP,274
 Putnam,SE 07,President,,Donald J. Trump,REP,362
 Putnam,SE 08,President,,Donald J. Trump,REP,459
 Putnam,SE 09,President,,Donald J. Trump,REP,316
-Putnam,SE 10,President,,Donald J. Trump,REP,367
+Putnam,SE 10,President,,Donald J. Trump,REP,368
 Putnam,SE 11,President,,Donald J. Trump,REP,373
 Putnam,SE 12,President,,Donald J. Trump,REP,247
 Putnam,SE 13,President,,Donald J. Trump,REP,246


### PR DESCRIPTION
I noticed the presidential election results didn't match up with the state results so I went through the results and checked trump's and biden's (the two candidates whose results didn't match) precincts manually. Putnam election results website: https://putnamboe.com/election-results/

After going through, the results are still off from the state results. Biden has 29,955 votes, but on the state results he has 24,953. However, on the county results document, Biden does have 29,953. I'm not sure why there's a difference between the state and county results. This should be checked out.

I checked each precinct manually, and only for Biden and Trump. The other candidates have accurate vote counts but I didn't verify them. I also didn't verify the other elections. They should also be checked out.