### PR TITLE
Clean district numbers from SD## to ## (issue 73)

### DIFF
--- a/2012/counties/20121106__ny__general__bronx__precinct.csv
+++ b/2012/counties/20121106__ny__general__bronx__precinct.csv
@@ -12119,4461 +12119,4461 @@ Bronx,87088,President,,,writeins,0
 Bronx,87089,President,,,writeins,0
 Bronx,87090,President,,,writeins,0
 Bronx,87091,President,,,writeins,0
-Bronx,77001,State Senate,SD29,Dem,Jose Serrano,48
-Bronx,77002,State Senate,SD29,Dem,Jose Serrano,357
-Bronx,77003,State Senate,SD29,Dem,Jose Serrano,534
-Bronx,77004,State Senate,SD29,Dem,Jose Serrano,507
-Bronx,77005,State Senate,SD29,Dem,Jose Serrano,585
-Bronx,77006,State Senate,SD29,Dem,Jose Serrano,450
-Bronx,77007,State Senate,SD29,Dem,Jose Serrano,581
-Bronx,77008,State Senate,SD29,Dem,Jose Serrano,510
-Bronx,77009,State Senate,SD29,Dem,Jose Serrano,577
-Bronx,77010,State Senate,SD29,Dem,Jose Serrano,719
-Bronx,77011,State Senate,SD29,Dem,Jose Serrano,484
-Bronx,77012,State Senate,SD29,Dem,Jose Serrano,286
-Bronx,77013,State Senate,SD29,Dem,Jose Serrano,531
-Bronx,77014,State Senate,SD29,Dem,Jose Serrano,583
-Bronx,77015,State Senate,SD29,Dem,Jose Serrano,544
-Bronx,77016,State Senate,SD29,Dem,Jose Serrano,565
-Bronx,77017,State Senate,SD29,Dem,Jose Serrano,67
-Bronx,77018,State Senate,SD29,Dem,Jose Serrano,458
-Bronx,77019,State Senate,SD29,Dem,Jose Serrano,284
-Bronx,77020,State Senate,SD29,Dem,Jose Serrano,458
-Bronx,77021,State Senate,SD29,Dem,Jose Serrano,543
-Bronx,77022,State Senate,SD29,Dem,Jose Serrano,261
-Bronx,77023,State Senate,SD29,Dem,Jose Serrano,457
-Bronx,77024,State Senate,SD29,Dem,Jose Serrano,430
-Bronx,77025,State Senate,SD29,Dem,Jose Serrano,580
-Bronx,77026,State Senate,SD29,Dem,Jose Serrano,267
-Bronx,77027,State Senate,SD29,Dem,Jose Serrano,419
-Bronx,77028,State Senate,SD29,Dem,Jose Serrano,425
-Bronx,77032,State Senate,SD29,Dem,Jose Serrano,70
-Bronx,77034,State Senate,SD29,Dem,Jose Serrano,507
-Bronx,77035,State Senate,SD29,Dem,Jose Serrano,504
-Bronx,77036,State Senate,SD29,Dem,Jose Serrano,263
-Bronx,77040,State Senate,SD29,Dem,Jose Serrano,442
-Bronx,77041,State Senate,SD29,Dem,Jose Serrano,289
-Bronx,77046,State Senate,SD29,Dem,Jose Serrano,426
-Bronx,77047,State Senate,SD29,Dem,Jose Serrano,611
-Bronx,77048,State Senate,SD29,Dem,Jose Serrano,423
-Bronx,77049,State Senate,SD29,Dem,Jose Serrano,146
-Bronx,77061,State Senate,SD29,Dem,Jose Serrano,127
-Bronx,77065,State Senate,SD29,Dem,Jose Serrano,536
-Bronx,77066,State Senate,SD29,Dem,Jose Serrano,0
-Bronx,79067,State Senate,SD29,Dem,Jose Serrano,0
-Bronx,84001,State Senate,SD29,Dem,Jose Serrano,416
-Bronx,84002,State Senate,SD29,Dem,Jose Serrano,108
-Bronx,84003,State Senate,SD29,Dem,Jose Serrano,416
-Bronx,84004,State Senate,SD29,Dem,Jose Serrano,404
-Bronx,84005,State Senate,SD29,Dem,Jose Serrano,536
-Bronx,84006,State Senate,SD29,Dem,Jose Serrano,600
-Bronx,84007,State Senate,SD29,Dem,Jose Serrano,427
-Bronx,84008,State Senate,SD29,Dem,Jose Serrano,543
-Bronx,84009,State Senate,SD29,Dem,Jose Serrano,318
-Bronx,84010,State Senate,SD29,Dem,Jose Serrano,441
-Bronx,84011,State Senate,SD29,Dem,Jose Serrano,403
-Bronx,84012,State Senate,SD29,Dem,Jose Serrano,186
-Bronx,84013,State Senate,SD29,Dem,Jose Serrano,507
-Bronx,84014,State Senate,SD29,Dem,Jose Serrano,410
-Bronx,84015,State Senate,SD29,Dem,Jose Serrano,242
-Bronx,84016,State Senate,SD29,Dem,Jose Serrano,426
-Bronx,84017,State Senate,SD29,Dem,Jose Serrano,270
-Bronx,84018,State Senate,SD29,Dem,Jose Serrano,91
-Bronx,84019,State Senate,SD29,Dem,Jose Serrano,411
-Bronx,84020,State Senate,SD29,Dem,Jose Serrano,228
-Bronx,84021,State Senate,SD29,Dem,Jose Serrano,50
-Bronx,84022,State Senate,SD29,Dem,Jose Serrano,72
-Bronx,84023,State Senate,SD29,Dem,Jose Serrano,418
-Bronx,84024,State Senate,SD29,Dem,Jose Serrano,501
-Bronx,84025,State Senate,SD29,Dem,Jose Serrano,284
-Bronx,84026,State Senate,SD29,Dem,Jose Serrano,294
-Bronx,84027,State Senate,SD29,Dem,Jose Serrano,273
-Bronx,84028,State Senate,SD29,Dem,Jose Serrano,423
-Bronx,84029,State Senate,SD29,Dem,Jose Serrano,162
-Bronx,84030,State Senate,SD29,Dem,Jose Serrano,274
-Bronx,84031,State Senate,SD29,Dem,Jose Serrano,241
-Bronx,84032,State Senate,SD29,Dem,Jose Serrano,248
-Bronx,84033,State Senate,SD29,Dem,Jose Serrano,322
-Bronx,84034,State Senate,SD29,Dem,Jose Serrano,544
-Bronx,84035,State Senate,SD29,Dem,Jose Serrano,297
-Bronx,84040,State Senate,SD29,Dem,Jose Serrano,394
-Bronx,84041,State Senate,SD29,Dem,Jose Serrano,371
-Bronx,84042,State Senate,SD29,Dem,Jose Serrano,428
-Bronx,84043,State Senate,SD29,Dem,Jose Serrano,329
-Bronx,84044,State Senate,SD29,Dem,Jose Serrano,362
-Bronx,84045,State Senate,SD29,Dem,Jose Serrano,321
-Bronx,84046,State Senate,SD29,Dem,Jose Serrano,260
-Bronx,84047,State Senate,SD29,Dem,Jose Serrano,137
-Bronx,84054,State Senate,SD29,Dem,Jose Serrano,428
-Bronx,84055,State Senate,SD29,Dem,Jose Serrano,383
-Bronx,84056,State Senate,SD29,Dem,Jose Serrano,340
-Bronx,84057,State Senate,SD29,Dem,Jose Serrano,360
-Bronx,84058,State Senate,SD29,Dem,Jose Serrano,354
-Bronx,84059,State Senate,SD29,Dem,Jose Serrano,383
-Bronx,84060,State Senate,SD29,Dem,Jose Serrano,339
-Bronx,84061,State Senate,SD29,Dem,Jose Serrano,345
-Bronx,84062,State Senate,SD29,Dem,Jose Serrano,320
-Bronx,84063,State Senate,SD29,Dem,Jose Serrano,338
-Bronx,84064,State Senate,SD29,Dem,Jose Serrano,473
-Bronx,84065,State Senate,SD29,Dem,Jose Serrano,308
-Bronx,84066,State Senate,SD29,Dem,Jose Serrano,366
-Bronx,84067,State Senate,SD29,Dem,Jose Serrano,327
-Bronx,84068,State Senate,SD29,Dem,Jose Serrano,328
-Bronx,84069,State Senate,SD29,Dem,Jose Serrano,165
-Bronx,84070,State Senate,SD29,Dem,Jose Serrano,170
-Bronx,84071,State Senate,SD29,Dem,Jose Serrano,374
-Bronx,84072,State Senate,SD29,Dem,Jose Serrano,439
-Bronx,84080,State Senate,SD29,Dem,Jose Serrano,388
-Bronx,86001,State Senate,SD29,Dem,Jose Serrano,474
-Bronx,86002,State Senate,SD29,Dem,Jose Serrano,431
-Bronx,86003,State Senate,SD29,Dem,Jose Serrano,550
-Bronx,86004,State Senate,SD29,Dem,Jose Serrano,268
-Bronx,86005,State Senate,SD29,Dem,Jose Serrano,227
-Bronx,86006,State Senate,SD29,Dem,Jose Serrano,315
-Bronx,86007,State Senate,SD29,Dem,Jose Serrano,326
-Bronx,77001,State Senate,SD29,WF,Jose Serrano,1
-Bronx,77002,State Senate,SD29,WF,Jose Serrano,7
-Bronx,77003,State Senate,SD29,WF,Jose Serrano,3
-Bronx,77004,State Senate,SD29,WF,Jose Serrano,8
-Bronx,77005,State Senate,SD29,WF,Jose Serrano,5
-Bronx,77006,State Senate,SD29,WF,Jose Serrano,2
-Bronx,77007,State Senate,SD29,WF,Jose Serrano,3
-Bronx,77008,State Senate,SD29,WF,Jose Serrano,4
-Bronx,77009,State Senate,SD29,WF,Jose Serrano,3
-Bronx,77010,State Senate,SD29,WF,Jose Serrano,4
-Bronx,77011,State Senate,SD29,WF,Jose Serrano,3
-Bronx,77012,State Senate,SD29,WF,Jose Serrano,6
-Bronx,77013,State Senate,SD29,WF,Jose Serrano,5
-Bronx,77014,State Senate,SD29,WF,Jose Serrano,6
-Bronx,77015,State Senate,SD29,WF,Jose Serrano,11
-Bronx,77016,State Senate,SD29,WF,Jose Serrano,9
-Bronx,77017,State Senate,SD29,WF,Jose Serrano,0
-Bronx,77018,State Senate,SD29,WF,Jose Serrano,2
-Bronx,77019,State Senate,SD29,WF,Jose Serrano,4
-Bronx,77020,State Senate,SD29,WF,Jose Serrano,2
-Bronx,77021,State Senate,SD29,WF,Jose Serrano,2
-Bronx,77022,State Senate,SD29,WF,Jose Serrano,1
-Bronx,77023,State Senate,SD29,WF,Jose Serrano,4
-Bronx,77024,State Senate,SD29,WF,Jose Serrano,2
-Bronx,77025,State Senate,SD29,WF,Jose Serrano,6
-Bronx,77026,State Senate,SD29,WF,Jose Serrano,9
-Bronx,77027,State Senate,SD29,WF,Jose Serrano,4
-Bronx,77028,State Senate,SD29,WF,Jose Serrano,12
-Bronx,77032,State Senate,SD29,WF,Jose Serrano,4
-Bronx,77034,State Senate,SD29,WF,Jose Serrano,1
-Bronx,77035,State Senate,SD29,WF,Jose Serrano,2
-Bronx,77036,State Senate,SD29,WF,Jose Serrano,1
-Bronx,77040,State Senate,SD29,WF,Jose Serrano,9
-Bronx,77041,State Senate,SD29,WF,Jose Serrano,4
-Bronx,77046,State Senate,SD29,WF,Jose Serrano,10
-Bronx,77047,State Senate,SD29,WF,Jose Serrano,6
-Bronx,77048,State Senate,SD29,WF,Jose Serrano,5
-Bronx,77049,State Senate,SD29,WF,Jose Serrano,2
-Bronx,77061,State Senate,SD29,WF,Jose Serrano,1
-Bronx,77065,State Senate,SD29,WF,Jose Serrano,8
-Bronx,77066,State Senate,SD29,WF,Jose Serrano,0
-Bronx,79067,State Senate,SD29,WF,Jose Serrano,0
-Bronx,84001,State Senate,SD29,WF,Jose Serrano,5
-Bronx,84002,State Senate,SD29,WF,Jose Serrano,0
-Bronx,84003,State Senate,SD29,WF,Jose Serrano,5
-Bronx,84004,State Senate,SD29,WF,Jose Serrano,7
-Bronx,84005,State Senate,SD29,WF,Jose Serrano,6
-Bronx,84006,State Senate,SD29,WF,Jose Serrano,3
-Bronx,84007,State Senate,SD29,WF,Jose Serrano,4
-Bronx,84008,State Senate,SD29,WF,Jose Serrano,7
-Bronx,84009,State Senate,SD29,WF,Jose Serrano,5
-Bronx,84010,State Senate,SD29,WF,Jose Serrano,11
-Bronx,84011,State Senate,SD29,WF,Jose Serrano,2
-Bronx,84012,State Senate,SD29,WF,Jose Serrano,3
-Bronx,84013,State Senate,SD29,WF,Jose Serrano,6
-Bronx,84014,State Senate,SD29,WF,Jose Serrano,12
-Bronx,84015,State Senate,SD29,WF,Jose Serrano,5
-Bronx,84016,State Senate,SD29,WF,Jose Serrano,4
-Bronx,84017,State Senate,SD29,WF,Jose Serrano,5
-Bronx,84018,State Senate,SD29,WF,Jose Serrano,0
-Bronx,84019,State Senate,SD29,WF,Jose Serrano,9
-Bronx,84020,State Senate,SD29,WF,Jose Serrano,6
-Bronx,84021,State Senate,SD29,WF,Jose Serrano,3
-Bronx,84022,State Senate,SD29,WF,Jose Serrano,1
-Bronx,84023,State Senate,SD29,WF,Jose Serrano,7
-Bronx,84024,State Senate,SD29,WF,Jose Serrano,4
-Bronx,84025,State Senate,SD29,WF,Jose Serrano,9
-Bronx,84026,State Senate,SD29,WF,Jose Serrano,4
-Bronx,84027,State Senate,SD29,WF,Jose Serrano,10
-Bronx,84028,State Senate,SD29,WF,Jose Serrano,9
-Bronx,84029,State Senate,SD29,WF,Jose Serrano,1
-Bronx,84030,State Senate,SD29,WF,Jose Serrano,4
-Bronx,84031,State Senate,SD29,WF,Jose Serrano,2
-Bronx,84032,State Senate,SD29,WF,Jose Serrano,2
-Bronx,84033,State Senate,SD29,WF,Jose Serrano,5
-Bronx,84034,State Senate,SD29,WF,Jose Serrano,14
-Bronx,84035,State Senate,SD29,WF,Jose Serrano,5
-Bronx,84040,State Senate,SD29,WF,Jose Serrano,2
-Bronx,84041,State Senate,SD29,WF,Jose Serrano,4
-Bronx,84042,State Senate,SD29,WF,Jose Serrano,4
-Bronx,84043,State Senate,SD29,WF,Jose Serrano,5
-Bronx,84044,State Senate,SD29,WF,Jose Serrano,10
-Bronx,84045,State Senate,SD29,WF,Jose Serrano,9
-Bronx,84046,State Senate,SD29,WF,Jose Serrano,1
-Bronx,84047,State Senate,SD29,WF,Jose Serrano,2
-Bronx,84054,State Senate,SD29,WF,Jose Serrano,5
-Bronx,84055,State Senate,SD29,WF,Jose Serrano,6
-Bronx,84056,State Senate,SD29,WF,Jose Serrano,11
-Bronx,84057,State Senate,SD29,WF,Jose Serrano,8
-Bronx,84058,State Senate,SD29,WF,Jose Serrano,5
-Bronx,84059,State Senate,SD29,WF,Jose Serrano,6
-Bronx,84060,State Senate,SD29,WF,Jose Serrano,7
-Bronx,84061,State Senate,SD29,WF,Jose Serrano,4
-Bronx,84062,State Senate,SD29,WF,Jose Serrano,10
-Bronx,84063,State Senate,SD29,WF,Jose Serrano,3
-Bronx,84064,State Senate,SD29,WF,Jose Serrano,2
-Bronx,84065,State Senate,SD29,WF,Jose Serrano,5
-Bronx,84066,State Senate,SD29,WF,Jose Serrano,3
-Bronx,84067,State Senate,SD29,WF,Jose Serrano,1
-Bronx,84068,State Senate,SD29,WF,Jose Serrano,2
-Bronx,84069,State Senate,SD29,WF,Jose Serrano,4
-Bronx,84070,State Senate,SD29,WF,Jose Serrano,4
-Bronx,84071,State Senate,SD29,WF,Jose Serrano,13
-Bronx,84072,State Senate,SD29,WF,Jose Serrano,12
-Bronx,84080,State Senate,SD29,WF,Jose Serrano,6
-Bronx,86001,State Senate,SD29,WF,Jose Serrano,4
-Bronx,86002,State Senate,SD29,WF,Jose Serrano,6
-Bronx,86003,State Senate,SD29,WF,Jose Serrano,3
-Bronx,86004,State Senate,SD29,WF,Jose Serrano,2
-Bronx,86005,State Senate,SD29,WF,Jose Serrano,0
-Bronx,86006,State Senate,SD29,WF,Jose Serrano,3
-Bronx,86007,State Senate,SD29,WF,Jose Serrano,17
-Bronx,77001,State Senate,SD29,Con,Robert Goodman,3
-Bronx,77002,State Senate,SD29,Con,Robert Goodman,2
-Bronx,77003,State Senate,SD29,Con,Robert Goodman,6
-Bronx,77004,State Senate,SD29,Con,Robert Goodman,5
-Bronx,77005,State Senate,SD29,Con,Robert Goodman,7
-Bronx,77006,State Senate,SD29,Con,Robert Goodman,5
-Bronx,77007,State Senate,SD29,Con,Robert Goodman,4
-Bronx,77008,State Senate,SD29,Con,Robert Goodman,3
-Bronx,77009,State Senate,SD29,Con,Robert Goodman,2
-Bronx,77010,State Senate,SD29,Con,Robert Goodman,5
-Bronx,77011,State Senate,SD29,Con,Robert Goodman,9
-Bronx,77012,State Senate,SD29,Con,Robert Goodman,2
-Bronx,77013,State Senate,SD29,Con,Robert Goodman,3
-Bronx,77014,State Senate,SD29,Con,Robert Goodman,4
-Bronx,77015,State Senate,SD29,Con,Robert Goodman,7
-Bronx,77016,State Senate,SD29,Con,Robert Goodman,4
-Bronx,77017,State Senate,SD29,Con,Robert Goodman,1
-Bronx,77018,State Senate,SD29,Con,Robert Goodman,7
-Bronx,77019,State Senate,SD29,Con,Robert Goodman,1
-Bronx,77020,State Senate,SD29,Con,Robert Goodman,3
-Bronx,77021,State Senate,SD29,Con,Robert Goodman,4
-Bronx,77022,State Senate,SD29,Con,Robert Goodman,0
-Bronx,77023,State Senate,SD29,Con,Robert Goodman,3
-Bronx,77024,State Senate,SD29,Con,Robert Goodman,1
-Bronx,77025,State Senate,SD29,Con,Robert Goodman,6
-Bronx,77026,State Senate,SD29,Con,Robert Goodman,4
-Bronx,77027,State Senate,SD29,Con,Robert Goodman,7
-Bronx,77028,State Senate,SD29,Con,Robert Goodman,8
-Bronx,77032,State Senate,SD29,Con,Robert Goodman,0
-Bronx,77034,State Senate,SD29,Con,Robert Goodman,2
-Bronx,77035,State Senate,SD29,Con,Robert Goodman,7
-Bronx,77036,State Senate,SD29,Con,Robert Goodman,10
-Bronx,77040,State Senate,SD29,Con,Robert Goodman,9
-Bronx,77041,State Senate,SD29,Con,Robert Goodman,0
-Bronx,77046,State Senate,SD29,Con,Robert Goodman,6
-Bronx,77047,State Senate,SD29,Con,Robert Goodman,5
-Bronx,77048,State Senate,SD29,Con,Robert Goodman,4
-Bronx,77049,State Senate,SD29,Con,Robert Goodman,2
-Bronx,77061,State Senate,SD29,Con,Robert Goodman,4
-Bronx,77065,State Senate,SD29,Con,Robert Goodman,4
-Bronx,77066,State Senate,SD29,Con,Robert Goodman,0
-Bronx,79067,State Senate,SD29,Con,Robert Goodman,0
-Bronx,84001,State Senate,SD29,Con,Robert Goodman,7
-Bronx,84002,State Senate,SD29,Con,Robert Goodman,0
-Bronx,84003,State Senate,SD29,Con,Robert Goodman,5
-Bronx,84004,State Senate,SD29,Con,Robert Goodman,2
-Bronx,84005,State Senate,SD29,Con,Robert Goodman,5
-Bronx,84006,State Senate,SD29,Con,Robert Goodman,7
-Bronx,84007,State Senate,SD29,Con,Robert Goodman,3
-Bronx,84008,State Senate,SD29,Con,Robert Goodman,3
-Bronx,84009,State Senate,SD29,Con,Robert Goodman,4
-Bronx,84010,State Senate,SD29,Con,Robert Goodman,3
-Bronx,84011,State Senate,SD29,Con,Robert Goodman,8
-Bronx,84012,State Senate,SD29,Con,Robert Goodman,3
-Bronx,84013,State Senate,SD29,Con,Robert Goodman,6
-Bronx,84014,State Senate,SD29,Con,Robert Goodman,13
-Bronx,84015,State Senate,SD29,Con,Robert Goodman,2
-Bronx,84016,State Senate,SD29,Con,Robert Goodman,4
-Bronx,84017,State Senate,SD29,Con,Robert Goodman,7
-Bronx,84018,State Senate,SD29,Con,Robert Goodman,1
-Bronx,84019,State Senate,SD29,Con,Robert Goodman,4
-Bronx,84020,State Senate,SD29,Con,Robert Goodman,9
-Bronx,84021,State Senate,SD29,Con,Robert Goodman,1
-Bronx,84022,State Senate,SD29,Con,Robert Goodman,5
-Bronx,84023,State Senate,SD29,Con,Robert Goodman,5
-Bronx,84024,State Senate,SD29,Con,Robert Goodman,7
-Bronx,84025,State Senate,SD29,Con,Robert Goodman,8
-Bronx,84026,State Senate,SD29,Con,Robert Goodman,3
-Bronx,84027,State Senate,SD29,Con,Robert Goodman,3
-Bronx,84028,State Senate,SD29,Con,Robert Goodman,5
-Bronx,84029,State Senate,SD29,Con,Robert Goodman,0
-Bronx,84030,State Senate,SD29,Con,Robert Goodman,5
-Bronx,84031,State Senate,SD29,Con,Robert Goodman,2
-Bronx,84032,State Senate,SD29,Con,Robert Goodman,0
-Bronx,84033,State Senate,SD29,Con,Robert Goodman,6
-Bronx,84034,State Senate,SD29,Con,Robert Goodman,10
-Bronx,84035,State Senate,SD29,Con,Robert Goodman,9
-Bronx,84040,State Senate,SD29,Con,Robert Goodman,6
-Bronx,84041,State Senate,SD29,Con,Robert Goodman,3
-Bronx,84042,State Senate,SD29,Con,Robert Goodman,3
-Bronx,84043,State Senate,SD29,Con,Robert Goodman,3
-Bronx,84044,State Senate,SD29,Con,Robert Goodman,6
-Bronx,84045,State Senate,SD29,Con,Robert Goodman,2
-Bronx,84046,State Senate,SD29,Con,Robert Goodman,6
-Bronx,84047,State Senate,SD29,Con,Robert Goodman,3
-Bronx,84054,State Senate,SD29,Con,Robert Goodman,8
-Bronx,84055,State Senate,SD29,Con,Robert Goodman,6
-Bronx,84056,State Senate,SD29,Con,Robert Goodman,6
-Bronx,84057,State Senate,SD29,Con,Robert Goodman,11
-Bronx,84058,State Senate,SD29,Con,Robert Goodman,10
-Bronx,84059,State Senate,SD29,Con,Robert Goodman,5
-Bronx,84060,State Senate,SD29,Con,Robert Goodman,3
-Bronx,84061,State Senate,SD29,Con,Robert Goodman,2
-Bronx,84062,State Senate,SD29,Con,Robert Goodman,5
-Bronx,84063,State Senate,SD29,Con,Robert Goodman,2
-Bronx,84064,State Senate,SD29,Con,Robert Goodman,14
-Bronx,84065,State Senate,SD29,Con,Robert Goodman,2
-Bronx,84066,State Senate,SD29,Con,Robert Goodman,7
-Bronx,84067,State Senate,SD29,Con,Robert Goodman,2
-Bronx,84068,State Senate,SD29,Con,Robert Goodman,4
-Bronx,84069,State Senate,SD29,Con,Robert Goodman,5
-Bronx,84070,State Senate,SD29,Con,Robert Goodman,1
-Bronx,84071,State Senate,SD29,Con,Robert Goodman,15
-Bronx,84072,State Senate,SD29,Con,Robert Goodman,6
-Bronx,84080,State Senate,SD29,Con,Robert Goodman,5
-Bronx,86001,State Senate,SD29,Con,Robert Goodman,1
-Bronx,86002,State Senate,SD29,Con,Robert Goodman,7
-Bronx,86003,State Senate,SD29,Con,Robert Goodman,4
-Bronx,86004,State Senate,SD29,Con,Robert Goodman,4
-Bronx,86005,State Senate,SD29,Con,Robert Goodman,3
-Bronx,86006,State Senate,SD29,Con,Robert Goodman,2
-Bronx,86007,State Senate,SD29,Con,Robert Goodman,7
-Bronx,77001,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,77002,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,77003,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,77004,State Senate,SD29,Green,Thomas Siracuse,4
-Bronx,77005,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,77006,State Senate,SD29,Green,Thomas Siracuse,3
-Bronx,77007,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,77008,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,77009,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,77010,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,77011,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,77012,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,77013,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,77014,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,77015,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,77016,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,77017,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,77018,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,77019,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,77020,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,77021,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,77022,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,77023,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,77024,State Senate,SD29,Green,Thomas Siracuse,5
-Bronx,77025,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,77026,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,77027,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,77028,State Senate,SD29,Green,Thomas Siracuse,3
-Bronx,77032,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,77034,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,77035,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,77036,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,77040,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,77041,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,77046,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,77047,State Senate,SD29,Green,Thomas Siracuse,3
-Bronx,77048,State Senate,SD29,Green,Thomas Siracuse,4
-Bronx,77049,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,77061,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,77065,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,77066,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,79067,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,84001,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,84002,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,84003,State Senate,SD29,Green,Thomas Siracuse,3
-Bronx,84004,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,84005,State Senate,SD29,Green,Thomas Siracuse,3
-Bronx,84006,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,84007,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,84008,State Senate,SD29,Green,Thomas Siracuse,3
-Bronx,84009,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,84010,State Senate,SD29,Green,Thomas Siracuse,4
-Bronx,84011,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,84012,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,84013,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,84014,State Senate,SD29,Green,Thomas Siracuse,5
-Bronx,84015,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,84016,State Senate,SD29,Green,Thomas Siracuse,3
-Bronx,84017,State Senate,SD29,Green,Thomas Siracuse,6
-Bronx,84018,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,84019,State Senate,SD29,Green,Thomas Siracuse,3
-Bronx,84020,State Senate,SD29,Green,Thomas Siracuse,7
-Bronx,84021,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,84022,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,84023,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,84024,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,84025,State Senate,SD29,Green,Thomas Siracuse,10
-Bronx,84026,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,84027,State Senate,SD29,Green,Thomas Siracuse,3
-Bronx,84028,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,84029,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,84030,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,84031,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,84032,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,84033,State Senate,SD29,Green,Thomas Siracuse,3
-Bronx,84034,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,84035,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,84040,State Senate,SD29,Green,Thomas Siracuse,3
-Bronx,84041,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,84042,State Senate,SD29,Green,Thomas Siracuse,3
-Bronx,84043,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,84044,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,84045,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,84046,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,84047,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,84054,State Senate,SD29,Green,Thomas Siracuse,4
-Bronx,84055,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,84056,State Senate,SD29,Green,Thomas Siracuse,3
-Bronx,84057,State Senate,SD29,Green,Thomas Siracuse,3
-Bronx,84058,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,84059,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,84060,State Senate,SD29,Green,Thomas Siracuse,3
-Bronx,84061,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,84062,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,84063,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,84064,State Senate,SD29,Green,Thomas Siracuse,3
-Bronx,84065,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,84066,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,84067,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,84068,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,84069,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,84070,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,84071,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,84072,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,84080,State Senate,SD29,Green,Thomas Siracuse,3
-Bronx,86001,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,86002,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,86003,State Senate,SD29,Green,Thomas Siracuse,3
-Bronx,86004,State Senate,SD29,Green,Thomas Siracuse,1
-Bronx,86005,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,86006,State Senate,SD29,Green,Thomas Siracuse,0
-Bronx,86007,State Senate,SD29,Green,Thomas Siracuse,2
-Bronx,77001,State Senate,SD29,Ind,writein,0
-Bronx,77002,State Senate,SD29,Ind,writein,0
-Bronx,77003,State Senate,SD29,Ind,writein,0
-Bronx,77004,State Senate,SD29,Ind,writein,0
-Bronx,77005,State Senate,SD29,Ind,writein,0
-Bronx,77006,State Senate,SD29,Ind,writein,0
-Bronx,77007,State Senate,SD29,Ind,writein,1
-Bronx,77008,State Senate,SD29,Ind,writein,0
-Bronx,77009,State Senate,SD29,Ind,writein,0
-Bronx,77010,State Senate,SD29,Ind,writein,0
-Bronx,77011,State Senate,SD29,Ind,writein,0
-Bronx,77012,State Senate,SD29,Ind,writein,0
-Bronx,77013,State Senate,SD29,Ind,writein,0
-Bronx,77014,State Senate,SD29,Ind,writein,0
-Bronx,77015,State Senate,SD29,Ind,writein,0
-Bronx,77016,State Senate,SD29,Ind,writein,0
-Bronx,77017,State Senate,SD29,Ind,writein,0
-Bronx,77018,State Senate,SD29,Ind,writein,0
-Bronx,77019,State Senate,SD29,Ind,writein,0
-Bronx,77020,State Senate,SD29,Ind,writein,0
-Bronx,77021,State Senate,SD29,Ind,writein,0
-Bronx,77022,State Senate,SD29,Ind,writein,0
-Bronx,77023,State Senate,SD29,Ind,writein,0
-Bronx,77024,State Senate,SD29,Ind,writein,0
-Bronx,77025,State Senate,SD29,Ind,writein,0
-Bronx,77026,State Senate,SD29,Ind,writein,0
-Bronx,77027,State Senate,SD29,Ind,writein,0
-Bronx,77028,State Senate,SD29,Ind,writein,0
-Bronx,77032,State Senate,SD29,Ind,writein,0
-Bronx,77034,State Senate,SD29,Ind,writein,0
-Bronx,77035,State Senate,SD29,Ind,writein,0
-Bronx,77036,State Senate,SD29,Ind,writein,0
-Bronx,77040,State Senate,SD29,Ind,writein,0
-Bronx,77041,State Senate,SD29,Ind,writein,0
-Bronx,77046,State Senate,SD29,Ind,writein,0
-Bronx,77047,State Senate,SD29,Ind,writein,0
-Bronx,77048,State Senate,SD29,Ind,writein,0
-Bronx,77049,State Senate,SD29,Ind,writein,0
-Bronx,77061,State Senate,SD29,Ind,writein,0
-Bronx,77065,State Senate,SD29,Ind,writein,0
-Bronx,77066,State Senate,SD29,Ind,writein,0
-Bronx,79067,State Senate,SD29,Ind,writein,0
-Bronx,84001,State Senate,SD29,Ind,writein,0
-Bronx,84002,State Senate,SD29,Ind,writein,0
-Bronx,84003,State Senate,SD29,Ind,writein,0
-Bronx,84004,State Senate,SD29,Ind,writein,0
-Bronx,84005,State Senate,SD29,Ind,writein,0
-Bronx,84006,State Senate,SD29,Ind,writein,0
-Bronx,84007,State Senate,SD29,Ind,writein,0
-Bronx,84008,State Senate,SD29,Ind,writein,0
-Bronx,84009,State Senate,SD29,Ind,writein,0
-Bronx,84010,State Senate,SD29,Ind,writein,0
-Bronx,84011,State Senate,SD29,Ind,writein,0
-Bronx,84012,State Senate,SD29,Ind,writein,0
-Bronx,84013,State Senate,SD29,Ind,writein,0
-Bronx,84014,State Senate,SD29,Ind,writein,0
-Bronx,84015,State Senate,SD29,Ind,writein,0
-Bronx,84016,State Senate,SD29,Ind,writein,0
-Bronx,84017,State Senate,SD29,Ind,writein,0
-Bronx,84018,State Senate,SD29,Ind,writein,0
-Bronx,84019,State Senate,SD29,Ind,writein,0
-Bronx,84020,State Senate,SD29,Ind,writein,0
-Bronx,84021,State Senate,SD29,Ind,writein,0
-Bronx,84022,State Senate,SD29,Ind,writein,0
-Bronx,84023,State Senate,SD29,Ind,writein,0
-Bronx,84024,State Senate,SD29,Ind,writein,0
-Bronx,84025,State Senate,SD29,Ind,writein,0
-Bronx,84026,State Senate,SD29,Ind,writein,0
-Bronx,84027,State Senate,SD29,Ind,writein,1
-Bronx,84028,State Senate,SD29,Ind,writein,0
-Bronx,84029,State Senate,SD29,Ind,writein,0
-Bronx,84030,State Senate,SD29,Ind,writein,0
-Bronx,84031,State Senate,SD29,Ind,writein,0
-Bronx,84032,State Senate,SD29,Ind,writein,0
-Bronx,84033,State Senate,SD29,Ind,writein,0
-Bronx,84034,State Senate,SD29,Ind,writein,1
-Bronx,84035,State Senate,SD29,Ind,writein,0
-Bronx,84040,State Senate,SD29,Ind,writein,0
-Bronx,84041,State Senate,SD29,Ind,writein,0
-Bronx,84042,State Senate,SD29,Ind,writein,0
-Bronx,84043,State Senate,SD29,Ind,writein,0
-Bronx,84044,State Senate,SD29,Ind,writein,2
-Bronx,84045,State Senate,SD29,Ind,writein,0
-Bronx,84046,State Senate,SD29,Ind,writein,0
-Bronx,84047,State Senate,SD29,Ind,writein,0
-Bronx,84054,State Senate,SD29,Ind,writein,0
-Bronx,84055,State Senate,SD29,Ind,writein,0
-Bronx,84056,State Senate,SD29,Ind,writein,0
-Bronx,84057,State Senate,SD29,Ind,writein,0
-Bronx,84058,State Senate,SD29,Ind,writein,0
-Bronx,84059,State Senate,SD29,Ind,writein,0
-Bronx,84060,State Senate,SD29,Ind,writein,0
-Bronx,84061,State Senate,SD29,Ind,writein,0
-Bronx,84062,State Senate,SD29,Ind,writein,0
-Bronx,84063,State Senate,SD29,Ind,writein,0
-Bronx,84064,State Senate,SD29,Ind,writein,0
-Bronx,84065,State Senate,SD29,Ind,writein,0
-Bronx,84066,State Senate,SD29,Ind,writein,0
-Bronx,84067,State Senate,SD29,Ind,writein,0
-Bronx,84068,State Senate,SD29,Ind,writein,0
-Bronx,84069,State Senate,SD29,Ind,writein,0
-Bronx,84070,State Senate,SD29,Ind,writein,0
-Bronx,84071,State Senate,SD29,Ind,writein,0
-Bronx,84072,State Senate,SD29,Ind,writein,1
-Bronx,84080,State Senate,SD29,Ind,writein,1
-Bronx,86001,State Senate,SD29,Ind,writein,0
-Bronx,86002,State Senate,SD29,Ind,writein,0
-Bronx,86003,State Senate,SD29,Ind,writein,0
-Bronx,86004,State Senate,SD29,Ind,writein,0
-Bronx,86005,State Senate,SD29,Ind,writein,0
-Bronx,86006,State Senate,SD29,Ind,writein,0
-Bronx,86007,State Senate,SD29,Ind,writein,0
-Bronx,77050,State Senate,SD32,Ind,David Johnson,14
-Bronx,77051,State Senate,SD32,Ind,David Johnson,6
-Bronx,77052,State Senate,SD32,Ind,David Johnson,2
-Bronx,77053,State Senate,SD32,Ind,David Johnson,5
-Bronx,77054,State Senate,SD32,Ind,David Johnson,2
-Bronx,77055,State Senate,SD32,Ind,David Johnson,7
-Bronx,77056,State Senate,SD32,Ind,David Johnson,8
-Bronx,77057,State Senate,SD32,Ind,David Johnson,8
-Bronx,77058,State Senate,SD32,Ind,David Johnson,31
-Bronx,77059,State Senate,SD32,Ind,David Johnson,31
-Bronx,77060,State Senate,SD32,Ind,David Johnson,16
-Bronx,77062,State Senate,SD32,Ind,David Johnson,7
-Bronx,77063,State Senate,SD32,Ind,David Johnson,9
-Bronx,77064,State Senate,SD32,Ind,David Johnson,5
-Bronx,79006,State Senate,SD32,Ind,David Johnson,14
-Bronx,79011,State Senate,SD32,Ind,David Johnson,3
-Bronx,79012,State Senate,SD32,Ind,David Johnson,2
-Bronx,79014,State Senate,SD32,Ind,David Johnson,4
-Bronx,79015,State Senate,SD32,Ind,David Johnson,4
-Bronx,79016,State Senate,SD32,Ind,David Johnson,9
-Bronx,79017,State Senate,SD32,Ind,David Johnson,12
-Bronx,79018,State Senate,SD32,Ind,David Johnson,3
-Bronx,79019,State Senate,SD32,Ind,David Johnson,11
-Bronx,79021,State Senate,SD32,Ind,David Johnson,16
-Bronx,79022,State Senate,SD32,Ind,David Johnson,9
-Bronx,79023,State Senate,SD32,Ind,David Johnson,14
-Bronx,79024,State Senate,SD32,Ind,David Johnson,9
-Bronx,79025,State Senate,SD32,Ind,David Johnson,10
-Bronx,79026,State Senate,SD32,Ind,David Johnson,5
-Bronx,79027,State Senate,SD32,Ind,David Johnson,8
-Bronx,79028,State Senate,SD32,Ind,David Johnson,9
-Bronx,79038,State Senate,SD32,Ind,David Johnson,10
-Bronx,79039,State Senate,SD32,Ind,David Johnson,10
-Bronx,79040,State Senate,SD32,Ind,David Johnson,4
-Bronx,79041,State Senate,SD32,Ind,David Johnson,10
-Bronx,79042,State Senate,SD32,Ind,David Johnson,9
-Bronx,79043,State Senate,SD32,Ind,David Johnson,15
-Bronx,79044,State Senate,SD32,Ind,David Johnson,10
-Bronx,79045,State Senate,SD32,Ind,David Johnson,6
-Bronx,79046,State Senate,SD32,Ind,David Johnson,4
-Bronx,79047,State Senate,SD32,Ind,David Johnson,4
-Bronx,79048,State Senate,SD32,Ind,David Johnson,7
-Bronx,79049,State Senate,SD32,Ind,David Johnson,3
-Bronx,79050,State Senate,SD32,Ind,David Johnson,11
-Bronx,79051,State Senate,SD32,Ind,David Johnson,14
-Bronx,79052,State Senate,SD32,Ind,David Johnson,19
-Bronx,79053,State Senate,SD32,Ind,David Johnson,11
-Bronx,79054,State Senate,SD32,Ind,David Johnson,5
-Bronx,79055,State Senate,SD32,Ind,David Johnson,4
-Bronx,79056,State Senate,SD32,Ind,David Johnson,14
-Bronx,79057,State Senate,SD32,Ind,David Johnson,27
-Bronx,79058,State Senate,SD32,Ind,David Johnson,15
-Bronx,79059,State Senate,SD32,Ind,David Johnson,8
-Bronx,79060,State Senate,SD32,Ind,David Johnson,4
-Bronx,79061,State Senate,SD32,Ind,David Johnson,3
-Bronx,79062,State Senate,SD32,Ind,David Johnson,13
-Bronx,79063,State Senate,SD32,Ind,David Johnson,2
-Bronx,79064,State Senate,SD32,Ind,David Johnson,2
-Bronx,79065,State Senate,SD32,Ind,David Johnson,6
-Bronx,79066,State Senate,SD32,Ind,David Johnson,7
-Bronx,79068,State Senate,SD32,Ind,David Johnson,27
-Bronx,79069,State Senate,SD32,Ind,David Johnson,27
-Bronx,79070,State Senate,SD32,Ind,David Johnson,19
-Bronx,79071,State Senate,SD32,Ind,David Johnson,2
-Bronx,79072,State Senate,SD32,Ind,David Johnson,8
-Bronx,79073,State Senate,SD32,Ind,David Johnson,10
-Bronx,79075,State Senate,SD32,Ind,David Johnson,18
-Bronx,79076,State Senate,SD32,Ind,David Johnson,0
-Bronx,82029,State Senate,SD32,Ind,David Johnson,2
-Bronx,82030,State Senate,SD32,Ind,David Johnson,30
-Bronx,84036,State Senate,SD32,Ind,David Johnson,0
-Bronx,84037,State Senate,SD32,Ind,David Johnson,4
-Bronx,84038,State Senate,SD32,Ind,David Johnson,10
-Bronx,84039,State Senate,SD32,Ind,David Johnson,12
-Bronx,84048,State Senate,SD32,Ind,David Johnson,9
-Bronx,84049,State Senate,SD32,Ind,David Johnson,19
-Bronx,84050,State Senate,SD32,Ind,David Johnson,11
-Bronx,84051,State Senate,SD32,Ind,David Johnson,7
-Bronx,84052,State Senate,SD32,Ind,David Johnson,9
-Bronx,84053,State Senate,SD32,Ind,David Johnson,0
-Bronx,84074,State Senate,SD32,Ind,David Johnson,6
-Bronx,84075,State Senate,SD32,Ind,David Johnson,8
-Bronx,85014,State Senate,SD32,Ind,David Johnson,5
-Bronx,85015,State Senate,SD32,Ind,David Johnson,7
-Bronx,85016,State Senate,SD32,Ind,David Johnson,8
-Bronx,85017,State Senate,SD32,Ind,David Johnson,9
-Bronx,85018,State Senate,SD32,Ind,David Johnson,14
-Bronx,85019,State Senate,SD32,Ind,David Johnson,13
-Bronx,85020,State Senate,SD32,Ind,David Johnson,9
-Bronx,85021,State Senate,SD32,Ind,David Johnson,13
-Bronx,85022,State Senate,SD32,Ind,David Johnson,7
-Bronx,85023,State Senate,SD32,Ind,David Johnson,3
-Bronx,85024,State Senate,SD32,Ind,David Johnson,22
-Bronx,85025,State Senate,SD32,Ind,David Johnson,19
-Bronx,85026,State Senate,SD32,Ind,David Johnson,8
-Bronx,85027,State Senate,SD32,Ind,David Johnson,10
-Bronx,85029,State Senate,SD32,Ind,David Johnson,4
-Bronx,85030,State Senate,SD32,Ind,David Johnson,11
-Bronx,85031,State Senate,SD32,Ind,David Johnson,8
-Bronx,85032,State Senate,SD32,Ind,David Johnson,16
-Bronx,85033,State Senate,SD32,Ind,David Johnson,19
-Bronx,85034,State Senate,SD32,Ind,David Johnson,3
-Bronx,85039,State Senate,SD32,Ind,David Johnson,12
-Bronx,85040,State Senate,SD32,Ind,David Johnson,5
-Bronx,85041,State Senate,SD32,Ind,David Johnson,9
-Bronx,85042,State Senate,SD32,Ind,David Johnson,10
-Bronx,85043,State Senate,SD32,Ind,David Johnson,7
-Bronx,85044,State Senate,SD32,Ind,David Johnson,7
-Bronx,85045,State Senate,SD32,Ind,David Johnson,9
-Bronx,85046,State Senate,SD32,Ind,David Johnson,12
-Bronx,85047,State Senate,SD32,Ind,David Johnson,6
-Bronx,85048,State Senate,SD32,Ind,David Johnson,11
-Bronx,85049,State Senate,SD32,Ind,David Johnson,16
-Bronx,85050,State Senate,SD32,Ind,David Johnson,13
-Bronx,85051,State Senate,SD32,Ind,David Johnson,8
-Bronx,85052,State Senate,SD32,Ind,David Johnson,18
-Bronx,85053,State Senate,SD32,Ind,David Johnson,16
-Bronx,85054,State Senate,SD32,Ind,David Johnson,5
-Bronx,85055,State Senate,SD32,Ind,David Johnson,8
-Bronx,85056,State Senate,SD32,Ind,David Johnson,1
-Bronx,85057,State Senate,SD32,Ind,David Johnson,8
-Bronx,85058,State Senate,SD32,Ind,David Johnson,10
-Bronx,85059,State Senate,SD32,Ind,David Johnson,12
-Bronx,85060,State Senate,SD32,Ind,David Johnson,12
-Bronx,85061,State Senate,SD32,Ind,David Johnson,11
-Bronx,85062,State Senate,SD32,Ind,David Johnson,11
-Bronx,85063,State Senate,SD32,Ind,David Johnson,10
-Bronx,85064,State Senate,SD32,Ind,David Johnson,7
-Bronx,85065,State Senate,SD32,Ind,David Johnson,14
-Bronx,85066,State Senate,SD32,Ind,David Johnson,24
-Bronx,85067,State Senate,SD32,Ind,David Johnson,15
-Bronx,85068,State Senate,SD32,Ind,David Johnson,11
-Bronx,85069,State Senate,SD32,Ind,David Johnson,6
-Bronx,85070,State Senate,SD32,Ind,David Johnson,5
-Bronx,85071,State Senate,SD32,Ind,David Johnson,2
-Bronx,85072,State Senate,SD32,Ind,David Johnson,2
-Bronx,87002,State Senate,SD32,Ind,David Johnson,0
-Bronx,87004,State Senate,SD32,Ind,David Johnson,17
-Bronx,87005,State Senate,SD32,Ind,David Johnson,9
-Bronx,87006,State Senate,SD32,Ind,David Johnson,22
-Bronx,87007,State Senate,SD32,Ind,David Johnson,9
-Bronx,87008,State Senate,SD32,Ind,David Johnson,6
-Bronx,87009,State Senate,SD32,Ind,David Johnson,8
-Bronx,87010,State Senate,SD32,Ind,David Johnson,14
-Bronx,87011,State Senate,SD32,Ind,David Johnson,10
-Bronx,87012,State Senate,SD32,Ind,David Johnson,3
-Bronx,87013,State Senate,SD32,Ind,David Johnson,2
-Bronx,87014,State Senate,SD32,Ind,David Johnson,3
-Bronx,87022,State Senate,SD32,Ind,David Johnson,15
-Bronx,87026,State Senate,SD32,Ind,David Johnson,20
-Bronx,87027,State Senate,SD32,Ind,David Johnson,10
-Bronx,87028,State Senate,SD32,Ind,David Johnson,21
-Bronx,87029,State Senate,SD32,Ind,David Johnson,22
-Bronx,87030,State Senate,SD32,Ind,David Johnson,3
-Bronx,87031,State Senate,SD32,Ind,David Johnson,4
-Bronx,87032,State Senate,SD32,Ind,David Johnson,15
-Bronx,87033,State Senate,SD32,Ind,David Johnson,17
-Bronx,87034,State Senate,SD32,Ind,David Johnson,8
-Bronx,87035,State Senate,SD32,Ind,David Johnson,22
-Bronx,87036,State Senate,SD32,Ind,David Johnson,16
-Bronx,87037,State Senate,SD32,Ind,David Johnson,20
-Bronx,87038,State Senate,SD32,Ind,David Johnson,23
-Bronx,87039,State Senate,SD32,Ind,David Johnson,21
-Bronx,87040,State Senate,SD32,Ind,David Johnson,12
-Bronx,87041,State Senate,SD32,Ind,David Johnson,10
-Bronx,87042,State Senate,SD32,Ind,David Johnson,12
-Bronx,87045,State Senate,SD32,Ind,David Johnson,2
-Bronx,87046,State Senate,SD32,Ind,David Johnson,19
-Bronx,87047,State Senate,SD32,Ind,David Johnson,17
-Bronx,87048,State Senate,SD32,Ind,David Johnson,16
-Bronx,87049,State Senate,SD32,Ind,David Johnson,27
-Bronx,87050,State Senate,SD32,Ind,David Johnson,28
-Bronx,87051,State Senate,SD32,Ind,David Johnson,29
-Bronx,87052,State Senate,SD32,Ind,David Johnson,22
-Bronx,87053,State Senate,SD32,Ind,David Johnson,22
-Bronx,87054,State Senate,SD32,Ind,David Johnson,27
-Bronx,87055,State Senate,SD32,Ind,David Johnson,31
-Bronx,87056,State Senate,SD32,Ind,David Johnson,24
-Bronx,87057,State Senate,SD32,Ind,David Johnson,15
-Bronx,87058,State Senate,SD32,Ind,David Johnson,15
-Bronx,87059,State Senate,SD32,Ind,David Johnson,18
-Bronx,87060,State Senate,SD32,Ind,David Johnson,16
-Bronx,87061,State Senate,SD32,Ind,David Johnson,16
-Bronx,87062,State Senate,SD32,Ind,David Johnson,34
-Bronx,87063,State Senate,SD32,Ind,David Johnson,5
-Bronx,87064,State Senate,SD32,Ind,David Johnson,0
-Bronx,87083,State Senate,SD32,Ind,David Johnson,4
-Bronx,87084,State Senate,SD32,Ind,David Johnson,18
-Bronx,87085,State Senate,SD32,Ind,David Johnson,16
-Bronx,87086,State Senate,SD32,Ind,David Johnson,7
-Bronx,87087,State Senate,SD32,Ind,David Johnson,23
-Bronx,87088,State Senate,SD32,Ind,David Johnson,7
-Bronx,87089,State Senate,SD32,Ind,David Johnson,15
-Bronx,87090,State Senate,SD32,Ind,David Johnson,4
-Bronx,87091,State Senate,SD32,Ind,David Johnson,8
-Bronx,77050,State Senate,SD32,Dem,Ruben Diaz,582
-Bronx,77051,State Senate,SD32,Dem,Ruben Diaz,322
-Bronx,77052,State Senate,SD32,Dem,Ruben Diaz,43
-Bronx,77053,State Senate,SD32,Dem,Ruben Diaz,353
-Bronx,77054,State Senate,SD32,Dem,Ruben Diaz,405
-Bronx,77055,State Senate,SD32,Dem,Ruben Diaz,462
-Bronx,77056,State Senate,SD32,Dem,Ruben Diaz,383
-Bronx,77057,State Senate,SD32,Dem,Ruben Diaz,369
-Bronx,77058,State Senate,SD32,Dem,Ruben Diaz,549
-Bronx,77059,State Senate,SD32,Dem,Ruben Diaz,566
-Bronx,77060,State Senate,SD32,Dem,Ruben Diaz,332
-Bronx,77062,State Senate,SD32,Dem,Ruben Diaz,382
-Bronx,77063,State Senate,SD32,Dem,Ruben Diaz,447
-Bronx,77064,State Senate,SD32,Dem,Ruben Diaz,130
-Bronx,79006,State Senate,SD32,Dem,Ruben Diaz,302
-Bronx,79011,State Senate,SD32,Dem,Ruben Diaz,146
-Bronx,79012,State Senate,SD32,Dem,Ruben Diaz,103
-Bronx,79014,State Senate,SD32,Dem,Ruben Diaz,163
-Bronx,79015,State Senate,SD32,Dem,Ruben Diaz,416
-Bronx,79016,State Senate,SD32,Dem,Ruben Diaz,453
-Bronx,79017,State Senate,SD32,Dem,Ruben Diaz,430
-Bronx,79018,State Senate,SD32,Dem,Ruben Diaz,156
-Bronx,79019,State Senate,SD32,Dem,Ruben Diaz,114
-Bronx,79021,State Senate,SD32,Dem,Ruben Diaz,344
-Bronx,79022,State Senate,SD32,Dem,Ruben Diaz,443
-Bronx,79023,State Senate,SD32,Dem,Ruben Diaz,299
-Bronx,79024,State Senate,SD32,Dem,Ruben Diaz,254
-Bronx,79025,State Senate,SD32,Dem,Ruben Diaz,381
-Bronx,79026,State Senate,SD32,Dem,Ruben Diaz,372
-Bronx,79027,State Senate,SD32,Dem,Ruben Diaz,456
-Bronx,79028,State Senate,SD32,Dem,Ruben Diaz,536
-Bronx,79038,State Senate,SD32,Dem,Ruben Diaz,459
-Bronx,79039,State Senate,SD32,Dem,Ruben Diaz,406
-Bronx,79040,State Senate,SD32,Dem,Ruben Diaz,417
-Bronx,79041,State Senate,SD32,Dem,Ruben Diaz,373
-Bronx,79042,State Senate,SD32,Dem,Ruben Diaz,397
-Bronx,79043,State Senate,SD32,Dem,Ruben Diaz,317
-Bronx,79044,State Senate,SD32,Dem,Ruben Diaz,362
-Bronx,79045,State Senate,SD32,Dem,Ruben Diaz,301
-Bronx,79046,State Senate,SD32,Dem,Ruben Diaz,402
-Bronx,79047,State Senate,SD32,Dem,Ruben Diaz,500
-Bronx,79048,State Senate,SD32,Dem,Ruben Diaz,328
-Bronx,79049,State Senate,SD32,Dem,Ruben Diaz,402
-Bronx,79050,State Senate,SD32,Dem,Ruben Diaz,457
-Bronx,79051,State Senate,SD32,Dem,Ruben Diaz,420
-Bronx,79052,State Senate,SD32,Dem,Ruben Diaz,480
-Bronx,79053,State Senate,SD32,Dem,Ruben Diaz,403
-Bronx,79054,State Senate,SD32,Dem,Ruben Diaz,270
-Bronx,79055,State Senate,SD32,Dem,Ruben Diaz,464
-Bronx,79056,State Senate,SD32,Dem,Ruben Diaz,430
-Bronx,79057,State Senate,SD32,Dem,Ruben Diaz,665
-Bronx,79058,State Senate,SD32,Dem,Ruben Diaz,421
-Bronx,79059,State Senate,SD32,Dem,Ruben Diaz,387
-Bronx,79060,State Senate,SD32,Dem,Ruben Diaz,177
-Bronx,79061,State Senate,SD32,Dem,Ruben Diaz,416
-Bronx,79062,State Senate,SD32,Dem,Ruben Diaz,329
-Bronx,79063,State Senate,SD32,Dem,Ruben Diaz,428
-Bronx,79064,State Senate,SD32,Dem,Ruben Diaz,421
-Bronx,79065,State Senate,SD32,Dem,Ruben Diaz,460
-Bronx,79066,State Senate,SD32,Dem,Ruben Diaz,367
-Bronx,79068,State Senate,SD32,Dem,Ruben Diaz,501
-Bronx,79069,State Senate,SD32,Dem,Ruben Diaz,534
-Bronx,79070,State Senate,SD32,Dem,Ruben Diaz,523
-Bronx,79071,State Senate,SD32,Dem,Ruben Diaz,167
-Bronx,79072,State Senate,SD32,Dem,Ruben Diaz,401
-Bronx,79073,State Senate,SD32,Dem,Ruben Diaz,275
-Bronx,79075,State Senate,SD32,Dem,Ruben Diaz,598
-Bronx,79076,State Senate,SD32,Dem,Ruben Diaz,0
-Bronx,82029,State Senate,SD32,Dem,Ruben Diaz,65
-Bronx,82030,State Senate,SD32,Dem,Ruben Diaz,344
-Bronx,84036,State Senate,SD32,Dem,Ruben Diaz,109
-Bronx,84037,State Senate,SD32,Dem,Ruben Diaz,357
-Bronx,84038,State Senate,SD32,Dem,Ruben Diaz,313
-Bronx,84039,State Senate,SD32,Dem,Ruben Diaz,485
-Bronx,84048,State Senate,SD32,Dem,Ruben Diaz,326
-Bronx,84049,State Senate,SD32,Dem,Ruben Diaz,211
-Bronx,84050,State Senate,SD32,Dem,Ruben Diaz,238
-Bronx,84051,State Senate,SD32,Dem,Ruben Diaz,501
-Bronx,84052,State Senate,SD32,Dem,Ruben Diaz,444
-Bronx,84053,State Senate,SD32,Dem,Ruben Diaz,0
-Bronx,84074,State Senate,SD32,Dem,Ruben Diaz,373
-Bronx,84075,State Senate,SD32,Dem,Ruben Diaz,405
-Bronx,85014,State Senate,SD32,Dem,Ruben Diaz,226
-Bronx,85015,State Senate,SD32,Dem,Ruben Diaz,341
-Bronx,85016,State Senate,SD32,Dem,Ruben Diaz,182
-Bronx,85017,State Senate,SD32,Dem,Ruben Diaz,354
-Bronx,85018,State Senate,SD32,Dem,Ruben Diaz,533
-Bronx,85019,State Senate,SD32,Dem,Ruben Diaz,514
-Bronx,85020,State Senate,SD32,Dem,Ruben Diaz,472
-Bronx,85021,State Senate,SD32,Dem,Ruben Diaz,449
-Bronx,85022,State Senate,SD32,Dem,Ruben Diaz,345
-Bronx,85023,State Senate,SD32,Dem,Ruben Diaz,332
-Bronx,85024,State Senate,SD32,Dem,Ruben Diaz,493
-Bronx,85025,State Senate,SD32,Dem,Ruben Diaz,551
-Bronx,85026,State Senate,SD32,Dem,Ruben Diaz,303
-Bronx,85027,State Senate,SD32,Dem,Ruben Diaz,289
-Bronx,85029,State Senate,SD32,Dem,Ruben Diaz,306
-Bronx,85030,State Senate,SD32,Dem,Ruben Diaz,415
-Bronx,85031,State Senate,SD32,Dem,Ruben Diaz,452
-Bronx,85032,State Senate,SD32,Dem,Ruben Diaz,435
-Bronx,85033,State Senate,SD32,Dem,Ruben Diaz,407
-Bronx,85034,State Senate,SD32,Dem,Ruben Diaz,441
-Bronx,85039,State Senate,SD32,Dem,Ruben Diaz,444
-Bronx,85040,State Senate,SD32,Dem,Ruben Diaz,246
-Bronx,85041,State Senate,SD32,Dem,Ruben Diaz,426
-Bronx,85042,State Senate,SD32,Dem,Ruben Diaz,468
-Bronx,85043,State Senate,SD32,Dem,Ruben Diaz,302
-Bronx,85044,State Senate,SD32,Dem,Ruben Diaz,353
-Bronx,85045,State Senate,SD32,Dem,Ruben Diaz,402
-Bronx,85046,State Senate,SD32,Dem,Ruben Diaz,438
-Bronx,85047,State Senate,SD32,Dem,Ruben Diaz,337
-Bronx,85048,State Senate,SD32,Dem,Ruben Diaz,368
-Bronx,85049,State Senate,SD32,Dem,Ruben Diaz,445
-Bronx,85050,State Senate,SD32,Dem,Ruben Diaz,345
-Bronx,85051,State Senate,SD32,Dem,Ruben Diaz,259
-Bronx,85052,State Senate,SD32,Dem,Ruben Diaz,385
-Bronx,85053,State Senate,SD32,Dem,Ruben Diaz,446
-Bronx,85054,State Senate,SD32,Dem,Ruben Diaz,376
-Bronx,85055,State Senate,SD32,Dem,Ruben Diaz,415
-Bronx,85056,State Senate,SD32,Dem,Ruben Diaz,24
-Bronx,85057,State Senate,SD32,Dem,Ruben Diaz,257
-Bronx,85058,State Senate,SD32,Dem,Ruben Diaz,406
-Bronx,85059,State Senate,SD32,Dem,Ruben Diaz,452
-Bronx,85060,State Senate,SD32,Dem,Ruben Diaz,512
-Bronx,85061,State Senate,SD32,Dem,Ruben Diaz,198
-Bronx,85062,State Senate,SD32,Dem,Ruben Diaz,476
-Bronx,85063,State Senate,SD32,Dem,Ruben Diaz,379
-Bronx,85064,State Senate,SD32,Dem,Ruben Diaz,399
-Bronx,85065,State Senate,SD32,Dem,Ruben Diaz,474
-Bronx,85066,State Senate,SD32,Dem,Ruben Diaz,450
-Bronx,85067,State Senate,SD32,Dem,Ruben Diaz,300
-Bronx,85068,State Senate,SD32,Dem,Ruben Diaz,437
-Bronx,85069,State Senate,SD32,Dem,Ruben Diaz,447
-Bronx,85070,State Senate,SD32,Dem,Ruben Diaz,326
-Bronx,85071,State Senate,SD32,Dem,Ruben Diaz,219
-Bronx,85072,State Senate,SD32,Dem,Ruben Diaz,79
-Bronx,87002,State Senate,SD32,Dem,Ruben Diaz,0
-Bronx,87004,State Senate,SD32,Dem,Ruben Diaz,359
-Bronx,87005,State Senate,SD32,Dem,Ruben Diaz,412
-Bronx,87006,State Senate,SD32,Dem,Ruben Diaz,388
-Bronx,87007,State Senate,SD32,Dem,Ruben Diaz,381
-Bronx,87008,State Senate,SD32,Dem,Ruben Diaz,305
-Bronx,87009,State Senate,SD32,Dem,Ruben Diaz,284
-Bronx,87010,State Senate,SD32,Dem,Ruben Diaz,420
-Bronx,87011,State Senate,SD32,Dem,Ruben Diaz,422
-Bronx,87012,State Senate,SD32,Dem,Ruben Diaz,40
-Bronx,87013,State Senate,SD32,Dem,Ruben Diaz,122
-Bronx,87014,State Senate,SD32,Dem,Ruben Diaz,77
-Bronx,87022,State Senate,SD32,Dem,Ruben Diaz,261
-Bronx,87026,State Senate,SD32,Dem,Ruben Diaz,428
-Bronx,87027,State Senate,SD32,Dem,Ruben Diaz,243
-Bronx,87028,State Senate,SD32,Dem,Ruben Diaz,431
-Bronx,87029,State Senate,SD32,Dem,Ruben Diaz,282
-Bronx,87030,State Senate,SD32,Dem,Ruben Diaz,123
-Bronx,87031,State Senate,SD32,Dem,Ruben Diaz,254
-Bronx,87032,State Senate,SD32,Dem,Ruben Diaz,486
-Bronx,87033,State Senate,SD32,Dem,Ruben Diaz,444
-Bronx,87034,State Senate,SD32,Dem,Ruben Diaz,362
-Bronx,87035,State Senate,SD32,Dem,Ruben Diaz,354
-Bronx,87036,State Senate,SD32,Dem,Ruben Diaz,384
-Bronx,87037,State Senate,SD32,Dem,Ruben Diaz,426
-Bronx,87038,State Senate,SD32,Dem,Ruben Diaz,497
-Bronx,87039,State Senate,SD32,Dem,Ruben Diaz,495
-Bronx,87040,State Senate,SD32,Dem,Ruben Diaz,545
-Bronx,87041,State Senate,SD32,Dem,Ruben Diaz,216
-Bronx,87042,State Senate,SD32,Dem,Ruben Diaz,499
-Bronx,87045,State Senate,SD32,Dem,Ruben Diaz,40
-Bronx,87046,State Senate,SD32,Dem,Ruben Diaz,348
-Bronx,87047,State Senate,SD32,Dem,Ruben Diaz,502
-Bronx,87048,State Senate,SD32,Dem,Ruben Diaz,482
-Bronx,87049,State Senate,SD32,Dem,Ruben Diaz,459
-Bronx,87050,State Senate,SD32,Dem,Ruben Diaz,496
-Bronx,87051,State Senate,SD32,Dem,Ruben Diaz,525
-Bronx,87052,State Senate,SD32,Dem,Ruben Diaz,479
-Bronx,87053,State Senate,SD32,Dem,Ruben Diaz,555
-Bronx,87054,State Senate,SD32,Dem,Ruben Diaz,483
-Bronx,87055,State Senate,SD32,Dem,Ruben Diaz,461
-Bronx,87056,State Senate,SD32,Dem,Ruben Diaz,472
-Bronx,87057,State Senate,SD32,Dem,Ruben Diaz,525
-Bronx,87058,State Senate,SD32,Dem,Ruben Diaz,255
-Bronx,87059,State Senate,SD32,Dem,Ruben Diaz,513
-Bronx,87060,State Senate,SD32,Dem,Ruben Diaz,364
-Bronx,87061,State Senate,SD32,Dem,Ruben Diaz,453
-Bronx,87062,State Senate,SD32,Dem,Ruben Diaz,567
-Bronx,87063,State Senate,SD32,Dem,Ruben Diaz,26
-Bronx,87064,State Senate,SD32,Dem,Ruben Diaz,4
-Bronx,87083,State Senate,SD32,Dem,Ruben Diaz,27
-Bronx,87084,State Senate,SD32,Dem,Ruben Diaz,425
-Bronx,87085,State Senate,SD32,Dem,Ruben Diaz,520
-Bronx,87086,State Senate,SD32,Dem,Ruben Diaz,188
-Bronx,87087,State Senate,SD32,Dem,Ruben Diaz,456
-Bronx,87088,State Senate,SD32,Dem,Ruben Diaz,469
-Bronx,87089,State Senate,SD32,Dem,Ruben Diaz,410
-Bronx,87090,State Senate,SD32,Dem,Ruben Diaz,431
-Bronx,87091,State Senate,SD32,Dem,Ruben Diaz,261
-Bronx,77050,State Senate,SD32,Rep,Ruben Diaz,14
-Bronx,77051,State Senate,SD32,Rep,Ruben Diaz,1
-Bronx,77052,State Senate,SD32,Rep,Ruben Diaz,1
-Bronx,77053,State Senate,SD32,Rep,Ruben Diaz,11
-Bronx,77054,State Senate,SD32,Rep,Ruben Diaz,6
-Bronx,77055,State Senate,SD32,Rep,Ruben Diaz,3
-Bronx,77056,State Senate,SD32,Rep,Ruben Diaz,3
-Bronx,77057,State Senate,SD32,Rep,Ruben Diaz,6
-Bronx,77058,State Senate,SD32,Rep,Ruben Diaz,11
-Bronx,77059,State Senate,SD32,Rep,Ruben Diaz,10
-Bronx,77060,State Senate,SD32,Rep,Ruben Diaz,10
-Bronx,77062,State Senate,SD32,Rep,Ruben Diaz,10
-Bronx,77063,State Senate,SD32,Rep,Ruben Diaz,11
-Bronx,77064,State Senate,SD32,Rep,Ruben Diaz,2
-Bronx,79006,State Senate,SD32,Rep,Ruben Diaz,3
-Bronx,79011,State Senate,SD32,Rep,Ruben Diaz,1
-Bronx,79012,State Senate,SD32,Rep,Ruben Diaz,0
-Bronx,79014,State Senate,SD32,Rep,Ruben Diaz,2
-Bronx,79015,State Senate,SD32,Rep,Ruben Diaz,6
-Bronx,79016,State Senate,SD32,Rep,Ruben Diaz,4
-Bronx,79017,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,79018,State Senate,SD32,Rep,Ruben Diaz,5
-Bronx,79019,State Senate,SD32,Rep,Ruben Diaz,3
-Bronx,79021,State Senate,SD32,Rep,Ruben Diaz,14
-Bronx,79022,State Senate,SD32,Rep,Ruben Diaz,5
-Bronx,79023,State Senate,SD32,Rep,Ruben Diaz,7
-Bronx,79024,State Senate,SD32,Rep,Ruben Diaz,11
-Bronx,79025,State Senate,SD32,Rep,Ruben Diaz,1
-Bronx,79026,State Senate,SD32,Rep,Ruben Diaz,10
-Bronx,79027,State Senate,SD32,Rep,Ruben Diaz,5
-Bronx,79028,State Senate,SD32,Rep,Ruben Diaz,9
-Bronx,79038,State Senate,SD32,Rep,Ruben Diaz,3
-Bronx,79039,State Senate,SD32,Rep,Ruben Diaz,3
-Bronx,79040,State Senate,SD32,Rep,Ruben Diaz,7
-Bronx,79041,State Senate,SD32,Rep,Ruben Diaz,3
-Bronx,79042,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,79043,State Senate,SD32,Rep,Ruben Diaz,4
-Bronx,79044,State Senate,SD32,Rep,Ruben Diaz,5
-Bronx,79045,State Senate,SD32,Rep,Ruben Diaz,4
-Bronx,79046,State Senate,SD32,Rep,Ruben Diaz,5
-Bronx,79047,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,79048,State Senate,SD32,Rep,Ruben Diaz,3
-Bronx,79049,State Senate,SD32,Rep,Ruben Diaz,1
-Bronx,79050,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,79051,State Senate,SD32,Rep,Ruben Diaz,5
-Bronx,79052,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,79053,State Senate,SD32,Rep,Ruben Diaz,7
-Bronx,79054,State Senate,SD32,Rep,Ruben Diaz,5
-Bronx,79055,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,79056,State Senate,SD32,Rep,Ruben Diaz,9
-Bronx,79057,State Senate,SD32,Rep,Ruben Diaz,17
-Bronx,79058,State Senate,SD32,Rep,Ruben Diaz,17
-Bronx,79059,State Senate,SD32,Rep,Ruben Diaz,10
-Bronx,79060,State Senate,SD32,Rep,Ruben Diaz,3
-Bronx,79061,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,79062,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,79063,State Senate,SD32,Rep,Ruben Diaz,10
-Bronx,79064,State Senate,SD32,Rep,Ruben Diaz,2
-Bronx,79065,State Senate,SD32,Rep,Ruben Diaz,6
-Bronx,79066,State Senate,SD32,Rep,Ruben Diaz,6
-Bronx,79068,State Senate,SD32,Rep,Ruben Diaz,5
-Bronx,79069,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,79070,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,79071,State Senate,SD32,Rep,Ruben Diaz,2
-Bronx,79072,State Senate,SD32,Rep,Ruben Diaz,7
-Bronx,79073,State Senate,SD32,Rep,Ruben Diaz,5
-Bronx,79075,State Senate,SD32,Rep,Ruben Diaz,9
-Bronx,79076,State Senate,SD32,Rep,Ruben Diaz,0
-Bronx,82029,State Senate,SD32,Rep,Ruben Diaz,6
-Bronx,82030,State Senate,SD32,Rep,Ruben Diaz,41
-Bronx,84036,State Senate,SD32,Rep,Ruben Diaz,0
-Bronx,84037,State Senate,SD32,Rep,Ruben Diaz,3
-Bronx,84038,State Senate,SD32,Rep,Ruben Diaz,10
-Bronx,84039,State Senate,SD32,Rep,Ruben Diaz,7
-Bronx,84048,State Senate,SD32,Rep,Ruben Diaz,9
-Bronx,84049,State Senate,SD32,Rep,Ruben Diaz,10
-Bronx,84050,State Senate,SD32,Rep,Ruben Diaz,5
-Bronx,84051,State Senate,SD32,Rep,Ruben Diaz,10
-Bronx,84052,State Senate,SD32,Rep,Ruben Diaz,7
-Bronx,84053,State Senate,SD32,Rep,Ruben Diaz,0
-Bronx,84074,State Senate,SD32,Rep,Ruben Diaz,17
-Bronx,84075,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,85014,State Senate,SD32,Rep,Ruben Diaz,1
-Bronx,85015,State Senate,SD32,Rep,Ruben Diaz,3
-Bronx,85016,State Senate,SD32,Rep,Ruben Diaz,1
-Bronx,85017,State Senate,SD32,Rep,Ruben Diaz,5
-Bronx,85018,State Senate,SD32,Rep,Ruben Diaz,7
-Bronx,85019,State Senate,SD32,Rep,Ruben Diaz,1
-Bronx,85020,State Senate,SD32,Rep,Ruben Diaz,2
-Bronx,85021,State Senate,SD32,Rep,Ruben Diaz,4
-Bronx,85022,State Senate,SD32,Rep,Ruben Diaz,9
-Bronx,85023,State Senate,SD32,Rep,Ruben Diaz,1
-Bronx,85024,State Senate,SD32,Rep,Ruben Diaz,7
-Bronx,85025,State Senate,SD32,Rep,Ruben Diaz,4
-Bronx,85026,State Senate,SD32,Rep,Ruben Diaz,5
-Bronx,85027,State Senate,SD32,Rep,Ruben Diaz,11
-Bronx,85029,State Senate,SD32,Rep,Ruben Diaz,4
-Bronx,85030,State Senate,SD32,Rep,Ruben Diaz,3
-Bronx,85031,State Senate,SD32,Rep,Ruben Diaz,4
-Bronx,85032,State Senate,SD32,Rep,Ruben Diaz,18
-Bronx,85033,State Senate,SD32,Rep,Ruben Diaz,11
-Bronx,85034,State Senate,SD32,Rep,Ruben Diaz,12
-Bronx,85039,State Senate,SD32,Rep,Ruben Diaz,4
-Bronx,85040,State Senate,SD32,Rep,Ruben Diaz,10
-Bronx,85041,State Senate,SD32,Rep,Ruben Diaz,16
-Bronx,85042,State Senate,SD32,Rep,Ruben Diaz,5
-Bronx,85043,State Senate,SD32,Rep,Ruben Diaz,9
-Bronx,85044,State Senate,SD32,Rep,Ruben Diaz,4
-Bronx,85045,State Senate,SD32,Rep,Ruben Diaz,7
-Bronx,85046,State Senate,SD32,Rep,Ruben Diaz,7
-Bronx,85047,State Senate,SD32,Rep,Ruben Diaz,6
-Bronx,85048,State Senate,SD32,Rep,Ruben Diaz,9
-Bronx,85049,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,85050,State Senate,SD32,Rep,Ruben Diaz,6
-Bronx,85051,State Senate,SD32,Rep,Ruben Diaz,5
-Bronx,85052,State Senate,SD32,Rep,Ruben Diaz,1
-Bronx,85053,State Senate,SD32,Rep,Ruben Diaz,9
-Bronx,85054,State Senate,SD32,Rep,Ruben Diaz,18
-Bronx,85055,State Senate,SD32,Rep,Ruben Diaz,2
-Bronx,85056,State Senate,SD32,Rep,Ruben Diaz,1
-Bronx,85057,State Senate,SD32,Rep,Ruben Diaz,2
-Bronx,85058,State Senate,SD32,Rep,Ruben Diaz,13
-Bronx,85059,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,85060,State Senate,SD32,Rep,Ruben Diaz,7
-Bronx,85061,State Senate,SD32,Rep,Ruben Diaz,7
-Bronx,85062,State Senate,SD32,Rep,Ruben Diaz,13
-Bronx,85063,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,85064,State Senate,SD32,Rep,Ruben Diaz,12
-Bronx,85065,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,85066,State Senate,SD32,Rep,Ruben Diaz,15
-Bronx,85067,State Senate,SD32,Rep,Ruben Diaz,14
-Bronx,85068,State Senate,SD32,Rep,Ruben Diaz,13
-Bronx,85069,State Senate,SD32,Rep,Ruben Diaz,3
-Bronx,85070,State Senate,SD32,Rep,Ruben Diaz,7
-Bronx,85071,State Senate,SD32,Rep,Ruben Diaz,3
-Bronx,85072,State Senate,SD32,Rep,Ruben Diaz,1
-Bronx,87002,State Senate,SD32,Rep,Ruben Diaz,0
-Bronx,87004,State Senate,SD32,Rep,Ruben Diaz,9
-Bronx,87005,State Senate,SD32,Rep,Ruben Diaz,6
-Bronx,87006,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,87007,State Senate,SD32,Rep,Ruben Diaz,11
-Bronx,87008,State Senate,SD32,Rep,Ruben Diaz,5
-Bronx,87009,State Senate,SD32,Rep,Ruben Diaz,5
-Bronx,87010,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,87011,State Senate,SD32,Rep,Ruben Diaz,9
-Bronx,87012,State Senate,SD32,Rep,Ruben Diaz,0
-Bronx,87013,State Senate,SD32,Rep,Ruben Diaz,4
-Bronx,87014,State Senate,SD32,Rep,Ruben Diaz,2
-Bronx,87022,State Senate,SD32,Rep,Ruben Diaz,6
-Bronx,87026,State Senate,SD32,Rep,Ruben Diaz,14
-Bronx,87027,State Senate,SD32,Rep,Ruben Diaz,6
-Bronx,87028,State Senate,SD32,Rep,Ruben Diaz,17
-Bronx,87029,State Senate,SD32,Rep,Ruben Diaz,13
-Bronx,87030,State Senate,SD32,Rep,Ruben Diaz,3
-Bronx,87031,State Senate,SD32,Rep,Ruben Diaz,9
-Bronx,87032,State Senate,SD32,Rep,Ruben Diaz,13
-Bronx,87033,State Senate,SD32,Rep,Ruben Diaz,9
-Bronx,87034,State Senate,SD32,Rep,Ruben Diaz,16
-Bronx,87035,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,87036,State Senate,SD32,Rep,Ruben Diaz,18
-Bronx,87037,State Senate,SD32,Rep,Ruben Diaz,26
-Bronx,87038,State Senate,SD32,Rep,Ruben Diaz,11
-Bronx,87039,State Senate,SD32,Rep,Ruben Diaz,19
-Bronx,87040,State Senate,SD32,Rep,Ruben Diaz,23
-Bronx,87041,State Senate,SD32,Rep,Ruben Diaz,13
-Bronx,87042,State Senate,SD32,Rep,Ruben Diaz,4
-Bronx,87045,State Senate,SD32,Rep,Ruben Diaz,11
-Bronx,87046,State Senate,SD32,Rep,Ruben Diaz,23
-Bronx,87047,State Senate,SD32,Rep,Ruben Diaz,17
-Bronx,87048,State Senate,SD32,Rep,Ruben Diaz,17
-Bronx,87049,State Senate,SD32,Rep,Ruben Diaz,21
-Bronx,87050,State Senate,SD32,Rep,Ruben Diaz,16
-Bronx,87051,State Senate,SD32,Rep,Ruben Diaz,13
-Bronx,87052,State Senate,SD32,Rep,Ruben Diaz,10
-Bronx,87053,State Senate,SD32,Rep,Ruben Diaz,19
-Bronx,87054,State Senate,SD32,Rep,Ruben Diaz,18
-Bronx,87055,State Senate,SD32,Rep,Ruben Diaz,14
-Bronx,87056,State Senate,SD32,Rep,Ruben Diaz,15
-Bronx,87057,State Senate,SD32,Rep,Ruben Diaz,20
-Bronx,87058,State Senate,SD32,Rep,Ruben Diaz,10
-Bronx,87059,State Senate,SD32,Rep,Ruben Diaz,19
-Bronx,87060,State Senate,SD32,Rep,Ruben Diaz,7
-Bronx,87061,State Senate,SD32,Rep,Ruben Diaz,11
-Bronx,87062,State Senate,SD32,Rep,Ruben Diaz,10
-Bronx,87063,State Senate,SD32,Rep,Ruben Diaz,1
-Bronx,87064,State Senate,SD32,Rep,Ruben Diaz,0
-Bronx,87083,State Senate,SD32,Rep,Ruben Diaz,0
-Bronx,87084,State Senate,SD32,Rep,Ruben Diaz,13
-Bronx,87085,State Senate,SD32,Rep,Ruben Diaz,16
-Bronx,87086,State Senate,SD32,Rep,Ruben Diaz,0
-Bronx,87087,State Senate,SD32,Rep,Ruben Diaz,9
-Bronx,87088,State Senate,SD32,Rep,Ruben Diaz,8
-Bronx,87089,State Senate,SD32,Rep,Ruben Diaz,5
-Bronx,87090,State Senate,SD32,Rep,Ruben Diaz,2
-Bronx,87091,State Senate,SD32,Rep,Ruben Diaz,10
-Bronx,77050,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,77051,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,77052,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,77053,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,77054,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,77055,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,77056,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,77057,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,77058,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,77059,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,77060,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,77062,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,77063,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,77064,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,79006,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,79011,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,79012,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,79014,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,79015,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,79016,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,79017,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,79018,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,79019,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,79021,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,79022,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,79023,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,79024,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,79025,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,79026,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,79027,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,79028,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,79038,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,79039,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,79040,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,79041,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,79042,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,79043,State Senate,SD32,Con,Ruben Diaz,6
-Bronx,79044,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,79045,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,79046,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,79047,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,79048,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,79049,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,79050,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,79051,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,79052,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,79053,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,79054,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,79055,State Senate,SD32,Con,Ruben Diaz,6
-Bronx,79056,State Senate,SD32,Con,Ruben Diaz,6
-Bronx,79057,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,79058,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,79059,State Senate,SD32,Con,Ruben Diaz,6
-Bronx,79060,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,79061,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,79062,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,79063,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,79064,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,79065,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,79066,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,79068,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,79069,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,79070,State Senate,SD32,Con,Ruben Diaz,7
-Bronx,79071,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,79072,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,79073,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,79075,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,79076,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,82029,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,82030,State Senate,SD32,Con,Ruben Diaz,9
-Bronx,84036,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,84037,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,84038,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,84039,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,84048,State Senate,SD32,Con,Ruben Diaz,6
-Bronx,84049,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,84050,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,84051,State Senate,SD32,Con,Ruben Diaz,6
-Bronx,84052,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,84053,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,84074,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,84075,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,85014,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,85015,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,85016,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,85017,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,85018,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,85019,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,85020,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,85021,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,85022,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,85023,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,85024,State Senate,SD32,Con,Ruben Diaz,7
-Bronx,85025,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,85026,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,85027,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,85029,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,85030,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,85031,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,85032,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,85033,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,85034,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,85039,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,85040,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,85041,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,85042,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,85043,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,85044,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,85045,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,85046,State Senate,SD32,Con,Ruben Diaz,7
-Bronx,85047,State Senate,SD32,Con,Ruben Diaz,6
-Bronx,85048,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,85049,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,85050,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,85051,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,85052,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,85053,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,85054,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,85055,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,85056,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,85057,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,85058,State Senate,SD32,Con,Ruben Diaz,8
-Bronx,85059,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,85060,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,85061,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,85062,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,85063,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,85064,State Senate,SD32,Con,Ruben Diaz,6
-Bronx,85065,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,85066,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,85067,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,85068,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,85069,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,85070,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,85071,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,85072,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,87002,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,87004,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,87005,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,87006,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,87007,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,87008,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,87009,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,87010,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,87011,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,87012,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,87013,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,87014,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,87022,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,87026,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,87027,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,87028,State Senate,SD32,Con,Ruben Diaz,8
-Bronx,87029,State Senate,SD32,Con,Ruben Diaz,8
-Bronx,87030,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,87031,State Senate,SD32,Con,Ruben Diaz,7
-Bronx,87032,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,87033,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,87034,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,87035,State Senate,SD32,Con,Ruben Diaz,7
-Bronx,87036,State Senate,SD32,Con,Ruben Diaz,12
-Bronx,87037,State Senate,SD32,Con,Ruben Diaz,15
-Bronx,87038,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,87039,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,87040,State Senate,SD32,Con,Ruben Diaz,11
-Bronx,87041,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,87042,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,87045,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,87046,State Senate,SD32,Con,Ruben Diaz,6
-Bronx,87047,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,87048,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,87049,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,87050,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,87051,State Senate,SD32,Con,Ruben Diaz,8
-Bronx,87052,State Senate,SD32,Con,Ruben Diaz,7
-Bronx,87053,State Senate,SD32,Con,Ruben Diaz,6
-Bronx,87054,State Senate,SD32,Con,Ruben Diaz,6
-Bronx,87055,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,87056,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,87057,State Senate,SD32,Con,Ruben Diaz,6
-Bronx,87058,State Senate,SD32,Con,Ruben Diaz,1
-Bronx,87059,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,87060,State Senate,SD32,Con,Ruben Diaz,6
-Bronx,87061,State Senate,SD32,Con,Ruben Diaz,4
-Bronx,87062,State Senate,SD32,Con,Ruben Diaz,6
-Bronx,87063,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,87064,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,87083,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,87084,State Senate,SD32,Con,Ruben Diaz,5
-Bronx,87085,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,87086,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,87087,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,87088,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,87089,State Senate,SD32,Con,Ruben Diaz,2
-Bronx,87090,State Senate,SD32,Con,Ruben Diaz,3
-Bronx,87091,State Senate,SD32,Con,Ruben Diaz,0
-Bronx,77050,State Senate,SD32,Ind,writein,0
-Bronx,77051,State Senate,SD32,Ind,writein,0
-Bronx,77052,State Senate,SD32,Ind,writein,0
-Bronx,77053,State Senate,SD32,Ind,writein,0
-Bronx,77054,State Senate,SD32,Ind,writein,0
-Bronx,77055,State Senate,SD32,Ind,writein,0
-Bronx,77056,State Senate,SD32,Ind,writein,0
-Bronx,77057,State Senate,SD32,Ind,writein,0
-Bronx,77058,State Senate,SD32,Ind,writein,0
-Bronx,77059,State Senate,SD32,Ind,writein,0
-Bronx,77060,State Senate,SD32,Ind,writein,0
-Bronx,77062,State Senate,SD32,Ind,writein,0
-Bronx,77063,State Senate,SD32,Ind,writein,0
-Bronx,77064,State Senate,SD32,Ind,writein,0
-Bronx,79006,State Senate,SD32,Ind,writein,0
-Bronx,79011,State Senate,SD32,Ind,writein,0
-Bronx,79012,State Senate,SD32,Ind,writein,0
-Bronx,79014,State Senate,SD32,Ind,writein,0
-Bronx,79015,State Senate,SD32,Ind,writein,0
-Bronx,79016,State Senate,SD32,Ind,writein,1
-Bronx,79017,State Senate,SD32,Ind,writein,0
-Bronx,79018,State Senate,SD32,Ind,writein,0
-Bronx,79019,State Senate,SD32,Ind,writein,0
-Bronx,79021,State Senate,SD32,Ind,writein,0
-Bronx,79022,State Senate,SD32,Ind,writein,0
-Bronx,79023,State Senate,SD32,Ind,writein,0
-Bronx,79024,State Senate,SD32,Ind,writein,0
-Bronx,79025,State Senate,SD32,Ind,writein,0
-Bronx,79026,State Senate,SD32,Ind,writein,0
-Bronx,79027,State Senate,SD32,Ind,writein,0
-Bronx,79028,State Senate,SD32,Ind,writein,0
-Bronx,79038,State Senate,SD32,Ind,writein,0
-Bronx,79039,State Senate,SD32,Ind,writein,0
-Bronx,79040,State Senate,SD32,Ind,writein,0
-Bronx,79041,State Senate,SD32,Ind,writein,0
-Bronx,79042,State Senate,SD32,Ind,writein,0
-Bronx,79043,State Senate,SD32,Ind,writein,0
-Bronx,79044,State Senate,SD32,Ind,writein,0
-Bronx,79045,State Senate,SD32,Ind,writein,0
-Bronx,79046,State Senate,SD32,Ind,writein,0
-Bronx,79047,State Senate,SD32,Ind,writein,1
-Bronx,79048,State Senate,SD32,Ind,writein,0
-Bronx,79049,State Senate,SD32,Ind,writein,0
-Bronx,79050,State Senate,SD32,Ind,writein,0
-Bronx,79051,State Senate,SD32,Ind,writein,1
-Bronx,79052,State Senate,SD32,Ind,writein,0
-Bronx,79053,State Senate,SD32,Ind,writein,0
-Bronx,79054,State Senate,SD32,Ind,writein,1
-Bronx,79055,State Senate,SD32,Ind,writein,0
-Bronx,79056,State Senate,SD32,Ind,writein,0
-Bronx,79057,State Senate,SD32,Ind,writein,0
-Bronx,79058,State Senate,SD32,Ind,writein,0
-Bronx,79059,State Senate,SD32,Ind,writein,0
-Bronx,79060,State Senate,SD32,Ind,writein,0
-Bronx,79061,State Senate,SD32,Ind,writein,0
-Bronx,79062,State Senate,SD32,Ind,writein,0
-Bronx,79063,State Senate,SD32,Ind,writein,0
-Bronx,79064,State Senate,SD32,Ind,writein,0
-Bronx,79065,State Senate,SD32,Ind,writein,0
-Bronx,79066,State Senate,SD32,Ind,writein,0
-Bronx,79068,State Senate,SD32,Ind,writein,0
-Bronx,79069,State Senate,SD32,Ind,writein,0
-Bronx,79070,State Senate,SD32,Ind,writein,0
-Bronx,79071,State Senate,SD32,Ind,writein,0
-Bronx,79072,State Senate,SD32,Ind,writein,0
-Bronx,79073,State Senate,SD32,Ind,writein,0
-Bronx,79075,State Senate,SD32,Ind,writein,0
-Bronx,79076,State Senate,SD32,Ind,writein,0
-Bronx,82029,State Senate,SD32,Ind,writein,0
-Bronx,82030,State Senate,SD32,Ind,writein,0
-Bronx,84036,State Senate,SD32,Ind,writein,0
-Bronx,84037,State Senate,SD32,Ind,writein,0
-Bronx,84038,State Senate,SD32,Ind,writein,0
-Bronx,84039,State Senate,SD32,Ind,writein,0
-Bronx,84048,State Senate,SD32,Ind,writein,0
-Bronx,84049,State Senate,SD32,Ind,writein,0
-Bronx,84050,State Senate,SD32,Ind,writein,0
-Bronx,84051,State Senate,SD32,Ind,writein,0
-Bronx,84052,State Senate,SD32,Ind,writein,1
-Bronx,84053,State Senate,SD32,Ind,writein,0
-Bronx,84074,State Senate,SD32,Ind,writein,1
-Bronx,84075,State Senate,SD32,Ind,writein,0
-Bronx,85014,State Senate,SD32,Ind,writein,0
-Bronx,85015,State Senate,SD32,Ind,writein,0
-Bronx,85016,State Senate,SD32,Ind,writein,0
-Bronx,85017,State Senate,SD32,Ind,writein,0
-Bronx,85018,State Senate,SD32,Ind,writein,0
-Bronx,85019,State Senate,SD32,Ind,writein,0
-Bronx,85020,State Senate,SD32,Ind,writein,0
-Bronx,85021,State Senate,SD32,Ind,writein,0
-Bronx,85022,State Senate,SD32,Ind,writein,0
-Bronx,85023,State Senate,SD32,Ind,writein,0
-Bronx,85024,State Senate,SD32,Ind,writein,0
-Bronx,85025,State Senate,SD32,Ind,writein,0
-Bronx,85026,State Senate,SD32,Ind,writein,0
-Bronx,85027,State Senate,SD32,Ind,writein,0
-Bronx,85029,State Senate,SD32,Ind,writein,0
-Bronx,85030,State Senate,SD32,Ind,writein,0
-Bronx,85031,State Senate,SD32,Ind,writein,0
-Bronx,85032,State Senate,SD32,Ind,writein,0
-Bronx,85033,State Senate,SD32,Ind,writein,0
-Bronx,85034,State Senate,SD32,Ind,writein,0
-Bronx,85039,State Senate,SD32,Ind,writein,0
-Bronx,85040,State Senate,SD32,Ind,writein,0
-Bronx,85041,State Senate,SD32,Ind,writein,0
-Bronx,85042,State Senate,SD32,Ind,writein,0
-Bronx,85043,State Senate,SD32,Ind,writein,0
-Bronx,85044,State Senate,SD32,Ind,writein,0
-Bronx,85045,State Senate,SD32,Ind,writein,0
-Bronx,85046,State Senate,SD32,Ind,writein,0
-Bronx,85047,State Senate,SD32,Ind,writein,0
-Bronx,85048,State Senate,SD32,Ind,writein,0
-Bronx,85049,State Senate,SD32,Ind,writein,0
-Bronx,85050,State Senate,SD32,Ind,writein,0
-Bronx,85051,State Senate,SD32,Ind,writein,1
-Bronx,85052,State Senate,SD32,Ind,writein,0
-Bronx,85053,State Senate,SD32,Ind,writein,0
-Bronx,85054,State Senate,SD32,Ind,writein,1
-Bronx,85055,State Senate,SD32,Ind,writein,0
-Bronx,85056,State Senate,SD32,Ind,writein,0
-Bronx,85057,State Senate,SD32,Ind,writein,0
-Bronx,85058,State Senate,SD32,Ind,writein,0
-Bronx,85059,State Senate,SD32,Ind,writein,0
-Bronx,85060,State Senate,SD32,Ind,writein,0
-Bronx,85061,State Senate,SD32,Ind,writein,1
-Bronx,85062,State Senate,SD32,Ind,writein,0
-Bronx,85063,State Senate,SD32,Ind,writein,0
-Bronx,85064,State Senate,SD32,Ind,writein,0
-Bronx,85065,State Senate,SD32,Ind,writein,0
-Bronx,85066,State Senate,SD32,Ind,writein,0
-Bronx,85067,State Senate,SD32,Ind,writein,0
-Bronx,85068,State Senate,SD32,Ind,writein,0
-Bronx,85069,State Senate,SD32,Ind,writein,0
-Bronx,85070,State Senate,SD32,Ind,writein,0
-Bronx,85071,State Senate,SD32,Ind,writein,0
-Bronx,85072,State Senate,SD32,Ind,writein,0
-Bronx,87002,State Senate,SD32,Ind,writein,0
-Bronx,87004,State Senate,SD32,Ind,writein,0
-Bronx,87005,State Senate,SD32,Ind,writein,0
-Bronx,87006,State Senate,SD32,Ind,writein,0
-Bronx,87007,State Senate,SD32,Ind,writein,0
-Bronx,87008,State Senate,SD32,Ind,writein,0
-Bronx,87009,State Senate,SD32,Ind,writein,1
-Bronx,87010,State Senate,SD32,Ind,writein,0
-Bronx,87011,State Senate,SD32,Ind,writein,1
-Bronx,87012,State Senate,SD32,Ind,writein,0
-Bronx,87013,State Senate,SD32,Ind,writein,0
-Bronx,87014,State Senate,SD32,Ind,writein,0
-Bronx,87022,State Senate,SD32,Ind,writein,0
-Bronx,87026,State Senate,SD32,Ind,writein,0
-Bronx,87027,State Senate,SD32,Ind,writein,0
-Bronx,87028,State Senate,SD32,Ind,writein,0
-Bronx,87029,State Senate,SD32,Ind,writein,0
-Bronx,87030,State Senate,SD32,Ind,writein,0
-Bronx,87031,State Senate,SD32,Ind,writein,0
-Bronx,87032,State Senate,SD32,Ind,writein,0
-Bronx,87033,State Senate,SD32,Ind,writein,0
-Bronx,87034,State Senate,SD32,Ind,writein,0
-Bronx,87035,State Senate,SD32,Ind,writein,0
-Bronx,87036,State Senate,SD32,Ind,writein,0
-Bronx,87037,State Senate,SD32,Ind,writein,1
-Bronx,87038,State Senate,SD32,Ind,writein,0
-Bronx,87039,State Senate,SD32,Ind,writein,0
-Bronx,87040,State Senate,SD32,Ind,writein,1
-Bronx,87041,State Senate,SD32,Ind,writein,1
-Bronx,87042,State Senate,SD32,Ind,writein,0
-Bronx,87045,State Senate,SD32,Ind,writein,0
-Bronx,87046,State Senate,SD32,Ind,writein,0
-Bronx,87047,State Senate,SD32,Ind,writein,0
-Bronx,87048,State Senate,SD32,Ind,writein,0
-Bronx,87049,State Senate,SD32,Ind,writein,1
-Bronx,87050,State Senate,SD32,Ind,writein,0
-Bronx,87051,State Senate,SD32,Ind,writein,0
-Bronx,87052,State Senate,SD32,Ind,writein,0
-Bronx,87053,State Senate,SD32,Ind,writein,0
-Bronx,87054,State Senate,SD32,Ind,writein,0
-Bronx,87055,State Senate,SD32,Ind,writein,1
-Bronx,87056,State Senate,SD32,Ind,writein,0
-Bronx,87057,State Senate,SD32,Ind,writein,1
-Bronx,87058,State Senate,SD32,Ind,writein,1
-Bronx,87059,State Senate,SD32,Ind,writein,0
-Bronx,87060,State Senate,SD32,Ind,writein,0
-Bronx,87061,State Senate,SD32,Ind,writein,0
-Bronx,87062,State Senate,SD32,Ind,writein,0
-Bronx,87063,State Senate,SD32,Ind,writein,0
-Bronx,87064,State Senate,SD32,Ind,writein,0
-Bronx,87083,State Senate,SD32,Ind,writein,0
-Bronx,87084,State Senate,SD32,Ind,writein,0
-Bronx,87085,State Senate,SD32,Ind,writein,0
-Bronx,87086,State Senate,SD32,Ind,writein,0
-Bronx,87087,State Senate,SD32,Ind,writein,0
-Bronx,87088,State Senate,SD32,Ind,writein,0
-Bronx,87089,State Senate,SD32,Ind,writein,0
-Bronx,87090,State Senate,SD32,Ind,writein,0
-Bronx,87091,State Senate,SD32,Ind,writein,0
-Bronx,77029,State Senate,SD33,Dem,Gustavo Rivera,203
-Bronx,77030,State Senate,SD33,Dem,Gustavo Rivera,287
-Bronx,77033,State Senate,SD33,Dem,Gustavo Rivera,83
-Bronx,77037,State Senate,SD33,Dem,Gustavo Rivera,622
-Bronx,77038,State Senate,SD33,Dem,Gustavo Rivera,409
-Bronx,77039,State Senate,SD33,Dem,Gustavo Rivera,395
-Bronx,77042,State Senate,SD33,Dem,Gustavo Rivera,299
-Bronx,77043,State Senate,SD33,Dem,Gustavo Rivera,557
-Bronx,77044,State Senate,SD33,Dem,Gustavo Rivera,429
-Bronx,77045,State Senate,SD33,Dem,Gustavo Rivera,552
-Bronx,78001,State Senate,SD33,Dem,Gustavo Rivera,503
-Bronx,78002,State Senate,SD33,Dem,Gustavo Rivera,482
-Bronx,78003,State Senate,SD33,Dem,Gustavo Rivera,183
-Bronx,78004,State Senate,SD33,Dem,Gustavo Rivera,490
-Bronx,78005,State Senate,SD33,Dem,Gustavo Rivera,423
-Bronx,78006,State Senate,SD33,Dem,Gustavo Rivera,490
-Bronx,78008,State Senate,SD33,Dem,Gustavo Rivera,298
-Bronx,78009,State Senate,SD33,Dem,Gustavo Rivera,443
-Bronx,78010,State Senate,SD33,Dem,Gustavo Rivera,478
-Bronx,78011,State Senate,SD33,Dem,Gustavo Rivera,461
-Bronx,78012,State Senate,SD33,Dem,Gustavo Rivera,472
-Bronx,78013,State Senate,SD33,Dem,Gustavo Rivera,483
-Bronx,78014,State Senate,SD33,Dem,Gustavo Rivera,294
-Bronx,78015,State Senate,SD33,Dem,Gustavo Rivera,241
-Bronx,78017,State Senate,SD33,Dem,Gustavo Rivera,361
-Bronx,78018,State Senate,SD33,Dem,Gustavo Rivera,205
-Bronx,78019,State Senate,SD33,Dem,Gustavo Rivera,339
-Bronx,78020,State Senate,SD33,Dem,Gustavo Rivera,362
-Bronx,78021,State Senate,SD33,Dem,Gustavo Rivera,494
-Bronx,78022,State Senate,SD33,Dem,Gustavo Rivera,445
-Bronx,78023,State Senate,SD33,Dem,Gustavo Rivera,445
-Bronx,78024,State Senate,SD33,Dem,Gustavo Rivera,469
-Bronx,78025,State Senate,SD33,Dem,Gustavo Rivera,396
-Bronx,78026,State Senate,SD33,Dem,Gustavo Rivera,335
-Bronx,78027,State Senate,SD33,Dem,Gustavo Rivera,332
-Bronx,78028,State Senate,SD33,Dem,Gustavo Rivera,500
-Bronx,78029,State Senate,SD33,Dem,Gustavo Rivera,332
-Bronx,78043,State Senate,SD33,Dem,Gustavo Rivera,123
-Bronx,78044,State Senate,SD33,Dem,Gustavo Rivera,508
-Bronx,78045,State Senate,SD33,Dem,Gustavo Rivera,505
-Bronx,78046,State Senate,SD33,Dem,Gustavo Rivera,474
-Bronx,78047,State Senate,SD33,Dem,Gustavo Rivera,374
-Bronx,78048,State Senate,SD33,Dem,Gustavo Rivera,505
-Bronx,78049,State Senate,SD33,Dem,Gustavo Rivera,445
-Bronx,78050,State Senate,SD33,Dem,Gustavo Rivera,427
-Bronx,78051,State Senate,SD33,Dem,Gustavo Rivera,464
-Bronx,78052,State Senate,SD33,Dem,Gustavo Rivera,456
-Bronx,78053,State Senate,SD33,Dem,Gustavo Rivera,398
-Bronx,78054,State Senate,SD33,Dem,Gustavo Rivera,274
-Bronx,78056,State Senate,SD33,Dem,Gustavo Rivera,2
-Bronx,79001,State Senate,SD33,Dem,Gustavo Rivera,464
-Bronx,79002,State Senate,SD33,Dem,Gustavo Rivera,328
-Bronx,79003,State Senate,SD33,Dem,Gustavo Rivera,468
-Bronx,79004,State Senate,SD33,Dem,Gustavo Rivera,444
-Bronx,79005,State Senate,SD33,Dem,Gustavo Rivera,482
-Bronx,79007,State Senate,SD33,Dem,Gustavo Rivera,360
-Bronx,79008,State Senate,SD33,Dem,Gustavo Rivera,246
-Bronx,79009,State Senate,SD33,Dem,Gustavo Rivera,334
-Bronx,79010,State Senate,SD33,Dem,Gustavo Rivera,310
-Bronx,79013,State Senate,SD33,Dem,Gustavo Rivera,407
-Bronx,79020,State Senate,SD33,Dem,Gustavo Rivera,300
-Bronx,79029,State Senate,SD33,Dem,Gustavo Rivera,197
-Bronx,79030,State Senate,SD33,Dem,Gustavo Rivera,605
-Bronx,79031,State Senate,SD33,Dem,Gustavo Rivera,430
-Bronx,79032,State Senate,SD33,Dem,Gustavo Rivera,362
-Bronx,79033,State Senate,SD33,Dem,Gustavo Rivera,343
-Bronx,79034,State Senate,SD33,Dem,Gustavo Rivera,528
-Bronx,79035,State Senate,SD33,Dem,Gustavo Rivera,462
-Bronx,79036,State Senate,SD33,Dem,Gustavo Rivera,442
-Bronx,79037,State Senate,SD33,Dem,Gustavo Rivera,633
-Bronx,79074,State Senate,SD33,Dem,Gustavo Rivera,72
-Bronx,80009,State Senate,SD33,Dem,Gustavo Rivera,180
-Bronx,80010,State Senate,SD33,Dem,Gustavo Rivera,236
-Bronx,80011,State Senate,SD33,Dem,Gustavo Rivera,77
-Bronx,80012,State Senate,SD33,Dem,Gustavo Rivera,168
-Bronx,80013,State Senate,SD33,Dem,Gustavo Rivera,287
-Bronx,80014,State Senate,SD33,Dem,Gustavo Rivera,146
-Bronx,80015,State Senate,SD33,Dem,Gustavo Rivera,30
-Bronx,81001,State Senate,SD33,Dem,Gustavo Rivera,344
-Bronx,81002,State Senate,SD33,Dem,Gustavo Rivera,305
-Bronx,81003,State Senate,SD33,Dem,Gustavo Rivera,118
-Bronx,81004,State Senate,SD33,Dem,Gustavo Rivera,475
-Bronx,81005,State Senate,SD33,Dem,Gustavo Rivera,443
-Bronx,81006,State Senate,SD33,Dem,Gustavo Rivera,392
-Bronx,81007,State Senate,SD33,Dem,Gustavo Rivera,466
-Bronx,81008,State Senate,SD33,Dem,Gustavo Rivera,207
-Bronx,81009,State Senate,SD33,Dem,Gustavo Rivera,303
-Bronx,81011,State Senate,SD33,Dem,Gustavo Rivera,7
-Bronx,81038,State Senate,SD33,Dem,Gustavo Rivera,476
-Bronx,81039,State Senate,SD33,Dem,Gustavo Rivera,233
-Bronx,81040,State Senate,SD33,Dem,Gustavo Rivera,450
-Bronx,81045,State Senate,SD33,Dem,Gustavo Rivera,73
-Bronx,81046,State Senate,SD33,Dem,Gustavo Rivera,151
-Bronx,81108,State Senate,SD33,Dem,Gustavo Rivera,126
-Bronx,86008,State Senate,SD33,Dem,Gustavo Rivera,333
-Bronx,86009,State Senate,SD33,Dem,Gustavo Rivera,427
-Bronx,86010,State Senate,SD33,Dem,Gustavo Rivera,293
-Bronx,86011,State Senate,SD33,Dem,Gustavo Rivera,630
-Bronx,86012,State Senate,SD33,Dem,Gustavo Rivera,408
-Bronx,86013,State Senate,SD33,Dem,Gustavo Rivera,358
-Bronx,86014,State Senate,SD33,Dem,Gustavo Rivera,535
-Bronx,86015,State Senate,SD33,Dem,Gustavo Rivera,403
-Bronx,86016,State Senate,SD33,Dem,Gustavo Rivera,390
-Bronx,86017,State Senate,SD33,Dem,Gustavo Rivera,371
-Bronx,86018,State Senate,SD33,Dem,Gustavo Rivera,387
-Bronx,86019,State Senate,SD33,Dem,Gustavo Rivera,556
-Bronx,86020,State Senate,SD33,Dem,Gustavo Rivera,438
-Bronx,86021,State Senate,SD33,Dem,Gustavo Rivera,1
-Bronx,86022,State Senate,SD33,Dem,Gustavo Rivera,463
-Bronx,86023,State Senate,SD33,Dem,Gustavo Rivera,501
-Bronx,86024,State Senate,SD33,Dem,Gustavo Rivera,449
-Bronx,86025,State Senate,SD33,Dem,Gustavo Rivera,494
-Bronx,86026,State Senate,SD33,Dem,Gustavo Rivera,575
-Bronx,86027,State Senate,SD33,Dem,Gustavo Rivera,630
-Bronx,86028,State Senate,SD33,Dem,Gustavo Rivera,478
-Bronx,86029,State Senate,SD33,Dem,Gustavo Rivera,495
-Bronx,86030,State Senate,SD33,Dem,Gustavo Rivera,534
-Bronx,86031,State Senate,SD33,Dem,Gustavo Rivera,503
-Bronx,86032,State Senate,SD33,Dem,Gustavo Rivera,410
-Bronx,86033,State Senate,SD33,Dem,Gustavo Rivera,580
-Bronx,86034,State Senate,SD33,Dem,Gustavo Rivera,484
-Bronx,86035,State Senate,SD33,Dem,Gustavo Rivera,492
-Bronx,86036,State Senate,SD33,Dem,Gustavo Rivera,503
-Bronx,86037,State Senate,SD33,Dem,Gustavo Rivera,360
-Bronx,86038,State Senate,SD33,Dem,Gustavo Rivera,184
-Bronx,86039,State Senate,SD33,Dem,Gustavo Rivera,308
-Bronx,86040,State Senate,SD33,Dem,Gustavo Rivera,433
-Bronx,86041,State Senate,SD33,Dem,Gustavo Rivera,421
-Bronx,86042,State Senate,SD33,Dem,Gustavo Rivera,5
-Bronx,86043,State Senate,SD33,Dem,Gustavo Rivera,24
-Bronx,86044,State Senate,SD33,Dem,Gustavo Rivera,161
-Bronx,86045,State Senate,SD33,Dem,Gustavo Rivera,392
-Bronx,86046,State Senate,SD33,Dem,Gustavo Rivera,350
-Bronx,86047,State Senate,SD33,Dem,Gustavo Rivera,578
-Bronx,86048,State Senate,SD33,Dem,Gustavo Rivera,296
-Bronx,86049,State Senate,SD33,Dem,Gustavo Rivera,480
-Bronx,86050,State Senate,SD33,Dem,Gustavo Rivera,528
-Bronx,86051,State Senate,SD33,Dem,Gustavo Rivera,340
-Bronx,86052,State Senate,SD33,Dem,Gustavo Rivera,477
-Bronx,86053,State Senate,SD33,Dem,Gustavo Rivera,364
-Bronx,86054,State Senate,SD33,Dem,Gustavo Rivera,506
-Bronx,86055,State Senate,SD33,Dem,Gustavo Rivera,518
-Bronx,86056,State Senate,SD33,Dem,Gustavo Rivera,394
-Bronx,86057,State Senate,SD33,Dem,Gustavo Rivera,337
-Bronx,87003,State Senate,SD33,Dem,Gustavo Rivera,252
-Bronx,87015,State Senate,SD33,Dem,Gustavo Rivera,133
-Bronx,87016,State Senate,SD33,Dem,Gustavo Rivera,145
-Bronx,87017,State Senate,SD33,Dem,Gustavo Rivera,134
-Bronx,87018,State Senate,SD33,Dem,Gustavo Rivera,303
-Bronx,87019,State Senate,SD33,Dem,Gustavo Rivera,345
-Bronx,87020,State Senate,SD33,Dem,Gustavo Rivera,337
-Bronx,87023,State Senate,SD33,Dem,Gustavo Rivera,403
-Bronx,87024,State Senate,SD33,Dem,Gustavo Rivera,16
-Bronx,87025,State Senate,SD33,Dem,Gustavo Rivera,120
-Bronx,77029,State Senate,SD33,WF,Gustavo Rivera,8
-Bronx,77030,State Senate,SD33,WF,Gustavo Rivera,5
-Bronx,77033,State Senate,SD33,WF,Gustavo Rivera,1
-Bronx,77037,State Senate,SD33,WF,Gustavo Rivera,5
-Bronx,77038,State Senate,SD33,WF,Gustavo Rivera,3
-Bronx,77039,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,77042,State Senate,SD33,WF,Gustavo Rivera,0
-Bronx,77043,State Senate,SD33,WF,Gustavo Rivera,9
-Bronx,77044,State Senate,SD33,WF,Gustavo Rivera,5
-Bronx,77045,State Senate,SD33,WF,Gustavo Rivera,9
-Bronx,78001,State Senate,SD33,WF,Gustavo Rivera,8
-Bronx,78002,State Senate,SD33,WF,Gustavo Rivera,13
-Bronx,78003,State Senate,SD33,WF,Gustavo Rivera,3
-Bronx,78004,State Senate,SD33,WF,Gustavo Rivera,6
-Bronx,78005,State Senate,SD33,WF,Gustavo Rivera,9
-Bronx,78006,State Senate,SD33,WF,Gustavo Rivera,6
-Bronx,78008,State Senate,SD33,WF,Gustavo Rivera,4
-Bronx,78009,State Senate,SD33,WF,Gustavo Rivera,15
-Bronx,78010,State Senate,SD33,WF,Gustavo Rivera,8
-Bronx,78011,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,78012,State Senate,SD33,WF,Gustavo Rivera,5
-Bronx,78013,State Senate,SD33,WF,Gustavo Rivera,4
-Bronx,78014,State Senate,SD33,WF,Gustavo Rivera,4
-Bronx,78015,State Senate,SD33,WF,Gustavo Rivera,2
-Bronx,78017,State Senate,SD33,WF,Gustavo Rivera,3
-Bronx,78018,State Senate,SD33,WF,Gustavo Rivera,2
-Bronx,78019,State Senate,SD33,WF,Gustavo Rivera,0
-Bronx,78020,State Senate,SD33,WF,Gustavo Rivera,12
-Bronx,78021,State Senate,SD33,WF,Gustavo Rivera,9
-Bronx,78022,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,78023,State Senate,SD33,WF,Gustavo Rivera,12
-Bronx,78024,State Senate,SD33,WF,Gustavo Rivera,6
-Bronx,78025,State Senate,SD33,WF,Gustavo Rivera,2
-Bronx,78026,State Senate,SD33,WF,Gustavo Rivera,8
-Bronx,78027,State Senate,SD33,WF,Gustavo Rivera,6
-Bronx,78028,State Senate,SD33,WF,Gustavo Rivera,11
-Bronx,78029,State Senate,SD33,WF,Gustavo Rivera,9
-Bronx,78043,State Senate,SD33,WF,Gustavo Rivera,1
-Bronx,78044,State Senate,SD33,WF,Gustavo Rivera,11
-Bronx,78045,State Senate,SD33,WF,Gustavo Rivera,8
-Bronx,78046,State Senate,SD33,WF,Gustavo Rivera,5
-Bronx,78047,State Senate,SD33,WF,Gustavo Rivera,6
-Bronx,78048,State Senate,SD33,WF,Gustavo Rivera,15
-Bronx,78049,State Senate,SD33,WF,Gustavo Rivera,12
-Bronx,78050,State Senate,SD33,WF,Gustavo Rivera,9
-Bronx,78051,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,78052,State Senate,SD33,WF,Gustavo Rivera,4
-Bronx,78053,State Senate,SD33,WF,Gustavo Rivera,4
-Bronx,78054,State Senate,SD33,WF,Gustavo Rivera,5
-Bronx,78056,State Senate,SD33,WF,Gustavo Rivera,0
-Bronx,79001,State Senate,SD33,WF,Gustavo Rivera,1
-Bronx,79002,State Senate,SD33,WF,Gustavo Rivera,14
-Bronx,79003,State Senate,SD33,WF,Gustavo Rivera,6
-Bronx,79004,State Senate,SD33,WF,Gustavo Rivera,4
-Bronx,79005,State Senate,SD33,WF,Gustavo Rivera,4
-Bronx,79007,State Senate,SD33,WF,Gustavo Rivera,6
-Bronx,79008,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,79009,State Senate,SD33,WF,Gustavo Rivera,14
-Bronx,79010,State Senate,SD33,WF,Gustavo Rivera,4
-Bronx,79013,State Senate,SD33,WF,Gustavo Rivera,24
-Bronx,79020,State Senate,SD33,WF,Gustavo Rivera,1
-Bronx,79029,State Senate,SD33,WF,Gustavo Rivera,2
-Bronx,79030,State Senate,SD33,WF,Gustavo Rivera,12
-Bronx,79031,State Senate,SD33,WF,Gustavo Rivera,2
-Bronx,79032,State Senate,SD33,WF,Gustavo Rivera,8
-Bronx,79033,State Senate,SD33,WF,Gustavo Rivera,4
-Bronx,79034,State Senate,SD33,WF,Gustavo Rivera,9
-Bronx,79035,State Senate,SD33,WF,Gustavo Rivera,5
-Bronx,79036,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,79037,State Senate,SD33,WF,Gustavo Rivera,5
-Bronx,79074,State Senate,SD33,WF,Gustavo Rivera,1
-Bronx,80009,State Senate,SD33,WF,Gustavo Rivera,8
-Bronx,80010,State Senate,SD33,WF,Gustavo Rivera,5
-Bronx,80011,State Senate,SD33,WF,Gustavo Rivera,6
-Bronx,80012,State Senate,SD33,WF,Gustavo Rivera,10
-Bronx,80013,State Senate,SD33,WF,Gustavo Rivera,5
-Bronx,80014,State Senate,SD33,WF,Gustavo Rivera,3
-Bronx,80015,State Senate,SD33,WF,Gustavo Rivera,0
-Bronx,81001,State Senate,SD33,WF,Gustavo Rivera,1
-Bronx,81002,State Senate,SD33,WF,Gustavo Rivera,6
-Bronx,81003,State Senate,SD33,WF,Gustavo Rivera,0
-Bronx,81004,State Senate,SD33,WF,Gustavo Rivera,10
-Bronx,81005,State Senate,SD33,WF,Gustavo Rivera,8
-Bronx,81006,State Senate,SD33,WF,Gustavo Rivera,16
-Bronx,81007,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,81008,State Senate,SD33,WF,Gustavo Rivera,4
-Bronx,81009,State Senate,SD33,WF,Gustavo Rivera,4
-Bronx,81011,State Senate,SD33,WF,Gustavo Rivera,1
-Bronx,81038,State Senate,SD33,WF,Gustavo Rivera,12
-Bronx,81039,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,81040,State Senate,SD33,WF,Gustavo Rivera,13
-Bronx,81045,State Senate,SD33,WF,Gustavo Rivera,0
-Bronx,81046,State Senate,SD33,WF,Gustavo Rivera,5
-Bronx,81108,State Senate,SD33,WF,Gustavo Rivera,3
-Bronx,86008,State Senate,SD33,WF,Gustavo Rivera,6
-Bronx,86009,State Senate,SD33,WF,Gustavo Rivera,4
-Bronx,86010,State Senate,SD33,WF,Gustavo Rivera,1
-Bronx,86011,State Senate,SD33,WF,Gustavo Rivera,12
-Bronx,86012,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,86013,State Senate,SD33,WF,Gustavo Rivera,5
-Bronx,86014,State Senate,SD33,WF,Gustavo Rivera,14
-Bronx,86015,State Senate,SD33,WF,Gustavo Rivera,5
-Bronx,86016,State Senate,SD33,WF,Gustavo Rivera,5
-Bronx,86017,State Senate,SD33,WF,Gustavo Rivera,15
-Bronx,86018,State Senate,SD33,WF,Gustavo Rivera,2
-Bronx,86019,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,86020,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,86021,State Senate,SD33,WF,Gustavo Rivera,0
-Bronx,86022,State Senate,SD33,WF,Gustavo Rivera,5
-Bronx,86023,State Senate,SD33,WF,Gustavo Rivera,8
-Bronx,86024,State Senate,SD33,WF,Gustavo Rivera,4
-Bronx,86025,State Senate,SD33,WF,Gustavo Rivera,5
-Bronx,86026,State Senate,SD33,WF,Gustavo Rivera,0
-Bronx,86027,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,86028,State Senate,SD33,WF,Gustavo Rivera,8
-Bronx,86029,State Senate,SD33,WF,Gustavo Rivera,3
-Bronx,86030,State Senate,SD33,WF,Gustavo Rivera,6
-Bronx,86031,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,86032,State Senate,SD33,WF,Gustavo Rivera,2
-Bronx,86033,State Senate,SD33,WF,Gustavo Rivera,11
-Bronx,86034,State Senate,SD33,WF,Gustavo Rivera,6
-Bronx,86035,State Senate,SD33,WF,Gustavo Rivera,5
-Bronx,86036,State Senate,SD33,WF,Gustavo Rivera,9
-Bronx,86037,State Senate,SD33,WF,Gustavo Rivera,6
-Bronx,86038,State Senate,SD33,WF,Gustavo Rivera,0
-Bronx,86039,State Senate,SD33,WF,Gustavo Rivera,4
-Bronx,86040,State Senate,SD33,WF,Gustavo Rivera,14
-Bronx,86041,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,86042,State Senate,SD33,WF,Gustavo Rivera,0
-Bronx,86043,State Senate,SD33,WF,Gustavo Rivera,0
-Bronx,86044,State Senate,SD33,WF,Gustavo Rivera,6
-Bronx,86045,State Senate,SD33,WF,Gustavo Rivera,4
-Bronx,86046,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,86047,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,86048,State Senate,SD33,WF,Gustavo Rivera,6
-Bronx,86049,State Senate,SD33,WF,Gustavo Rivera,12
-Bronx,86050,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,86051,State Senate,SD33,WF,Gustavo Rivera,6
-Bronx,86052,State Senate,SD33,WF,Gustavo Rivera,3
-Bronx,86053,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,86054,State Senate,SD33,WF,Gustavo Rivera,6
-Bronx,86055,State Senate,SD33,WF,Gustavo Rivera,9
-Bronx,86056,State Senate,SD33,WF,Gustavo Rivera,12
-Bronx,86057,State Senate,SD33,WF,Gustavo Rivera,1
-Bronx,87003,State Senate,SD33,WF,Gustavo Rivera,3
-Bronx,87015,State Senate,SD33,WF,Gustavo Rivera,5
-Bronx,87016,State Senate,SD33,WF,Gustavo Rivera,4
-Bronx,87017,State Senate,SD33,WF,Gustavo Rivera,2
-Bronx,87018,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,87019,State Senate,SD33,WF,Gustavo Rivera,9
-Bronx,87020,State Senate,SD33,WF,Gustavo Rivera,7
-Bronx,87023,State Senate,SD33,WF,Gustavo Rivera,8
-Bronx,87024,State Senate,SD33,WF,Gustavo Rivera,3
-Bronx,87025,State Senate,SD33,WF,Gustavo Rivera,3
-Bronx,77029,State Senate,SD33,Rep,Michael Waters,3
-Bronx,77030,State Senate,SD33,Rep,Michael Waters,2
-Bronx,77033,State Senate,SD33,Rep,Michael Waters,0
-Bronx,77037,State Senate,SD33,Rep,Michael Waters,8
-Bronx,77038,State Senate,SD33,Rep,Michael Waters,12
-Bronx,77039,State Senate,SD33,Rep,Michael Waters,9
-Bronx,77042,State Senate,SD33,Rep,Michael Waters,3
-Bronx,77043,State Senate,SD33,Rep,Michael Waters,8
-Bronx,77044,State Senate,SD33,Rep,Michael Waters,6
-Bronx,77045,State Senate,SD33,Rep,Michael Waters,13
-Bronx,78001,State Senate,SD33,Rep,Michael Waters,6
-Bronx,78002,State Senate,SD33,Rep,Michael Waters,7
-Bronx,78003,State Senate,SD33,Rep,Michael Waters,14
-Bronx,78004,State Senate,SD33,Rep,Michael Waters,21
-Bronx,78005,State Senate,SD33,Rep,Michael Waters,24
-Bronx,78006,State Senate,SD33,Rep,Michael Waters,35
-Bronx,78008,State Senate,SD33,Rep,Michael Waters,27
-Bronx,78009,State Senate,SD33,Rep,Michael Waters,34
-Bronx,78010,State Senate,SD33,Rep,Michael Waters,8
-Bronx,78011,State Senate,SD33,Rep,Michael Waters,9
-Bronx,78012,State Senate,SD33,Rep,Michael Waters,16
-Bronx,78013,State Senate,SD33,Rep,Michael Waters,14
-Bronx,78014,State Senate,SD33,Rep,Michael Waters,10
-Bronx,78015,State Senate,SD33,Rep,Michael Waters,12
-Bronx,78017,State Senate,SD33,Rep,Michael Waters,3
-Bronx,78018,State Senate,SD33,Rep,Michael Waters,10
-Bronx,78019,State Senate,SD33,Rep,Michael Waters,17
-Bronx,78020,State Senate,SD33,Rep,Michael Waters,16
-Bronx,78021,State Senate,SD33,Rep,Michael Waters,9
-Bronx,78022,State Senate,SD33,Rep,Michael Waters,18
-Bronx,78023,State Senate,SD33,Rep,Michael Waters,16
-Bronx,78024,State Senate,SD33,Rep,Michael Waters,15
-Bronx,78025,State Senate,SD33,Rep,Michael Waters,10
-Bronx,78026,State Senate,SD33,Rep,Michael Waters,10
-Bronx,78027,State Senate,SD33,Rep,Michael Waters,8
-Bronx,78028,State Senate,SD33,Rep,Michael Waters,33
-Bronx,78029,State Senate,SD33,Rep,Michael Waters,8
-Bronx,78043,State Senate,SD33,Rep,Michael Waters,5
-Bronx,78044,State Senate,SD33,Rep,Michael Waters,26
-Bronx,78045,State Senate,SD33,Rep,Michael Waters,21
-Bronx,78046,State Senate,SD33,Rep,Michael Waters,23
-Bronx,78047,State Senate,SD33,Rep,Michael Waters,11
-Bronx,78048,State Senate,SD33,Rep,Michael Waters,30
-Bronx,78049,State Senate,SD33,Rep,Michael Waters,19
-Bronx,78050,State Senate,SD33,Rep,Michael Waters,18
-Bronx,78051,State Senate,SD33,Rep,Michael Waters,14
-Bronx,78052,State Senate,SD33,Rep,Michael Waters,13
-Bronx,78053,State Senate,SD33,Rep,Michael Waters,14
-Bronx,78054,State Senate,SD33,Rep,Michael Waters,12
-Bronx,78056,State Senate,SD33,Rep,Michael Waters,0
-Bronx,79001,State Senate,SD33,Rep,Michael Waters,16
-Bronx,79002,State Senate,SD33,Rep,Michael Waters,8
-Bronx,79003,State Senate,SD33,Rep,Michael Waters,6
-Bronx,79004,State Senate,SD33,Rep,Michael Waters,12
-Bronx,79005,State Senate,SD33,Rep,Michael Waters,8
-Bronx,79007,State Senate,SD33,Rep,Michael Waters,5
-Bronx,79008,State Senate,SD33,Rep,Michael Waters,4
-Bronx,79009,State Senate,SD33,Rep,Michael Waters,4
-Bronx,79010,State Senate,SD33,Rep,Michael Waters,5
-Bronx,79013,State Senate,SD33,Rep,Michael Waters,6
-Bronx,79020,State Senate,SD33,Rep,Michael Waters,6
-Bronx,79029,State Senate,SD33,Rep,Michael Waters,2
-Bronx,79030,State Senate,SD33,Rep,Michael Waters,9
-Bronx,79031,State Senate,SD33,Rep,Michael Waters,3
-Bronx,79032,State Senate,SD33,Rep,Michael Waters,9
-Bronx,79033,State Senate,SD33,Rep,Michael Waters,8
-Bronx,79034,State Senate,SD33,Rep,Michael Waters,10
-Bronx,79035,State Senate,SD33,Rep,Michael Waters,7
-Bronx,79036,State Senate,SD33,Rep,Michael Waters,1
-Bronx,79037,State Senate,SD33,Rep,Michael Waters,7
-Bronx,79074,State Senate,SD33,Rep,Michael Waters,0
-Bronx,80009,State Senate,SD33,Rep,Michael Waters,16
-Bronx,80010,State Senate,SD33,Rep,Michael Waters,43
-Bronx,80011,State Senate,SD33,Rep,Michael Waters,8
-Bronx,80012,State Senate,SD33,Rep,Michael Waters,14
-Bronx,80013,State Senate,SD33,Rep,Michael Waters,47
-Bronx,80014,State Senate,SD33,Rep,Michael Waters,17
-Bronx,80015,State Senate,SD33,Rep,Michael Waters,1
-Bronx,81001,State Senate,SD33,Rep,Michael Waters,18
-Bronx,81002,State Senate,SD33,Rep,Michael Waters,34
-Bronx,81003,State Senate,SD33,Rep,Michael Waters,10
-Bronx,81004,State Senate,SD33,Rep,Michael Waters,36
-Bronx,81005,State Senate,SD33,Rep,Michael Waters,25
-Bronx,81006,State Senate,SD33,Rep,Michael Waters,36
-Bronx,81007,State Senate,SD33,Rep,Michael Waters,27
-Bronx,81008,State Senate,SD33,Rep,Michael Waters,9
-Bronx,81009,State Senate,SD33,Rep,Michael Waters,5
-Bronx,81011,State Senate,SD33,Rep,Michael Waters,0
-Bronx,81038,State Senate,SD33,Rep,Michael Waters,21
-Bronx,81039,State Senate,SD33,Rep,Michael Waters,19
-Bronx,81040,State Senate,SD33,Rep,Michael Waters,25
-Bronx,81045,State Senate,SD33,Rep,Michael Waters,10
-Bronx,81046,State Senate,SD33,Rep,Michael Waters,15
-Bronx,81108,State Senate,SD33,Rep,Michael Waters,24
-Bronx,86008,State Senate,SD33,Rep,Michael Waters,3
-Bronx,86009,State Senate,SD33,Rep,Michael Waters,11
-Bronx,86010,State Senate,SD33,Rep,Michael Waters,6
-Bronx,86011,State Senate,SD33,Rep,Michael Waters,16
-Bronx,86012,State Senate,SD33,Rep,Michael Waters,20
-Bronx,86013,State Senate,SD33,Rep,Michael Waters,8
-Bronx,86014,State Senate,SD33,Rep,Michael Waters,9
-Bronx,86015,State Senate,SD33,Rep,Michael Waters,10
-Bronx,86016,State Senate,SD33,Rep,Michael Waters,15
-Bronx,86017,State Senate,SD33,Rep,Michael Waters,16
-Bronx,86018,State Senate,SD33,Rep,Michael Waters,8
-Bronx,86019,State Senate,SD33,Rep,Michael Waters,14
-Bronx,86020,State Senate,SD33,Rep,Michael Waters,17
-Bronx,86021,State Senate,SD33,Rep,Michael Waters,0
-Bronx,86022,State Senate,SD33,Rep,Michael Waters,16
-Bronx,86023,State Senate,SD33,Rep,Michael Waters,12
-Bronx,86024,State Senate,SD33,Rep,Michael Waters,13
-Bronx,86025,State Senate,SD33,Rep,Michael Waters,19
-Bronx,86026,State Senate,SD33,Rep,Michael Waters,15
-Bronx,86027,State Senate,SD33,Rep,Michael Waters,19
-Bronx,86028,State Senate,SD33,Rep,Michael Waters,7
-Bronx,86029,State Senate,SD33,Rep,Michael Waters,17
-Bronx,86030,State Senate,SD33,Rep,Michael Waters,21
-Bronx,86031,State Senate,SD33,Rep,Michael Waters,17
-Bronx,86032,State Senate,SD33,Rep,Michael Waters,11
-Bronx,86033,State Senate,SD33,Rep,Michael Waters,8
-Bronx,86034,State Senate,SD33,Rep,Michael Waters,5
-Bronx,86035,State Senate,SD33,Rep,Michael Waters,12
-Bronx,86036,State Senate,SD33,Rep,Michael Waters,11
-Bronx,86037,State Senate,SD33,Rep,Michael Waters,8
-Bronx,86038,State Senate,SD33,Rep,Michael Waters,1
-Bronx,86039,State Senate,SD33,Rep,Michael Waters,12
-Bronx,86040,State Senate,SD33,Rep,Michael Waters,9
-Bronx,86041,State Senate,SD33,Rep,Michael Waters,4
-Bronx,86042,State Senate,SD33,Rep,Michael Waters,0
-Bronx,86043,State Senate,SD33,Rep,Michael Waters,1
-Bronx,86044,State Senate,SD33,Rep,Michael Waters,1
-Bronx,86045,State Senate,SD33,Rep,Michael Waters,7
-Bronx,86046,State Senate,SD33,Rep,Michael Waters,8
-Bronx,86047,State Senate,SD33,Rep,Michael Waters,8
-Bronx,86048,State Senate,SD33,Rep,Michael Waters,3
-Bronx,86049,State Senate,SD33,Rep,Michael Waters,10
-Bronx,86050,State Senate,SD33,Rep,Michael Waters,7
-Bronx,86051,State Senate,SD33,Rep,Michael Waters,5
-Bronx,86052,State Senate,SD33,Rep,Michael Waters,12
-Bronx,86053,State Senate,SD33,Rep,Michael Waters,11
-Bronx,86054,State Senate,SD33,Rep,Michael Waters,6
-Bronx,86055,State Senate,SD33,Rep,Michael Waters,9
-Bronx,86056,State Senate,SD33,Rep,Michael Waters,8
-Bronx,86057,State Senate,SD33,Rep,Michael Waters,5
-Bronx,87003,State Senate,SD33,Rep,Michael Waters,5
-Bronx,87015,State Senate,SD33,Rep,Michael Waters,2
-Bronx,87016,State Senate,SD33,Rep,Michael Waters,6
-Bronx,87017,State Senate,SD33,Rep,Michael Waters,7
-Bronx,87018,State Senate,SD33,Rep,Michael Waters,14
-Bronx,87019,State Senate,SD33,Rep,Michael Waters,14
-Bronx,87020,State Senate,SD33,Rep,Michael Waters,31
-Bronx,87023,State Senate,SD33,Rep,Michael Waters,21
-Bronx,87024,State Senate,SD33,Rep,Michael Waters,8
-Bronx,87025,State Senate,SD33,Rep,Michael Waters,9
-Bronx,77029,State Senate,SD33,Con,Michael Waters,1
-Bronx,77030,State Senate,SD33,Con,Michael Waters,1
-Bronx,77033,State Senate,SD33,Con,Michael Waters,0
-Bronx,77037,State Senate,SD33,Con,Michael Waters,3
-Bronx,77038,State Senate,SD33,Con,Michael Waters,3
-Bronx,77039,State Senate,SD33,Con,Michael Waters,6
-Bronx,77042,State Senate,SD33,Con,Michael Waters,2
-Bronx,77043,State Senate,SD33,Con,Michael Waters,1
-Bronx,77044,State Senate,SD33,Con,Michael Waters,1
-Bronx,77045,State Senate,SD33,Con,Michael Waters,3
-Bronx,78001,State Senate,SD33,Con,Michael Waters,3
-Bronx,78002,State Senate,SD33,Con,Michael Waters,0
-Bronx,78003,State Senate,SD33,Con,Michael Waters,5
-Bronx,78004,State Senate,SD33,Con,Michael Waters,4
-Bronx,78005,State Senate,SD33,Con,Michael Waters,3
-Bronx,78006,State Senate,SD33,Con,Michael Waters,2
-Bronx,78008,State Senate,SD33,Con,Michael Waters,12
-Bronx,78009,State Senate,SD33,Con,Michael Waters,5
-Bronx,78010,State Senate,SD33,Con,Michael Waters,9
-Bronx,78011,State Senate,SD33,Con,Michael Waters,0
-Bronx,78012,State Senate,SD33,Con,Michael Waters,7
-Bronx,78013,State Senate,SD33,Con,Michael Waters,5
-Bronx,78014,State Senate,SD33,Con,Michael Waters,2
-Bronx,78015,State Senate,SD33,Con,Michael Waters,1
-Bronx,78017,State Senate,SD33,Con,Michael Waters,1
-Bronx,78018,State Senate,SD33,Con,Michael Waters,1
-Bronx,78019,State Senate,SD33,Con,Michael Waters,1
-Bronx,78020,State Senate,SD33,Con,Michael Waters,5
-Bronx,78021,State Senate,SD33,Con,Michael Waters,4
-Bronx,78022,State Senate,SD33,Con,Michael Waters,2
-Bronx,78023,State Senate,SD33,Con,Michael Waters,3
-Bronx,78024,State Senate,SD33,Con,Michael Waters,6
-Bronx,78025,State Senate,SD33,Con,Michael Waters,2
-Bronx,78026,State Senate,SD33,Con,Michael Waters,1
-Bronx,78027,State Senate,SD33,Con,Michael Waters,3
-Bronx,78028,State Senate,SD33,Con,Michael Waters,3
-Bronx,78029,State Senate,SD33,Con,Michael Waters,2
-Bronx,78043,State Senate,SD33,Con,Michael Waters,0
-Bronx,78044,State Senate,SD33,Con,Michael Waters,2
-Bronx,78045,State Senate,SD33,Con,Michael Waters,6
-Bronx,78046,State Senate,SD33,Con,Michael Waters,4
-Bronx,78047,State Senate,SD33,Con,Michael Waters,4
-Bronx,78048,State Senate,SD33,Con,Michael Waters,10
-Bronx,78049,State Senate,SD33,Con,Michael Waters,4
-Bronx,78050,State Senate,SD33,Con,Michael Waters,3
-Bronx,78051,State Senate,SD33,Con,Michael Waters,1
-Bronx,78052,State Senate,SD33,Con,Michael Waters,2
-Bronx,78053,State Senate,SD33,Con,Michael Waters,2
-Bronx,78054,State Senate,SD33,Con,Michael Waters,2
-Bronx,78056,State Senate,SD33,Con,Michael Waters,0
-Bronx,79001,State Senate,SD33,Con,Michael Waters,2
-Bronx,79002,State Senate,SD33,Con,Michael Waters,2
-Bronx,79003,State Senate,SD33,Con,Michael Waters,4
-Bronx,79004,State Senate,SD33,Con,Michael Waters,2
-Bronx,79005,State Senate,SD33,Con,Michael Waters,3
-Bronx,79007,State Senate,SD33,Con,Michael Waters,2
-Bronx,79008,State Senate,SD33,Con,Michael Waters,2
-Bronx,79009,State Senate,SD33,Con,Michael Waters,6
-Bronx,79010,State Senate,SD33,Con,Michael Waters,3
-Bronx,79013,State Senate,SD33,Con,Michael Waters,1
-Bronx,79020,State Senate,SD33,Con,Michael Waters,0
-Bronx,79029,State Senate,SD33,Con,Michael Waters,0
-Bronx,79030,State Senate,SD33,Con,Michael Waters,2
-Bronx,79031,State Senate,SD33,Con,Michael Waters,2
-Bronx,79032,State Senate,SD33,Con,Michael Waters,1
-Bronx,79033,State Senate,SD33,Con,Michael Waters,1
-Bronx,79034,State Senate,SD33,Con,Michael Waters,5
-Bronx,79035,State Senate,SD33,Con,Michael Waters,1
-Bronx,79036,State Senate,SD33,Con,Michael Waters,1
-Bronx,79037,State Senate,SD33,Con,Michael Waters,1
-Bronx,79074,State Senate,SD33,Con,Michael Waters,0
-Bronx,80009,State Senate,SD33,Con,Michael Waters,2
-Bronx,80010,State Senate,SD33,Con,Michael Waters,8
-Bronx,80011,State Senate,SD33,Con,Michael Waters,2
-Bronx,80012,State Senate,SD33,Con,Michael Waters,2
-Bronx,80013,State Senate,SD33,Con,Michael Waters,6
-Bronx,80014,State Senate,SD33,Con,Michael Waters,3
-Bronx,80015,State Senate,SD33,Con,Michael Waters,0
-Bronx,81001,State Senate,SD33,Con,Michael Waters,3
-Bronx,81002,State Senate,SD33,Con,Michael Waters,5
-Bronx,81003,State Senate,SD33,Con,Michael Waters,0
-Bronx,81004,State Senate,SD33,Con,Michael Waters,7
-Bronx,81005,State Senate,SD33,Con,Michael Waters,1
-Bronx,81006,State Senate,SD33,Con,Michael Waters,1
-Bronx,81007,State Senate,SD33,Con,Michael Waters,6
-Bronx,81008,State Senate,SD33,Con,Michael Waters,0
-Bronx,81009,State Senate,SD33,Con,Michael Waters,4
-Bronx,81011,State Senate,SD33,Con,Michael Waters,0
-Bronx,81038,State Senate,SD33,Con,Michael Waters,7
-Bronx,81039,State Senate,SD33,Con,Michael Waters,7
-Bronx,81040,State Senate,SD33,Con,Michael Waters,4
-Bronx,81045,State Senate,SD33,Con,Michael Waters,3
-Bronx,81046,State Senate,SD33,Con,Michael Waters,1
-Bronx,81108,State Senate,SD33,Con,Michael Waters,4
-Bronx,86008,State Senate,SD33,Con,Michael Waters,2
-Bronx,86009,State Senate,SD33,Con,Michael Waters,1
-Bronx,86010,State Senate,SD33,Con,Michael Waters,1
-Bronx,86011,State Senate,SD33,Con,Michael Waters,1
-Bronx,86012,State Senate,SD33,Con,Michael Waters,12
-Bronx,86013,State Senate,SD33,Con,Michael Waters,4
-Bronx,86014,State Senate,SD33,Con,Michael Waters,4
-Bronx,86015,State Senate,SD33,Con,Michael Waters,0
-Bronx,86016,State Senate,SD33,Con,Michael Waters,7
-Bronx,86017,State Senate,SD33,Con,Michael Waters,5
-Bronx,86018,State Senate,SD33,Con,Michael Waters,0
-Bronx,86019,State Senate,SD33,Con,Michael Waters,4
-Bronx,86020,State Senate,SD33,Con,Michael Waters,4
-Bronx,86021,State Senate,SD33,Con,Michael Waters,0
-Bronx,86022,State Senate,SD33,Con,Michael Waters,2
-Bronx,86023,State Senate,SD33,Con,Michael Waters,2
-Bronx,86024,State Senate,SD33,Con,Michael Waters,2
-Bronx,86025,State Senate,SD33,Con,Michael Waters,2
-Bronx,86026,State Senate,SD33,Con,Michael Waters,2
-Bronx,86027,State Senate,SD33,Con,Michael Waters,6
-Bronx,86028,State Senate,SD33,Con,Michael Waters,2
-Bronx,86029,State Senate,SD33,Con,Michael Waters,6
-Bronx,86030,State Senate,SD33,Con,Michael Waters,2
-Bronx,86031,State Senate,SD33,Con,Michael Waters,4
-Bronx,86032,State Senate,SD33,Con,Michael Waters,4
-Bronx,86033,State Senate,SD33,Con,Michael Waters,1
-Bronx,86034,State Senate,SD33,Con,Michael Waters,1
-Bronx,86035,State Senate,SD33,Con,Michael Waters,2
-Bronx,86036,State Senate,SD33,Con,Michael Waters,1
-Bronx,86037,State Senate,SD33,Con,Michael Waters,2
-Bronx,86038,State Senate,SD33,Con,Michael Waters,0
-Bronx,86039,State Senate,SD33,Con,Michael Waters,1
-Bronx,86040,State Senate,SD33,Con,Michael Waters,4
-Bronx,86041,State Senate,SD33,Con,Michael Waters,1
-Bronx,86042,State Senate,SD33,Con,Michael Waters,0
-Bronx,86043,State Senate,SD33,Con,Michael Waters,0
-Bronx,86044,State Senate,SD33,Con,Michael Waters,1
-Bronx,86045,State Senate,SD33,Con,Michael Waters,0
-Bronx,86046,State Senate,SD33,Con,Michael Waters,3
-Bronx,86047,State Senate,SD33,Con,Michael Waters,5
-Bronx,86048,State Senate,SD33,Con,Michael Waters,2
-Bronx,86049,State Senate,SD33,Con,Michael Waters,2
-Bronx,86050,State Senate,SD33,Con,Michael Waters,4
-Bronx,86051,State Senate,SD33,Con,Michael Waters,1
-Bronx,86052,State Senate,SD33,Con,Michael Waters,2
-Bronx,86053,State Senate,SD33,Con,Michael Waters,1
-Bronx,86054,State Senate,SD33,Con,Michael Waters,3
-Bronx,86055,State Senate,SD33,Con,Michael Waters,4
-Bronx,86056,State Senate,SD33,Con,Michael Waters,3
-Bronx,86057,State Senate,SD33,Con,Michael Waters,1
-Bronx,87003,State Senate,SD33,Con,Michael Waters,0
-Bronx,87015,State Senate,SD33,Con,Michael Waters,0
-Bronx,87016,State Senate,SD33,Con,Michael Waters,1
-Bronx,87017,State Senate,SD33,Con,Michael Waters,2
-Bronx,87018,State Senate,SD33,Con,Michael Waters,3
-Bronx,87019,State Senate,SD33,Con,Michael Waters,1
-Bronx,87020,State Senate,SD33,Con,Michael Waters,4
-Bronx,87023,State Senate,SD33,Con,Michael Waters,6
-Bronx,87024,State Senate,SD33,Con,Michael Waters,0
-Bronx,87025,State Senate,SD33,Con,Michael Waters,1
-Bronx,77029,State Senate,SD33,Ind,writein,0
-Bronx,77030,State Senate,SD33,Ind,writein,0
-Bronx,77033,State Senate,SD33,Ind,writein,0
-Bronx,77037,State Senate,SD33,Ind,writein,0
-Bronx,77038,State Senate,SD33,Ind,writein,0
-Bronx,77039,State Senate,SD33,Ind,writein,0
-Bronx,77042,State Senate,SD33,Ind,writein,0
-Bronx,77043,State Senate,SD33,Ind,writein,0
-Bronx,77044,State Senate,SD33,Ind,writein,0
-Bronx,77045,State Senate,SD33,Ind,writein,0
-Bronx,78001,State Senate,SD33,Ind,writein,0
-Bronx,78002,State Senate,SD33,Ind,writein,0
-Bronx,78003,State Senate,SD33,Ind,writein,0
-Bronx,78004,State Senate,SD33,Ind,writein,0
-Bronx,78005,State Senate,SD33,Ind,writein,0
-Bronx,78006,State Senate,SD33,Ind,writein,0
-Bronx,78008,State Senate,SD33,Ind,writein,3
-Bronx,78009,State Senate,SD33,Ind,writein,0
-Bronx,78010,State Senate,SD33,Ind,writein,0
-Bronx,78011,State Senate,SD33,Ind,writein,0
-Bronx,78012,State Senate,SD33,Ind,writein,0
-Bronx,78013,State Senate,SD33,Ind,writein,0
-Bronx,78014,State Senate,SD33,Ind,writein,0
-Bronx,78015,State Senate,SD33,Ind,writein,0
-Bronx,78017,State Senate,SD33,Ind,writein,0
-Bronx,78018,State Senate,SD33,Ind,writein,0
-Bronx,78019,State Senate,SD33,Ind,writein,0
-Bronx,78020,State Senate,SD33,Ind,writein,0
-Bronx,78021,State Senate,SD33,Ind,writein,0
-Bronx,78022,State Senate,SD33,Ind,writein,0
-Bronx,78023,State Senate,SD33,Ind,writein,1
-Bronx,78024,State Senate,SD33,Ind,writein,1
-Bronx,78025,State Senate,SD33,Ind,writein,0
-Bronx,78026,State Senate,SD33,Ind,writein,1
-Bronx,78027,State Senate,SD33,Ind,writein,0
-Bronx,78028,State Senate,SD33,Ind,writein,1
-Bronx,78029,State Senate,SD33,Ind,writein,0
-Bronx,78043,State Senate,SD33,Ind,writein,0
-Bronx,78044,State Senate,SD33,Ind,writein,0
-Bronx,78045,State Senate,SD33,Ind,writein,0
-Bronx,78046,State Senate,SD33,Ind,writein,0
-Bronx,78047,State Senate,SD33,Ind,writein,0
-Bronx,78048,State Senate,SD33,Ind,writein,2
-Bronx,78049,State Senate,SD33,Ind,writein,1
-Bronx,78050,State Senate,SD33,Ind,writein,1
-Bronx,78051,State Senate,SD33,Ind,writein,0
-Bronx,78052,State Senate,SD33,Ind,writein,0
-Bronx,78053,State Senate,SD33,Ind,writein,0
-Bronx,78054,State Senate,SD33,Ind,writein,0
-Bronx,78056,State Senate,SD33,Ind,writein,0
-Bronx,79001,State Senate,SD33,Ind,writein,1
-Bronx,79002,State Senate,SD33,Ind,writein,0
-Bronx,79003,State Senate,SD33,Ind,writein,0
-Bronx,79004,State Senate,SD33,Ind,writein,0
-Bronx,79005,State Senate,SD33,Ind,writein,0
-Bronx,79007,State Senate,SD33,Ind,writein,0
-Bronx,79008,State Senate,SD33,Ind,writein,0
-Bronx,79009,State Senate,SD33,Ind,writein,0
-Bronx,79010,State Senate,SD33,Ind,writein,0
-Bronx,79013,State Senate,SD33,Ind,writein,0
-Bronx,79020,State Senate,SD33,Ind,writein,0
-Bronx,79029,State Senate,SD33,Ind,writein,0
-Bronx,79030,State Senate,SD33,Ind,writein,0
-Bronx,79031,State Senate,SD33,Ind,writein,0
-Bronx,79032,State Senate,SD33,Ind,writein,0
-Bronx,79033,State Senate,SD33,Ind,writein,0
-Bronx,79034,State Senate,SD33,Ind,writein,0
-Bronx,79035,State Senate,SD33,Ind,writein,0
-Bronx,79036,State Senate,SD33,Ind,writein,0
-Bronx,79037,State Senate,SD33,Ind,writein,0
-Bronx,79074,State Senate,SD33,Ind,writein,0
-Bronx,80009,State Senate,SD33,Ind,writein,0
-Bronx,80010,State Senate,SD33,Ind,writein,0
-Bronx,80011,State Senate,SD33,Ind,writein,0
-Bronx,80012,State Senate,SD33,Ind,writein,0
-Bronx,80013,State Senate,SD33,Ind,writein,0
-Bronx,80014,State Senate,SD33,Ind,writein,0
-Bronx,80015,State Senate,SD33,Ind,writein,0
-Bronx,81001,State Senate,SD33,Ind,writein,0
-Bronx,81002,State Senate,SD33,Ind,writein,0
-Bronx,81003,State Senate,SD33,Ind,writein,0
-Bronx,81004,State Senate,SD33,Ind,writein,0
-Bronx,81005,State Senate,SD33,Ind,writein,0
-Bronx,81006,State Senate,SD33,Ind,writein,1
-Bronx,81007,State Senate,SD33,Ind,writein,0
-Bronx,81008,State Senate,SD33,Ind,writein,0
-Bronx,81009,State Senate,SD33,Ind,writein,0
-Bronx,81011,State Senate,SD33,Ind,writein,0
-Bronx,81038,State Senate,SD33,Ind,writein,0
-Bronx,81039,State Senate,SD33,Ind,writein,0
-Bronx,81040,State Senate,SD33,Ind,writein,0
-Bronx,81045,State Senate,SD33,Ind,writein,0
-Bronx,81046,State Senate,SD33,Ind,writein,0
-Bronx,81108,State Senate,SD33,Ind,writein,0
-Bronx,86008,State Senate,SD33,Ind,writein,0
-Bronx,86009,State Senate,SD33,Ind,writein,0
-Bronx,86010,State Senate,SD33,Ind,writein,0
-Bronx,86011,State Senate,SD33,Ind,writein,0
-Bronx,86012,State Senate,SD33,Ind,writein,0
-Bronx,86013,State Senate,SD33,Ind,writein,0
-Bronx,86014,State Senate,SD33,Ind,writein,0
-Bronx,86015,State Senate,SD33,Ind,writein,0
-Bronx,86016,State Senate,SD33,Ind,writein,0
-Bronx,86017,State Senate,SD33,Ind,writein,0
-Bronx,86018,State Senate,SD33,Ind,writein,0
-Bronx,86019,State Senate,SD33,Ind,writein,0
-Bronx,86020,State Senate,SD33,Ind,writein,0
-Bronx,86021,State Senate,SD33,Ind,writein,0
-Bronx,86022,State Senate,SD33,Ind,writein,0
-Bronx,86023,State Senate,SD33,Ind,writein,0
-Bronx,86024,State Senate,SD33,Ind,writein,0
-Bronx,86025,State Senate,SD33,Ind,writein,0
-Bronx,86026,State Senate,SD33,Ind,writein,0
-Bronx,86027,State Senate,SD33,Ind,writein,0
-Bronx,86028,State Senate,SD33,Ind,writein,0
-Bronx,86029,State Senate,SD33,Ind,writein,0
-Bronx,86030,State Senate,SD33,Ind,writein,0
-Bronx,86031,State Senate,SD33,Ind,writein,0
-Bronx,86032,State Senate,SD33,Ind,writein,0
-Bronx,86033,State Senate,SD33,Ind,writein,0
-Bronx,86034,State Senate,SD33,Ind,writein,0
-Bronx,86035,State Senate,SD33,Ind,writein,0
-Bronx,86036,State Senate,SD33,Ind,writein,0
-Bronx,86037,State Senate,SD33,Ind,writein,0
-Bronx,86038,State Senate,SD33,Ind,writein,0
-Bronx,86039,State Senate,SD33,Ind,writein,0
-Bronx,86040,State Senate,SD33,Ind,writein,0
-Bronx,86041,State Senate,SD33,Ind,writein,0
-Bronx,86042,State Senate,SD33,Ind,writein,0
-Bronx,86043,State Senate,SD33,Ind,writein,0
-Bronx,86044,State Senate,SD33,Ind,writein,0
-Bronx,86045,State Senate,SD33,Ind,writein,0
-Bronx,86046,State Senate,SD33,Ind,writein,0
-Bronx,86047,State Senate,SD33,Ind,writein,1
-Bronx,86048,State Senate,SD33,Ind,writein,0
-Bronx,86049,State Senate,SD33,Ind,writein,0
-Bronx,86050,State Senate,SD33,Ind,writein,0
-Bronx,86051,State Senate,SD33,Ind,writein,0
-Bronx,86052,State Senate,SD33,Ind,writein,0
-Bronx,86053,State Senate,SD33,Ind,writein,0
-Bronx,86054,State Senate,SD33,Ind,writein,0
-Bronx,86055,State Senate,SD33,Ind,writein,0
-Bronx,86056,State Senate,SD33,Ind,writein,0
-Bronx,86057,State Senate,SD33,Ind,writein,0
-Bronx,87003,State Senate,SD33,Ind,writein,0
-Bronx,87015,State Senate,SD33,Ind,writein,0
-Bronx,87016,State Senate,SD33,Ind,writein,0
-Bronx,87017,State Senate,SD33,Ind,writein,0
-Bronx,87018,State Senate,SD33,Ind,writein,0
-Bronx,87019,State Senate,SD33,Ind,writein,0
-Bronx,87020,State Senate,SD33,Ind,writein,1
-Bronx,87023,State Senate,SD33,Ind,writein,0
-Bronx,87024,State Senate,SD33,Ind,writein,0
-Bronx,87025,State Senate,SD33,Ind,writein,0
-Bronx,78007,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,78016,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,78030,State Senate,SD34,Green,Carl Lundgren,6
-Bronx,78031,State Senate,SD34,Green,Carl Lundgren,11
-Bronx,78036,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,78037,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,78040,State Senate,SD34,Green,Carl Lundgren,8
-Bronx,78041,State Senate,SD34,Green,Carl Lundgren,6
-Bronx,78055,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,78058,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,80001,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,80002,State Senate,SD34,Green,Carl Lundgren,14
-Bronx,80003,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,80004,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,80005,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,80006,State Senate,SD34,Green,Carl Lundgren,7
-Bronx,80007,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,80008,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,80016,State Senate,SD34,Green,Carl Lundgren,9
-Bronx,80017,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,80018,State Senate,SD34,Green,Carl Lundgren,6
-Bronx,80019,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,80020,State Senate,SD34,Green,Carl Lundgren,7
-Bronx,80021,State Senate,SD34,Green,Carl Lundgren,8
-Bronx,80022,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,80023,State Senate,SD34,Green,Carl Lundgren,7
-Bronx,80024,State Senate,SD34,Green,Carl Lundgren,12
-Bronx,80025,State Senate,SD34,Green,Carl Lundgren,7
-Bronx,80026,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,80027,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,80028,State Senate,SD34,Green,Carl Lundgren,6
-Bronx,80029,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,80030,State Senate,SD34,Green,Carl Lundgren,6
-Bronx,80031,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,80032,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,80033,State Senate,SD34,Green,Carl Lundgren,6
-Bronx,80034,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,80035,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,80036,State Senate,SD34,Green,Carl Lundgren,7
-Bronx,80037,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,80038,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,80039,State Senate,SD34,Green,Carl Lundgren,6
-Bronx,80040,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,80041,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,80042,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,80043,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,80044,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,80045,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,80046,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,80047,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,80048,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,80049,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,80050,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,80051,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,80066,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,80067,State Senate,SD34,Green,Carl Lundgren,10
-Bronx,80068,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,80069,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,81010,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,81012,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,81013,State Senate,SD34,Green,Carl Lundgren,12
-Bronx,81014,State Senate,SD34,Green,Carl Lundgren,7
-Bronx,81015,State Senate,SD34,Green,Carl Lundgren,11
-Bronx,81016,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,81025,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,81026,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,81027,State Senate,SD34,Green,Carl Lundgren,6
-Bronx,81028,State Senate,SD34,Green,Carl Lundgren,7
-Bronx,81029,State Senate,SD34,Green,Carl Lundgren,10
-Bronx,81030,State Senate,SD34,Green,Carl Lundgren,11
-Bronx,81031,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,81032,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,81033,State Senate,SD34,Green,Carl Lundgren,7
-Bronx,81034,State Senate,SD34,Green,Carl Lundgren,11
-Bronx,81035,State Senate,SD34,Green,Carl Lundgren,6
-Bronx,81036,State Senate,SD34,Green,Carl Lundgren,30
-Bronx,81037,State Senate,SD34,Green,Carl Lundgren,6
-Bronx,81041,State Senate,SD34,Green,Carl Lundgren,15
-Bronx,81042,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,81043,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,81044,State Senate,SD34,Green,Carl Lundgren,8
-Bronx,81047,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,81048,State Senate,SD34,Green,Carl Lundgren,19
-Bronx,81049,State Senate,SD34,Green,Carl Lundgren,21
-Bronx,81050,State Senate,SD34,Green,Carl Lundgren,14
-Bronx,81051,State Senate,SD34,Green,Carl Lundgren,10
-Bronx,81052,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,81053,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,81054,State Senate,SD34,Green,Carl Lundgren,14
-Bronx,81055,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,81056,State Senate,SD34,Green,Carl Lundgren,9
-Bronx,81057,State Senate,SD34,Green,Carl Lundgren,9
-Bronx,81058,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,81059,State Senate,SD34,Green,Carl Lundgren,12
-Bronx,81060,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,81061,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,81062,State Senate,SD34,Green,Carl Lundgren,15
-Bronx,81063,State Senate,SD34,Green,Carl Lundgren,12
-Bronx,81064,State Senate,SD34,Green,Carl Lundgren,10
-Bronx,81065,State Senate,SD34,Green,Carl Lundgren,12
-Bronx,81066,State Senate,SD34,Green,Carl Lundgren,6
-Bronx,81067,State Senate,SD34,Green,Carl Lundgren,7
-Bronx,81068,State Senate,SD34,Green,Carl Lundgren,18
-Bronx,81069,State Senate,SD34,Green,Carl Lundgren,10
-Bronx,81070,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,81071,State Senate,SD34,Green,Carl Lundgren,11
-Bronx,81072,State Senate,SD34,Green,Carl Lundgren,18
-Bronx,81073,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,81074,State Senate,SD34,Green,Carl Lundgren,13
-Bronx,81075,State Senate,SD34,Green,Carl Lundgren,12
-Bronx,81076,State Senate,SD34,Green,Carl Lundgren,9
-Bronx,81077,State Senate,SD34,Green,Carl Lundgren,12
-Bronx,81078,State Senate,SD34,Green,Carl Lundgren,17
-Bronx,81079,State Senate,SD34,Green,Carl Lundgren,6
-Bronx,81080,State Senate,SD34,Green,Carl Lundgren,15
-Bronx,81081,State Senate,SD34,Green,Carl Lundgren,11
-Bronx,81082,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,81083,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,81084,State Senate,SD34,Green,Carl Lundgren,9
-Bronx,81085,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,81086,State Senate,SD34,Green,Carl Lundgren,10
-Bronx,81087,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,81088,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,81089,State Senate,SD34,Green,Carl Lundgren,13
-Bronx,81090,State Senate,SD34,Green,Carl Lundgren,15
-Bronx,81091,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,81104,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,82001,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,82002,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,82003,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,82004,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,82005,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,82006,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,82007,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,82008,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,82009,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,82010,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,82011,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,82012,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,82013,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,82014,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,82015,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,82016,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,82017,State Senate,SD34,Green,Carl Lundgren,6
-Bronx,82018,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,82019,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,82020,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,82021,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,82022,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,82023,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,82024,State Senate,SD34,Green,Carl Lundgren,8
-Bronx,82025,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,82026,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,82027,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,82028,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,82031,State Senate,SD34,Green,Carl Lundgren,7
-Bronx,82032,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,82033,State Senate,SD34,Green,Carl Lundgren,6
-Bronx,82034,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,82035,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,82036,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,82037,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,82038,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,82039,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,82040,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,82041,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,82042,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,82043,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,82044,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,82045,State Senate,SD34,Green,Carl Lundgren,6
-Bronx,82046,State Senate,SD34,Green,Carl Lundgren,7
-Bronx,82047,State Senate,SD34,Green,Carl Lundgren,7
-Bronx,82048,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,82049,State Senate,SD34,Green,Carl Lundgren,7
-Bronx,82050,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,82051,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,82052,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,82053,State Senate,SD34,Green,Carl Lundgren,7
-Bronx,82055,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,82056,State Senate,SD34,Green,Carl Lundgren,9
-Bronx,82057,State Senate,SD34,Green,Carl Lundgren,7
-Bronx,82058,State Senate,SD34,Green,Carl Lundgren,7
-Bronx,82059,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,82060,State Senate,SD34,Green,Carl Lundgren,11
-Bronx,82061,State Senate,SD34,Green,Carl Lundgren,16
-Bronx,82062,State Senate,SD34,Green,Carl Lundgren,11
-Bronx,82063,State Senate,SD34,Green,Carl Lundgren,10
-Bronx,82064,State Senate,SD34,Green,Carl Lundgren,5
-Bronx,82106,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,82107,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,83068,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,84073,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,84077,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,84078,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,85001,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,85002,State Senate,SD34,Green,Carl Lundgren,6
-Bronx,85003,State Senate,SD34,Green,Carl Lundgren,6
-Bronx,85004,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,85005,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,85006,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,85007,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,85008,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,85009,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,85010,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,85011,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,85012,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,85028,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,85037,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,85038,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,85076,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,87044,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,87065,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,87066,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,87067,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,87068,State Senate,SD34,Green,Carl Lundgren,6
-Bronx,87069,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,87072,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,87073,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,87074,State Senate,SD34,Green,Carl Lundgren,7
-Bronx,87075,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,87076,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,87077,State Senate,SD34,Green,Carl Lundgren,3
-Bronx,87078,State Senate,SD34,Green,Carl Lundgren,2
-Bronx,87079,State Senate,SD34,Green,Carl Lundgren,0
-Bronx,87080,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,87081,State Senate,SD34,Green,Carl Lundgren,4
-Bronx,87082,State Senate,SD34,Green,Carl Lundgren,1
-Bronx,78007,State Senate,SD34,Con,Elizabeth Perri,6
-Bronx,78016,State Senate,SD34,Con,Elizabeth Perri,5
-Bronx,78030,State Senate,SD34,Con,Elizabeth Perri,14
-Bronx,78031,State Senate,SD34,Con,Elizabeth Perri,7
-Bronx,78036,State Senate,SD34,Con,Elizabeth Perri,6
-Bronx,78037,State Senate,SD34,Con,Elizabeth Perri,1
-Bronx,78040,State Senate,SD34,Con,Elizabeth Perri,15
-Bronx,78041,State Senate,SD34,Con,Elizabeth Perri,20
-Bronx,78055,State Senate,SD34,Con,Elizabeth Perri,17
-Bronx,78058,State Senate,SD34,Con,Elizabeth Perri,1
-Bronx,80001,State Senate,SD34,Con,Elizabeth Perri,9
-Bronx,80002,State Senate,SD34,Con,Elizabeth Perri,6
-Bronx,80003,State Senate,SD34,Con,Elizabeth Perri,20
-Bronx,80004,State Senate,SD34,Con,Elizabeth Perri,18
-Bronx,80005,State Senate,SD34,Con,Elizabeth Perri,16
-Bronx,80006,State Senate,SD34,Con,Elizabeth Perri,20
-Bronx,80007,State Senate,SD34,Con,Elizabeth Perri,14
-Bronx,80008,State Senate,SD34,Con,Elizabeth Perri,8
-Bronx,80016,State Senate,SD34,Con,Elizabeth Perri,15
-Bronx,80017,State Senate,SD34,Con,Elizabeth Perri,3
-Bronx,80018,State Senate,SD34,Con,Elizabeth Perri,16
-Bronx,80019,State Senate,SD34,Con,Elizabeth Perri,11
-Bronx,80020,State Senate,SD34,Con,Elizabeth Perri,12
-Bronx,80021,State Senate,SD34,Con,Elizabeth Perri,9
-Bronx,80022,State Senate,SD34,Con,Elizabeth Perri,8
-Bronx,80023,State Senate,SD34,Con,Elizabeth Perri,11
-Bronx,80024,State Senate,SD34,Con,Elizabeth Perri,12
-Bronx,80025,State Senate,SD34,Con,Elizabeth Perri,7
-Bronx,80026,State Senate,SD34,Con,Elizabeth Perri,16
-Bronx,80027,State Senate,SD34,Con,Elizabeth Perri,8
-Bronx,80028,State Senate,SD34,Con,Elizabeth Perri,14
-Bronx,80029,State Senate,SD34,Con,Elizabeth Perri,11
-Bronx,80030,State Senate,SD34,Con,Elizabeth Perri,27
-Bronx,80031,State Senate,SD34,Con,Elizabeth Perri,33
-Bronx,80032,State Senate,SD34,Con,Elizabeth Perri,22
-Bronx,80033,State Senate,SD34,Con,Elizabeth Perri,29
-Bronx,80034,State Senate,SD34,Con,Elizabeth Perri,21
-Bronx,80035,State Senate,SD34,Con,Elizabeth Perri,16
-Bronx,80036,State Senate,SD34,Con,Elizabeth Perri,19
-Bronx,80037,State Senate,SD34,Con,Elizabeth Perri,25
-Bronx,80038,State Senate,SD34,Con,Elizabeth Perri,12
-Bronx,80039,State Senate,SD34,Con,Elizabeth Perri,14
-Bronx,80040,State Senate,SD34,Con,Elizabeth Perri,6
-Bronx,80041,State Senate,SD34,Con,Elizabeth Perri,6
-Bronx,80042,State Senate,SD34,Con,Elizabeth Perri,2
-Bronx,80043,State Senate,SD34,Con,Elizabeth Perri,11
-Bronx,80044,State Senate,SD34,Con,Elizabeth Perri,9
-Bronx,80045,State Senate,SD34,Con,Elizabeth Perri,6
-Bronx,80046,State Senate,SD34,Con,Elizabeth Perri,10
-Bronx,80047,State Senate,SD34,Con,Elizabeth Perri,5
-Bronx,80048,State Senate,SD34,Con,Elizabeth Perri,6
-Bronx,80049,State Senate,SD34,Con,Elizabeth Perri,0
-Bronx,80050,State Senate,SD34,Con,Elizabeth Perri,9
-Bronx,80051,State Senate,SD34,Con,Elizabeth Perri,11
-Bronx,80066,State Senate,SD34,Con,Elizabeth Perri,13
-Bronx,80067,State Senate,SD34,Con,Elizabeth Perri,13
-Bronx,80068,State Senate,SD34,Con,Elizabeth Perri,23
-Bronx,80069,State Senate,SD34,Con,Elizabeth Perri,6
-Bronx,81010,State Senate,SD34,Con,Elizabeth Perri,3
-Bronx,81012,State Senate,SD34,Con,Elizabeth Perri,19
-Bronx,81013,State Senate,SD34,Con,Elizabeth Perri,14
-Bronx,81014,State Senate,SD34,Con,Elizabeth Perri,15
-Bronx,81015,State Senate,SD34,Con,Elizabeth Perri,14
-Bronx,81016,State Senate,SD34,Con,Elizabeth Perri,4
-Bronx,81025,State Senate,SD34,Con,Elizabeth Perri,22
-Bronx,81026,State Senate,SD34,Con,Elizabeth Perri,19
-Bronx,81027,State Senate,SD34,Con,Elizabeth Perri,28
-Bronx,81028,State Senate,SD34,Con,Elizabeth Perri,35
-Bronx,81029,State Senate,SD34,Con,Elizabeth Perri,19
-Bronx,81030,State Senate,SD34,Con,Elizabeth Perri,41
-Bronx,81031,State Senate,SD34,Con,Elizabeth Perri,34
-Bronx,81032,State Senate,SD34,Con,Elizabeth Perri,26
-Bronx,81033,State Senate,SD34,Con,Elizabeth Perri,21
-Bronx,81034,State Senate,SD34,Con,Elizabeth Perri,18
-Bronx,81035,State Senate,SD34,Con,Elizabeth Perri,11
-Bronx,81036,State Senate,SD34,Con,Elizabeth Perri,25
-Bronx,81037,State Senate,SD34,Con,Elizabeth Perri,14
-Bronx,81041,State Senate,SD34,Con,Elizabeth Perri,18
-Bronx,81042,State Senate,SD34,Con,Elizabeth Perri,1
-Bronx,81043,State Senate,SD34,Con,Elizabeth Perri,14
-Bronx,81044,State Senate,SD34,Con,Elizabeth Perri,12
-Bronx,81047,State Senate,SD34,Con,Elizabeth Perri,2
-Bronx,81048,State Senate,SD34,Con,Elizabeth Perri,20
-Bronx,81049,State Senate,SD34,Con,Elizabeth Perri,23
-Bronx,81050,State Senate,SD34,Con,Elizabeth Perri,19
-Bronx,81051,State Senate,SD34,Con,Elizabeth Perri,23
-Bronx,81052,State Senate,SD34,Con,Elizabeth Perri,10
-Bronx,81053,State Senate,SD34,Con,Elizabeth Perri,4
-Bronx,81054,State Senate,SD34,Con,Elizabeth Perri,28
-Bronx,81055,State Senate,SD34,Con,Elizabeth Perri,23
-Bronx,81056,State Senate,SD34,Con,Elizabeth Perri,35
-Bronx,81057,State Senate,SD34,Con,Elizabeth Perri,19
-Bronx,81058,State Senate,SD34,Con,Elizabeth Perri,7
-Bronx,81059,State Senate,SD34,Con,Elizabeth Perri,36
-Bronx,81060,State Senate,SD34,Con,Elizabeth Perri,47
-Bronx,81061,State Senate,SD34,Con,Elizabeth Perri,15
-Bronx,81062,State Senate,SD34,Con,Elizabeth Perri,15
-Bronx,81063,State Senate,SD34,Con,Elizabeth Perri,35
-Bronx,81064,State Senate,SD34,Con,Elizabeth Perri,23
-Bronx,81065,State Senate,SD34,Con,Elizabeth Perri,32
-Bronx,81066,State Senate,SD34,Con,Elizabeth Perri,15
-Bronx,81067,State Senate,SD34,Con,Elizabeth Perri,12
-Bronx,81068,State Senate,SD34,Con,Elizabeth Perri,32
-Bronx,81069,State Senate,SD34,Con,Elizabeth Perri,19
-Bronx,81070,State Senate,SD34,Con,Elizabeth Perri,11
-Bronx,81071,State Senate,SD34,Con,Elizabeth Perri,11
-Bronx,81072,State Senate,SD34,Con,Elizabeth Perri,17
-Bronx,81073,State Senate,SD34,Con,Elizabeth Perri,14
-Bronx,81074,State Senate,SD34,Con,Elizabeth Perri,14
-Bronx,81075,State Senate,SD34,Con,Elizabeth Perri,15
-Bronx,81076,State Senate,SD34,Con,Elizabeth Perri,8
-Bronx,81077,State Senate,SD34,Con,Elizabeth Perri,19
-Bronx,81078,State Senate,SD34,Con,Elizabeth Perri,25
-Bronx,81079,State Senate,SD34,Con,Elizabeth Perri,20
-Bronx,81080,State Senate,SD34,Con,Elizabeth Perri,25
-Bronx,81081,State Senate,SD34,Con,Elizabeth Perri,5
-Bronx,81082,State Senate,SD34,Con,Elizabeth Perri,17
-Bronx,81083,State Senate,SD34,Con,Elizabeth Perri,9
-Bronx,81084,State Senate,SD34,Con,Elizabeth Perri,24
-Bronx,81085,State Senate,SD34,Con,Elizabeth Perri,13
-Bronx,81086,State Senate,SD34,Con,Elizabeth Perri,13
-Bronx,81087,State Senate,SD34,Con,Elizabeth Perri,14
-Bronx,81088,State Senate,SD34,Con,Elizabeth Perri,26
-Bronx,81089,State Senate,SD34,Con,Elizabeth Perri,7
-Bronx,81090,State Senate,SD34,Con,Elizabeth Perri,10
-Bronx,81091,State Senate,SD34,Con,Elizabeth Perri,0
-Bronx,81104,State Senate,SD34,Con,Elizabeth Perri,0
-Bronx,82001,State Senate,SD34,Con,Elizabeth Perri,42
-Bronx,82002,State Senate,SD34,Con,Elizabeth Perri,50
-Bronx,82003,State Senate,SD34,Con,Elizabeth Perri,22
-Bronx,82004,State Senate,SD34,Con,Elizabeth Perri,23
-Bronx,82005,State Senate,SD34,Con,Elizabeth Perri,19
-Bronx,82006,State Senate,SD34,Con,Elizabeth Perri,28
-Bronx,82007,State Senate,SD34,Con,Elizabeth Perri,31
-Bronx,82008,State Senate,SD34,Con,Elizabeth Perri,8
-Bronx,82009,State Senate,SD34,Con,Elizabeth Perri,10
-Bronx,82010,State Senate,SD34,Con,Elizabeth Perri,30
-Bronx,82011,State Senate,SD34,Con,Elizabeth Perri,17
-Bronx,82012,State Senate,SD34,Con,Elizabeth Perri,3
-Bronx,82013,State Senate,SD34,Con,Elizabeth Perri,3
-Bronx,82014,State Senate,SD34,Con,Elizabeth Perri,6
-Bronx,82015,State Senate,SD34,Con,Elizabeth Perri,2
-Bronx,82016,State Senate,SD34,Con,Elizabeth Perri,11
-Bronx,82017,State Senate,SD34,Con,Elizabeth Perri,25
-Bronx,82018,State Senate,SD34,Con,Elizabeth Perri,7
-Bronx,82019,State Senate,SD34,Con,Elizabeth Perri,23
-Bronx,82020,State Senate,SD34,Con,Elizabeth Perri,20
-Bronx,82021,State Senate,SD34,Con,Elizabeth Perri,16
-Bronx,82022,State Senate,SD34,Con,Elizabeth Perri,19
-Bronx,82023,State Senate,SD34,Con,Elizabeth Perri,4
-Bronx,82024,State Senate,SD34,Con,Elizabeth Perri,13
-Bronx,82025,State Senate,SD34,Con,Elizabeth Perri,30
-Bronx,82026,State Senate,SD34,Con,Elizabeth Perri,2
-Bronx,82027,State Senate,SD34,Con,Elizabeth Perri,3
-Bronx,82028,State Senate,SD34,Con,Elizabeth Perri,7
-Bronx,82031,State Senate,SD34,Con,Elizabeth Perri,17
-Bronx,82032,State Senate,SD34,Con,Elizabeth Perri,23
-Bronx,82033,State Senate,SD34,Con,Elizabeth Perri,14
-Bronx,82034,State Senate,SD34,Con,Elizabeth Perri,17
-Bronx,82035,State Senate,SD34,Con,Elizabeth Perri,33
-Bronx,82036,State Senate,SD34,Con,Elizabeth Perri,22
-Bronx,82037,State Senate,SD34,Con,Elizabeth Perri,17
-Bronx,82038,State Senate,SD34,Con,Elizabeth Perri,27
-Bronx,82039,State Senate,SD34,Con,Elizabeth Perri,31
-Bronx,82040,State Senate,SD34,Con,Elizabeth Perri,30
-Bronx,82041,State Senate,SD34,Con,Elizabeth Perri,26
-Bronx,82042,State Senate,SD34,Con,Elizabeth Perri,10
-Bronx,82043,State Senate,SD34,Con,Elizabeth Perri,24
-Bronx,82044,State Senate,SD34,Con,Elizabeth Perri,25
-Bronx,82045,State Senate,SD34,Con,Elizabeth Perri,26
-Bronx,82046,State Senate,SD34,Con,Elizabeth Perri,37
-Bronx,82047,State Senate,SD34,Con,Elizabeth Perri,35
-Bronx,82048,State Senate,SD34,Con,Elizabeth Perri,39
-Bronx,82049,State Senate,SD34,Con,Elizabeth Perri,41
-Bronx,82050,State Senate,SD34,Con,Elizabeth Perri,7
-Bronx,82051,State Senate,SD34,Con,Elizabeth Perri,19
-Bronx,82052,State Senate,SD34,Con,Elizabeth Perri,30
-Bronx,82053,State Senate,SD34,Con,Elizabeth Perri,26
-Bronx,82055,State Senate,SD34,Con,Elizabeth Perri,15
-Bronx,82056,State Senate,SD34,Con,Elizabeth Perri,36
-Bronx,82057,State Senate,SD34,Con,Elizabeth Perri,24
-Bronx,82058,State Senate,SD34,Con,Elizabeth Perri,21
-Bronx,82059,State Senate,SD34,Con,Elizabeth Perri,2
-Bronx,82060,State Senate,SD34,Con,Elizabeth Perri,26
-Bronx,82061,State Senate,SD34,Con,Elizabeth Perri,28
-Bronx,82062,State Senate,SD34,Con,Elizabeth Perri,25
-Bronx,82063,State Senate,SD34,Con,Elizabeth Perri,16
-Bronx,82064,State Senate,SD34,Con,Elizabeth Perri,14
-Bronx,82106,State Senate,SD34,Con,Elizabeth Perri,1
-Bronx,82107,State Senate,SD34,Con,Elizabeth Perri,7
-Bronx,83068,State Senate,SD34,Con,Elizabeth Perri,0
-Bronx,84073,State Senate,SD34,Con,Elizabeth Perri,1
-Bronx,84077,State Senate,SD34,Con,Elizabeth Perri,8
-Bronx,84078,State Senate,SD34,Con,Elizabeth Perri,0
-Bronx,85001,State Senate,SD34,Con,Elizabeth Perri,9
-Bronx,85002,State Senate,SD34,Con,Elizabeth Perri,12
-Bronx,85003,State Senate,SD34,Con,Elizabeth Perri,15
-Bronx,85004,State Senate,SD34,Con,Elizabeth Perri,11
-Bronx,85005,State Senate,SD34,Con,Elizabeth Perri,10
-Bronx,85006,State Senate,SD34,Con,Elizabeth Perri,6
-Bronx,85007,State Senate,SD34,Con,Elizabeth Perri,10
-Bronx,85008,State Senate,SD34,Con,Elizabeth Perri,9
-Bronx,85009,State Senate,SD34,Con,Elizabeth Perri,5
-Bronx,85010,State Senate,SD34,Con,Elizabeth Perri,4
-Bronx,85011,State Senate,SD34,Con,Elizabeth Perri,7
-Bronx,85012,State Senate,SD34,Con,Elizabeth Perri,3
-Bronx,85028,State Senate,SD34,Con,Elizabeth Perri,1
-Bronx,85037,State Senate,SD34,Con,Elizabeth Perri,7
-Bronx,85038,State Senate,SD34,Con,Elizabeth Perri,8
-Bronx,85076,State Senate,SD34,Con,Elizabeth Perri,1
-Bronx,87044,State Senate,SD34,Con,Elizabeth Perri,1
-Bronx,87065,State Senate,SD34,Con,Elizabeth Perri,7
-Bronx,87066,State Senate,SD34,Con,Elizabeth Perri,4
-Bronx,87067,State Senate,SD34,Con,Elizabeth Perri,1
-Bronx,87068,State Senate,SD34,Con,Elizabeth Perri,7
-Bronx,87069,State Senate,SD34,Con,Elizabeth Perri,11
-Bronx,87072,State Senate,SD34,Con,Elizabeth Perri,6
-Bronx,87073,State Senate,SD34,Con,Elizabeth Perri,0
-Bronx,87074,State Senate,SD34,Con,Elizabeth Perri,8
-Bronx,87075,State Senate,SD34,Con,Elizabeth Perri,11
-Bronx,87076,State Senate,SD34,Con,Elizabeth Perri,17
-Bronx,87077,State Senate,SD34,Con,Elizabeth Perri,11
-Bronx,87078,State Senate,SD34,Con,Elizabeth Perri,9
-Bronx,87079,State Senate,SD34,Con,Elizabeth Perri,0
-Bronx,87080,State Senate,SD34,Con,Elizabeth Perri,11
-Bronx,87081,State Senate,SD34,Con,Elizabeth Perri,9
-Bronx,87082,State Senate,SD34,Con,Elizabeth Perri,7
-Bronx,78007,State Senate,SD34,Dem,Jeffrey Klein,87
-Bronx,78016,State Senate,SD34,Dem,Jeffrey Klein,283
-Bronx,78030,State Senate,SD34,Dem,Jeffrey Klein,456
-Bronx,78031,State Senate,SD34,Dem,Jeffrey Klein,498
-Bronx,78036,State Senate,SD34,Dem,Jeffrey Klein,340
-Bronx,78037,State Senate,SD34,Dem,Jeffrey Klein,38
-Bronx,78040,State Senate,SD34,Dem,Jeffrey Klein,269
-Bronx,78041,State Senate,SD34,Dem,Jeffrey Klein,631
-Bronx,78055,State Senate,SD34,Dem,Jeffrey Klein,112
-Bronx,78058,State Senate,SD34,Dem,Jeffrey Klein,14
-Bronx,80001,State Senate,SD34,Dem,Jeffrey Klein,184
-Bronx,80002,State Senate,SD34,Dem,Jeffrey Klein,122
-Bronx,80003,State Senate,SD34,Dem,Jeffrey Klein,130
-Bronx,80004,State Senate,SD34,Dem,Jeffrey Klein,150
-Bronx,80005,State Senate,SD34,Dem,Jeffrey Klein,96
-Bronx,80006,State Senate,SD34,Dem,Jeffrey Klein,158
-Bronx,80007,State Senate,SD34,Dem,Jeffrey Klein,193
-Bronx,80008,State Senate,SD34,Dem,Jeffrey Klein,182
-Bronx,80016,State Senate,SD34,Dem,Jeffrey Klein,451
-Bronx,80017,State Senate,SD34,Dem,Jeffrey Klein,399
-Bronx,80018,State Senate,SD34,Dem,Jeffrey Klein,172
-Bronx,80019,State Senate,SD34,Dem,Jeffrey Klein,106
-Bronx,80020,State Senate,SD34,Dem,Jeffrey Klein,281
-Bronx,80021,State Senate,SD34,Dem,Jeffrey Klein,392
-Bronx,80022,State Senate,SD34,Dem,Jeffrey Klein,243
-Bronx,80023,State Senate,SD34,Dem,Jeffrey Klein,419
-Bronx,80024,State Senate,SD34,Dem,Jeffrey Klein,573
-Bronx,80025,State Senate,SD34,Dem,Jeffrey Klein,371
-Bronx,80026,State Senate,SD34,Dem,Jeffrey Klein,263
-Bronx,80027,State Senate,SD34,Dem,Jeffrey Klein,179
-Bronx,80028,State Senate,SD34,Dem,Jeffrey Klein,198
-Bronx,80029,State Senate,SD34,Dem,Jeffrey Klein,76
-Bronx,80030,State Senate,SD34,Dem,Jeffrey Klein,223
-Bronx,80031,State Senate,SD34,Dem,Jeffrey Klein,314
-Bronx,80032,State Senate,SD34,Dem,Jeffrey Klein,197
-Bronx,80033,State Senate,SD34,Dem,Jeffrey Klein,186
-Bronx,80034,State Senate,SD34,Dem,Jeffrey Klein,276
-Bronx,80035,State Senate,SD34,Dem,Jeffrey Klein,222
-Bronx,80036,State Senate,SD34,Dem,Jeffrey Klein,372
-Bronx,80037,State Senate,SD34,Dem,Jeffrey Klein,119
-Bronx,80038,State Senate,SD34,Dem,Jeffrey Klein,209
-Bronx,80039,State Senate,SD34,Dem,Jeffrey Klein,239
-Bronx,80040,State Senate,SD34,Dem,Jeffrey Klein,252
-Bronx,80041,State Senate,SD34,Dem,Jeffrey Klein,544
-Bronx,80042,State Senate,SD34,Dem,Jeffrey Klein,336
-Bronx,80043,State Senate,SD34,Dem,Jeffrey Klein,247
-Bronx,80044,State Senate,SD34,Dem,Jeffrey Klein,188
-Bronx,80045,State Senate,SD34,Dem,Jeffrey Klein,274
-Bronx,80046,State Senate,SD34,Dem,Jeffrey Klein,301
-Bronx,80047,State Senate,SD34,Dem,Jeffrey Klein,269
-Bronx,80048,State Senate,SD34,Dem,Jeffrey Klein,228
-Bronx,80049,State Senate,SD34,Dem,Jeffrey Klein,47
-Bronx,80050,State Senate,SD34,Dem,Jeffrey Klein,420
-Bronx,80051,State Senate,SD34,Dem,Jeffrey Klein,150
-Bronx,80066,State Senate,SD34,Dem,Jeffrey Klein,155
-Bronx,80067,State Senate,SD34,Dem,Jeffrey Klein,297
-Bronx,80068,State Senate,SD34,Dem,Jeffrey Klein,327
-Bronx,80069,State Senate,SD34,Dem,Jeffrey Klein,158
-Bronx,81010,State Senate,SD34,Dem,Jeffrey Klein,72
-Bronx,81012,State Senate,SD34,Dem,Jeffrey Klein,200
-Bronx,81013,State Senate,SD34,Dem,Jeffrey Klein,405
-Bronx,81014,State Senate,SD34,Dem,Jeffrey Klein,371
-Bronx,81015,State Senate,SD34,Dem,Jeffrey Klein,369
-Bronx,81016,State Senate,SD34,Dem,Jeffrey Klein,24
-Bronx,81025,State Senate,SD34,Dem,Jeffrey Klein,161
-Bronx,81026,State Senate,SD34,Dem,Jeffrey Klein,117
-Bronx,81027,State Senate,SD34,Dem,Jeffrey Klein,142
-Bronx,81028,State Senate,SD34,Dem,Jeffrey Klein,128
-Bronx,81029,State Senate,SD34,Dem,Jeffrey Klein,117
-Bronx,81030,State Senate,SD34,Dem,Jeffrey Klein,158
-Bronx,81031,State Senate,SD34,Dem,Jeffrey Klein,129
-Bronx,81032,State Senate,SD34,Dem,Jeffrey Klein,104
-Bronx,81033,State Senate,SD34,Dem,Jeffrey Klein,497
-Bronx,81034,State Senate,SD34,Dem,Jeffrey Klein,387
-Bronx,81035,State Senate,SD34,Dem,Jeffrey Klein,356
-Bronx,81036,State Senate,SD34,Dem,Jeffrey Klein,605
-Bronx,81037,State Senate,SD34,Dem,Jeffrey Klein,351
-Bronx,81041,State Senate,SD34,Dem,Jeffrey Klein,387
-Bronx,81042,State Senate,SD34,Dem,Jeffrey Klein,5
-Bronx,81043,State Senate,SD34,Dem,Jeffrey Klein,253
-Bronx,81044,State Senate,SD34,Dem,Jeffrey Klein,171
-Bronx,81047,State Senate,SD34,Dem,Jeffrey Klein,78
-Bronx,81048,State Senate,SD34,Dem,Jeffrey Klein,238
-Bronx,81049,State Senate,SD34,Dem,Jeffrey Klein,236
-Bronx,81050,State Senate,SD34,Dem,Jeffrey Klein,307
-Bronx,81051,State Senate,SD34,Dem,Jeffrey Klein,239
-Bronx,81052,State Senate,SD34,Dem,Jeffrey Klein,129
-Bronx,81053,State Senate,SD34,Dem,Jeffrey Klein,95
-Bronx,81054,State Senate,SD34,Dem,Jeffrey Klein,338
-Bronx,81055,State Senate,SD34,Dem,Jeffrey Klein,383
-Bronx,81056,State Senate,SD34,Dem,Jeffrey Klein,327
-Bronx,81057,State Senate,SD34,Dem,Jeffrey Klein,175
-Bronx,81058,State Senate,SD34,Dem,Jeffrey Klein,257
-Bronx,81059,State Senate,SD34,Dem,Jeffrey Klein,173
-Bronx,81060,State Senate,SD34,Dem,Jeffrey Klein,239
-Bronx,81061,State Senate,SD34,Dem,Jeffrey Klein,150
-Bronx,81062,State Senate,SD34,Dem,Jeffrey Klein,308
-Bronx,81063,State Senate,SD34,Dem,Jeffrey Klein,267
-Bronx,81064,State Senate,SD34,Dem,Jeffrey Klein,548
-Bronx,81065,State Senate,SD34,Dem,Jeffrey Klein,338
-Bronx,81066,State Senate,SD34,Dem,Jeffrey Klein,169
-Bronx,81067,State Senate,SD34,Dem,Jeffrey Klein,210
-Bronx,81068,State Senate,SD34,Dem,Jeffrey Klein,411
-Bronx,81069,State Senate,SD34,Dem,Jeffrey Klein,450
-Bronx,81070,State Senate,SD34,Dem,Jeffrey Klein,233
-Bronx,81071,State Senate,SD34,Dem,Jeffrey Klein,409
-Bronx,81072,State Senate,SD34,Dem,Jeffrey Klein,333
-Bronx,81073,State Senate,SD34,Dem,Jeffrey Klein,277
-Bronx,81074,State Senate,SD34,Dem,Jeffrey Klein,287
-Bronx,81075,State Senate,SD34,Dem,Jeffrey Klein,298
-Bronx,81076,State Senate,SD34,Dem,Jeffrey Klein,318
-Bronx,81077,State Senate,SD34,Dem,Jeffrey Klein,322
-Bronx,81078,State Senate,SD34,Dem,Jeffrey Klein,488
-Bronx,81079,State Senate,SD34,Dem,Jeffrey Klein,283
-Bronx,81080,State Senate,SD34,Dem,Jeffrey Klein,401
-Bronx,81081,State Senate,SD34,Dem,Jeffrey Klein,289
-Bronx,81082,State Senate,SD34,Dem,Jeffrey Klein,271
-Bronx,81083,State Senate,SD34,Dem,Jeffrey Klein,304
-Bronx,81084,State Senate,SD34,Dem,Jeffrey Klein,423
-Bronx,81085,State Senate,SD34,Dem,Jeffrey Klein,212
-Bronx,81086,State Senate,SD34,Dem,Jeffrey Klein,298
-Bronx,81087,State Senate,SD34,Dem,Jeffrey Klein,281
-Bronx,81088,State Senate,SD34,Dem,Jeffrey Klein,225
-Bronx,81089,State Senate,SD34,Dem,Jeffrey Klein,262
-Bronx,81090,State Senate,SD34,Dem,Jeffrey Klein,296
-Bronx,81091,State Senate,SD34,Dem,Jeffrey Klein,213
-Bronx,81104,State Senate,SD34,Dem,Jeffrey Klein,42
-Bronx,82001,State Senate,SD34,Dem,Jeffrey Klein,200
-Bronx,82002,State Senate,SD34,Dem,Jeffrey Klein,206
-Bronx,82003,State Senate,SD34,Dem,Jeffrey Klein,124
-Bronx,82004,State Senate,SD34,Dem,Jeffrey Klein,228
-Bronx,82005,State Senate,SD34,Dem,Jeffrey Klein,308
-Bronx,82006,State Senate,SD34,Dem,Jeffrey Klein,229
-Bronx,82007,State Senate,SD34,Dem,Jeffrey Klein,211
-Bronx,82008,State Senate,SD34,Dem,Jeffrey Klein,393
-Bronx,82009,State Senate,SD34,Dem,Jeffrey Klein,213
-Bronx,82010,State Senate,SD34,Dem,Jeffrey Klein,396
-Bronx,82011,State Senate,SD34,Dem,Jeffrey Klein,327
-Bronx,82012,State Senate,SD34,Dem,Jeffrey Klein,282
-Bronx,82013,State Senate,SD34,Dem,Jeffrey Klein,387
-Bronx,82014,State Senate,SD34,Dem,Jeffrey Klein,157
-Bronx,82015,State Senate,SD34,Dem,Jeffrey Klein,426
-Bronx,82016,State Senate,SD34,Dem,Jeffrey Klein,247
-Bronx,82017,State Senate,SD34,Dem,Jeffrey Klein,316
-Bronx,82018,State Senate,SD34,Dem,Jeffrey Klein,189
-Bronx,82019,State Senate,SD34,Dem,Jeffrey Klein,168
-Bronx,82020,State Senate,SD34,Dem,Jeffrey Klein,179
-Bronx,82021,State Senate,SD34,Dem,Jeffrey Klein,180
-Bronx,82022,State Senate,SD34,Dem,Jeffrey Klein,290
-Bronx,82023,State Senate,SD34,Dem,Jeffrey Klein,320
-Bronx,82024,State Senate,SD34,Dem,Jeffrey Klein,349
-Bronx,82025,State Senate,SD34,Dem,Jeffrey Klein,254
-Bronx,82026,State Senate,SD34,Dem,Jeffrey Klein,55
-Bronx,82027,State Senate,SD34,Dem,Jeffrey Klein,186
-Bronx,82028,State Senate,SD34,Dem,Jeffrey Klein,341
-Bronx,82031,State Senate,SD34,Dem,Jeffrey Klein,524
-Bronx,82032,State Senate,SD34,Dem,Jeffrey Klein,293
-Bronx,82033,State Senate,SD34,Dem,Jeffrey Klein,239
-Bronx,82034,State Senate,SD34,Dem,Jeffrey Klein,198
-Bronx,82035,State Senate,SD34,Dem,Jeffrey Klein,302
-Bronx,82036,State Senate,SD34,Dem,Jeffrey Klein,345
-Bronx,82037,State Senate,SD34,Dem,Jeffrey Klein,261
-Bronx,82038,State Senate,SD34,Dem,Jeffrey Klein,267
-Bronx,82039,State Senate,SD34,Dem,Jeffrey Klein,327
-Bronx,82040,State Senate,SD34,Dem,Jeffrey Klein,195
-Bronx,82041,State Senate,SD34,Dem,Jeffrey Klein,226
-Bronx,82042,State Senate,SD34,Dem,Jeffrey Klein,127
-Bronx,82043,State Senate,SD34,Dem,Jeffrey Klein,172
-Bronx,82044,State Senate,SD34,Dem,Jeffrey Klein,187
-Bronx,82045,State Senate,SD34,Dem,Jeffrey Klein,155
-Bronx,82046,State Senate,SD34,Dem,Jeffrey Klein,178
-Bronx,82047,State Senate,SD34,Dem,Jeffrey Klein,170
-Bronx,82048,State Senate,SD34,Dem,Jeffrey Klein,190
-Bronx,82049,State Senate,SD34,Dem,Jeffrey Klein,231
-Bronx,82050,State Senate,SD34,Dem,Jeffrey Klein,179
-Bronx,82051,State Senate,SD34,Dem,Jeffrey Klein,290
-Bronx,82052,State Senate,SD34,Dem,Jeffrey Klein,279
-Bronx,82053,State Senate,SD34,Dem,Jeffrey Klein,217
-Bronx,82055,State Senate,SD34,Dem,Jeffrey Klein,159
-Bronx,82056,State Senate,SD34,Dem,Jeffrey Klein,352
-Bronx,82057,State Senate,SD34,Dem,Jeffrey Klein,284
-Bronx,82058,State Senate,SD34,Dem,Jeffrey Klein,201
-Bronx,82059,State Senate,SD34,Dem,Jeffrey Klein,13
-Bronx,82060,State Senate,SD34,Dem,Jeffrey Klein,207
-Bronx,82061,State Senate,SD34,Dem,Jeffrey Klein,268
-Bronx,82062,State Senate,SD34,Dem,Jeffrey Klein,235
-Bronx,82063,State Senate,SD34,Dem,Jeffrey Klein,193
-Bronx,82064,State Senate,SD34,Dem,Jeffrey Klein,153
-Bronx,82106,State Senate,SD34,Dem,Jeffrey Klein,103
-Bronx,82107,State Senate,SD34,Dem,Jeffrey Klein,86
-Bronx,83068,State Senate,SD34,Dem,Jeffrey Klein,1
-Bronx,84073,State Senate,SD34,Dem,Jeffrey Klein,68
-Bronx,84077,State Senate,SD34,Dem,Jeffrey Klein,271
-Bronx,84078,State Senate,SD34,Dem,Jeffrey Klein,21
-Bronx,85001,State Senate,SD34,Dem,Jeffrey Klein,360
-Bronx,85002,State Senate,SD34,Dem,Jeffrey Klein,327
-Bronx,85003,State Senate,SD34,Dem,Jeffrey Klein,440
-Bronx,85004,State Senate,SD34,Dem,Jeffrey Klein,337
-Bronx,85005,State Senate,SD34,Dem,Jeffrey Klein,419
-Bronx,85006,State Senate,SD34,Dem,Jeffrey Klein,231
-Bronx,85007,State Senate,SD34,Dem,Jeffrey Klein,311
-Bronx,85008,State Senate,SD34,Dem,Jeffrey Klein,453
-Bronx,85009,State Senate,SD34,Dem,Jeffrey Klein,266
-Bronx,85010,State Senate,SD34,Dem,Jeffrey Klein,343
-Bronx,85011,State Senate,SD34,Dem,Jeffrey Klein,376
-Bronx,85012,State Senate,SD34,Dem,Jeffrey Klein,390
-Bronx,85028,State Senate,SD34,Dem,Jeffrey Klein,48
-Bronx,85037,State Senate,SD34,Dem,Jeffrey Klein,407
-Bronx,85038,State Senate,SD34,Dem,Jeffrey Klein,274
-Bronx,85076,State Senate,SD34,Dem,Jeffrey Klein,35
-Bronx,87044,State Senate,SD34,Dem,Jeffrey Klein,81
-Bronx,87065,State Senate,SD34,Dem,Jeffrey Klein,215
-Bronx,87066,State Senate,SD34,Dem,Jeffrey Klein,233
-Bronx,87067,State Senate,SD34,Dem,Jeffrey Klein,225
-Bronx,87068,State Senate,SD34,Dem,Jeffrey Klein,428
-Bronx,87069,State Senate,SD34,Dem,Jeffrey Klein,316
-Bronx,87072,State Senate,SD34,Dem,Jeffrey Klein,221
-Bronx,87073,State Senate,SD34,Dem,Jeffrey Klein,27
-Bronx,87074,State Senate,SD34,Dem,Jeffrey Klein,374
-Bronx,87075,State Senate,SD34,Dem,Jeffrey Klein,297
-Bronx,87076,State Senate,SD34,Dem,Jeffrey Klein,288
-Bronx,87077,State Senate,SD34,Dem,Jeffrey Klein,359
-Bronx,87078,State Senate,SD34,Dem,Jeffrey Klein,420
-Bronx,87079,State Senate,SD34,Dem,Jeffrey Klein,23
-Bronx,87080,State Senate,SD34,Dem,Jeffrey Klein,277
-Bronx,87081,State Senate,SD34,Dem,Jeffrey Klein,329
-Bronx,87082,State Senate,SD34,Dem,Jeffrey Klein,359
-Bronx,78007,State Senate,SD34,Rep,Jeffrey Klein,15
-Bronx,78016,State Senate,SD34,Rep,Jeffrey Klein,18
-Bronx,78030,State Senate,SD34,Rep,Jeffrey Klein,33
-Bronx,78031,State Senate,SD34,Rep,Jeffrey Klein,31
-Bronx,78036,State Senate,SD34,Rep,Jeffrey Klein,9
-Bronx,78037,State Senate,SD34,Rep,Jeffrey Klein,3
-Bronx,78040,State Senate,SD34,Rep,Jeffrey Klein,33
-Bronx,78041,State Senate,SD34,Rep,Jeffrey Klein,75
-Bronx,78055,State Senate,SD34,Rep,Jeffrey Klein,21
-Bronx,78058,State Senate,SD34,Rep,Jeffrey Klein,3
-Bronx,80001,State Senate,SD34,Rep,Jeffrey Klein,35
-Bronx,80002,State Senate,SD34,Rep,Jeffrey Klein,26
-Bronx,80003,State Senate,SD34,Rep,Jeffrey Klein,172
-Bronx,80004,State Senate,SD34,Rep,Jeffrey Klein,82
-Bronx,80005,State Senate,SD34,Rep,Jeffrey Klein,55
-Bronx,80006,State Senate,SD34,Rep,Jeffrey Klein,55
-Bronx,80007,State Senate,SD34,Rep,Jeffrey Klein,52
-Bronx,80008,State Senate,SD34,Rep,Jeffrey Klein,50
-Bronx,80016,State Senate,SD34,Rep,Jeffrey Klein,37
-Bronx,80017,State Senate,SD34,Rep,Jeffrey Klein,20
-Bronx,80018,State Senate,SD34,Rep,Jeffrey Klein,82
-Bronx,80019,State Senate,SD34,Rep,Jeffrey Klein,74
-Bronx,80020,State Senate,SD34,Rep,Jeffrey Klein,54
-Bronx,80021,State Senate,SD34,Rep,Jeffrey Klein,39
-Bronx,80022,State Senate,SD34,Rep,Jeffrey Klein,17
-Bronx,80023,State Senate,SD34,Rep,Jeffrey Klein,49
-Bronx,80024,State Senate,SD34,Rep,Jeffrey Klein,39
-Bronx,80025,State Senate,SD34,Rep,Jeffrey Klein,21
-Bronx,80026,State Senate,SD34,Rep,Jeffrey Klein,28
-Bronx,80027,State Senate,SD34,Rep,Jeffrey Klein,48
-Bronx,80028,State Senate,SD34,Rep,Jeffrey Klein,70
-Bronx,80029,State Senate,SD34,Rep,Jeffrey Klein,31
-Bronx,80030,State Senate,SD34,Rep,Jeffrey Klein,117
-Bronx,80031,State Senate,SD34,Rep,Jeffrey Klein,135
-Bronx,80032,State Senate,SD34,Rep,Jeffrey Klein,103
-Bronx,80033,State Senate,SD34,Rep,Jeffrey Klein,83
-Bronx,80034,State Senate,SD34,Rep,Jeffrey Klein,106
-Bronx,80035,State Senate,SD34,Rep,Jeffrey Klein,99
-Bronx,80036,State Senate,SD34,Rep,Jeffrey Klein,92
-Bronx,80037,State Senate,SD34,Rep,Jeffrey Klein,47
-Bronx,80038,State Senate,SD34,Rep,Jeffrey Klein,44
-Bronx,80039,State Senate,SD34,Rep,Jeffrey Klein,54
-Bronx,80040,State Senate,SD34,Rep,Jeffrey Klein,7
-Bronx,80041,State Senate,SD34,Rep,Jeffrey Klein,33
-Bronx,80042,State Senate,SD34,Rep,Jeffrey Klein,16
-Bronx,80043,State Senate,SD34,Rep,Jeffrey Klein,21
-Bronx,80044,State Senate,SD34,Rep,Jeffrey Klein,33
-Bronx,80045,State Senate,SD34,Rep,Jeffrey Klein,45
-Bronx,80046,State Senate,SD34,Rep,Jeffrey Klein,18
-Bronx,80047,State Senate,SD34,Rep,Jeffrey Klein,22
-Bronx,80048,State Senate,SD34,Rep,Jeffrey Klein,24
-Bronx,80049,State Senate,SD34,Rep,Jeffrey Klein,1
-Bronx,80050,State Senate,SD34,Rep,Jeffrey Klein,25
-Bronx,80051,State Senate,SD34,Rep,Jeffrey Klein,39
-Bronx,80066,State Senate,SD34,Rep,Jeffrey Klein,68
-Bronx,80067,State Senate,SD34,Rep,Jeffrey Klein,65
-Bronx,80068,State Senate,SD34,Rep,Jeffrey Klein,91
-Bronx,80069,State Senate,SD34,Rep,Jeffrey Klein,9
-Bronx,81010,State Senate,SD34,Rep,Jeffrey Klein,7
-Bronx,81012,State Senate,SD34,Rep,Jeffrey Klein,19
-Bronx,81013,State Senate,SD34,Rep,Jeffrey Klein,35
-Bronx,81014,State Senate,SD34,Rep,Jeffrey Klein,35
-Bronx,81015,State Senate,SD34,Rep,Jeffrey Klein,47
-Bronx,81016,State Senate,SD34,Rep,Jeffrey Klein,22
-Bronx,81025,State Senate,SD34,Rep,Jeffrey Klein,76
-Bronx,81026,State Senate,SD34,Rep,Jeffrey Klein,43
-Bronx,81027,State Senate,SD34,Rep,Jeffrey Klein,70
-Bronx,81028,State Senate,SD34,Rep,Jeffrey Klein,103
-Bronx,81029,State Senate,SD34,Rep,Jeffrey Klein,55
-Bronx,81030,State Senate,SD34,Rep,Jeffrey Klein,99
-Bronx,81031,State Senate,SD34,Rep,Jeffrey Klein,79
-Bronx,81032,State Senate,SD34,Rep,Jeffrey Klein,86
-Bronx,81033,State Senate,SD34,Rep,Jeffrey Klein,54
-Bronx,81034,State Senate,SD34,Rep,Jeffrey Klein,59
-Bronx,81035,State Senate,SD34,Rep,Jeffrey Klein,56
-Bronx,81036,State Senate,SD34,Rep,Jeffrey Klein,59
-Bronx,81037,State Senate,SD34,Rep,Jeffrey Klein,51
-Bronx,81041,State Senate,SD34,Rep,Jeffrey Klein,83
-Bronx,81042,State Senate,SD34,Rep,Jeffrey Klein,0
-Bronx,81043,State Senate,SD34,Rep,Jeffrey Klein,31
-Bronx,81044,State Senate,SD34,Rep,Jeffrey Klein,40
-Bronx,81047,State Senate,SD34,Rep,Jeffrey Klein,27
-Bronx,81048,State Senate,SD34,Rep,Jeffrey Klein,52
-Bronx,81049,State Senate,SD34,Rep,Jeffrey Klein,56
-Bronx,81050,State Senate,SD34,Rep,Jeffrey Klein,45
-Bronx,81051,State Senate,SD34,Rep,Jeffrey Klein,39
-Bronx,81052,State Senate,SD34,Rep,Jeffrey Klein,23
-Bronx,81053,State Senate,SD34,Rep,Jeffrey Klein,52
-Bronx,81054,State Senate,SD34,Rep,Jeffrey Klein,40
-Bronx,81055,State Senate,SD34,Rep,Jeffrey Klein,83
-Bronx,81056,State Senate,SD34,Rep,Jeffrey Klein,54
-Bronx,81057,State Senate,SD34,Rep,Jeffrey Klein,51
-Bronx,81058,State Senate,SD34,Rep,Jeffrey Klein,38
-Bronx,81059,State Senate,SD34,Rep,Jeffrey Klein,56
-Bronx,81060,State Senate,SD34,Rep,Jeffrey Klein,89
-Bronx,81061,State Senate,SD34,Rep,Jeffrey Klein,40
-Bronx,81062,State Senate,SD34,Rep,Jeffrey Klein,46
-Bronx,81063,State Senate,SD34,Rep,Jeffrey Klein,90
-Bronx,81064,State Senate,SD34,Rep,Jeffrey Klein,71
-Bronx,81065,State Senate,SD34,Rep,Jeffrey Klein,91
-Bronx,81066,State Senate,SD34,Rep,Jeffrey Klein,58
-Bronx,81067,State Senate,SD34,Rep,Jeffrey Klein,46
-Bronx,81068,State Senate,SD34,Rep,Jeffrey Klein,123
-Bronx,81069,State Senate,SD34,Rep,Jeffrey Klein,71
-Bronx,81070,State Senate,SD34,Rep,Jeffrey Klein,45
-Bronx,81071,State Senate,SD34,Rep,Jeffrey Klein,97
-Bronx,81072,State Senate,SD34,Rep,Jeffrey Klein,74
-Bronx,81073,State Senate,SD34,Rep,Jeffrey Klein,75
-Bronx,81074,State Senate,SD34,Rep,Jeffrey Klein,74
-Bronx,81075,State Senate,SD34,Rep,Jeffrey Klein,55
-Bronx,81076,State Senate,SD34,Rep,Jeffrey Klein,49
-Bronx,81077,State Senate,SD34,Rep,Jeffrey Klein,50
-Bronx,81078,State Senate,SD34,Rep,Jeffrey Klein,88
-Bronx,81079,State Senate,SD34,Rep,Jeffrey Klein,94
-Bronx,81080,State Senate,SD34,Rep,Jeffrey Klein,62
-Bronx,81081,State Senate,SD34,Rep,Jeffrey Klein,34
-Bronx,81082,State Senate,SD34,Rep,Jeffrey Klein,49
-Bronx,81083,State Senate,SD34,Rep,Jeffrey Klein,54
-Bronx,81084,State Senate,SD34,Rep,Jeffrey Klein,71
-Bronx,81085,State Senate,SD34,Rep,Jeffrey Klein,53
-Bronx,81086,State Senate,SD34,Rep,Jeffrey Klein,65
-Bronx,81087,State Senate,SD34,Rep,Jeffrey Klein,50
-Bronx,81088,State Senate,SD34,Rep,Jeffrey Klein,71
-Bronx,81089,State Senate,SD34,Rep,Jeffrey Klein,33
-Bronx,81090,State Senate,SD34,Rep,Jeffrey Klein,41
-Bronx,81091,State Senate,SD34,Rep,Jeffrey Klein,21
-Bronx,81104,State Senate,SD34,Rep,Jeffrey Klein,3
-Bronx,82001,State Senate,SD34,Rep,Jeffrey Klein,191
-Bronx,82002,State Senate,SD34,Rep,Jeffrey Klein,169
-Bronx,82003,State Senate,SD34,Rep,Jeffrey Klein,108
-Bronx,82004,State Senate,SD34,Rep,Jeffrey Klein,160
-Bronx,82005,State Senate,SD34,Rep,Jeffrey Klein,143
-Bronx,82006,State Senate,SD34,Rep,Jeffrey Klein,91
-Bronx,82007,State Senate,SD34,Rep,Jeffrey Klein,126
-Bronx,82008,State Senate,SD34,Rep,Jeffrey Klein,62
-Bronx,82009,State Senate,SD34,Rep,Jeffrey Klein,65
-Bronx,82010,State Senate,SD34,Rep,Jeffrey Klein,88
-Bronx,82011,State Senate,SD34,Rep,Jeffrey Klein,55
-Bronx,82012,State Senate,SD34,Rep,Jeffrey Klein,5
-Bronx,82013,State Senate,SD34,Rep,Jeffrey Klein,10
-Bronx,82014,State Senate,SD34,Rep,Jeffrey Klein,4
-Bronx,82015,State Senate,SD34,Rep,Jeffrey Klein,15
-Bronx,82016,State Senate,SD34,Rep,Jeffrey Klein,62
-Bronx,82017,State Senate,SD34,Rep,Jeffrey Klein,116
-Bronx,82018,State Senate,SD34,Rep,Jeffrey Klein,29
-Bronx,82019,State Senate,SD34,Rep,Jeffrey Klein,69
-Bronx,82020,State Senate,SD34,Rep,Jeffrey Klein,104
-Bronx,82021,State Senate,SD34,Rep,Jeffrey Klein,55
-Bronx,82022,State Senate,SD34,Rep,Jeffrey Klein,70
-Bronx,82023,State Senate,SD34,Rep,Jeffrey Klein,15
-Bronx,82024,State Senate,SD34,Rep,Jeffrey Klein,77
-Bronx,82025,State Senate,SD34,Rep,Jeffrey Klein,76
-Bronx,82026,State Senate,SD34,Rep,Jeffrey Klein,1
-Bronx,82027,State Senate,SD34,Rep,Jeffrey Klein,9
-Bronx,82028,State Senate,SD34,Rep,Jeffrey Klein,33
-Bronx,82031,State Senate,SD34,Rep,Jeffrey Klein,38
-Bronx,82032,State Senate,SD34,Rep,Jeffrey Klein,97
-Bronx,82033,State Senate,SD34,Rep,Jeffrey Klein,109
-Bronx,82034,State Senate,SD34,Rep,Jeffrey Klein,74
-Bronx,82035,State Senate,SD34,Rep,Jeffrey Klein,129
-Bronx,82036,State Senate,SD34,Rep,Jeffrey Klein,139
-Bronx,82037,State Senate,SD34,Rep,Jeffrey Klein,59
-Bronx,82038,State Senate,SD34,Rep,Jeffrey Klein,60
-Bronx,82039,State Senate,SD34,Rep,Jeffrey Klein,99
-Bronx,82040,State Senate,SD34,Rep,Jeffrey Klein,116
-Bronx,82041,State Senate,SD34,Rep,Jeffrey Klein,135
-Bronx,82042,State Senate,SD34,Rep,Jeffrey Klein,79
-Bronx,82043,State Senate,SD34,Rep,Jeffrey Klein,123
-Bronx,82044,State Senate,SD34,Rep,Jeffrey Klein,136
-Bronx,82045,State Senate,SD34,Rep,Jeffrey Klein,135
-Bronx,82046,State Senate,SD34,Rep,Jeffrey Klein,143
-Bronx,82047,State Senate,SD34,Rep,Jeffrey Klein,142
-Bronx,82048,State Senate,SD34,Rep,Jeffrey Klein,136
-Bronx,82049,State Senate,SD34,Rep,Jeffrey Klein,227
-Bronx,82050,State Senate,SD34,Rep,Jeffrey Klein,52
-Bronx,82051,State Senate,SD34,Rep,Jeffrey Klein,57
-Bronx,82052,State Senate,SD34,Rep,Jeffrey Klein,101
-Bronx,82053,State Senate,SD34,Rep,Jeffrey Klein,48
-Bronx,82055,State Senate,SD34,Rep,Jeffrey Klein,88
-Bronx,82056,State Senate,SD34,Rep,Jeffrey Klein,158
-Bronx,82057,State Senate,SD34,Rep,Jeffrey Klein,132
-Bronx,82058,State Senate,SD34,Rep,Jeffrey Klein,131
-Bronx,82059,State Senate,SD34,Rep,Jeffrey Klein,7
-Bronx,82060,State Senate,SD34,Rep,Jeffrey Klein,145
-Bronx,82061,State Senate,SD34,Rep,Jeffrey Klein,157
-Bronx,82062,State Senate,SD34,Rep,Jeffrey Klein,125
-Bronx,82063,State Senate,SD34,Rep,Jeffrey Klein,115
-Bronx,82064,State Senate,SD34,Rep,Jeffrey Klein,20
-Bronx,82106,State Senate,SD34,Rep,Jeffrey Klein,16
-Bronx,82107,State Senate,SD34,Rep,Jeffrey Klein,38
-Bronx,83068,State Senate,SD34,Rep,Jeffrey Klein,0
-Bronx,84073,State Senate,SD34,Rep,Jeffrey Klein,1
-Bronx,84077,State Senate,SD34,Rep,Jeffrey Klein,2
-Bronx,84078,State Senate,SD34,Rep,Jeffrey Klein,3
-Bronx,85001,State Senate,SD34,Rep,Jeffrey Klein,14
-Bronx,85002,State Senate,SD34,Rep,Jeffrey Klein,17
-Bronx,85003,State Senate,SD34,Rep,Jeffrey Klein,28
-Bronx,85004,State Senate,SD34,Rep,Jeffrey Klein,16
-Bronx,85005,State Senate,SD34,Rep,Jeffrey Klein,19
-Bronx,85006,State Senate,SD34,Rep,Jeffrey Klein,10
-Bronx,85007,State Senate,SD34,Rep,Jeffrey Klein,26
-Bronx,85008,State Senate,SD34,Rep,Jeffrey Klein,17
-Bronx,85009,State Senate,SD34,Rep,Jeffrey Klein,9
-Bronx,85010,State Senate,SD34,Rep,Jeffrey Klein,5
-Bronx,85011,State Senate,SD34,Rep,Jeffrey Klein,1
-Bronx,85012,State Senate,SD34,Rep,Jeffrey Klein,8
-Bronx,85028,State Senate,SD34,Rep,Jeffrey Klein,3
-Bronx,85037,State Senate,SD34,Rep,Jeffrey Klein,5
-Bronx,85038,State Senate,SD34,Rep,Jeffrey Klein,7
-Bronx,85076,State Senate,SD34,Rep,Jeffrey Klein,1
-Bronx,87044,State Senate,SD34,Rep,Jeffrey Klein,10
-Bronx,87065,State Senate,SD34,Rep,Jeffrey Klein,23
-Bronx,87066,State Senate,SD34,Rep,Jeffrey Klein,14
-Bronx,87067,State Senate,SD34,Rep,Jeffrey Klein,11
-Bronx,87068,State Senate,SD34,Rep,Jeffrey Klein,34
-Bronx,87069,State Senate,SD34,Rep,Jeffrey Klein,19
-Bronx,87072,State Senate,SD34,Rep,Jeffrey Klein,25
-Bronx,87073,State Senate,SD34,Rep,Jeffrey Klein,1
-Bronx,87074,State Senate,SD34,Rep,Jeffrey Klein,33
-Bronx,87075,State Senate,SD34,Rep,Jeffrey Klein,22
-Bronx,87076,State Senate,SD34,Rep,Jeffrey Klein,31
-Bronx,87077,State Senate,SD34,Rep,Jeffrey Klein,15
-Bronx,87078,State Senate,SD34,Rep,Jeffrey Klein,23
-Bronx,87079,State Senate,SD34,Rep,Jeffrey Klein,0
-Bronx,87080,State Senate,SD34,Rep,Jeffrey Klein,12
-Bronx,87081,State Senate,SD34,Rep,Jeffrey Klein,17
-Bronx,87082,State Senate,SD34,Rep,Jeffrey Klein,13
-Bronx,78007,State Senate,SD34,WF,Jeffrey Klein,4
-Bronx,78016,State Senate,SD34,WF,Jeffrey Klein,4
-Bronx,78030,State Senate,SD34,WF,Jeffrey Klein,13
-Bronx,78031,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,78036,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,78037,State Senate,SD34,WF,Jeffrey Klein,2
-Bronx,78040,State Senate,SD34,WF,Jeffrey Klein,10
-Bronx,78041,State Senate,SD34,WF,Jeffrey Klein,13
-Bronx,78055,State Senate,SD34,WF,Jeffrey Klein,2
-Bronx,78058,State Senate,SD34,WF,Jeffrey Klein,1
-Bronx,80001,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,80002,State Senate,SD34,WF,Jeffrey Klein,2
-Bronx,80003,State Senate,SD34,WF,Jeffrey Klein,14
-Bronx,80004,State Senate,SD34,WF,Jeffrey Klein,5
-Bronx,80005,State Senate,SD34,WF,Jeffrey Klein,3
-Bronx,80006,State Senate,SD34,WF,Jeffrey Klein,9
-Bronx,80007,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,80008,State Senate,SD34,WF,Jeffrey Klein,12
-Bronx,80016,State Senate,SD34,WF,Jeffrey Klein,13
-Bronx,80017,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,80018,State Senate,SD34,WF,Jeffrey Klein,7
-Bronx,80019,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,80020,State Senate,SD34,WF,Jeffrey Klein,20
-Bronx,80021,State Senate,SD34,WF,Jeffrey Klein,11
-Bronx,80022,State Senate,SD34,WF,Jeffrey Klein,11
-Bronx,80023,State Senate,SD34,WF,Jeffrey Klein,11
-Bronx,80024,State Senate,SD34,WF,Jeffrey Klein,22
-Bronx,80025,State Senate,SD34,WF,Jeffrey Klein,13
-Bronx,80026,State Senate,SD34,WF,Jeffrey Klein,10
-Bronx,80027,State Senate,SD34,WF,Jeffrey Klein,4
-Bronx,80028,State Senate,SD34,WF,Jeffrey Klein,9
-Bronx,80029,State Senate,SD34,WF,Jeffrey Klein,5
-Bronx,80030,State Senate,SD34,WF,Jeffrey Klein,7
-Bronx,80031,State Senate,SD34,WF,Jeffrey Klein,9
-Bronx,80032,State Senate,SD34,WF,Jeffrey Klein,12
-Bronx,80033,State Senate,SD34,WF,Jeffrey Klein,2
-Bronx,80034,State Senate,SD34,WF,Jeffrey Klein,8
-Bronx,80035,State Senate,SD34,WF,Jeffrey Klein,4
-Bronx,80036,State Senate,SD34,WF,Jeffrey Klein,15
-Bronx,80037,State Senate,SD34,WF,Jeffrey Klein,9
-Bronx,80038,State Senate,SD34,WF,Jeffrey Klein,5
-Bronx,80039,State Senate,SD34,WF,Jeffrey Klein,13
-Bronx,80040,State Senate,SD34,WF,Jeffrey Klein,5
-Bronx,80041,State Senate,SD34,WF,Jeffrey Klein,5
-Bronx,80042,State Senate,SD34,WF,Jeffrey Klein,3
-Bronx,80043,State Senate,SD34,WF,Jeffrey Klein,7
-Bronx,80044,State Senate,SD34,WF,Jeffrey Klein,5
-Bronx,80045,State Senate,SD34,WF,Jeffrey Klein,11
-Bronx,80046,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,80047,State Senate,SD34,WF,Jeffrey Klein,12
-Bronx,80048,State Senate,SD34,WF,Jeffrey Klein,2
-Bronx,80049,State Senate,SD34,WF,Jeffrey Klein,2
-Bronx,80050,State Senate,SD34,WF,Jeffrey Klein,10
-Bronx,80051,State Senate,SD34,WF,Jeffrey Klein,4
-Bronx,80066,State Senate,SD34,WF,Jeffrey Klein,1
-Bronx,80067,State Senate,SD34,WF,Jeffrey Klein,4
-Bronx,80068,State Senate,SD34,WF,Jeffrey Klein,5
-Bronx,80069,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,81010,State Senate,SD34,WF,Jeffrey Klein,2
-Bronx,81012,State Senate,SD34,WF,Jeffrey Klein,3
-Bronx,81013,State Senate,SD34,WF,Jeffrey Klein,11
-Bronx,81014,State Senate,SD34,WF,Jeffrey Klein,15
-Bronx,81015,State Senate,SD34,WF,Jeffrey Klein,13
-Bronx,81016,State Senate,SD34,WF,Jeffrey Klein,0
-Bronx,81025,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,81026,State Senate,SD34,WF,Jeffrey Klein,4
-Bronx,81027,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,81028,State Senate,SD34,WF,Jeffrey Klein,4
-Bronx,81029,State Senate,SD34,WF,Jeffrey Klein,7
-Bronx,81030,State Senate,SD34,WF,Jeffrey Klein,8
-Bronx,81031,State Senate,SD34,WF,Jeffrey Klein,1
-Bronx,81032,State Senate,SD34,WF,Jeffrey Klein,10
-Bronx,81033,State Senate,SD34,WF,Jeffrey Klein,23
-Bronx,81034,State Senate,SD34,WF,Jeffrey Klein,24
-Bronx,81035,State Senate,SD34,WF,Jeffrey Klein,15
-Bronx,81036,State Senate,SD34,WF,Jeffrey Klein,28
-Bronx,81037,State Senate,SD34,WF,Jeffrey Klein,14
-Bronx,81041,State Senate,SD34,WF,Jeffrey Klein,14
-Bronx,81042,State Senate,SD34,WF,Jeffrey Klein,0
-Bronx,81043,State Senate,SD34,WF,Jeffrey Klein,7
-Bronx,81044,State Senate,SD34,WF,Jeffrey Klein,4
-Bronx,81047,State Senate,SD34,WF,Jeffrey Klein,5
-Bronx,81048,State Senate,SD34,WF,Jeffrey Klein,18
-Bronx,81049,State Senate,SD34,WF,Jeffrey Klein,11
-Bronx,81050,State Senate,SD34,WF,Jeffrey Klein,14
-Bronx,81051,State Senate,SD34,WF,Jeffrey Klein,17
-Bronx,81052,State Senate,SD34,WF,Jeffrey Klein,3
-Bronx,81053,State Senate,SD34,WF,Jeffrey Klein,1
-Bronx,81054,State Senate,SD34,WF,Jeffrey Klein,12
-Bronx,81055,State Senate,SD34,WF,Jeffrey Klein,14
-Bronx,81056,State Senate,SD34,WF,Jeffrey Klein,8
-Bronx,81057,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,81058,State Senate,SD34,WF,Jeffrey Klein,12
-Bronx,81059,State Senate,SD34,WF,Jeffrey Klein,12
-Bronx,81060,State Senate,SD34,WF,Jeffrey Klein,10
-Bronx,81061,State Senate,SD34,WF,Jeffrey Klein,4
-Bronx,81062,State Senate,SD34,WF,Jeffrey Klein,11
-Bronx,81063,State Senate,SD34,WF,Jeffrey Klein,9
-Bronx,81064,State Senate,SD34,WF,Jeffrey Klein,16
-Bronx,81065,State Senate,SD34,WF,Jeffrey Klein,15
-Bronx,81066,State Senate,SD34,WF,Jeffrey Klein,5
-Bronx,81067,State Senate,SD34,WF,Jeffrey Klein,12
-Bronx,81068,State Senate,SD34,WF,Jeffrey Klein,20
-Bronx,81069,State Senate,SD34,WF,Jeffrey Klein,14
-Bronx,81070,State Senate,SD34,WF,Jeffrey Klein,8
-Bronx,81071,State Senate,SD34,WF,Jeffrey Klein,12
-Bronx,81072,State Senate,SD34,WF,Jeffrey Klein,8
-Bronx,81073,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,81074,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,81075,State Senate,SD34,WF,Jeffrey Klein,15
-Bronx,81076,State Senate,SD34,WF,Jeffrey Klein,13
-Bronx,81077,State Senate,SD34,WF,Jeffrey Klein,13
-Bronx,81078,State Senate,SD34,WF,Jeffrey Klein,19
-Bronx,81079,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,81080,State Senate,SD34,WF,Jeffrey Klein,24
-Bronx,81081,State Senate,SD34,WF,Jeffrey Klein,15
-Bronx,81082,State Senate,SD34,WF,Jeffrey Klein,9
-Bronx,81083,State Senate,SD34,WF,Jeffrey Klein,15
-Bronx,81084,State Senate,SD34,WF,Jeffrey Klein,22
-Bronx,81085,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,81086,State Senate,SD34,WF,Jeffrey Klein,11
-Bronx,81087,State Senate,SD34,WF,Jeffrey Klein,8
-Bronx,81088,State Senate,SD34,WF,Jeffrey Klein,8
-Bronx,81089,State Senate,SD34,WF,Jeffrey Klein,16
-Bronx,81090,State Senate,SD34,WF,Jeffrey Klein,8
-Bronx,81091,State Senate,SD34,WF,Jeffrey Klein,0
-Bronx,81104,State Senate,SD34,WF,Jeffrey Klein,1
-Bronx,82001,State Senate,SD34,WF,Jeffrey Klein,19
-Bronx,82002,State Senate,SD34,WF,Jeffrey Klein,10
-Bronx,82003,State Senate,SD34,WF,Jeffrey Klein,10
-Bronx,82004,State Senate,SD34,WF,Jeffrey Klein,17
-Bronx,82005,State Senate,SD34,WF,Jeffrey Klein,15
-Bronx,82006,State Senate,SD34,WF,Jeffrey Klein,4
-Bronx,82007,State Senate,SD34,WF,Jeffrey Klein,11
-Bronx,82008,State Senate,SD34,WF,Jeffrey Klein,11
-Bronx,82009,State Senate,SD34,WF,Jeffrey Klein,11
-Bronx,82010,State Senate,SD34,WF,Jeffrey Klein,17
-Bronx,82011,State Senate,SD34,WF,Jeffrey Klein,10
-Bronx,82012,State Senate,SD34,WF,Jeffrey Klein,8
-Bronx,82013,State Senate,SD34,WF,Jeffrey Klein,4
-Bronx,82014,State Senate,SD34,WF,Jeffrey Klein,2
-Bronx,82015,State Senate,SD34,WF,Jeffrey Klein,5
-Bronx,82016,State Senate,SD34,WF,Jeffrey Klein,7
-Bronx,82017,State Senate,SD34,WF,Jeffrey Klein,13
-Bronx,82018,State Senate,SD34,WF,Jeffrey Klein,9
-Bronx,82019,State Senate,SD34,WF,Jeffrey Klein,9
-Bronx,82020,State Senate,SD34,WF,Jeffrey Klein,12
-Bronx,82021,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,82022,State Senate,SD34,WF,Jeffrey Klein,9
-Bronx,82023,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,82024,State Senate,SD34,WF,Jeffrey Klein,9
-Bronx,82025,State Senate,SD34,WF,Jeffrey Klein,18
-Bronx,82026,State Senate,SD34,WF,Jeffrey Klein,4
-Bronx,82027,State Senate,SD34,WF,Jeffrey Klein,2
-Bronx,82028,State Senate,SD34,WF,Jeffrey Klein,9
-Bronx,82031,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,82032,State Senate,SD34,WF,Jeffrey Klein,9
-Bronx,82033,State Senate,SD34,WF,Jeffrey Klein,13
-Bronx,82034,State Senate,SD34,WF,Jeffrey Klein,7
-Bronx,82035,State Senate,SD34,WF,Jeffrey Klein,11
-Bronx,82036,State Senate,SD34,WF,Jeffrey Klein,12
-Bronx,82037,State Senate,SD34,WF,Jeffrey Klein,7
-Bronx,82038,State Senate,SD34,WF,Jeffrey Klein,12
-Bronx,82039,State Senate,SD34,WF,Jeffrey Klein,15
-Bronx,82040,State Senate,SD34,WF,Jeffrey Klein,11
-Bronx,82041,State Senate,SD34,WF,Jeffrey Klein,8
-Bronx,82042,State Senate,SD34,WF,Jeffrey Klein,5
-Bronx,82043,State Senate,SD34,WF,Jeffrey Klein,8
-Bronx,82044,State Senate,SD34,WF,Jeffrey Klein,12
-Bronx,82045,State Senate,SD34,WF,Jeffrey Klein,8
-Bronx,82046,State Senate,SD34,WF,Jeffrey Klein,12
-Bronx,82047,State Senate,SD34,WF,Jeffrey Klein,9
-Bronx,82048,State Senate,SD34,WF,Jeffrey Klein,17
-Bronx,82049,State Senate,SD34,WF,Jeffrey Klein,13
-Bronx,82050,State Senate,SD34,WF,Jeffrey Klein,7
-Bronx,82051,State Senate,SD34,WF,Jeffrey Klein,14
-Bronx,82052,State Senate,SD34,WF,Jeffrey Klein,13
-Bronx,82053,State Senate,SD34,WF,Jeffrey Klein,7
-Bronx,82055,State Senate,SD34,WF,Jeffrey Klein,9
-Bronx,82056,State Senate,SD34,WF,Jeffrey Klein,14
-Bronx,82057,State Senate,SD34,WF,Jeffrey Klein,5
-Bronx,82058,State Senate,SD34,WF,Jeffrey Klein,12
-Bronx,82059,State Senate,SD34,WF,Jeffrey Klein,0
-Bronx,82060,State Senate,SD34,WF,Jeffrey Klein,18
-Bronx,82061,State Senate,SD34,WF,Jeffrey Klein,19
-Bronx,82062,State Senate,SD34,WF,Jeffrey Klein,9
-Bronx,82063,State Senate,SD34,WF,Jeffrey Klein,11
-Bronx,82064,State Senate,SD34,WF,Jeffrey Klein,3
-Bronx,82106,State Senate,SD34,WF,Jeffrey Klein,0
-Bronx,82107,State Senate,SD34,WF,Jeffrey Klein,2
-Bronx,83068,State Senate,SD34,WF,Jeffrey Klein,0
-Bronx,84073,State Senate,SD34,WF,Jeffrey Klein,1
-Bronx,84077,State Senate,SD34,WF,Jeffrey Klein,3
-Bronx,84078,State Senate,SD34,WF,Jeffrey Klein,1
-Bronx,85001,State Senate,SD34,WF,Jeffrey Klein,8
-Bronx,85002,State Senate,SD34,WF,Jeffrey Klein,8
-Bronx,85003,State Senate,SD34,WF,Jeffrey Klein,11
-Bronx,85004,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,85005,State Senate,SD34,WF,Jeffrey Klein,7
-Bronx,85006,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,85007,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,85008,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,85009,State Senate,SD34,WF,Jeffrey Klein,1
-Bronx,85010,State Senate,SD34,WF,Jeffrey Klein,4
-Bronx,85011,State Senate,SD34,WF,Jeffrey Klein,7
-Bronx,85012,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,85028,State Senate,SD34,WF,Jeffrey Klein,0
-Bronx,85037,State Senate,SD34,WF,Jeffrey Klein,2
-Bronx,85038,State Senate,SD34,WF,Jeffrey Klein,4
-Bronx,85076,State Senate,SD34,WF,Jeffrey Klein,1
-Bronx,87044,State Senate,SD34,WF,Jeffrey Klein,2
-Bronx,87065,State Senate,SD34,WF,Jeffrey Klein,5
-Bronx,87066,State Senate,SD34,WF,Jeffrey Klein,3
-Bronx,87067,State Senate,SD34,WF,Jeffrey Klein,1
-Bronx,87068,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,87069,State Senate,SD34,WF,Jeffrey Klein,5
-Bronx,87072,State Senate,SD34,WF,Jeffrey Klein,6
-Bronx,87073,State Senate,SD34,WF,Jeffrey Klein,3
-Bronx,87074,State Senate,SD34,WF,Jeffrey Klein,4
-Bronx,87075,State Senate,SD34,WF,Jeffrey Klein,7
-Bronx,87076,State Senate,SD34,WF,Jeffrey Klein,3
-Bronx,87077,State Senate,SD34,WF,Jeffrey Klein,8
-Bronx,87078,State Senate,SD34,WF,Jeffrey Klein,9
-Bronx,87079,State Senate,SD34,WF,Jeffrey Klein,0
-Bronx,87080,State Senate,SD34,WF,Jeffrey Klein,5
-Bronx,87081,State Senate,SD34,WF,Jeffrey Klein,7
-Bronx,87082,State Senate,SD34,WF,Jeffrey Klein,5
-Bronx,78007,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,78016,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,78030,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,78031,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,78036,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,78037,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,78040,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,78041,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,78055,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,78058,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,80001,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,80002,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,80003,State Senate,SD34,Ind,Jeffrey Klein,9
-Bronx,80004,State Senate,SD34,Ind,Jeffrey Klein,8
-Bronx,80005,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,80006,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,80007,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,80008,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,80016,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,80017,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,80018,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,80019,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,80020,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,80021,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,80022,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,80023,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,80024,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,80025,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,80026,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,80027,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,80028,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,80029,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,80030,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,80031,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,80032,State Senate,SD34,Ind,Jeffrey Klein,6
-Bronx,80033,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,80034,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,80035,State Senate,SD34,Ind,Jeffrey Klein,6
-Bronx,80036,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,80037,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,80038,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,80039,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,80040,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,80041,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,80042,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,80043,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,80044,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,80045,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,80046,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,80047,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,80048,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,80049,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,80050,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,80051,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,80066,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,80067,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,80068,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,80069,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,81010,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,81012,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,81013,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,81014,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,81015,State Senate,SD34,Ind,Jeffrey Klein,6
-Bronx,81016,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,81025,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,81026,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,81027,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,81028,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,81029,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,81030,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,81031,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,81032,State Senate,SD34,Ind,Jeffrey Klein,6
-Bronx,81033,State Senate,SD34,Ind,Jeffrey Klein,6
-Bronx,81034,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,81035,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,81036,State Senate,SD34,Ind,Jeffrey Klein,19
-Bronx,81037,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,81041,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,81042,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,81043,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,81044,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,81047,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,81048,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,81049,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,81050,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,81051,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,81052,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,81053,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,81054,State Senate,SD34,Ind,Jeffrey Klein,7
-Bronx,81055,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,81056,State Senate,SD34,Ind,Jeffrey Klein,7
-Bronx,81057,State Senate,SD34,Ind,Jeffrey Klein,9
-Bronx,81058,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,81059,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,81060,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,81061,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,81062,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,81063,State Senate,SD34,Ind,Jeffrey Klein,6
-Bronx,81064,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,81065,State Senate,SD34,Ind,Jeffrey Klein,6
-Bronx,81066,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,81067,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,81068,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,81069,State Senate,SD34,Ind,Jeffrey Klein,9
-Bronx,81070,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,81071,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,81072,State Senate,SD34,Ind,Jeffrey Klein,7
-Bronx,81073,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,81074,State Senate,SD34,Ind,Jeffrey Klein,7
-Bronx,81075,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,81076,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,81077,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,81078,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,81079,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,81080,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,81081,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,81082,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,81083,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,81084,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,81085,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,81086,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,81087,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,81088,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,81089,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,81090,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,81091,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,81104,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,82001,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,82002,State Senate,SD34,Ind,Jeffrey Klein,6
-Bronx,82003,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,82004,State Senate,SD34,Ind,Jeffrey Klein,9
-Bronx,82005,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,82006,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,82007,State Senate,SD34,Ind,Jeffrey Klein,8
-Bronx,82008,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,82009,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,82010,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,82011,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,82012,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,82013,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,82014,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,82015,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,82016,State Senate,SD34,Ind,Jeffrey Klein,6
-Bronx,82017,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,82018,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,82019,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,82020,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,82021,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,82022,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,82023,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,82024,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,82025,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,82026,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,82027,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,82028,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,82031,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,82032,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,82033,State Senate,SD34,Ind,Jeffrey Klein,6
-Bronx,82034,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,82035,State Senate,SD34,Ind,Jeffrey Klein,9
-Bronx,82036,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,82037,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,82038,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,82039,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,82040,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,82041,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,82042,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,82043,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,82044,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,82045,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,82046,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,82047,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,82048,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,82049,State Senate,SD34,Ind,Jeffrey Klein,6
-Bronx,82050,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,82051,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,82052,State Senate,SD34,Ind,Jeffrey Klein,6
-Bronx,82053,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,82055,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,82056,State Senate,SD34,Ind,Jeffrey Klein,8
-Bronx,82057,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,82058,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,82059,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,82060,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,82061,State Senate,SD34,Ind,Jeffrey Klein,9
-Bronx,82062,State Senate,SD34,Ind,Jeffrey Klein,10
-Bronx,82063,State Senate,SD34,Ind,Jeffrey Klein,11
-Bronx,82064,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,82106,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,82107,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,83068,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,84073,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,84077,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,84078,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,85001,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,85002,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,85003,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,85004,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,85005,State Senate,SD34,Ind,Jeffrey Klein,3
-Bronx,85006,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,85007,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,85008,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,85009,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,85010,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,85011,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,85012,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,85028,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,85037,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,85038,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,85076,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,87044,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,87065,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,87066,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,87067,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,87068,State Senate,SD34,Ind,Jeffrey Klein,5
-Bronx,87069,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,87072,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,87073,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,87074,State Senate,SD34,Ind,Jeffrey Klein,0
-Bronx,87075,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,87076,State Senate,SD34,Ind,Jeffrey Klein,4
-Bronx,87077,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,87078,State Senate,SD34,Ind,Jeffrey Klein,2
-Bronx,87079,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,87080,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,87081,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,87082,State Senate,SD34,Ind,Jeffrey Klein,1
-Bronx,78007,State Senate,SD34,Ind,writein,0
-Bronx,78016,State Senate,SD34,Ind,writein,0
-Bronx,78030,State Senate,SD34,Ind,writein,0
-Bronx,78031,State Senate,SD34,Ind,writein,0
-Bronx,78036,State Senate,SD34,Ind,writein,0
-Bronx,78037,State Senate,SD34,Ind,writein,0
-Bronx,78040,State Senate,SD34,Ind,writein,0
-Bronx,78041,State Senate,SD34,Ind,writein,0
-Bronx,78055,State Senate,SD34,Ind,writein,0
-Bronx,78058,State Senate,SD34,Ind,writein,0
-Bronx,80001,State Senate,SD34,Ind,writein,0
-Bronx,80002,State Senate,SD34,Ind,writein,0
-Bronx,80003,State Senate,SD34,Ind,writein,1
-Bronx,80004,State Senate,SD34,Ind,writein,0
-Bronx,80005,State Senate,SD34,Ind,writein,0
-Bronx,80006,State Senate,SD34,Ind,writein,0
-Bronx,80007,State Senate,SD34,Ind,writein,0
-Bronx,80008,State Senate,SD34,Ind,writein,0
-Bronx,80016,State Senate,SD34,Ind,writein,0
-Bronx,80017,State Senate,SD34,Ind,writein,0
-Bronx,80018,State Senate,SD34,Ind,writein,0
-Bronx,80019,State Senate,SD34,Ind,writein,0
-Bronx,80020,State Senate,SD34,Ind,writein,0
-Bronx,80021,State Senate,SD34,Ind,writein,0
-Bronx,80022,State Senate,SD34,Ind,writein,0
-Bronx,80023,State Senate,SD34,Ind,writein,0
-Bronx,80024,State Senate,SD34,Ind,writein,0
-Bronx,80025,State Senate,SD34,Ind,writein,0
-Bronx,80026,State Senate,SD34,Ind,writein,0
-Bronx,80027,State Senate,SD34,Ind,writein,0
-Bronx,80028,State Senate,SD34,Ind,writein,0
-Bronx,80029,State Senate,SD34,Ind,writein,0
-Bronx,80030,State Senate,SD34,Ind,writein,1
-Bronx,80031,State Senate,SD34,Ind,writein,0
-Bronx,80032,State Senate,SD34,Ind,writein,0
-Bronx,80033,State Senate,SD34,Ind,writein,0
-Bronx,80034,State Senate,SD34,Ind,writein,0
-Bronx,80035,State Senate,SD34,Ind,writein,0
-Bronx,80036,State Senate,SD34,Ind,writein,0
-Bronx,80037,State Senate,SD34,Ind,writein,0
-Bronx,80038,State Senate,SD34,Ind,writein,0
-Bronx,80039,State Senate,SD34,Ind,writein,0
-Bronx,80040,State Senate,SD34,Ind,writein,0
-Bronx,80041,State Senate,SD34,Ind,writein,0
-Bronx,80042,State Senate,SD34,Ind,writein,0
-Bronx,80043,State Senate,SD34,Ind,writein,0
-Bronx,80044,State Senate,SD34,Ind,writein,0
-Bronx,80045,State Senate,SD34,Ind,writein,0
-Bronx,80046,State Senate,SD34,Ind,writein,0
-Bronx,80047,State Senate,SD34,Ind,writein,1
-Bronx,80048,State Senate,SD34,Ind,writein,0
-Bronx,80049,State Senate,SD34,Ind,writein,0
-Bronx,80050,State Senate,SD34,Ind,writein,0
-Bronx,80051,State Senate,SD34,Ind,writein,0
-Bronx,80066,State Senate,SD34,Ind,writein,0
-Bronx,80067,State Senate,SD34,Ind,writein,0
-Bronx,80068,State Senate,SD34,Ind,writein,0
-Bronx,80069,State Senate,SD34,Ind,writein,1
-Bronx,81010,State Senate,SD34,Ind,writein,1
-Bronx,81012,State Senate,SD34,Ind,writein,0
-Bronx,81013,State Senate,SD34,Ind,writein,1
-Bronx,81014,State Senate,SD34,Ind,writein,0
-Bronx,81015,State Senate,SD34,Ind,writein,2
-Bronx,81016,State Senate,SD34,Ind,writein,0
-Bronx,81025,State Senate,SD34,Ind,writein,1
-Bronx,81026,State Senate,SD34,Ind,writein,1
-Bronx,81027,State Senate,SD34,Ind,writein,0
-Bronx,81028,State Senate,SD34,Ind,writein,0
-Bronx,81029,State Senate,SD34,Ind,writein,0
-Bronx,81030,State Senate,SD34,Ind,writein,0
-Bronx,81031,State Senate,SD34,Ind,writein,1
-Bronx,81032,State Senate,SD34,Ind,writein,0
-Bronx,81033,State Senate,SD34,Ind,writein,0
-Bronx,81034,State Senate,SD34,Ind,writein,4
-Bronx,81035,State Senate,SD34,Ind,writein,0
-Bronx,81036,State Senate,SD34,Ind,writein,5
-Bronx,81037,State Senate,SD34,Ind,writein,1
-Bronx,81041,State Senate,SD34,Ind,writein,0
-Bronx,81042,State Senate,SD34,Ind,writein,0
-Bronx,81043,State Senate,SD34,Ind,writein,0
-Bronx,81044,State Senate,SD34,Ind,writein,0
-Bronx,81047,State Senate,SD34,Ind,writein,0
-Bronx,81048,State Senate,SD34,Ind,writein,0
-Bronx,81049,State Senate,SD34,Ind,writein,1
-Bronx,81050,State Senate,SD34,Ind,writein,0
-Bronx,81051,State Senate,SD34,Ind,writein,1
-Bronx,81052,State Senate,SD34,Ind,writein,1
-Bronx,81053,State Senate,SD34,Ind,writein,0
-Bronx,81054,State Senate,SD34,Ind,writein,0
-Bronx,81055,State Senate,SD34,Ind,writein,0
-Bronx,81056,State Senate,SD34,Ind,writein,1
-Bronx,81057,State Senate,SD34,Ind,writein,0
-Bronx,81058,State Senate,SD34,Ind,writein,0
-Bronx,81059,State Senate,SD34,Ind,writein,0
-Bronx,81060,State Senate,SD34,Ind,writein,0
-Bronx,81061,State Senate,SD34,Ind,writein,0
-Bronx,81062,State Senate,SD34,Ind,writein,0
-Bronx,81063,State Senate,SD34,Ind,writein,0
-Bronx,81064,State Senate,SD34,Ind,writein,0
-Bronx,81065,State Senate,SD34,Ind,writein,0
-Bronx,81066,State Senate,SD34,Ind,writein,0
-Bronx,81067,State Senate,SD34,Ind,writein,0
-Bronx,81068,State Senate,SD34,Ind,writein,0
-Bronx,81069,State Senate,SD34,Ind,writein,1
-Bronx,81070,State Senate,SD34,Ind,writein,0
-Bronx,81071,State Senate,SD34,Ind,writein,0
-Bronx,81072,State Senate,SD34,Ind,writein,0
-Bronx,81073,State Senate,SD34,Ind,writein,1
-Bronx,81074,State Senate,SD34,Ind,writein,1
-Bronx,81075,State Senate,SD34,Ind,writein,0
-Bronx,81076,State Senate,SD34,Ind,writein,0
-Bronx,81077,State Senate,SD34,Ind,writein,2
-Bronx,81078,State Senate,SD34,Ind,writein,0
-Bronx,81079,State Senate,SD34,Ind,writein,0
-Bronx,81080,State Senate,SD34,Ind,writein,0
-Bronx,81081,State Senate,SD34,Ind,writein,0
-Bronx,81082,State Senate,SD34,Ind,writein,0
-Bronx,81083,State Senate,SD34,Ind,writein,0
-Bronx,81084,State Senate,SD34,Ind,writein,3
-Bronx,81085,State Senate,SD34,Ind,writein,1
-Bronx,81086,State Senate,SD34,Ind,writein,1
-Bronx,81087,State Senate,SD34,Ind,writein,0
-Bronx,81088,State Senate,SD34,Ind,writein,1
-Bronx,81089,State Senate,SD34,Ind,writein,0
-Bronx,81090,State Senate,SD34,Ind,writein,0
-Bronx,81091,State Senate,SD34,Ind,writein,0
-Bronx,81104,State Senate,SD34,Ind,writein,0
-Bronx,82001,State Senate,SD34,Ind,writein,0
-Bronx,82002,State Senate,SD34,Ind,writein,0
-Bronx,82003,State Senate,SD34,Ind,writein,0
-Bronx,82004,State Senate,SD34,Ind,writein,0
-Bronx,82005,State Senate,SD34,Ind,writein,0
-Bronx,82006,State Senate,SD34,Ind,writein,0
-Bronx,82007,State Senate,SD34,Ind,writein,0
-Bronx,82008,State Senate,SD34,Ind,writein,0
-Bronx,82009,State Senate,SD34,Ind,writein,0
-Bronx,82010,State Senate,SD34,Ind,writein,0
-Bronx,82011,State Senate,SD34,Ind,writein,0
-Bronx,82012,State Senate,SD34,Ind,writein,0
-Bronx,82013,State Senate,SD34,Ind,writein,0
-Bronx,82014,State Senate,SD34,Ind,writein,0
-Bronx,82015,State Senate,SD34,Ind,writein,0
-Bronx,82016,State Senate,SD34,Ind,writein,0
-Bronx,82017,State Senate,SD34,Ind,writein,1
-Bronx,82018,State Senate,SD34,Ind,writein,0
-Bronx,82019,State Senate,SD34,Ind,writein,0
-Bronx,82020,State Senate,SD34,Ind,writein,0
-Bronx,82021,State Senate,SD34,Ind,writein,0
-Bronx,82022,State Senate,SD34,Ind,writein,0
-Bronx,82023,State Senate,SD34,Ind,writein,0
-Bronx,82024,State Senate,SD34,Ind,writein,0
-Bronx,82025,State Senate,SD34,Ind,writein,0
-Bronx,82026,State Senate,SD34,Ind,writein,0
-Bronx,82027,State Senate,SD34,Ind,writein,0
-Bronx,82028,State Senate,SD34,Ind,writein,0
-Bronx,82031,State Senate,SD34,Ind,writein,0
-Bronx,82032,State Senate,SD34,Ind,writein,1
-Bronx,82033,State Senate,SD34,Ind,writein,0
-Bronx,82034,State Senate,SD34,Ind,writein,0
-Bronx,82035,State Senate,SD34,Ind,writein,0
-Bronx,82036,State Senate,SD34,Ind,writein,0
-Bronx,82037,State Senate,SD34,Ind,writein,0
-Bronx,82038,State Senate,SD34,Ind,writein,1
-Bronx,82039,State Senate,SD34,Ind,writein,0
-Bronx,82040,State Senate,SD34,Ind,writein,0
-Bronx,82041,State Senate,SD34,Ind,writein,0
-Bronx,82042,State Senate,SD34,Ind,writein,0
-Bronx,82043,State Senate,SD34,Ind,writein,0
-Bronx,82044,State Senate,SD34,Ind,writein,0
-Bronx,82045,State Senate,SD34,Ind,writein,0
-Bronx,82046,State Senate,SD34,Ind,writein,0
-Bronx,82047,State Senate,SD34,Ind,writein,0
-Bronx,82048,State Senate,SD34,Ind,writein,0
-Bronx,82049,State Senate,SD34,Ind,writein,0
-Bronx,82050,State Senate,SD34,Ind,writein,0
-Bronx,82051,State Senate,SD34,Ind,writein,1
-Bronx,82052,State Senate,SD34,Ind,writein,0
-Bronx,82053,State Senate,SD34,Ind,writein,0
-Bronx,82055,State Senate,SD34,Ind,writein,0
-Bronx,82056,State Senate,SD34,Ind,writein,0
-Bronx,82057,State Senate,SD34,Ind,writein,0
-Bronx,82058,State Senate,SD34,Ind,writein,0
-Bronx,82059,State Senate,SD34,Ind,writein,0
-Bronx,82060,State Senate,SD34,Ind,writein,1
-Bronx,82061,State Senate,SD34,Ind,writein,1
-Bronx,82062,State Senate,SD34,Ind,writein,0
-Bronx,82063,State Senate,SD34,Ind,writein,0
-Bronx,82064,State Senate,SD34,Ind,writein,0
-Bronx,82106,State Senate,SD34,Ind,writein,0
-Bronx,82107,State Senate,SD34,Ind,writein,0
-Bronx,83068,State Senate,SD34,Ind,writein,0
-Bronx,84073,State Senate,SD34,Ind,writein,0
-Bronx,84077,State Senate,SD34,Ind,writein,0
-Bronx,84078,State Senate,SD34,Ind,writein,0
-Bronx,85001,State Senate,SD34,Ind,writein,0
-Bronx,85002,State Senate,SD34,Ind,writein,0
-Bronx,85003,State Senate,SD34,Ind,writein,0
-Bronx,85004,State Senate,SD34,Ind,writein,0
-Bronx,85005,State Senate,SD34,Ind,writein,0
-Bronx,85006,State Senate,SD34,Ind,writein,0
-Bronx,85007,State Senate,SD34,Ind,writein,0
-Bronx,85008,State Senate,SD34,Ind,writein,0
-Bronx,85009,State Senate,SD34,Ind,writein,0
-Bronx,85010,State Senate,SD34,Ind,writein,0
-Bronx,85011,State Senate,SD34,Ind,writein,0
-Bronx,85012,State Senate,SD34,Ind,writein,0
-Bronx,85028,State Senate,SD34,Ind,writein,0
-Bronx,85037,State Senate,SD34,Ind,writein,0
-Bronx,85038,State Senate,SD34,Ind,writein,0
-Bronx,85076,State Senate,SD34,Ind,writein,0
-Bronx,87044,State Senate,SD34,Ind,writein,0
-Bronx,87065,State Senate,SD34,Ind,writein,0
-Bronx,87066,State Senate,SD34,Ind,writein,0
-Bronx,87067,State Senate,SD34,Ind,writein,0
-Bronx,87068,State Senate,SD34,Ind,writein,0
-Bronx,87069,State Senate,SD34,Ind,writein,0
-Bronx,87072,State Senate,SD34,Ind,writein,0
-Bronx,87073,State Senate,SD34,Ind,writein,0
-Bronx,87074,State Senate,SD34,Ind,writein,0
-Bronx,87075,State Senate,SD34,Ind,writein,0
-Bronx,87076,State Senate,SD34,Ind,writein,0
-Bronx,87077,State Senate,SD34,Ind,writein,0
-Bronx,87078,State Senate,SD34,Ind,writein,0
-Bronx,87079,State Senate,SD34,Ind,writein,0
-Bronx,87080,State Senate,SD34,Ind,writein,0
-Bronx,87081,State Senate,SD34,Ind,writein,0
-Bronx,87082,State Senate,SD34,Ind,writein,0
-Bronx,78032,State Senate,SD36,Con,Robert Diamond,28
-Bronx,78033,State Senate,SD36,Con,Robert Diamond,33
-Bronx,78034,State Senate,SD36,Con,Robert Diamond,19
-Bronx,78035,State Senate,SD36,Con,Robert Diamond,6
-Bronx,80052,State Senate,SD36,Con,Robert Diamond,9
-Bronx,80053,State Senate,SD36,Con,Robert Diamond,14
-Bronx,80054,State Senate,SD36,Con,Robert Diamond,0
-Bronx,80055,State Senate,SD36,Con,Robert Diamond,11
-Bronx,80056,State Senate,SD36,Con,Robert Diamond,4
-Bronx,80057,State Senate,SD36,Con,Robert Diamond,13
-Bronx,80058,State Senate,SD36,Con,Robert Diamond,15
-Bronx,80059,State Senate,SD36,Con,Robert Diamond,4
-Bronx,80060,State Senate,SD36,Con,Robert Diamond,9
-Bronx,80061,State Senate,SD36,Con,Robert Diamond,2
-Bronx,80062,State Senate,SD36,Con,Robert Diamond,14
-Bronx,80063,State Senate,SD36,Con,Robert Diamond,9
-Bronx,80064,State Senate,SD36,Con,Robert Diamond,0
-Bronx,80065,State Senate,SD36,Con,Robert Diamond,1
-Bronx,80070,State Senate,SD36,Con,Robert Diamond,23
-Bronx,80071,State Senate,SD36,Con,Robert Diamond,14
-Bronx,80072,State Senate,SD36,Con,Robert Diamond,1
-Bronx,80073,State Senate,SD36,Con,Robert Diamond,9
-Bronx,80075,State Senate,SD36,Con,Robert Diamond,0
-Bronx,80076,State Senate,SD36,Con,Robert Diamond,0
-Bronx,80077,State Senate,SD36,Con,Robert Diamond,11
-Bronx,80078,State Senate,SD36,Con,Robert Diamond,18
-Bronx,80079,State Senate,SD36,Con,Robert Diamond,20
-Bronx,80080,State Senate,SD36,Con,Robert Diamond,6
-Bronx,80081,State Senate,SD36,Con,Robert Diamond,14
-Bronx,80082,State Senate,SD36,Con,Robert Diamond,11
-Bronx,80083,State Senate,SD36,Con,Robert Diamond,30
-Bronx,80084,State Senate,SD36,Con,Robert Diamond,14
-Bronx,80085,State Senate,SD36,Con,Robert Diamond,15
-Bronx,80086,State Senate,SD36,Con,Robert Diamond,10
-Bronx,80087,State Senate,SD36,Con,Robert Diamond,6
-Bronx,80089,State Senate,SD36,Con,Robert Diamond,7
-Bronx,80090,State Senate,SD36,Con,Robert Diamond,0
-Bronx,80091,State Senate,SD36,Con,Robert Diamond,14
-Bronx,80092,State Senate,SD36,Con,Robert Diamond,1
-Bronx,80093,State Senate,SD36,Con,Robert Diamond,2
-Bronx,80094,State Senate,SD36,Con,Robert Diamond,14
-Bronx,81017,State Senate,SD36,Con,Robert Diamond,6
-Bronx,81018,State Senate,SD36,Con,Robert Diamond,4
-Bronx,81019,State Senate,SD36,Con,Robert Diamond,9
-Bronx,81020,State Senate,SD36,Con,Robert Diamond,24
-Bronx,81021,State Senate,SD36,Con,Robert Diamond,10
-Bronx,81022,State Senate,SD36,Con,Robert Diamond,4
-Bronx,81023,State Senate,SD36,Con,Robert Diamond,11
-Bronx,81024,State Senate,SD36,Con,Robert Diamond,1
-Bronx,81092,State Senate,SD36,Con,Robert Diamond,1
-Bronx,81093,State Senate,SD36,Con,Robert Diamond,4
-Bronx,81094,State Senate,SD36,Con,Robert Diamond,18
-Bronx,81095,State Senate,SD36,Con,Robert Diamond,12
-Bronx,81096,State Senate,SD36,Con,Robert Diamond,14
-Bronx,81097,State Senate,SD36,Con,Robert Diamond,11
-Bronx,81098,State Senate,SD36,Con,Robert Diamond,19
-Bronx,81099,State Senate,SD36,Con,Robert Diamond,27
-Bronx,81100,State Senate,SD36,Con,Robert Diamond,9
-Bronx,81102,State Senate,SD36,Con,Robert Diamond,2
-Bronx,82054,State Senate,SD36,Con,Robert Diamond,2
-Bronx,82065,State Senate,SD36,Con,Robert Diamond,13
-Bronx,82066,State Senate,SD36,Con,Robert Diamond,7
-Bronx,82067,State Senate,SD36,Con,Robert Diamond,9
-Bronx,82068,State Senate,SD36,Con,Robert Diamond,9
-Bronx,82069,State Senate,SD36,Con,Robert Diamond,12
-Bronx,82070,State Senate,SD36,Con,Robert Diamond,8
-Bronx,82071,State Senate,SD36,Con,Robert Diamond,4
-Bronx,82072,State Senate,SD36,Con,Robert Diamond,10
-Bronx,82073,State Senate,SD36,Con,Robert Diamond,8
-Bronx,82074,State Senate,SD36,Con,Robert Diamond,12
-Bronx,82075,State Senate,SD36,Con,Robert Diamond,5
-Bronx,82076,State Senate,SD36,Con,Robert Diamond,2
-Bronx,82077,State Senate,SD36,Con,Robert Diamond,14
-Bronx,82078,State Senate,SD36,Con,Robert Diamond,7
-Bronx,82079,State Senate,SD36,Con,Robert Diamond,13
-Bronx,82080,State Senate,SD36,Con,Robert Diamond,6
-Bronx,82081,State Senate,SD36,Con,Robert Diamond,8
-Bronx,82082,State Senate,SD36,Con,Robert Diamond,7
-Bronx,82083,State Senate,SD36,Con,Robert Diamond,3
-Bronx,82084,State Senate,SD36,Con,Robert Diamond,4
-Bronx,82085,State Senate,SD36,Con,Robert Diamond,9
-Bronx,82086,State Senate,SD36,Con,Robert Diamond,8
-Bronx,82087,State Senate,SD36,Con,Robert Diamond,5
-Bronx,82088,State Senate,SD36,Con,Robert Diamond,11
-Bronx,82089,State Senate,SD36,Con,Robert Diamond,8
-Bronx,82090,State Senate,SD36,Con,Robert Diamond,5
-Bronx,82091,State Senate,SD36,Con,Robert Diamond,10
-Bronx,82092,State Senate,SD36,Con,Robert Diamond,12
-Bronx,82093,State Senate,SD36,Con,Robert Diamond,11
-Bronx,82094,State Senate,SD36,Con,Robert Diamond,11
-Bronx,82095,State Senate,SD36,Con,Robert Diamond,16
-Bronx,82096,State Senate,SD36,Con,Robert Diamond,3
-Bronx,82097,State Senate,SD36,Con,Robert Diamond,10
-Bronx,82098,State Senate,SD36,Con,Robert Diamond,18
-Bronx,82099,State Senate,SD36,Con,Robert Diamond,4
-Bronx,82100,State Senate,SD36,Con,Robert Diamond,5
-Bronx,82101,State Senate,SD36,Con,Robert Diamond,9
-Bronx,82102,State Senate,SD36,Con,Robert Diamond,4
-Bronx,82103,State Senate,SD36,Con,Robert Diamond,6
-Bronx,82104,State Senate,SD36,Con,Robert Diamond,5
-Bronx,82105,State Senate,SD36,Con,Robert Diamond,11
-Bronx,82117,State Senate,SD36,Con,Robert Diamond,0
-Bronx,83001,State Senate,SD36,Con,Robert Diamond,11
-Bronx,83002,State Senate,SD36,Con,Robert Diamond,2
-Bronx,83003,State Senate,SD36,Con,Robert Diamond,5
-Bronx,83004,State Senate,SD36,Con,Robert Diamond,4
-Bronx,83005,State Senate,SD36,Con,Robert Diamond,4
-Bronx,83006,State Senate,SD36,Con,Robert Diamond,4
-Bronx,83007,State Senate,SD36,Con,Robert Diamond,6
-Bronx,83008,State Senate,SD36,Con,Robert Diamond,2
-Bronx,83009,State Senate,SD36,Con,Robert Diamond,2
-Bronx,83010,State Senate,SD36,Con,Robert Diamond,6
-Bronx,83011,State Senate,SD36,Con,Robert Diamond,4
-Bronx,83013,State Senate,SD36,Con,Robert Diamond,5
-Bronx,83014,State Senate,SD36,Con,Robert Diamond,6
-Bronx,83015,State Senate,SD36,Con,Robert Diamond,6
-Bronx,83016,State Senate,SD36,Con,Robert Diamond,3
-Bronx,83017,State Senate,SD36,Con,Robert Diamond,7
-Bronx,83018,State Senate,SD36,Con,Robert Diamond,1
-Bronx,83019,State Senate,SD36,Con,Robert Diamond,2
-Bronx,83020,State Senate,SD36,Con,Robert Diamond,4
-Bronx,83021,State Senate,SD36,Con,Robert Diamond,6
-Bronx,83022,State Senate,SD36,Con,Robert Diamond,13
-Bronx,83023,State Senate,SD36,Con,Robert Diamond,6
-Bronx,83024,State Senate,SD36,Con,Robert Diamond,1
-Bronx,83025,State Senate,SD36,Con,Robert Diamond,5
-Bronx,83026,State Senate,SD36,Con,Robert Diamond,9
-Bronx,83027,State Senate,SD36,Con,Robert Diamond,9
-Bronx,83028,State Senate,SD36,Con,Robert Diamond,5
-Bronx,83029,State Senate,SD36,Con,Robert Diamond,8
-Bronx,83030,State Senate,SD36,Con,Robert Diamond,5
-Bronx,83031,State Senate,SD36,Con,Robert Diamond,7
-Bronx,83032,State Senate,SD36,Con,Robert Diamond,9
-Bronx,83033,State Senate,SD36,Con,Robert Diamond,5
-Bronx,83034,State Senate,SD36,Con,Robert Diamond,3
-Bronx,83035,State Senate,SD36,Con,Robert Diamond,3
-Bronx,83036,State Senate,SD36,Con,Robert Diamond,5
-Bronx,83037,State Senate,SD36,Con,Robert Diamond,3
-Bronx,83038,State Senate,SD36,Con,Robert Diamond,3
-Bronx,83039,State Senate,SD36,Con,Robert Diamond,5
-Bronx,83040,State Senate,SD36,Con,Robert Diamond,2
-Bronx,83041,State Senate,SD36,Con,Robert Diamond,5
-Bronx,83042,State Senate,SD36,Con,Robert Diamond,4
-Bronx,83043,State Senate,SD36,Con,Robert Diamond,1
-Bronx,83044,State Senate,SD36,Con,Robert Diamond,4
-Bronx,83045,State Senate,SD36,Con,Robert Diamond,3
-Bronx,83046,State Senate,SD36,Con,Robert Diamond,11
-Bronx,83047,State Senate,SD36,Con,Robert Diamond,5
-Bronx,83048,State Senate,SD36,Con,Robert Diamond,2
-Bronx,83049,State Senate,SD36,Con,Robert Diamond,6
-Bronx,83050,State Senate,SD36,Con,Robert Diamond,5
-Bronx,83051,State Senate,SD36,Con,Robert Diamond,4
-Bronx,83052,State Senate,SD36,Con,Robert Diamond,12
-Bronx,83053,State Senate,SD36,Con,Robert Diamond,0
-Bronx,83054,State Senate,SD36,Con,Robert Diamond,3
-Bronx,83055,State Senate,SD36,Con,Robert Diamond,6
-Bronx,83056,State Senate,SD36,Con,Robert Diamond,5
-Bronx,83057,State Senate,SD36,Con,Robert Diamond,6
-Bronx,83058,State Senate,SD36,Con,Robert Diamond,2
-Bronx,83059,State Senate,SD36,Con,Robert Diamond,5
-Bronx,83060,State Senate,SD36,Con,Robert Diamond,4
-Bronx,83061,State Senate,SD36,Con,Robert Diamond,1
-Bronx,83062,State Senate,SD36,Con,Robert Diamond,2
-Bronx,83063,State Senate,SD36,Con,Robert Diamond,4
-Bronx,83064,State Senate,SD36,Con,Robert Diamond,7
-Bronx,83065,State Senate,SD36,Con,Robert Diamond,5
-Bronx,83066,State Senate,SD36,Con,Robert Diamond,5
-Bronx,83067,State Senate,SD36,Con,Robert Diamond,13
-Bronx,83069,State Senate,SD36,Con,Robert Diamond,14
-Bronx,83070,State Senate,SD36,Con,Robert Diamond,7
-Bronx,83071,State Senate,SD36,Con,Robert Diamond,11
-Bronx,83072,State Senate,SD36,Con,Robert Diamond,7
-Bronx,83073,State Senate,SD36,Con,Robert Diamond,3
-Bronx,83074,State Senate,SD36,Con,Robert Diamond,12
-Bronx,83075,State Senate,SD36,Con,Robert Diamond,6
-Bronx,83076,State Senate,SD36,Con,Robert Diamond,11
-Bronx,83077,State Senate,SD36,Con,Robert Diamond,7
-Bronx,83078,State Senate,SD36,Con,Robert Diamond,2
-Bronx,83079,State Senate,SD36,Con,Robert Diamond,4
-Bronx,83080,State Senate,SD36,Con,Robert Diamond,2
-Bronx,83081,State Senate,SD36,Con,Robert Diamond,5
-Bronx,83082,State Senate,SD36,Con,Robert Diamond,9
-Bronx,83083,State Senate,SD36,Con,Robert Diamond,7
-Bronx,83084,State Senate,SD36,Con,Robert Diamond,2
-Bronx,83085,State Senate,SD36,Con,Robert Diamond,2
-Bronx,83086,State Senate,SD36,Con,Robert Diamond,6
-Bronx,83087,State Senate,SD36,Con,Robert Diamond,0
-Bronx,78032,State Senate,SD36,Dem,Ruth Haskell-Thompson,500
-Bronx,78033,State Senate,SD36,Dem,Ruth Haskell-Thompson,548
-Bronx,78034,State Senate,SD36,Dem,Ruth Haskell-Thompson,287
-Bronx,78035,State Senate,SD36,Dem,Ruth Haskell-Thompson,124
-Bronx,80052,State Senate,SD36,Dem,Ruth Haskell-Thompson,383
-Bronx,80053,State Senate,SD36,Dem,Ruth Haskell-Thompson,285
-Bronx,80054,State Senate,SD36,Dem,Ruth Haskell-Thompson,15
-Bronx,80055,State Senate,SD36,Dem,Ruth Haskell-Thompson,251
-Bronx,80056,State Senate,SD36,Dem,Ruth Haskell-Thompson,22
-Bronx,80057,State Senate,SD36,Dem,Ruth Haskell-Thompson,191
-Bronx,80058,State Senate,SD36,Dem,Ruth Haskell-Thompson,259
-Bronx,80059,State Senate,SD36,Dem,Ruth Haskell-Thompson,75
-Bronx,80060,State Senate,SD36,Dem,Ruth Haskell-Thompson,488
-Bronx,80061,State Senate,SD36,Dem,Ruth Haskell-Thompson,279
-Bronx,80062,State Senate,SD36,Dem,Ruth Haskell-Thompson,356
-Bronx,80063,State Senate,SD36,Dem,Ruth Haskell-Thompson,456
-Bronx,80064,State Senate,SD36,Dem,Ruth Haskell-Thompson,113
-Bronx,80065,State Senate,SD36,Dem,Ruth Haskell-Thompson,52
-Bronx,80070,State Senate,SD36,Dem,Ruth Haskell-Thompson,410
-Bronx,80071,State Senate,SD36,Dem,Ruth Haskell-Thompson,260
-Bronx,80072,State Senate,SD36,Dem,Ruth Haskell-Thompson,46
-Bronx,80073,State Senate,SD36,Dem,Ruth Haskell-Thompson,184
-Bronx,80075,State Senate,SD36,Dem,Ruth Haskell-Thompson,7
-Bronx,80076,State Senate,SD36,Dem,Ruth Haskell-Thompson,8
-Bronx,80077,State Senate,SD36,Dem,Ruth Haskell-Thompson,521
-Bronx,80078,State Senate,SD36,Dem,Ruth Haskell-Thompson,456
-Bronx,80079,State Senate,SD36,Dem,Ruth Haskell-Thompson,431
-Bronx,80080,State Senate,SD36,Dem,Ruth Haskell-Thompson,305
-Bronx,80081,State Senate,SD36,Dem,Ruth Haskell-Thompson,417
-Bronx,80082,State Senate,SD36,Dem,Ruth Haskell-Thompson,184
-Bronx,80083,State Senate,SD36,Dem,Ruth Haskell-Thompson,519
-Bronx,80084,State Senate,SD36,Dem,Ruth Haskell-Thompson,213
-Bronx,80085,State Senate,SD36,Dem,Ruth Haskell-Thompson,534
-Bronx,80086,State Senate,SD36,Dem,Ruth Haskell-Thompson,445
-Bronx,80087,State Senate,SD36,Dem,Ruth Haskell-Thompson,199
-Bronx,80089,State Senate,SD36,Dem,Ruth Haskell-Thompson,119
-Bronx,80090,State Senate,SD36,Dem,Ruth Haskell-Thompson,443
-Bronx,80091,State Senate,SD36,Dem,Ruth Haskell-Thompson,221
-Bronx,80092,State Senate,SD36,Dem,Ruth Haskell-Thompson,483
-Bronx,80093,State Senate,SD36,Dem,Ruth Haskell-Thompson,572
-Bronx,80094,State Senate,SD36,Dem,Ruth Haskell-Thompson,581
-Bronx,81017,State Senate,SD36,Dem,Ruth Haskell-Thompson,357
-Bronx,81018,State Senate,SD36,Dem,Ruth Haskell-Thompson,296
-Bronx,81019,State Senate,SD36,Dem,Ruth Haskell-Thompson,385
-Bronx,81020,State Senate,SD36,Dem,Ruth Haskell-Thompson,511
-Bronx,81021,State Senate,SD36,Dem,Ruth Haskell-Thompson,491
-Bronx,81022,State Senate,SD36,Dem,Ruth Haskell-Thompson,358
-Bronx,81023,State Senate,SD36,Dem,Ruth Haskell-Thompson,533
-Bronx,81024,State Senate,SD36,Dem,Ruth Haskell-Thompson,354
-Bronx,81092,State Senate,SD36,Dem,Ruth Haskell-Thompson,250
-Bronx,81093,State Senate,SD36,Dem,Ruth Haskell-Thompson,409
-Bronx,81094,State Senate,SD36,Dem,Ruth Haskell-Thompson,310
-Bronx,81095,State Senate,SD36,Dem,Ruth Haskell-Thompson,160
-Bronx,81096,State Senate,SD36,Dem,Ruth Haskell-Thompson,259
-Bronx,81097,State Senate,SD36,Dem,Ruth Haskell-Thompson,357
-Bronx,81098,State Senate,SD36,Dem,Ruth Haskell-Thompson,320
-Bronx,81099,State Senate,SD36,Dem,Ruth Haskell-Thompson,461
-Bronx,81100,State Senate,SD36,Dem,Ruth Haskell-Thompson,287
-Bronx,81102,State Senate,SD36,Dem,Ruth Haskell-Thompson,106
-Bronx,82054,State Senate,SD36,Dem,Ruth Haskell-Thompson,55
-Bronx,82065,State Senate,SD36,Dem,Ruth Haskell-Thompson,348
-Bronx,82066,State Senate,SD36,Dem,Ruth Haskell-Thompson,351
-Bronx,82067,State Senate,SD36,Dem,Ruth Haskell-Thompson,440
-Bronx,82068,State Senate,SD36,Dem,Ruth Haskell-Thompson,324
-Bronx,82069,State Senate,SD36,Dem,Ruth Haskell-Thompson,359
-Bronx,82070,State Senate,SD36,Dem,Ruth Haskell-Thompson,305
-Bronx,82071,State Senate,SD36,Dem,Ruth Haskell-Thompson,360
-Bronx,82072,State Senate,SD36,Dem,Ruth Haskell-Thompson,393
-Bronx,82073,State Senate,SD36,Dem,Ruth Haskell-Thompson,330
-Bronx,82074,State Senate,SD36,Dem,Ruth Haskell-Thompson,289
-Bronx,82075,State Senate,SD36,Dem,Ruth Haskell-Thompson,308
-Bronx,82076,State Senate,SD36,Dem,Ruth Haskell-Thompson,356
-Bronx,82077,State Senate,SD36,Dem,Ruth Haskell-Thompson,416
-Bronx,82078,State Senate,SD36,Dem,Ruth Haskell-Thompson,386
-Bronx,82079,State Senate,SD36,Dem,Ruth Haskell-Thompson,405
-Bronx,82080,State Senate,SD36,Dem,Ruth Haskell-Thompson,361
-Bronx,82081,State Senate,SD36,Dem,Ruth Haskell-Thompson,379
-Bronx,82082,State Senate,SD36,Dem,Ruth Haskell-Thompson,221
-Bronx,82083,State Senate,SD36,Dem,Ruth Haskell-Thompson,272
-Bronx,82084,State Senate,SD36,Dem,Ruth Haskell-Thompson,313
-Bronx,82085,State Senate,SD36,Dem,Ruth Haskell-Thompson,316
-Bronx,82086,State Senate,SD36,Dem,Ruth Haskell-Thompson,320
-Bronx,82087,State Senate,SD36,Dem,Ruth Haskell-Thompson,329
-Bronx,82088,State Senate,SD36,Dem,Ruth Haskell-Thompson,378
-Bronx,82089,State Senate,SD36,Dem,Ruth Haskell-Thompson,385
-Bronx,82090,State Senate,SD36,Dem,Ruth Haskell-Thompson,353
-Bronx,82091,State Senate,SD36,Dem,Ruth Haskell-Thompson,361
-Bronx,82092,State Senate,SD36,Dem,Ruth Haskell-Thompson,457
-Bronx,82093,State Senate,SD36,Dem,Ruth Haskell-Thompson,349
-Bronx,82094,State Senate,SD36,Dem,Ruth Haskell-Thompson,366
-Bronx,82095,State Senate,SD36,Dem,Ruth Haskell-Thompson,331
-Bronx,82096,State Senate,SD36,Dem,Ruth Haskell-Thompson,305
-Bronx,82097,State Senate,SD36,Dem,Ruth Haskell-Thompson,377
-Bronx,82098,State Senate,SD36,Dem,Ruth Haskell-Thompson,425
-Bronx,82099,State Senate,SD36,Dem,Ruth Haskell-Thompson,425
-Bronx,82100,State Senate,SD36,Dem,Ruth Haskell-Thompson,367
-Bronx,82101,State Senate,SD36,Dem,Ruth Haskell-Thompson,355
-Bronx,82102,State Senate,SD36,Dem,Ruth Haskell-Thompson,302
-Bronx,82103,State Senate,SD36,Dem,Ruth Haskell-Thompson,302
-Bronx,82104,State Senate,SD36,Dem,Ruth Haskell-Thompson,410
-Bronx,82105,State Senate,SD36,Dem,Ruth Haskell-Thompson,380
-Bronx,82117,State Senate,SD36,Dem,Ruth Haskell-Thompson,33
-Bronx,83001,State Senate,SD36,Dem,Ruth Haskell-Thompson,573
-Bronx,83002,State Senate,SD36,Dem,Ruth Haskell-Thompson,66
-Bronx,83003,State Senate,SD36,Dem,Ruth Haskell-Thompson,310
-Bronx,83004,State Senate,SD36,Dem,Ruth Haskell-Thompson,195
-Bronx,83005,State Senate,SD36,Dem,Ruth Haskell-Thompson,102
-Bronx,83006,State Senate,SD36,Dem,Ruth Haskell-Thompson,432
-Bronx,83007,State Senate,SD36,Dem,Ruth Haskell-Thompson,478
-Bronx,83008,State Senate,SD36,Dem,Ruth Haskell-Thompson,324
-Bronx,83009,State Senate,SD36,Dem,Ruth Haskell-Thompson,381
-Bronx,83010,State Senate,SD36,Dem,Ruth Haskell-Thompson,647
-Bronx,83011,State Senate,SD36,Dem,Ruth Haskell-Thompson,479
-Bronx,83013,State Senate,SD36,Dem,Ruth Haskell-Thompson,546
-Bronx,83014,State Senate,SD36,Dem,Ruth Haskell-Thompson,679
-Bronx,83015,State Senate,SD36,Dem,Ruth Haskell-Thompson,586
-Bronx,83016,State Senate,SD36,Dem,Ruth Haskell-Thompson,536
-Bronx,83017,State Senate,SD36,Dem,Ruth Haskell-Thompson,468
-Bronx,83018,State Senate,SD36,Dem,Ruth Haskell-Thompson,472
-Bronx,83019,State Senate,SD36,Dem,Ruth Haskell-Thompson,402
-Bronx,83020,State Senate,SD36,Dem,Ruth Haskell-Thompson,370
-Bronx,83021,State Senate,SD36,Dem,Ruth Haskell-Thompson,408
-Bronx,83022,State Senate,SD36,Dem,Ruth Haskell-Thompson,426
-Bronx,83023,State Senate,SD36,Dem,Ruth Haskell-Thompson,419
-Bronx,83024,State Senate,SD36,Dem,Ruth Haskell-Thompson,195
-Bronx,83025,State Senate,SD36,Dem,Ruth Haskell-Thompson,313
-Bronx,83026,State Senate,SD36,Dem,Ruth Haskell-Thompson,271
-Bronx,83027,State Senate,SD36,Dem,Ruth Haskell-Thompson,453
-Bronx,83028,State Senate,SD36,Dem,Ruth Haskell-Thompson,643
-Bronx,83029,State Senate,SD36,Dem,Ruth Haskell-Thompson,307
-Bronx,83030,State Senate,SD36,Dem,Ruth Haskell-Thompson,388
-Bronx,83031,State Senate,SD36,Dem,Ruth Haskell-Thompson,520
-Bronx,83032,State Senate,SD36,Dem,Ruth Haskell-Thompson,477
-Bronx,83033,State Senate,SD36,Dem,Ruth Haskell-Thompson,461
-Bronx,83034,State Senate,SD36,Dem,Ruth Haskell-Thompson,462
-Bronx,83035,State Senate,SD36,Dem,Ruth Haskell-Thompson,333
-Bronx,83036,State Senate,SD36,Dem,Ruth Haskell-Thompson,208
-Bronx,83037,State Senate,SD36,Dem,Ruth Haskell-Thompson,374
-Bronx,83038,State Senate,SD36,Dem,Ruth Haskell-Thompson,410
-Bronx,83039,State Senate,SD36,Dem,Ruth Haskell-Thompson,384
-Bronx,83040,State Senate,SD36,Dem,Ruth Haskell-Thompson,341
-Bronx,83041,State Senate,SD36,Dem,Ruth Haskell-Thompson,344
-Bronx,83042,State Senate,SD36,Dem,Ruth Haskell-Thompson,433
-Bronx,83043,State Senate,SD36,Dem,Ruth Haskell-Thompson,413
-Bronx,83044,State Senate,SD36,Dem,Ruth Haskell-Thompson,490
-Bronx,83045,State Senate,SD36,Dem,Ruth Haskell-Thompson,509
-Bronx,83046,State Senate,SD36,Dem,Ruth Haskell-Thompson,389
-Bronx,83047,State Senate,SD36,Dem,Ruth Haskell-Thompson,395
-Bronx,83048,State Senate,SD36,Dem,Ruth Haskell-Thompson,366
-Bronx,83049,State Senate,SD36,Dem,Ruth Haskell-Thompson,393
-Bronx,83050,State Senate,SD36,Dem,Ruth Haskell-Thompson,386
-Bronx,83051,State Senate,SD36,Dem,Ruth Haskell-Thompson,387
-Bronx,83052,State Senate,SD36,Dem,Ruth Haskell-Thompson,416
-Bronx,83053,State Senate,SD36,Dem,Ruth Haskell-Thompson,404
-Bronx,83054,State Senate,SD36,Dem,Ruth Haskell-Thompson,347
-Bronx,83055,State Senate,SD36,Dem,Ruth Haskell-Thompson,492
-Bronx,83056,State Senate,SD36,Dem,Ruth Haskell-Thompson,491
-Bronx,83057,State Senate,SD36,Dem,Ruth Haskell-Thompson,468
-Bronx,83058,State Senate,SD36,Dem,Ruth Haskell-Thompson,339
-Bronx,83059,State Senate,SD36,Dem,Ruth Haskell-Thompson,485
-Bronx,83060,State Senate,SD36,Dem,Ruth Haskell-Thompson,209
-Bronx,83061,State Senate,SD36,Dem,Ruth Haskell-Thompson,339
-Bronx,83062,State Senate,SD36,Dem,Ruth Haskell-Thompson,283
-Bronx,83063,State Senate,SD36,Dem,Ruth Haskell-Thompson,284
-Bronx,83064,State Senate,SD36,Dem,Ruth Haskell-Thompson,389
-Bronx,83065,State Senate,SD36,Dem,Ruth Haskell-Thompson,347
-Bronx,83066,State Senate,SD36,Dem,Ruth Haskell-Thompson,510
-Bronx,83067,State Senate,SD36,Dem,Ruth Haskell-Thompson,607
-Bronx,83069,State Senate,SD36,Dem,Ruth Haskell-Thompson,661
-Bronx,83070,State Senate,SD36,Dem,Ruth Haskell-Thompson,508
-Bronx,83071,State Senate,SD36,Dem,Ruth Haskell-Thompson,524
-Bronx,83072,State Senate,SD36,Dem,Ruth Haskell-Thompson,361
-Bronx,83073,State Senate,SD36,Dem,Ruth Haskell-Thompson,495
-Bronx,83074,State Senate,SD36,Dem,Ruth Haskell-Thompson,475
-Bronx,83075,State Senate,SD36,Dem,Ruth Haskell-Thompson,511
-Bronx,83076,State Senate,SD36,Dem,Ruth Haskell-Thompson,495
-Bronx,83077,State Senate,SD36,Dem,Ruth Haskell-Thompson,447
-Bronx,83078,State Senate,SD36,Dem,Ruth Haskell-Thompson,357
-Bronx,83079,State Senate,SD36,Dem,Ruth Haskell-Thompson,404
-Bronx,83080,State Senate,SD36,Dem,Ruth Haskell-Thompson,441
-Bronx,83081,State Senate,SD36,Dem,Ruth Haskell-Thompson,547
-Bronx,83082,State Senate,SD36,Dem,Ruth Haskell-Thompson,645
-Bronx,83083,State Senate,SD36,Dem,Ruth Haskell-Thompson,438
-Bronx,83084,State Senate,SD36,Dem,Ruth Haskell-Thompson,16
-Bronx,83085,State Senate,SD36,Dem,Ruth Haskell-Thompson,202
-Bronx,83086,State Senate,SD36,Dem,Ruth Haskell-Thompson,234
-Bronx,83087,State Senate,SD36,Dem,Ruth Haskell-Thompson,55
-Bronx,78032,State Senate,SD36,Ind,writein,0
-Bronx,78033,State Senate,SD36,Ind,writein,0
-Bronx,78034,State Senate,SD36,Ind,writein,1
-Bronx,78035,State Senate,SD36,Ind,writein,0
-Bronx,80052,State Senate,SD36,Ind,writein,0
-Bronx,80053,State Senate,SD36,Ind,writein,0
-Bronx,80054,State Senate,SD36,Ind,writein,0
-Bronx,80055,State Senate,SD36,Ind,writein,0
-Bronx,80056,State Senate,SD36,Ind,writein,0
-Bronx,80057,State Senate,SD36,Ind,writein,0
-Bronx,80058,State Senate,SD36,Ind,writein,0
-Bronx,80059,State Senate,SD36,Ind,writein,0
-Bronx,80060,State Senate,SD36,Ind,writein,0
-Bronx,80061,State Senate,SD36,Ind,writein,0
-Bronx,80062,State Senate,SD36,Ind,writein,1
-Bronx,80063,State Senate,SD36,Ind,writein,0
-Bronx,80064,State Senate,SD36,Ind,writein,0
-Bronx,80065,State Senate,SD36,Ind,writein,1
-Bronx,80070,State Senate,SD36,Ind,writein,0
-Bronx,80071,State Senate,SD36,Ind,writein,0
-Bronx,80072,State Senate,SD36,Ind,writein,0
-Bronx,80073,State Senate,SD36,Ind,writein,0
-Bronx,80075,State Senate,SD36,Ind,writein,0
-Bronx,80076,State Senate,SD36,Ind,writein,0
-Bronx,80077,State Senate,SD36,Ind,writein,0
-Bronx,80078,State Senate,SD36,Ind,writein,0
-Bronx,80079,State Senate,SD36,Ind,writein,0
-Bronx,80080,State Senate,SD36,Ind,writein,0
-Bronx,80081,State Senate,SD36,Ind,writein,0
-Bronx,80082,State Senate,SD36,Ind,writein,0
-Bronx,80083,State Senate,SD36,Ind,writein,1
-Bronx,80084,State Senate,SD36,Ind,writein,0
-Bronx,80085,State Senate,SD36,Ind,writein,0
-Bronx,80086,State Senate,SD36,Ind,writein,0
-Bronx,80087,State Senate,SD36,Ind,writein,0
-Bronx,80089,State Senate,SD36,Ind,writein,1
-Bronx,80090,State Senate,SD36,Ind,writein,0
-Bronx,80091,State Senate,SD36,Ind,writein,1
-Bronx,80092,State Senate,SD36,Ind,writein,0
-Bronx,80093,State Senate,SD36,Ind,writein,0
-Bronx,80094,State Senate,SD36,Ind,writein,1
-Bronx,81017,State Senate,SD36,Ind,writein,1
-Bronx,81018,State Senate,SD36,Ind,writein,0
-Bronx,81019,State Senate,SD36,Ind,writein,0
-Bronx,81020,State Senate,SD36,Ind,writein,0
-Bronx,81021,State Senate,SD36,Ind,writein,1
-Bronx,81022,State Senate,SD36,Ind,writein,0
-Bronx,81023,State Senate,SD36,Ind,writein,0
-Bronx,81024,State Senate,SD36,Ind,writein,0
-Bronx,81092,State Senate,SD36,Ind,writein,0
-Bronx,81093,State Senate,SD36,Ind,writein,0
-Bronx,81094,State Senate,SD36,Ind,writein,0
-Bronx,81095,State Senate,SD36,Ind,writein,0
-Bronx,81096,State Senate,SD36,Ind,writein,0
-Bronx,81097,State Senate,SD36,Ind,writein,0
-Bronx,81098,State Senate,SD36,Ind,writein,0
-Bronx,81099,State Senate,SD36,Ind,writein,2
-Bronx,81100,State Senate,SD36,Ind,writein,0
-Bronx,81102,State Senate,SD36,Ind,writein,0
-Bronx,82054,State Senate,SD36,Ind,writein,0
-Bronx,82065,State Senate,SD36,Ind,writein,0
-Bronx,82066,State Senate,SD36,Ind,writein,0
-Bronx,82067,State Senate,SD36,Ind,writein,0
-Bronx,82068,State Senate,SD36,Ind,writein,0
-Bronx,82069,State Senate,SD36,Ind,writein,0
-Bronx,82070,State Senate,SD36,Ind,writein,1
-Bronx,82071,State Senate,SD36,Ind,writein,0
-Bronx,82072,State Senate,SD36,Ind,writein,0
-Bronx,82073,State Senate,SD36,Ind,writein,0
-Bronx,82074,State Senate,SD36,Ind,writein,0
-Bronx,82075,State Senate,SD36,Ind,writein,0
-Bronx,82076,State Senate,SD36,Ind,writein,0
-Bronx,82077,State Senate,SD36,Ind,writein,0
-Bronx,82078,State Senate,SD36,Ind,writein,0
-Bronx,82079,State Senate,SD36,Ind,writein,0
-Bronx,82080,State Senate,SD36,Ind,writein,0
-Bronx,82081,State Senate,SD36,Ind,writein,0
-Bronx,82082,State Senate,SD36,Ind,writein,0
-Bronx,82083,State Senate,SD36,Ind,writein,0
-Bronx,82084,State Senate,SD36,Ind,writein,0
-Bronx,82085,State Senate,SD36,Ind,writein,0
-Bronx,82086,State Senate,SD36,Ind,writein,0
-Bronx,82087,State Senate,SD36,Ind,writein,0
-Bronx,82088,State Senate,SD36,Ind,writein,0
-Bronx,82089,State Senate,SD36,Ind,writein,0
-Bronx,82090,State Senate,SD36,Ind,writein,0
-Bronx,82091,State Senate,SD36,Ind,writein,0
-Bronx,82092,State Senate,SD36,Ind,writein,0
-Bronx,82093,State Senate,SD36,Ind,writein,0
-Bronx,82094,State Senate,SD36,Ind,writein,0
-Bronx,82095,State Senate,SD36,Ind,writein,1
-Bronx,82096,State Senate,SD36,Ind,writein,0
-Bronx,82097,State Senate,SD36,Ind,writein,0
-Bronx,82098,State Senate,SD36,Ind,writein,0
-Bronx,82099,State Senate,SD36,Ind,writein,0
-Bronx,82100,State Senate,SD36,Ind,writein,0
-Bronx,82101,State Senate,SD36,Ind,writein,0
-Bronx,82102,State Senate,SD36,Ind,writein,0
-Bronx,82103,State Senate,SD36,Ind,writein,0
-Bronx,82104,State Senate,SD36,Ind,writein,0
-Bronx,82105,State Senate,SD36,Ind,writein,0
-Bronx,82117,State Senate,SD36,Ind,writein,0
-Bronx,83001,State Senate,SD36,Ind,writein,0
-Bronx,83002,State Senate,SD36,Ind,writein,0
-Bronx,83003,State Senate,SD36,Ind,writein,0
-Bronx,83004,State Senate,SD36,Ind,writein,0
-Bronx,83005,State Senate,SD36,Ind,writein,0
-Bronx,83006,State Senate,SD36,Ind,writein,0
-Bronx,83007,State Senate,SD36,Ind,writein,0
-Bronx,83008,State Senate,SD36,Ind,writein,0
-Bronx,83009,State Senate,SD36,Ind,writein,0
-Bronx,83010,State Senate,SD36,Ind,writein,0
-Bronx,83011,State Senate,SD36,Ind,writein,0
-Bronx,83013,State Senate,SD36,Ind,writein,0
-Bronx,83014,State Senate,SD36,Ind,writein,0
-Bronx,83015,State Senate,SD36,Ind,writein,0
-Bronx,83016,State Senate,SD36,Ind,writein,0
-Bronx,83017,State Senate,SD36,Ind,writein,0
-Bronx,83018,State Senate,SD36,Ind,writein,0
-Bronx,83019,State Senate,SD36,Ind,writein,0
-Bronx,83020,State Senate,SD36,Ind,writein,0
-Bronx,83021,State Senate,SD36,Ind,writein,0
-Bronx,83022,State Senate,SD36,Ind,writein,0
-Bronx,83023,State Senate,SD36,Ind,writein,0
-Bronx,83024,State Senate,SD36,Ind,writein,0
-Bronx,83025,State Senate,SD36,Ind,writein,0
-Bronx,83026,State Senate,SD36,Ind,writein,0
-Bronx,83027,State Senate,SD36,Ind,writein,0
-Bronx,83028,State Senate,SD36,Ind,writein,0
-Bronx,83029,State Senate,SD36,Ind,writein,0
-Bronx,83030,State Senate,SD36,Ind,writein,0
-Bronx,83031,State Senate,SD36,Ind,writein,0
-Bronx,83032,State Senate,SD36,Ind,writein,0
-Bronx,83033,State Senate,SD36,Ind,writein,0
-Bronx,83034,State Senate,SD36,Ind,writein,0
-Bronx,83035,State Senate,SD36,Ind,writein,0
-Bronx,83036,State Senate,SD36,Ind,writein,0
-Bronx,83037,State Senate,SD36,Ind,writein,0
-Bronx,83038,State Senate,SD36,Ind,writein,0
-Bronx,83039,State Senate,SD36,Ind,writein,0
-Bronx,83040,State Senate,SD36,Ind,writein,0
-Bronx,83041,State Senate,SD36,Ind,writein,0
-Bronx,83042,State Senate,SD36,Ind,writein,0
-Bronx,83043,State Senate,SD36,Ind,writein,0
-Bronx,83044,State Senate,SD36,Ind,writein,0
-Bronx,83045,State Senate,SD36,Ind,writein,0
-Bronx,83046,State Senate,SD36,Ind,writein,0
-Bronx,83047,State Senate,SD36,Ind,writein,0
-Bronx,83048,State Senate,SD36,Ind,writein,0
-Bronx,83049,State Senate,SD36,Ind,writein,0
-Bronx,83050,State Senate,SD36,Ind,writein,0
-Bronx,83051,State Senate,SD36,Ind,writein,0
-Bronx,83052,State Senate,SD36,Ind,writein,0
-Bronx,83053,State Senate,SD36,Ind,writein,0
-Bronx,83054,State Senate,SD36,Ind,writein,0
-Bronx,83055,State Senate,SD36,Ind,writein,0
-Bronx,83056,State Senate,SD36,Ind,writein,0
-Bronx,83057,State Senate,SD36,Ind,writein,0
-Bronx,83058,State Senate,SD36,Ind,writein,0
-Bronx,83059,State Senate,SD36,Ind,writein,0
-Bronx,83060,State Senate,SD36,Ind,writein,2
-Bronx,83061,State Senate,SD36,Ind,writein,0
-Bronx,83062,State Senate,SD36,Ind,writein,0
-Bronx,83063,State Senate,SD36,Ind,writein,0
-Bronx,83064,State Senate,SD36,Ind,writein,0
-Bronx,83065,State Senate,SD36,Ind,writein,0
-Bronx,83066,State Senate,SD36,Ind,writein,0
-Bronx,83067,State Senate,SD36,Ind,writein,0
-Bronx,83069,State Senate,SD36,Ind,writein,1
-Bronx,83070,State Senate,SD36,Ind,writein,1
-Bronx,83071,State Senate,SD36,Ind,writein,0
-Bronx,83072,State Senate,SD36,Ind,writein,0
-Bronx,83073,State Senate,SD36,Ind,writein,0
-Bronx,83074,State Senate,SD36,Ind,writein,0
-Bronx,83075,State Senate,SD36,Ind,writein,0
-Bronx,83076,State Senate,SD36,Ind,writein,0
-Bronx,83077,State Senate,SD36,Ind,writein,0
-Bronx,83078,State Senate,SD36,Ind,writein,0
-Bronx,83079,State Senate,SD36,Ind,writein,0
-Bronx,83080,State Senate,SD36,Ind,writein,0
-Bronx,83081,State Senate,SD36,Ind,writein,0
-Bronx,83082,State Senate,SD36,Ind,writein,0
-Bronx,83083,State Senate,SD36,Ind,writein,0
-Bronx,83084,State Senate,SD36,Ind,writein,0
-Bronx,83085,State Senate,SD36,Ind,writein,0
-Bronx,83086,State Senate,SD36,Ind,writein,0
-Bronx,83087,State Senate,SD36,Ind,writein,0
+Bronx,77001,State Senate,29,Dem,Jose Serrano,48
+Bronx,77002,State Senate,29,Dem,Jose Serrano,357
+Bronx,77003,State Senate,29,Dem,Jose Serrano,534
+Bronx,77004,State Senate,29,Dem,Jose Serrano,507
+Bronx,77005,State Senate,29,Dem,Jose Serrano,585
+Bronx,77006,State Senate,29,Dem,Jose Serrano,450
+Bronx,77007,State Senate,29,Dem,Jose Serrano,581
+Bronx,77008,State Senate,29,Dem,Jose Serrano,510
+Bronx,77009,State Senate,29,Dem,Jose Serrano,577
+Bronx,77010,State Senate,29,Dem,Jose Serrano,719
+Bronx,77011,State Senate,29,Dem,Jose Serrano,484
+Bronx,77012,State Senate,29,Dem,Jose Serrano,286
+Bronx,77013,State Senate,29,Dem,Jose Serrano,531
+Bronx,77014,State Senate,29,Dem,Jose Serrano,583
+Bronx,77015,State Senate,29,Dem,Jose Serrano,544
+Bronx,77016,State Senate,29,Dem,Jose Serrano,565
+Bronx,77017,State Senate,29,Dem,Jose Serrano,67
+Bronx,77018,State Senate,29,Dem,Jose Serrano,458
+Bronx,77019,State Senate,29,Dem,Jose Serrano,284
+Bronx,77020,State Senate,29,Dem,Jose Serrano,458
+Bronx,77021,State Senate,29,Dem,Jose Serrano,543
+Bronx,77022,State Senate,29,Dem,Jose Serrano,261
+Bronx,77023,State Senate,29,Dem,Jose Serrano,457
+Bronx,77024,State Senate,29,Dem,Jose Serrano,430
+Bronx,77025,State Senate,29,Dem,Jose Serrano,580
+Bronx,77026,State Senate,29,Dem,Jose Serrano,267
+Bronx,77027,State Senate,29,Dem,Jose Serrano,419
+Bronx,77028,State Senate,29,Dem,Jose Serrano,425
+Bronx,77032,State Senate,29,Dem,Jose Serrano,70
+Bronx,77034,State Senate,29,Dem,Jose Serrano,507
+Bronx,77035,State Senate,29,Dem,Jose Serrano,504
+Bronx,77036,State Senate,29,Dem,Jose Serrano,263
+Bronx,77040,State Senate,29,Dem,Jose Serrano,442
+Bronx,77041,State Senate,29,Dem,Jose Serrano,289
+Bronx,77046,State Senate,29,Dem,Jose Serrano,426
+Bronx,77047,State Senate,29,Dem,Jose Serrano,611
+Bronx,77048,State Senate,29,Dem,Jose Serrano,423
+Bronx,77049,State Senate,29,Dem,Jose Serrano,146
+Bronx,77061,State Senate,29,Dem,Jose Serrano,127
+Bronx,77065,State Senate,29,Dem,Jose Serrano,536
+Bronx,77066,State Senate,29,Dem,Jose Serrano,0
+Bronx,79067,State Senate,29,Dem,Jose Serrano,0
+Bronx,84001,State Senate,29,Dem,Jose Serrano,416
+Bronx,84002,State Senate,29,Dem,Jose Serrano,108
+Bronx,84003,State Senate,29,Dem,Jose Serrano,416
+Bronx,84004,State Senate,29,Dem,Jose Serrano,404
+Bronx,84005,State Senate,29,Dem,Jose Serrano,536
+Bronx,84006,State Senate,29,Dem,Jose Serrano,600
+Bronx,84007,State Senate,29,Dem,Jose Serrano,427
+Bronx,84008,State Senate,29,Dem,Jose Serrano,543
+Bronx,84009,State Senate,29,Dem,Jose Serrano,318
+Bronx,84010,State Senate,29,Dem,Jose Serrano,441
+Bronx,84011,State Senate,29,Dem,Jose Serrano,403
+Bronx,84012,State Senate,29,Dem,Jose Serrano,186
+Bronx,84013,State Senate,29,Dem,Jose Serrano,507
+Bronx,84014,State Senate,29,Dem,Jose Serrano,410
+Bronx,84015,State Senate,29,Dem,Jose Serrano,242
+Bronx,84016,State Senate,29,Dem,Jose Serrano,426
+Bronx,84017,State Senate,29,Dem,Jose Serrano,270
+Bronx,84018,State Senate,29,Dem,Jose Serrano,91
+Bronx,84019,State Senate,29,Dem,Jose Serrano,411
+Bronx,84020,State Senate,29,Dem,Jose Serrano,228
+Bronx,84021,State Senate,29,Dem,Jose Serrano,50
+Bronx,84022,State Senate,29,Dem,Jose Serrano,72
+Bronx,84023,State Senate,29,Dem,Jose Serrano,418
+Bronx,84024,State Senate,29,Dem,Jose Serrano,501
+Bronx,84025,State Senate,29,Dem,Jose Serrano,284
+Bronx,84026,State Senate,29,Dem,Jose Serrano,294
+Bronx,84027,State Senate,29,Dem,Jose Serrano,273
+Bronx,84028,State Senate,29,Dem,Jose Serrano,423
+Bronx,84029,State Senate,29,Dem,Jose Serrano,162
+Bronx,84030,State Senate,29,Dem,Jose Serrano,274
+Bronx,84031,State Senate,29,Dem,Jose Serrano,241
+Bronx,84032,State Senate,29,Dem,Jose Serrano,248
+Bronx,84033,State Senate,29,Dem,Jose Serrano,322
+Bronx,84034,State Senate,29,Dem,Jose Serrano,544
+Bronx,84035,State Senate,29,Dem,Jose Serrano,297
+Bronx,84040,State Senate,29,Dem,Jose Serrano,394
+Bronx,84041,State Senate,29,Dem,Jose Serrano,371
+Bronx,84042,State Senate,29,Dem,Jose Serrano,428
+Bronx,84043,State Senate,29,Dem,Jose Serrano,329
+Bronx,84044,State Senate,29,Dem,Jose Serrano,362
+Bronx,84045,State Senate,29,Dem,Jose Serrano,321
+Bronx,84046,State Senate,29,Dem,Jose Serrano,260
+Bronx,84047,State Senate,29,Dem,Jose Serrano,137
+Bronx,84054,State Senate,29,Dem,Jose Serrano,428
+Bronx,84055,State Senate,29,Dem,Jose Serrano,383
+Bronx,84056,State Senate,29,Dem,Jose Serrano,340
+Bronx,84057,State Senate,29,Dem,Jose Serrano,360
+Bronx,84058,State Senate,29,Dem,Jose Serrano,354
+Bronx,84059,State Senate,29,Dem,Jose Serrano,383
+Bronx,84060,State Senate,29,Dem,Jose Serrano,339
+Bronx,84061,State Senate,29,Dem,Jose Serrano,345
+Bronx,84062,State Senate,29,Dem,Jose Serrano,320
+Bronx,84063,State Senate,29,Dem,Jose Serrano,338
+Bronx,84064,State Senate,29,Dem,Jose Serrano,473
+Bronx,84065,State Senate,29,Dem,Jose Serrano,308
+Bronx,84066,State Senate,29,Dem,Jose Serrano,366
+Bronx,84067,State Senate,29,Dem,Jose Serrano,327
+Bronx,84068,State Senate,29,Dem,Jose Serrano,328
+Bronx,84069,State Senate,29,Dem,Jose Serrano,165
+Bronx,84070,State Senate,29,Dem,Jose Serrano,170
+Bronx,84071,State Senate,29,Dem,Jose Serrano,374
+Bronx,84072,State Senate,29,Dem,Jose Serrano,439
+Bronx,84080,State Senate,29,Dem,Jose Serrano,388
+Bronx,86001,State Senate,29,Dem,Jose Serrano,474
+Bronx,86002,State Senate,29,Dem,Jose Serrano,431
+Bronx,86003,State Senate,29,Dem,Jose Serrano,550
+Bronx,86004,State Senate,29,Dem,Jose Serrano,268
+Bronx,86005,State Senate,29,Dem,Jose Serrano,227
+Bronx,86006,State Senate,29,Dem,Jose Serrano,315
+Bronx,86007,State Senate,29,Dem,Jose Serrano,326
+Bronx,77001,State Senate,29,WF,Jose Serrano,1
+Bronx,77002,State Senate,29,WF,Jose Serrano,7
+Bronx,77003,State Senate,29,WF,Jose Serrano,3
+Bronx,77004,State Senate,29,WF,Jose Serrano,8
+Bronx,77005,State Senate,29,WF,Jose Serrano,5
+Bronx,77006,State Senate,29,WF,Jose Serrano,2
+Bronx,77007,State Senate,29,WF,Jose Serrano,3
+Bronx,77008,State Senate,29,WF,Jose Serrano,4
+Bronx,77009,State Senate,29,WF,Jose Serrano,3
+Bronx,77010,State Senate,29,WF,Jose Serrano,4
+Bronx,77011,State Senate,29,WF,Jose Serrano,3
+Bronx,77012,State Senate,29,WF,Jose Serrano,6
+Bronx,77013,State Senate,29,WF,Jose Serrano,5
+Bronx,77014,State Senate,29,WF,Jose Serrano,6
+Bronx,77015,State Senate,29,WF,Jose Serrano,11
+Bronx,77016,State Senate,29,WF,Jose Serrano,9
+Bronx,77017,State Senate,29,WF,Jose Serrano,0
+Bronx,77018,State Senate,29,WF,Jose Serrano,2
+Bronx,77019,State Senate,29,WF,Jose Serrano,4
+Bronx,77020,State Senate,29,WF,Jose Serrano,2
+Bronx,77021,State Senate,29,WF,Jose Serrano,2
+Bronx,77022,State Senate,29,WF,Jose Serrano,1
+Bronx,77023,State Senate,29,WF,Jose Serrano,4
+Bronx,77024,State Senate,29,WF,Jose Serrano,2
+Bronx,77025,State Senate,29,WF,Jose Serrano,6
+Bronx,77026,State Senate,29,WF,Jose Serrano,9
+Bronx,77027,State Senate,29,WF,Jose Serrano,4
+Bronx,77028,State Senate,29,WF,Jose Serrano,12
+Bronx,77032,State Senate,29,WF,Jose Serrano,4
+Bronx,77034,State Senate,29,WF,Jose Serrano,1
+Bronx,77035,State Senate,29,WF,Jose Serrano,2
+Bronx,77036,State Senate,29,WF,Jose Serrano,1
+Bronx,77040,State Senate,29,WF,Jose Serrano,9
+Bronx,77041,State Senate,29,WF,Jose Serrano,4
+Bronx,77046,State Senate,29,WF,Jose Serrano,10
+Bronx,77047,State Senate,29,WF,Jose Serrano,6
+Bronx,77048,State Senate,29,WF,Jose Serrano,5
+Bronx,77049,State Senate,29,WF,Jose Serrano,2
+Bronx,77061,State Senate,29,WF,Jose Serrano,1
+Bronx,77065,State Senate,29,WF,Jose Serrano,8
+Bronx,77066,State Senate,29,WF,Jose Serrano,0
+Bronx,79067,State Senate,29,WF,Jose Serrano,0
+Bronx,84001,State Senate,29,WF,Jose Serrano,5
+Bronx,84002,State Senate,29,WF,Jose Serrano,0
+Bronx,84003,State Senate,29,WF,Jose Serrano,5
+Bronx,84004,State Senate,29,WF,Jose Serrano,7
+Bronx,84005,State Senate,29,WF,Jose Serrano,6
+Bronx,84006,State Senate,29,WF,Jose Serrano,3
+Bronx,84007,State Senate,29,WF,Jose Serrano,4
+Bronx,84008,State Senate,29,WF,Jose Serrano,7
+Bronx,84009,State Senate,29,WF,Jose Serrano,5
+Bronx,84010,State Senate,29,WF,Jose Serrano,11
+Bronx,84011,State Senate,29,WF,Jose Serrano,2
+Bronx,84012,State Senate,29,WF,Jose Serrano,3
+Bronx,84013,State Senate,29,WF,Jose Serrano,6
+Bronx,84014,State Senate,29,WF,Jose Serrano,12
+Bronx,84015,State Senate,29,WF,Jose Serrano,5
+Bronx,84016,State Senate,29,WF,Jose Serrano,4
+Bronx,84017,State Senate,29,WF,Jose Serrano,5
+Bronx,84018,State Senate,29,WF,Jose Serrano,0
+Bronx,84019,State Senate,29,WF,Jose Serrano,9
+Bronx,84020,State Senate,29,WF,Jose Serrano,6
+Bronx,84021,State Senate,29,WF,Jose Serrano,3
+Bronx,84022,State Senate,29,WF,Jose Serrano,1
+Bronx,84023,State Senate,29,WF,Jose Serrano,7
+Bronx,84024,State Senate,29,WF,Jose Serrano,4
+Bronx,84025,State Senate,29,WF,Jose Serrano,9
+Bronx,84026,State Senate,29,WF,Jose Serrano,4
+Bronx,84027,State Senate,29,WF,Jose Serrano,10
+Bronx,84028,State Senate,29,WF,Jose Serrano,9
+Bronx,84029,State Senate,29,WF,Jose Serrano,1
+Bronx,84030,State Senate,29,WF,Jose Serrano,4
+Bronx,84031,State Senate,29,WF,Jose Serrano,2
+Bronx,84032,State Senate,29,WF,Jose Serrano,2
+Bronx,84033,State Senate,29,WF,Jose Serrano,5
+Bronx,84034,State Senate,29,WF,Jose Serrano,14
+Bronx,84035,State Senate,29,WF,Jose Serrano,5
+Bronx,84040,State Senate,29,WF,Jose Serrano,2
+Bronx,84041,State Senate,29,WF,Jose Serrano,4
+Bronx,84042,State Senate,29,WF,Jose Serrano,4
+Bronx,84043,State Senate,29,WF,Jose Serrano,5
+Bronx,84044,State Senate,29,WF,Jose Serrano,10
+Bronx,84045,State Senate,29,WF,Jose Serrano,9
+Bronx,84046,State Senate,29,WF,Jose Serrano,1
+Bronx,84047,State Senate,29,WF,Jose Serrano,2
+Bronx,84054,State Senate,29,WF,Jose Serrano,5
+Bronx,84055,State Senate,29,WF,Jose Serrano,6
+Bronx,84056,State Senate,29,WF,Jose Serrano,11
+Bronx,84057,State Senate,29,WF,Jose Serrano,8
+Bronx,84058,State Senate,29,WF,Jose Serrano,5
+Bronx,84059,State Senate,29,WF,Jose Serrano,6
+Bronx,84060,State Senate,29,WF,Jose Serrano,7
+Bronx,84061,State Senate,29,WF,Jose Serrano,4
+Bronx,84062,State Senate,29,WF,Jose Serrano,10
+Bronx,84063,State Senate,29,WF,Jose Serrano,3
+Bronx,84064,State Senate,29,WF,Jose Serrano,2
+Bronx,84065,State Senate,29,WF,Jose Serrano,5
+Bronx,84066,State Senate,29,WF,Jose Serrano,3
+Bronx,84067,State Senate,29,WF,Jose Serrano,1
+Bronx,84068,State Senate,29,WF,Jose Serrano,2
+Bronx,84069,State Senate,29,WF,Jose Serrano,4
+Bronx,84070,State Senate,29,WF,Jose Serrano,4
+Bronx,84071,State Senate,29,WF,Jose Serrano,13
+Bronx,84072,State Senate,29,WF,Jose Serrano,12
+Bronx,84080,State Senate,29,WF,Jose Serrano,6
+Bronx,86001,State Senate,29,WF,Jose Serrano,4
+Bronx,86002,State Senate,29,WF,Jose Serrano,6
+Bronx,86003,State Senate,29,WF,Jose Serrano,3
+Bronx,86004,State Senate,29,WF,Jose Serrano,2
+Bronx,86005,State Senate,29,WF,Jose Serrano,0
+Bronx,86006,State Senate,29,WF,Jose Serrano,3
+Bronx,86007,State Senate,29,WF,Jose Serrano,17
+Bronx,77001,State Senate,29,Con,Robert Goodman,3
+Bronx,77002,State Senate,29,Con,Robert Goodman,2
+Bronx,77003,State Senate,29,Con,Robert Goodman,6
+Bronx,77004,State Senate,29,Con,Robert Goodman,5
+Bronx,77005,State Senate,29,Con,Robert Goodman,7
+Bronx,77006,State Senate,29,Con,Robert Goodman,5
+Bronx,77007,State Senate,29,Con,Robert Goodman,4
+Bronx,77008,State Senate,29,Con,Robert Goodman,3
+Bronx,77009,State Senate,29,Con,Robert Goodman,2
+Bronx,77010,State Senate,29,Con,Robert Goodman,5
+Bronx,77011,State Senate,29,Con,Robert Goodman,9
+Bronx,77012,State Senate,29,Con,Robert Goodman,2
+Bronx,77013,State Senate,29,Con,Robert Goodman,3
+Bronx,77014,State Senate,29,Con,Robert Goodman,4
+Bronx,77015,State Senate,29,Con,Robert Goodman,7
+Bronx,77016,State Senate,29,Con,Robert Goodman,4
+Bronx,77017,State Senate,29,Con,Robert Goodman,1
+Bronx,77018,State Senate,29,Con,Robert Goodman,7
+Bronx,77019,State Senate,29,Con,Robert Goodman,1
+Bronx,77020,State Senate,29,Con,Robert Goodman,3
+Bronx,77021,State Senate,29,Con,Robert Goodman,4
+Bronx,77022,State Senate,29,Con,Robert Goodman,0
+Bronx,77023,State Senate,29,Con,Robert Goodman,3
+Bronx,77024,State Senate,29,Con,Robert Goodman,1
+Bronx,77025,State Senate,29,Con,Robert Goodman,6
+Bronx,77026,State Senate,29,Con,Robert Goodman,4
+Bronx,77027,State Senate,29,Con,Robert Goodman,7
+Bronx,77028,State Senate,29,Con,Robert Goodman,8
+Bronx,77032,State Senate,29,Con,Robert Goodman,0
+Bronx,77034,State Senate,29,Con,Robert Goodman,2
+Bronx,77035,State Senate,29,Con,Robert Goodman,7
+Bronx,77036,State Senate,29,Con,Robert Goodman,10
+Bronx,77040,State Senate,29,Con,Robert Goodman,9
+Bronx,77041,State Senate,29,Con,Robert Goodman,0
+Bronx,77046,State Senate,29,Con,Robert Goodman,6
+Bronx,77047,State Senate,29,Con,Robert Goodman,5
+Bronx,77048,State Senate,29,Con,Robert Goodman,4
+Bronx,77049,State Senate,29,Con,Robert Goodman,2
+Bronx,77061,State Senate,29,Con,Robert Goodman,4
+Bronx,77065,State Senate,29,Con,Robert Goodman,4
+Bronx,77066,State Senate,29,Con,Robert Goodman,0
+Bronx,79067,State Senate,29,Con,Robert Goodman,0
+Bronx,84001,State Senate,29,Con,Robert Goodman,7
+Bronx,84002,State Senate,29,Con,Robert Goodman,0
+Bronx,84003,State Senate,29,Con,Robert Goodman,5
+Bronx,84004,State Senate,29,Con,Robert Goodman,2
+Bronx,84005,State Senate,29,Con,Robert Goodman,5
+Bronx,84006,State Senate,29,Con,Robert Goodman,7
+Bronx,84007,State Senate,29,Con,Robert Goodman,3
+Bronx,84008,State Senate,29,Con,Robert Goodman,3
+Bronx,84009,State Senate,29,Con,Robert Goodman,4
+Bronx,84010,State Senate,29,Con,Robert Goodman,3
+Bronx,84011,State Senate,29,Con,Robert Goodman,8
+Bronx,84012,State Senate,29,Con,Robert Goodman,3
+Bronx,84013,State Senate,29,Con,Robert Goodman,6
+Bronx,84014,State Senate,29,Con,Robert Goodman,13
+Bronx,84015,State Senate,29,Con,Robert Goodman,2
+Bronx,84016,State Senate,29,Con,Robert Goodman,4
+Bronx,84017,State Senate,29,Con,Robert Goodman,7
+Bronx,84018,State Senate,29,Con,Robert Goodman,1
+Bronx,84019,State Senate,29,Con,Robert Goodman,4
+Bronx,84020,State Senate,29,Con,Robert Goodman,9
+Bronx,84021,State Senate,29,Con,Robert Goodman,1
+Bronx,84022,State Senate,29,Con,Robert Goodman,5
+Bronx,84023,State Senate,29,Con,Robert Goodman,5
+Bronx,84024,State Senate,29,Con,Robert Goodman,7
+Bronx,84025,State Senate,29,Con,Robert Goodman,8
+Bronx,84026,State Senate,29,Con,Robert Goodman,3
+Bronx,84027,State Senate,29,Con,Robert Goodman,3
+Bronx,84028,State Senate,29,Con,Robert Goodman,5
+Bronx,84029,State Senate,29,Con,Robert Goodman,0
+Bronx,84030,State Senate,29,Con,Robert Goodman,5
+Bronx,84031,State Senate,29,Con,Robert Goodman,2
+Bronx,84032,State Senate,29,Con,Robert Goodman,0
+Bronx,84033,State Senate,29,Con,Robert Goodman,6
+Bronx,84034,State Senate,29,Con,Robert Goodman,10
+Bronx,84035,State Senate,29,Con,Robert Goodman,9
+Bronx,84040,State Senate,29,Con,Robert Goodman,6
+Bronx,84041,State Senate,29,Con,Robert Goodman,3
+Bronx,84042,State Senate,29,Con,Robert Goodman,3
+Bronx,84043,State Senate,29,Con,Robert Goodman,3
+Bronx,84044,State Senate,29,Con,Robert Goodman,6
+Bronx,84045,State Senate,29,Con,Robert Goodman,2
+Bronx,84046,State Senate,29,Con,Robert Goodman,6
+Bronx,84047,State Senate,29,Con,Robert Goodman,3
+Bronx,84054,State Senate,29,Con,Robert Goodman,8
+Bronx,84055,State Senate,29,Con,Robert Goodman,6
+Bronx,84056,State Senate,29,Con,Robert Goodman,6
+Bronx,84057,State Senate,29,Con,Robert Goodman,11
+Bronx,84058,State Senate,29,Con,Robert Goodman,10
+Bronx,84059,State Senate,29,Con,Robert Goodman,5
+Bronx,84060,State Senate,29,Con,Robert Goodman,3
+Bronx,84061,State Senate,29,Con,Robert Goodman,2
+Bronx,84062,State Senate,29,Con,Robert Goodman,5
+Bronx,84063,State Senate,29,Con,Robert Goodman,2
+Bronx,84064,State Senate,29,Con,Robert Goodman,14
+Bronx,84065,State Senate,29,Con,Robert Goodman,2
+Bronx,84066,State Senate,29,Con,Robert Goodman,7
+Bronx,84067,State Senate,29,Con,Robert Goodman,2
+Bronx,84068,State Senate,29,Con,Robert Goodman,4
+Bronx,84069,State Senate,29,Con,Robert Goodman,5
+Bronx,84070,State Senate,29,Con,Robert Goodman,1
+Bronx,84071,State Senate,29,Con,Robert Goodman,15
+Bronx,84072,State Senate,29,Con,Robert Goodman,6
+Bronx,84080,State Senate,29,Con,Robert Goodman,5
+Bronx,86001,State Senate,29,Con,Robert Goodman,1
+Bronx,86002,State Senate,29,Con,Robert Goodman,7
+Bronx,86003,State Senate,29,Con,Robert Goodman,4
+Bronx,86004,State Senate,29,Con,Robert Goodman,4
+Bronx,86005,State Senate,29,Con,Robert Goodman,3
+Bronx,86006,State Senate,29,Con,Robert Goodman,2
+Bronx,86007,State Senate,29,Con,Robert Goodman,7
+Bronx,77001,State Senate,29,Green,Thomas Siracuse,1
+Bronx,77002,State Senate,29,Green,Thomas Siracuse,0
+Bronx,77003,State Senate,29,Green,Thomas Siracuse,0
+Bronx,77004,State Senate,29,Green,Thomas Siracuse,4
+Bronx,77005,State Senate,29,Green,Thomas Siracuse,2
+Bronx,77006,State Senate,29,Green,Thomas Siracuse,3
+Bronx,77007,State Senate,29,Green,Thomas Siracuse,0
+Bronx,77008,State Senate,29,Green,Thomas Siracuse,1
+Bronx,77009,State Senate,29,Green,Thomas Siracuse,2
+Bronx,77010,State Senate,29,Green,Thomas Siracuse,0
+Bronx,77011,State Senate,29,Green,Thomas Siracuse,2
+Bronx,77012,State Senate,29,Green,Thomas Siracuse,0
+Bronx,77013,State Senate,29,Green,Thomas Siracuse,1
+Bronx,77014,State Senate,29,Green,Thomas Siracuse,1
+Bronx,77015,State Senate,29,Green,Thomas Siracuse,2
+Bronx,77016,State Senate,29,Green,Thomas Siracuse,0
+Bronx,77017,State Senate,29,Green,Thomas Siracuse,0
+Bronx,77018,State Senate,29,Green,Thomas Siracuse,2
+Bronx,77019,State Senate,29,Green,Thomas Siracuse,1
+Bronx,77020,State Senate,29,Green,Thomas Siracuse,1
+Bronx,77021,State Senate,29,Green,Thomas Siracuse,2
+Bronx,77022,State Senate,29,Green,Thomas Siracuse,1
+Bronx,77023,State Senate,29,Green,Thomas Siracuse,0
+Bronx,77024,State Senate,29,Green,Thomas Siracuse,5
+Bronx,77025,State Senate,29,Green,Thomas Siracuse,2
+Bronx,77026,State Senate,29,Green,Thomas Siracuse,0
+Bronx,77027,State Senate,29,Green,Thomas Siracuse,2
+Bronx,77028,State Senate,29,Green,Thomas Siracuse,3
+Bronx,77032,State Senate,29,Green,Thomas Siracuse,1
+Bronx,77034,State Senate,29,Green,Thomas Siracuse,1
+Bronx,77035,State Senate,29,Green,Thomas Siracuse,0
+Bronx,77036,State Senate,29,Green,Thomas Siracuse,0
+Bronx,77040,State Senate,29,Green,Thomas Siracuse,2
+Bronx,77041,State Senate,29,Green,Thomas Siracuse,0
+Bronx,77046,State Senate,29,Green,Thomas Siracuse,2
+Bronx,77047,State Senate,29,Green,Thomas Siracuse,3
+Bronx,77048,State Senate,29,Green,Thomas Siracuse,4
+Bronx,77049,State Senate,29,Green,Thomas Siracuse,0
+Bronx,77061,State Senate,29,Green,Thomas Siracuse,0
+Bronx,77065,State Senate,29,Green,Thomas Siracuse,0
+Bronx,77066,State Senate,29,Green,Thomas Siracuse,0
+Bronx,79067,State Senate,29,Green,Thomas Siracuse,0
+Bronx,84001,State Senate,29,Green,Thomas Siracuse,2
+Bronx,84002,State Senate,29,Green,Thomas Siracuse,0
+Bronx,84003,State Senate,29,Green,Thomas Siracuse,3
+Bronx,84004,State Senate,29,Green,Thomas Siracuse,2
+Bronx,84005,State Senate,29,Green,Thomas Siracuse,3
+Bronx,84006,State Senate,29,Green,Thomas Siracuse,1
+Bronx,84007,State Senate,29,Green,Thomas Siracuse,2
+Bronx,84008,State Senate,29,Green,Thomas Siracuse,3
+Bronx,84009,State Senate,29,Green,Thomas Siracuse,0
+Bronx,84010,State Senate,29,Green,Thomas Siracuse,4
+Bronx,84011,State Senate,29,Green,Thomas Siracuse,2
+Bronx,84012,State Senate,29,Green,Thomas Siracuse,0
+Bronx,84013,State Senate,29,Green,Thomas Siracuse,0
+Bronx,84014,State Senate,29,Green,Thomas Siracuse,5
+Bronx,84015,State Senate,29,Green,Thomas Siracuse,2
+Bronx,84016,State Senate,29,Green,Thomas Siracuse,3
+Bronx,84017,State Senate,29,Green,Thomas Siracuse,6
+Bronx,84018,State Senate,29,Green,Thomas Siracuse,1
+Bronx,84019,State Senate,29,Green,Thomas Siracuse,3
+Bronx,84020,State Senate,29,Green,Thomas Siracuse,7
+Bronx,84021,State Senate,29,Green,Thomas Siracuse,1
+Bronx,84022,State Senate,29,Green,Thomas Siracuse,1
+Bronx,84023,State Senate,29,Green,Thomas Siracuse,2
+Bronx,84024,State Senate,29,Green,Thomas Siracuse,1
+Bronx,84025,State Senate,29,Green,Thomas Siracuse,10
+Bronx,84026,State Senate,29,Green,Thomas Siracuse,1
+Bronx,84027,State Senate,29,Green,Thomas Siracuse,3
+Bronx,84028,State Senate,29,Green,Thomas Siracuse,1
+Bronx,84029,State Senate,29,Green,Thomas Siracuse,0
+Bronx,84030,State Senate,29,Green,Thomas Siracuse,0
+Bronx,84031,State Senate,29,Green,Thomas Siracuse,0
+Bronx,84032,State Senate,29,Green,Thomas Siracuse,0
+Bronx,84033,State Senate,29,Green,Thomas Siracuse,3
+Bronx,84034,State Senate,29,Green,Thomas Siracuse,1
+Bronx,84035,State Senate,29,Green,Thomas Siracuse,2
+Bronx,84040,State Senate,29,Green,Thomas Siracuse,3
+Bronx,84041,State Senate,29,Green,Thomas Siracuse,2
+Bronx,84042,State Senate,29,Green,Thomas Siracuse,3
+Bronx,84043,State Senate,29,Green,Thomas Siracuse,1
+Bronx,84044,State Senate,29,Green,Thomas Siracuse,1
+Bronx,84045,State Senate,29,Green,Thomas Siracuse,0
+Bronx,84046,State Senate,29,Green,Thomas Siracuse,0
+Bronx,84047,State Senate,29,Green,Thomas Siracuse,1
+Bronx,84054,State Senate,29,Green,Thomas Siracuse,4
+Bronx,84055,State Senate,29,Green,Thomas Siracuse,2
+Bronx,84056,State Senate,29,Green,Thomas Siracuse,3
+Bronx,84057,State Senate,29,Green,Thomas Siracuse,3
+Bronx,84058,State Senate,29,Green,Thomas Siracuse,2
+Bronx,84059,State Senate,29,Green,Thomas Siracuse,2
+Bronx,84060,State Senate,29,Green,Thomas Siracuse,3
+Bronx,84061,State Senate,29,Green,Thomas Siracuse,0
+Bronx,84062,State Senate,29,Green,Thomas Siracuse,1
+Bronx,84063,State Senate,29,Green,Thomas Siracuse,0
+Bronx,84064,State Senate,29,Green,Thomas Siracuse,3
+Bronx,84065,State Senate,29,Green,Thomas Siracuse,0
+Bronx,84066,State Senate,29,Green,Thomas Siracuse,2
+Bronx,84067,State Senate,29,Green,Thomas Siracuse,1
+Bronx,84068,State Senate,29,Green,Thomas Siracuse,1
+Bronx,84069,State Senate,29,Green,Thomas Siracuse,0
+Bronx,84070,State Senate,29,Green,Thomas Siracuse,2
+Bronx,84071,State Senate,29,Green,Thomas Siracuse,2
+Bronx,84072,State Senate,29,Green,Thomas Siracuse,0
+Bronx,84080,State Senate,29,Green,Thomas Siracuse,3
+Bronx,86001,State Senate,29,Green,Thomas Siracuse,2
+Bronx,86002,State Senate,29,Green,Thomas Siracuse,1
+Bronx,86003,State Senate,29,Green,Thomas Siracuse,3
+Bronx,86004,State Senate,29,Green,Thomas Siracuse,1
+Bronx,86005,State Senate,29,Green,Thomas Siracuse,0
+Bronx,86006,State Senate,29,Green,Thomas Siracuse,0
+Bronx,86007,State Senate,29,Green,Thomas Siracuse,2
+Bronx,77001,State Senate,29,Ind,writein,0
+Bronx,77002,State Senate,29,Ind,writein,0
+Bronx,77003,State Senate,29,Ind,writein,0
+Bronx,77004,State Senate,29,Ind,writein,0
+Bronx,77005,State Senate,29,Ind,writein,0
+Bronx,77006,State Senate,29,Ind,writein,0
+Bronx,77007,State Senate,29,Ind,writein,1
+Bronx,77008,State Senate,29,Ind,writein,0
+Bronx,77009,State Senate,29,Ind,writein,0
+Bronx,77010,State Senate,29,Ind,writein,0
+Bronx,77011,State Senate,29,Ind,writein,0
+Bronx,77012,State Senate,29,Ind,writein,0
+Bronx,77013,State Senate,29,Ind,writein,0
+Bronx,77014,State Senate,29,Ind,writein,0
+Bronx,77015,State Senate,29,Ind,writein,0
+Bronx,77016,State Senate,29,Ind,writein,0
+Bronx,77017,State Senate,29,Ind,writein,0
+Bronx,77018,State Senate,29,Ind,writein,0
+Bronx,77019,State Senate,29,Ind,writein,0
+Bronx,77020,State Senate,29,Ind,writein,0
+Bronx,77021,State Senate,29,Ind,writein,0
+Bronx,77022,State Senate,29,Ind,writein,0
+Bronx,77023,State Senate,29,Ind,writein,0
+Bronx,77024,State Senate,29,Ind,writein,0
+Bronx,77025,State Senate,29,Ind,writein,0
+Bronx,77026,State Senate,29,Ind,writein,0
+Bronx,77027,State Senate,29,Ind,writein,0
+Bronx,77028,State Senate,29,Ind,writein,0
+Bronx,77032,State Senate,29,Ind,writein,0
+Bronx,77034,State Senate,29,Ind,writein,0
+Bronx,77035,State Senate,29,Ind,writein,0
+Bronx,77036,State Senate,29,Ind,writein,0
+Bronx,77040,State Senate,29,Ind,writein,0
+Bronx,77041,State Senate,29,Ind,writein,0
+Bronx,77046,State Senate,29,Ind,writein,0
+Bronx,77047,State Senate,29,Ind,writein,0
+Bronx,77048,State Senate,29,Ind,writein,0
+Bronx,77049,State Senate,29,Ind,writein,0
+Bronx,77061,State Senate,29,Ind,writein,0
+Bronx,77065,State Senate,29,Ind,writein,0
+Bronx,77066,State Senate,29,Ind,writein,0
+Bronx,79067,State Senate,29,Ind,writein,0
+Bronx,84001,State Senate,29,Ind,writein,0
+Bronx,84002,State Senate,29,Ind,writein,0
+Bronx,84003,State Senate,29,Ind,writein,0
+Bronx,84004,State Senate,29,Ind,writein,0
+Bronx,84005,State Senate,29,Ind,writein,0
+Bronx,84006,State Senate,29,Ind,writein,0
+Bronx,84007,State Senate,29,Ind,writein,0
+Bronx,84008,State Senate,29,Ind,writein,0
+Bronx,84009,State Senate,29,Ind,writein,0
+Bronx,84010,State Senate,29,Ind,writein,0
+Bronx,84011,State Senate,29,Ind,writein,0
+Bronx,84012,State Senate,29,Ind,writein,0
+Bronx,84013,State Senate,29,Ind,writein,0
+Bronx,84014,State Senate,29,Ind,writein,0
+Bronx,84015,State Senate,29,Ind,writein,0
+Bronx,84016,State Senate,29,Ind,writein,0
+Bronx,84017,State Senate,29,Ind,writein,0
+Bronx,84018,State Senate,29,Ind,writein,0
+Bronx,84019,State Senate,29,Ind,writein,0
+Bronx,84020,State Senate,29,Ind,writein,0
+Bronx,84021,State Senate,29,Ind,writein,0
+Bronx,84022,State Senate,29,Ind,writein,0
+Bronx,84023,State Senate,29,Ind,writein,0
+Bronx,84024,State Senate,29,Ind,writein,0
+Bronx,84025,State Senate,29,Ind,writein,0
+Bronx,84026,State Senate,29,Ind,writein,0
+Bronx,84027,State Senate,29,Ind,writein,1
+Bronx,84028,State Senate,29,Ind,writein,0
+Bronx,84029,State Senate,29,Ind,writein,0
+Bronx,84030,State Senate,29,Ind,writein,0
+Bronx,84031,State Senate,29,Ind,writein,0
+Bronx,84032,State Senate,29,Ind,writein,0
+Bronx,84033,State Senate,29,Ind,writein,0
+Bronx,84034,State Senate,29,Ind,writein,1
+Bronx,84035,State Senate,29,Ind,writein,0
+Bronx,84040,State Senate,29,Ind,writein,0
+Bronx,84041,State Senate,29,Ind,writein,0
+Bronx,84042,State Senate,29,Ind,writein,0
+Bronx,84043,State Senate,29,Ind,writein,0
+Bronx,84044,State Senate,29,Ind,writein,2
+Bronx,84045,State Senate,29,Ind,writein,0
+Bronx,84046,State Senate,29,Ind,writein,0
+Bronx,84047,State Senate,29,Ind,writein,0
+Bronx,84054,State Senate,29,Ind,writein,0
+Bronx,84055,State Senate,29,Ind,writein,0
+Bronx,84056,State Senate,29,Ind,writein,0
+Bronx,84057,State Senate,29,Ind,writein,0
+Bronx,84058,State Senate,29,Ind,writein,0
+Bronx,84059,State Senate,29,Ind,writein,0
+Bronx,84060,State Senate,29,Ind,writein,0
+Bronx,84061,State Senate,29,Ind,writein,0
+Bronx,84062,State Senate,29,Ind,writein,0
+Bronx,84063,State Senate,29,Ind,writein,0
+Bronx,84064,State Senate,29,Ind,writein,0
+Bronx,84065,State Senate,29,Ind,writein,0
+Bronx,84066,State Senate,29,Ind,writein,0
+Bronx,84067,State Senate,29,Ind,writein,0
+Bronx,84068,State Senate,29,Ind,writein,0
+Bronx,84069,State Senate,29,Ind,writein,0
+Bronx,84070,State Senate,29,Ind,writein,0
+Bronx,84071,State Senate,29,Ind,writein,0
+Bronx,84072,State Senate,29,Ind,writein,1
+Bronx,84080,State Senate,29,Ind,writein,1
+Bronx,86001,State Senate,29,Ind,writein,0
+Bronx,86002,State Senate,29,Ind,writein,0
+Bronx,86003,State Senate,29,Ind,writein,0
+Bronx,86004,State Senate,29,Ind,writein,0
+Bronx,86005,State Senate,29,Ind,writein,0
+Bronx,86006,State Senate,29,Ind,writein,0
+Bronx,86007,State Senate,29,Ind,writein,0
+Bronx,77050,State Senate,32,Ind,David Johnson,14
+Bronx,77051,State Senate,32,Ind,David Johnson,6
+Bronx,77052,State Senate,32,Ind,David Johnson,2
+Bronx,77053,State Senate,32,Ind,David Johnson,5
+Bronx,77054,State Senate,32,Ind,David Johnson,2
+Bronx,77055,State Senate,32,Ind,David Johnson,7
+Bronx,77056,State Senate,32,Ind,David Johnson,8
+Bronx,77057,State Senate,32,Ind,David Johnson,8
+Bronx,77058,State Senate,32,Ind,David Johnson,31
+Bronx,77059,State Senate,32,Ind,David Johnson,31
+Bronx,77060,State Senate,32,Ind,David Johnson,16
+Bronx,77062,State Senate,32,Ind,David Johnson,7
+Bronx,77063,State Senate,32,Ind,David Johnson,9
+Bronx,77064,State Senate,32,Ind,David Johnson,5
+Bronx,79006,State Senate,32,Ind,David Johnson,14
+Bronx,79011,State Senate,32,Ind,David Johnson,3
+Bronx,79012,State Senate,32,Ind,David Johnson,2
+Bronx,79014,State Senate,32,Ind,David Johnson,4
+Bronx,79015,State Senate,32,Ind,David Johnson,4
+Bronx,79016,State Senate,32,Ind,David Johnson,9
+Bronx,79017,State Senate,32,Ind,David Johnson,12
+Bronx,79018,State Senate,32,Ind,David Johnson,3
+Bronx,79019,State Senate,32,Ind,David Johnson,11
+Bronx,79021,State Senate,32,Ind,David Johnson,16
+Bronx,79022,State Senate,32,Ind,David Johnson,9
+Bronx,79023,State Senate,32,Ind,David Johnson,14
+Bronx,79024,State Senate,32,Ind,David Johnson,9
+Bronx,79025,State Senate,32,Ind,David Johnson,10
+Bronx,79026,State Senate,32,Ind,David Johnson,5
+Bronx,79027,State Senate,32,Ind,David Johnson,8
+Bronx,79028,State Senate,32,Ind,David Johnson,9
+Bronx,79038,State Senate,32,Ind,David Johnson,10
+Bronx,79039,State Senate,32,Ind,David Johnson,10
+Bronx,79040,State Senate,32,Ind,David Johnson,4
+Bronx,79041,State Senate,32,Ind,David Johnson,10
+Bronx,79042,State Senate,32,Ind,David Johnson,9
+Bronx,79043,State Senate,32,Ind,David Johnson,15
+Bronx,79044,State Senate,32,Ind,David Johnson,10
+Bronx,79045,State Senate,32,Ind,David Johnson,6
+Bronx,79046,State Senate,32,Ind,David Johnson,4
+Bronx,79047,State Senate,32,Ind,David Johnson,4
+Bronx,79048,State Senate,32,Ind,David Johnson,7
+Bronx,79049,State Senate,32,Ind,David Johnson,3
+Bronx,79050,State Senate,32,Ind,David Johnson,11
+Bronx,79051,State Senate,32,Ind,David Johnson,14
+Bronx,79052,State Senate,32,Ind,David Johnson,19
+Bronx,79053,State Senate,32,Ind,David Johnson,11
+Bronx,79054,State Senate,32,Ind,David Johnson,5
+Bronx,79055,State Senate,32,Ind,David Johnson,4
+Bronx,79056,State Senate,32,Ind,David Johnson,14
+Bronx,79057,State Senate,32,Ind,David Johnson,27
+Bronx,79058,State Senate,32,Ind,David Johnson,15
+Bronx,79059,State Senate,32,Ind,David Johnson,8
+Bronx,79060,State Senate,32,Ind,David Johnson,4
+Bronx,79061,State Senate,32,Ind,David Johnson,3
+Bronx,79062,State Senate,32,Ind,David Johnson,13
+Bronx,79063,State Senate,32,Ind,David Johnson,2
+Bronx,79064,State Senate,32,Ind,David Johnson,2
+Bronx,79065,State Senate,32,Ind,David Johnson,6
+Bronx,79066,State Senate,32,Ind,David Johnson,7
+Bronx,79068,State Senate,32,Ind,David Johnson,27
+Bronx,79069,State Senate,32,Ind,David Johnson,27
+Bronx,79070,State Senate,32,Ind,David Johnson,19
+Bronx,79071,State Senate,32,Ind,David Johnson,2
+Bronx,79072,State Senate,32,Ind,David Johnson,8
+Bronx,79073,State Senate,32,Ind,David Johnson,10
+Bronx,79075,State Senate,32,Ind,David Johnson,18
+Bronx,79076,State Senate,32,Ind,David Johnson,0
+Bronx,82029,State Senate,32,Ind,David Johnson,2
+Bronx,82030,State Senate,32,Ind,David Johnson,30
+Bronx,84036,State Senate,32,Ind,David Johnson,0
+Bronx,84037,State Senate,32,Ind,David Johnson,4
+Bronx,84038,State Senate,32,Ind,David Johnson,10
+Bronx,84039,State Senate,32,Ind,David Johnson,12
+Bronx,84048,State Senate,32,Ind,David Johnson,9
+Bronx,84049,State Senate,32,Ind,David Johnson,19
+Bronx,84050,State Senate,32,Ind,David Johnson,11
+Bronx,84051,State Senate,32,Ind,David Johnson,7
+Bronx,84052,State Senate,32,Ind,David Johnson,9
+Bronx,84053,State Senate,32,Ind,David Johnson,0
+Bronx,84074,State Senate,32,Ind,David Johnson,6
+Bronx,84075,State Senate,32,Ind,David Johnson,8
+Bronx,85014,State Senate,32,Ind,David Johnson,5
+Bronx,85015,State Senate,32,Ind,David Johnson,7
+Bronx,85016,State Senate,32,Ind,David Johnson,8
+Bronx,85017,State Senate,32,Ind,David Johnson,9
+Bronx,85018,State Senate,32,Ind,David Johnson,14
+Bronx,85019,State Senate,32,Ind,David Johnson,13
+Bronx,85020,State Senate,32,Ind,David Johnson,9
+Bronx,85021,State Senate,32,Ind,David Johnson,13
+Bronx,85022,State Senate,32,Ind,David Johnson,7
+Bronx,85023,State Senate,32,Ind,David Johnson,3
+Bronx,85024,State Senate,32,Ind,David Johnson,22
+Bronx,85025,State Senate,32,Ind,David Johnson,19
+Bronx,85026,State Senate,32,Ind,David Johnson,8
+Bronx,85027,State Senate,32,Ind,David Johnson,10
+Bronx,85029,State Senate,32,Ind,David Johnson,4
+Bronx,85030,State Senate,32,Ind,David Johnson,11
+Bronx,85031,State Senate,32,Ind,David Johnson,8
+Bronx,85032,State Senate,32,Ind,David Johnson,16
+Bronx,85033,State Senate,32,Ind,David Johnson,19
+Bronx,85034,State Senate,32,Ind,David Johnson,3
+Bronx,85039,State Senate,32,Ind,David Johnson,12
+Bronx,85040,State Senate,32,Ind,David Johnson,5
+Bronx,85041,State Senate,32,Ind,David Johnson,9
+Bronx,85042,State Senate,32,Ind,David Johnson,10
+Bronx,85043,State Senate,32,Ind,David Johnson,7
+Bronx,85044,State Senate,32,Ind,David Johnson,7
+Bronx,85045,State Senate,32,Ind,David Johnson,9
+Bronx,85046,State Senate,32,Ind,David Johnson,12
+Bronx,85047,State Senate,32,Ind,David Johnson,6
+Bronx,85048,State Senate,32,Ind,David Johnson,11
+Bronx,85049,State Senate,32,Ind,David Johnson,16
+Bronx,85050,State Senate,32,Ind,David Johnson,13
+Bronx,85051,State Senate,32,Ind,David Johnson,8
+Bronx,85052,State Senate,32,Ind,David Johnson,18
+Bronx,85053,State Senate,32,Ind,David Johnson,16
+Bronx,85054,State Senate,32,Ind,David Johnson,5
+Bronx,85055,State Senate,32,Ind,David Johnson,8
+Bronx,85056,State Senate,32,Ind,David Johnson,1
+Bronx,85057,State Senate,32,Ind,David Johnson,8
+Bronx,85058,State Senate,32,Ind,David Johnson,10
+Bronx,85059,State Senate,32,Ind,David Johnson,12
+Bronx,85060,State Senate,32,Ind,David Johnson,12
+Bronx,85061,State Senate,32,Ind,David Johnson,11
+Bronx,85062,State Senate,32,Ind,David Johnson,11
+Bronx,85063,State Senate,32,Ind,David Johnson,10
+Bronx,85064,State Senate,32,Ind,David Johnson,7
+Bronx,85065,State Senate,32,Ind,David Johnson,14
+Bronx,85066,State Senate,32,Ind,David Johnson,24
+Bronx,85067,State Senate,32,Ind,David Johnson,15
+Bronx,85068,State Senate,32,Ind,David Johnson,11
+Bronx,85069,State Senate,32,Ind,David Johnson,6
+Bronx,85070,State Senate,32,Ind,David Johnson,5
+Bronx,85071,State Senate,32,Ind,David Johnson,2
+Bronx,85072,State Senate,32,Ind,David Johnson,2
+Bronx,87002,State Senate,32,Ind,David Johnson,0
+Bronx,87004,State Senate,32,Ind,David Johnson,17
+Bronx,87005,State Senate,32,Ind,David Johnson,9
+Bronx,87006,State Senate,32,Ind,David Johnson,22
+Bronx,87007,State Senate,32,Ind,David Johnson,9
+Bronx,87008,State Senate,32,Ind,David Johnson,6
+Bronx,87009,State Senate,32,Ind,David Johnson,8
+Bronx,87010,State Senate,32,Ind,David Johnson,14
+Bronx,87011,State Senate,32,Ind,David Johnson,10
+Bronx,87012,State Senate,32,Ind,David Johnson,3
+Bronx,87013,State Senate,32,Ind,David Johnson,2
+Bronx,87014,State Senate,32,Ind,David Johnson,3
+Bronx,87022,State Senate,32,Ind,David Johnson,15
+Bronx,87026,State Senate,32,Ind,David Johnson,20
+Bronx,87027,State Senate,32,Ind,David Johnson,10
+Bronx,87028,State Senate,32,Ind,David Johnson,21
+Bronx,87029,State Senate,32,Ind,David Johnson,22
+Bronx,87030,State Senate,32,Ind,David Johnson,3
+Bronx,87031,State Senate,32,Ind,David Johnson,4
+Bronx,87032,State Senate,32,Ind,David Johnson,15
+Bronx,87033,State Senate,32,Ind,David Johnson,17
+Bronx,87034,State Senate,32,Ind,David Johnson,8
+Bronx,87035,State Senate,32,Ind,David Johnson,22
+Bronx,87036,State Senate,32,Ind,David Johnson,16
+Bronx,87037,State Senate,32,Ind,David Johnson,20
+Bronx,87038,State Senate,32,Ind,David Johnson,23
+Bronx,87039,State Senate,32,Ind,David Johnson,21
+Bronx,87040,State Senate,32,Ind,David Johnson,12
+Bronx,87041,State Senate,32,Ind,David Johnson,10
+Bronx,87042,State Senate,32,Ind,David Johnson,12
+Bronx,87045,State Senate,32,Ind,David Johnson,2
+Bronx,87046,State Senate,32,Ind,David Johnson,19
+Bronx,87047,State Senate,32,Ind,David Johnson,17
+Bronx,87048,State Senate,32,Ind,David Johnson,16
+Bronx,87049,State Senate,32,Ind,David Johnson,27
+Bronx,87050,State Senate,32,Ind,David Johnson,28
+Bronx,87051,State Senate,32,Ind,David Johnson,29
+Bronx,87052,State Senate,32,Ind,David Johnson,22
+Bronx,87053,State Senate,32,Ind,David Johnson,22
+Bronx,87054,State Senate,32,Ind,David Johnson,27
+Bronx,87055,State Senate,32,Ind,David Johnson,31
+Bronx,87056,State Senate,32,Ind,David Johnson,24
+Bronx,87057,State Senate,32,Ind,David Johnson,15
+Bronx,87058,State Senate,32,Ind,David Johnson,15
+Bronx,87059,State Senate,32,Ind,David Johnson,18
+Bronx,87060,State Senate,32,Ind,David Johnson,16
+Bronx,87061,State Senate,32,Ind,David Johnson,16
+Bronx,87062,State Senate,32,Ind,David Johnson,34
+Bronx,87063,State Senate,32,Ind,David Johnson,5
+Bronx,87064,State Senate,32,Ind,David Johnson,0
+Bronx,87083,State Senate,32,Ind,David Johnson,4
+Bronx,87084,State Senate,32,Ind,David Johnson,18
+Bronx,87085,State Senate,32,Ind,David Johnson,16
+Bronx,87086,State Senate,32,Ind,David Johnson,7
+Bronx,87087,State Senate,32,Ind,David Johnson,23
+Bronx,87088,State Senate,32,Ind,David Johnson,7
+Bronx,87089,State Senate,32,Ind,David Johnson,15
+Bronx,87090,State Senate,32,Ind,David Johnson,4
+Bronx,87091,State Senate,32,Ind,David Johnson,8
+Bronx,77050,State Senate,32,Dem,Ruben Diaz,582
+Bronx,77051,State Senate,32,Dem,Ruben Diaz,322
+Bronx,77052,State Senate,32,Dem,Ruben Diaz,43
+Bronx,77053,State Senate,32,Dem,Ruben Diaz,353
+Bronx,77054,State Senate,32,Dem,Ruben Diaz,405
+Bronx,77055,State Senate,32,Dem,Ruben Diaz,462
+Bronx,77056,State Senate,32,Dem,Ruben Diaz,383
+Bronx,77057,State Senate,32,Dem,Ruben Diaz,369
+Bronx,77058,State Senate,32,Dem,Ruben Diaz,549
+Bronx,77059,State Senate,32,Dem,Ruben Diaz,566
+Bronx,77060,State Senate,32,Dem,Ruben Diaz,332
+Bronx,77062,State Senate,32,Dem,Ruben Diaz,382
+Bronx,77063,State Senate,32,Dem,Ruben Diaz,447
+Bronx,77064,State Senate,32,Dem,Ruben Diaz,130
+Bronx,79006,State Senate,32,Dem,Ruben Diaz,302
+Bronx,79011,State Senate,32,Dem,Ruben Diaz,146
+Bronx,79012,State Senate,32,Dem,Ruben Diaz,103
+Bronx,79014,State Senate,32,Dem,Ruben Diaz,163
+Bronx,79015,State Senate,32,Dem,Ruben Diaz,416
+Bronx,79016,State Senate,32,Dem,Ruben Diaz,453
+Bronx,79017,State Senate,32,Dem,Ruben Diaz,430
+Bronx,79018,State Senate,32,Dem,Ruben Diaz,156
+Bronx,79019,State Senate,32,Dem,Ruben Diaz,114
+Bronx,79021,State Senate,32,Dem,Ruben Diaz,344
+Bronx,79022,State Senate,32,Dem,Ruben Diaz,443
+Bronx,79023,State Senate,32,Dem,Ruben Diaz,299
+Bronx,79024,State Senate,32,Dem,Ruben Diaz,254
+Bronx,79025,State Senate,32,Dem,Ruben Diaz,381
+Bronx,79026,State Senate,32,Dem,Ruben Diaz,372
+Bronx,79027,State Senate,32,Dem,Ruben Diaz,456
+Bronx,79028,State Senate,32,Dem,Ruben Diaz,536
+Bronx,79038,State Senate,32,Dem,Ruben Diaz,459
+Bronx,79039,State Senate,32,Dem,Ruben Diaz,406
+Bronx,79040,State Senate,32,Dem,Ruben Diaz,417
+Bronx,79041,State Senate,32,Dem,Ruben Diaz,373
+Bronx,79042,State Senate,32,Dem,Ruben Diaz,397
+Bronx,79043,State Senate,32,Dem,Ruben Diaz,317
+Bronx,79044,State Senate,32,Dem,Ruben Diaz,362
+Bronx,79045,State Senate,32,Dem,Ruben Diaz,301
+Bronx,79046,State Senate,32,Dem,Ruben Diaz,402
+Bronx,79047,State Senate,32,Dem,Ruben Diaz,500
+Bronx,79048,State Senate,32,Dem,Ruben Diaz,328
+Bronx,79049,State Senate,32,Dem,Ruben Diaz,402
+Bronx,79050,State Senate,32,Dem,Ruben Diaz,457
+Bronx,79051,State Senate,32,Dem,Ruben Diaz,420
+Bronx,79052,State Senate,32,Dem,Ruben Diaz,480
+Bronx,79053,State Senate,32,Dem,Ruben Diaz,403
+Bronx,79054,State Senate,32,Dem,Ruben Diaz,270
+Bronx,79055,State Senate,32,Dem,Ruben Diaz,464
+Bronx,79056,State Senate,32,Dem,Ruben Diaz,430
+Bronx,79057,State Senate,32,Dem,Ruben Diaz,665
+Bronx,79058,State Senate,32,Dem,Ruben Diaz,421
+Bronx,79059,State Senate,32,Dem,Ruben Diaz,387
+Bronx,79060,State Senate,32,Dem,Ruben Diaz,177
+Bronx,79061,State Senate,32,Dem,Ruben Diaz,416
+Bronx,79062,State Senate,32,Dem,Ruben Diaz,329
+Bronx,79063,State Senate,32,Dem,Ruben Diaz,428
+Bronx,79064,State Senate,32,Dem,Ruben Diaz,421
+Bronx,79065,State Senate,32,Dem,Ruben Diaz,460
+Bronx,79066,State Senate,32,Dem,Ruben Diaz,367
+Bronx,79068,State Senate,32,Dem,Ruben Diaz,501
+Bronx,79069,State Senate,32,Dem,Ruben Diaz,534
+Bronx,79070,State Senate,32,Dem,Ruben Diaz,523
+Bronx,79071,State Senate,32,Dem,Ruben Diaz,167
+Bronx,79072,State Senate,32,Dem,Ruben Diaz,401
+Bronx,79073,State Senate,32,Dem,Ruben Diaz,275
+Bronx,79075,State Senate,32,Dem,Ruben Diaz,598
+Bronx,79076,State Senate,32,Dem,Ruben Diaz,0
+Bronx,82029,State Senate,32,Dem,Ruben Diaz,65
+Bronx,82030,State Senate,32,Dem,Ruben Diaz,344
+Bronx,84036,State Senate,32,Dem,Ruben Diaz,109
+Bronx,84037,State Senate,32,Dem,Ruben Diaz,357
+Bronx,84038,State Senate,32,Dem,Ruben Diaz,313
+Bronx,84039,State Senate,32,Dem,Ruben Diaz,485
+Bronx,84048,State Senate,32,Dem,Ruben Diaz,326
+Bronx,84049,State Senate,32,Dem,Ruben Diaz,211
+Bronx,84050,State Senate,32,Dem,Ruben Diaz,238
+Bronx,84051,State Senate,32,Dem,Ruben Diaz,501
+Bronx,84052,State Senate,32,Dem,Ruben Diaz,444
+Bronx,84053,State Senate,32,Dem,Ruben Diaz,0
+Bronx,84074,State Senate,32,Dem,Ruben Diaz,373
+Bronx,84075,State Senate,32,Dem,Ruben Diaz,405
+Bronx,85014,State Senate,32,Dem,Ruben Diaz,226
+Bronx,85015,State Senate,32,Dem,Ruben Diaz,341
+Bronx,85016,State Senate,32,Dem,Ruben Diaz,182
+Bronx,85017,State Senate,32,Dem,Ruben Diaz,354
+Bronx,85018,State Senate,32,Dem,Ruben Diaz,533
+Bronx,85019,State Senate,32,Dem,Ruben Diaz,514
+Bronx,85020,State Senate,32,Dem,Ruben Diaz,472
+Bronx,85021,State Senate,32,Dem,Ruben Diaz,449
+Bronx,85022,State Senate,32,Dem,Ruben Diaz,345
+Bronx,85023,State Senate,32,Dem,Ruben Diaz,332
+Bronx,85024,State Senate,32,Dem,Ruben Diaz,493
+Bronx,85025,State Senate,32,Dem,Ruben Diaz,551
+Bronx,85026,State Senate,32,Dem,Ruben Diaz,303
+Bronx,85027,State Senate,32,Dem,Ruben Diaz,289
+Bronx,85029,State Senate,32,Dem,Ruben Diaz,306
+Bronx,85030,State Senate,32,Dem,Ruben Diaz,415
+Bronx,85031,State Senate,32,Dem,Ruben Diaz,452
+Bronx,85032,State Senate,32,Dem,Ruben Diaz,435
+Bronx,85033,State Senate,32,Dem,Ruben Diaz,407
+Bronx,85034,State Senate,32,Dem,Ruben Diaz,441
+Bronx,85039,State Senate,32,Dem,Ruben Diaz,444
+Bronx,85040,State Senate,32,Dem,Ruben Diaz,246
+Bronx,85041,State Senate,32,Dem,Ruben Diaz,426
+Bronx,85042,State Senate,32,Dem,Ruben Diaz,468
+Bronx,85043,State Senate,32,Dem,Ruben Diaz,302
+Bronx,85044,State Senate,32,Dem,Ruben Diaz,353
+Bronx,85045,State Senate,32,Dem,Ruben Diaz,402
+Bronx,85046,State Senate,32,Dem,Ruben Diaz,438
+Bronx,85047,State Senate,32,Dem,Ruben Diaz,337
+Bronx,85048,State Senate,32,Dem,Ruben Diaz,368
+Bronx,85049,State Senate,32,Dem,Ruben Diaz,445
+Bronx,85050,State Senate,32,Dem,Ruben Diaz,345
+Bronx,85051,State Senate,32,Dem,Ruben Diaz,259
+Bronx,85052,State Senate,32,Dem,Ruben Diaz,385
+Bronx,85053,State Senate,32,Dem,Ruben Diaz,446
+Bronx,85054,State Senate,32,Dem,Ruben Diaz,376
+Bronx,85055,State Senate,32,Dem,Ruben Diaz,415
+Bronx,85056,State Senate,32,Dem,Ruben Diaz,24
+Bronx,85057,State Senate,32,Dem,Ruben Diaz,257
+Bronx,85058,State Senate,32,Dem,Ruben Diaz,406
+Bronx,85059,State Senate,32,Dem,Ruben Diaz,452
+Bronx,85060,State Senate,32,Dem,Ruben Diaz,512
+Bronx,85061,State Senate,32,Dem,Ruben Diaz,198
+Bronx,85062,State Senate,32,Dem,Ruben Diaz,476
+Bronx,85063,State Senate,32,Dem,Ruben Diaz,379
+Bronx,85064,State Senate,32,Dem,Ruben Diaz,399
+Bronx,85065,State Senate,32,Dem,Ruben Diaz,474
+Bronx,85066,State Senate,32,Dem,Ruben Diaz,450
+Bronx,85067,State Senate,32,Dem,Ruben Diaz,300
+Bronx,85068,State Senate,32,Dem,Ruben Diaz,437
+Bronx,85069,State Senate,32,Dem,Ruben Diaz,447
+Bronx,85070,State Senate,32,Dem,Ruben Diaz,326
+Bronx,85071,State Senate,32,Dem,Ruben Diaz,219
+Bronx,85072,State Senate,32,Dem,Ruben Diaz,79
+Bronx,87002,State Senate,32,Dem,Ruben Diaz,0
+Bronx,87004,State Senate,32,Dem,Ruben Diaz,359
+Bronx,87005,State Senate,32,Dem,Ruben Diaz,412
+Bronx,87006,State Senate,32,Dem,Ruben Diaz,388
+Bronx,87007,State Senate,32,Dem,Ruben Diaz,381
+Bronx,87008,State Senate,32,Dem,Ruben Diaz,305
+Bronx,87009,State Senate,32,Dem,Ruben Diaz,284
+Bronx,87010,State Senate,32,Dem,Ruben Diaz,420
+Bronx,87011,State Senate,32,Dem,Ruben Diaz,422
+Bronx,87012,State Senate,32,Dem,Ruben Diaz,40
+Bronx,87013,State Senate,32,Dem,Ruben Diaz,122
+Bronx,87014,State Senate,32,Dem,Ruben Diaz,77
+Bronx,87022,State Senate,32,Dem,Ruben Diaz,261
+Bronx,87026,State Senate,32,Dem,Ruben Diaz,428
+Bronx,87027,State Senate,32,Dem,Ruben Diaz,243
+Bronx,87028,State Senate,32,Dem,Ruben Diaz,431
+Bronx,87029,State Senate,32,Dem,Ruben Diaz,282
+Bronx,87030,State Senate,32,Dem,Ruben Diaz,123
+Bronx,87031,State Senate,32,Dem,Ruben Diaz,254
+Bronx,87032,State Senate,32,Dem,Ruben Diaz,486
+Bronx,87033,State Senate,32,Dem,Ruben Diaz,444
+Bronx,87034,State Senate,32,Dem,Ruben Diaz,362
+Bronx,87035,State Senate,32,Dem,Ruben Diaz,354
+Bronx,87036,State Senate,32,Dem,Ruben Diaz,384
+Bronx,87037,State Senate,32,Dem,Ruben Diaz,426
+Bronx,87038,State Senate,32,Dem,Ruben Diaz,497
+Bronx,87039,State Senate,32,Dem,Ruben Diaz,495
+Bronx,87040,State Senate,32,Dem,Ruben Diaz,545
+Bronx,87041,State Senate,32,Dem,Ruben Diaz,216
+Bronx,87042,State Senate,32,Dem,Ruben Diaz,499
+Bronx,87045,State Senate,32,Dem,Ruben Diaz,40
+Bronx,87046,State Senate,32,Dem,Ruben Diaz,348
+Bronx,87047,State Senate,32,Dem,Ruben Diaz,502
+Bronx,87048,State Senate,32,Dem,Ruben Diaz,482
+Bronx,87049,State Senate,32,Dem,Ruben Diaz,459
+Bronx,87050,State Senate,32,Dem,Ruben Diaz,496
+Bronx,87051,State Senate,32,Dem,Ruben Diaz,525
+Bronx,87052,State Senate,32,Dem,Ruben Diaz,479
+Bronx,87053,State Senate,32,Dem,Ruben Diaz,555
+Bronx,87054,State Senate,32,Dem,Ruben Diaz,483
+Bronx,87055,State Senate,32,Dem,Ruben Diaz,461
+Bronx,87056,State Senate,32,Dem,Ruben Diaz,472
+Bronx,87057,State Senate,32,Dem,Ruben Diaz,525
+Bronx,87058,State Senate,32,Dem,Ruben Diaz,255
+Bronx,87059,State Senate,32,Dem,Ruben Diaz,513
+Bronx,87060,State Senate,32,Dem,Ruben Diaz,364
+Bronx,87061,State Senate,32,Dem,Ruben Diaz,453
+Bronx,87062,State Senate,32,Dem,Ruben Diaz,567
+Bronx,87063,State Senate,32,Dem,Ruben Diaz,26
+Bronx,87064,State Senate,32,Dem,Ruben Diaz,4
+Bronx,87083,State Senate,32,Dem,Ruben Diaz,27
+Bronx,87084,State Senate,32,Dem,Ruben Diaz,425
+Bronx,87085,State Senate,32,Dem,Ruben Diaz,520
+Bronx,87086,State Senate,32,Dem,Ruben Diaz,188
+Bronx,87087,State Senate,32,Dem,Ruben Diaz,456
+Bronx,87088,State Senate,32,Dem,Ruben Diaz,469
+Bronx,87089,State Senate,32,Dem,Ruben Diaz,410
+Bronx,87090,State Senate,32,Dem,Ruben Diaz,431
+Bronx,87091,State Senate,32,Dem,Ruben Diaz,261
+Bronx,77050,State Senate,32,Rep,Ruben Diaz,14
+Bronx,77051,State Senate,32,Rep,Ruben Diaz,1
+Bronx,77052,State Senate,32,Rep,Ruben Diaz,1
+Bronx,77053,State Senate,32,Rep,Ruben Diaz,11
+Bronx,77054,State Senate,32,Rep,Ruben Diaz,6
+Bronx,77055,State Senate,32,Rep,Ruben Diaz,3
+Bronx,77056,State Senate,32,Rep,Ruben Diaz,3
+Bronx,77057,State Senate,32,Rep,Ruben Diaz,6
+Bronx,77058,State Senate,32,Rep,Ruben Diaz,11
+Bronx,77059,State Senate,32,Rep,Ruben Diaz,10
+Bronx,77060,State Senate,32,Rep,Ruben Diaz,10
+Bronx,77062,State Senate,32,Rep,Ruben Diaz,10
+Bronx,77063,State Senate,32,Rep,Ruben Diaz,11
+Bronx,77064,State Senate,32,Rep,Ruben Diaz,2
+Bronx,79006,State Senate,32,Rep,Ruben Diaz,3
+Bronx,79011,State Senate,32,Rep,Ruben Diaz,1
+Bronx,79012,State Senate,32,Rep,Ruben Diaz,0
+Bronx,79014,State Senate,32,Rep,Ruben Diaz,2
+Bronx,79015,State Senate,32,Rep,Ruben Diaz,6
+Bronx,79016,State Senate,32,Rep,Ruben Diaz,4
+Bronx,79017,State Senate,32,Rep,Ruben Diaz,8
+Bronx,79018,State Senate,32,Rep,Ruben Diaz,5
+Bronx,79019,State Senate,32,Rep,Ruben Diaz,3
+Bronx,79021,State Senate,32,Rep,Ruben Diaz,14
+Bronx,79022,State Senate,32,Rep,Ruben Diaz,5
+Bronx,79023,State Senate,32,Rep,Ruben Diaz,7
+Bronx,79024,State Senate,32,Rep,Ruben Diaz,11
+Bronx,79025,State Senate,32,Rep,Ruben Diaz,1
+Bronx,79026,State Senate,32,Rep,Ruben Diaz,10
+Bronx,79027,State Senate,32,Rep,Ruben Diaz,5
+Bronx,79028,State Senate,32,Rep,Ruben Diaz,9
+Bronx,79038,State Senate,32,Rep,Ruben Diaz,3
+Bronx,79039,State Senate,32,Rep,Ruben Diaz,3
+Bronx,79040,State Senate,32,Rep,Ruben Diaz,7
+Bronx,79041,State Senate,32,Rep,Ruben Diaz,3
+Bronx,79042,State Senate,32,Rep,Ruben Diaz,8
+Bronx,79043,State Senate,32,Rep,Ruben Diaz,4
+Bronx,79044,State Senate,32,Rep,Ruben Diaz,5
+Bronx,79045,State Senate,32,Rep,Ruben Diaz,4
+Bronx,79046,State Senate,32,Rep,Ruben Diaz,5
+Bronx,79047,State Senate,32,Rep,Ruben Diaz,8
+Bronx,79048,State Senate,32,Rep,Ruben Diaz,3
+Bronx,79049,State Senate,32,Rep,Ruben Diaz,1
+Bronx,79050,State Senate,32,Rep,Ruben Diaz,8
+Bronx,79051,State Senate,32,Rep,Ruben Diaz,5
+Bronx,79052,State Senate,32,Rep,Ruben Diaz,8
+Bronx,79053,State Senate,32,Rep,Ruben Diaz,7
+Bronx,79054,State Senate,32,Rep,Ruben Diaz,5
+Bronx,79055,State Senate,32,Rep,Ruben Diaz,8
+Bronx,79056,State Senate,32,Rep,Ruben Diaz,9
+Bronx,79057,State Senate,32,Rep,Ruben Diaz,17
+Bronx,79058,State Senate,32,Rep,Ruben Diaz,17
+Bronx,79059,State Senate,32,Rep,Ruben Diaz,10
+Bronx,79060,State Senate,32,Rep,Ruben Diaz,3
+Bronx,79061,State Senate,32,Rep,Ruben Diaz,8
+Bronx,79062,State Senate,32,Rep,Ruben Diaz,8
+Bronx,79063,State Senate,32,Rep,Ruben Diaz,10
+Bronx,79064,State Senate,32,Rep,Ruben Diaz,2
+Bronx,79065,State Senate,32,Rep,Ruben Diaz,6
+Bronx,79066,State Senate,32,Rep,Ruben Diaz,6
+Bronx,79068,State Senate,32,Rep,Ruben Diaz,5
+Bronx,79069,State Senate,32,Rep,Ruben Diaz,8
+Bronx,79070,State Senate,32,Rep,Ruben Diaz,8
+Bronx,79071,State Senate,32,Rep,Ruben Diaz,2
+Bronx,79072,State Senate,32,Rep,Ruben Diaz,7
+Bronx,79073,State Senate,32,Rep,Ruben Diaz,5
+Bronx,79075,State Senate,32,Rep,Ruben Diaz,9
+Bronx,79076,State Senate,32,Rep,Ruben Diaz,0
+Bronx,82029,State Senate,32,Rep,Ruben Diaz,6
+Bronx,82030,State Senate,32,Rep,Ruben Diaz,41
+Bronx,84036,State Senate,32,Rep,Ruben Diaz,0
+Bronx,84037,State Senate,32,Rep,Ruben Diaz,3
+Bronx,84038,State Senate,32,Rep,Ruben Diaz,10
+Bronx,84039,State Senate,32,Rep,Ruben Diaz,7
+Bronx,84048,State Senate,32,Rep,Ruben Diaz,9
+Bronx,84049,State Senate,32,Rep,Ruben Diaz,10
+Bronx,84050,State Senate,32,Rep,Ruben Diaz,5
+Bronx,84051,State Senate,32,Rep,Ruben Diaz,10
+Bronx,84052,State Senate,32,Rep,Ruben Diaz,7
+Bronx,84053,State Senate,32,Rep,Ruben Diaz,0
+Bronx,84074,State Senate,32,Rep,Ruben Diaz,17
+Bronx,84075,State Senate,32,Rep,Ruben Diaz,8
+Bronx,85014,State Senate,32,Rep,Ruben Diaz,1
+Bronx,85015,State Senate,32,Rep,Ruben Diaz,3
+Bronx,85016,State Senate,32,Rep,Ruben Diaz,1
+Bronx,85017,State Senate,32,Rep,Ruben Diaz,5
+Bronx,85018,State Senate,32,Rep,Ruben Diaz,7
+Bronx,85019,State Senate,32,Rep,Ruben Diaz,1
+Bronx,85020,State Senate,32,Rep,Ruben Diaz,2
+Bronx,85021,State Senate,32,Rep,Ruben Diaz,4
+Bronx,85022,State Senate,32,Rep,Ruben Diaz,9
+Bronx,85023,State Senate,32,Rep,Ruben Diaz,1
+Bronx,85024,State Senate,32,Rep,Ruben Diaz,7
+Bronx,85025,State Senate,32,Rep,Ruben Diaz,4
+Bronx,85026,State Senate,32,Rep,Ruben Diaz,5
+Bronx,85027,State Senate,32,Rep,Ruben Diaz,11
+Bronx,85029,State Senate,32,Rep,Ruben Diaz,4
+Bronx,85030,State Senate,32,Rep,Ruben Diaz,3
+Bronx,85031,State Senate,32,Rep,Ruben Diaz,4
+Bronx,85032,State Senate,32,Rep,Ruben Diaz,18
+Bronx,85033,State Senate,32,Rep,Ruben Diaz,11
+Bronx,85034,State Senate,32,Rep,Ruben Diaz,12
+Bronx,85039,State Senate,32,Rep,Ruben Diaz,4
+Bronx,85040,State Senate,32,Rep,Ruben Diaz,10
+Bronx,85041,State Senate,32,Rep,Ruben Diaz,16
+Bronx,85042,State Senate,32,Rep,Ruben Diaz,5
+Bronx,85043,State Senate,32,Rep,Ruben Diaz,9
+Bronx,85044,State Senate,32,Rep,Ruben Diaz,4
+Bronx,85045,State Senate,32,Rep,Ruben Diaz,7
+Bronx,85046,State Senate,32,Rep,Ruben Diaz,7
+Bronx,85047,State Senate,32,Rep,Ruben Diaz,6
+Bronx,85048,State Senate,32,Rep,Ruben Diaz,9
+Bronx,85049,State Senate,32,Rep,Ruben Diaz,8
+Bronx,85050,State Senate,32,Rep,Ruben Diaz,6
+Bronx,85051,State Senate,32,Rep,Ruben Diaz,5
+Bronx,85052,State Senate,32,Rep,Ruben Diaz,1
+Bronx,85053,State Senate,32,Rep,Ruben Diaz,9
+Bronx,85054,State Senate,32,Rep,Ruben Diaz,18
+Bronx,85055,State Senate,32,Rep,Ruben Diaz,2
+Bronx,85056,State Senate,32,Rep,Ruben Diaz,1
+Bronx,85057,State Senate,32,Rep,Ruben Diaz,2
+Bronx,85058,State Senate,32,Rep,Ruben Diaz,13
+Bronx,85059,State Senate,32,Rep,Ruben Diaz,8
+Bronx,85060,State Senate,32,Rep,Ruben Diaz,7
+Bronx,85061,State Senate,32,Rep,Ruben Diaz,7
+Bronx,85062,State Senate,32,Rep,Ruben Diaz,13
+Bronx,85063,State Senate,32,Rep,Ruben Diaz,8
+Bronx,85064,State Senate,32,Rep,Ruben Diaz,12
+Bronx,85065,State Senate,32,Rep,Ruben Diaz,8
+Bronx,85066,State Senate,32,Rep,Ruben Diaz,15
+Bronx,85067,State Senate,32,Rep,Ruben Diaz,14
+Bronx,85068,State Senate,32,Rep,Ruben Diaz,13
+Bronx,85069,State Senate,32,Rep,Ruben Diaz,3
+Bronx,85070,State Senate,32,Rep,Ruben Diaz,7
+Bronx,85071,State Senate,32,Rep,Ruben Diaz,3
+Bronx,85072,State Senate,32,Rep,Ruben Diaz,1
+Bronx,87002,State Senate,32,Rep,Ruben Diaz,0
+Bronx,87004,State Senate,32,Rep,Ruben Diaz,9
+Bronx,87005,State Senate,32,Rep,Ruben Diaz,6
+Bronx,87006,State Senate,32,Rep,Ruben Diaz,8
+Bronx,87007,State Senate,32,Rep,Ruben Diaz,11
+Bronx,87008,State Senate,32,Rep,Ruben Diaz,5
+Bronx,87009,State Senate,32,Rep,Ruben Diaz,5
+Bronx,87010,State Senate,32,Rep,Ruben Diaz,8
+Bronx,87011,State Senate,32,Rep,Ruben Diaz,9
+Bronx,87012,State Senate,32,Rep,Ruben Diaz,0
+Bronx,87013,State Senate,32,Rep,Ruben Diaz,4
+Bronx,87014,State Senate,32,Rep,Ruben Diaz,2
+Bronx,87022,State Senate,32,Rep,Ruben Diaz,6
+Bronx,87026,State Senate,32,Rep,Ruben Diaz,14
+Bronx,87027,State Senate,32,Rep,Ruben Diaz,6
+Bronx,87028,State Senate,32,Rep,Ruben Diaz,17
+Bronx,87029,State Senate,32,Rep,Ruben Diaz,13
+Bronx,87030,State Senate,32,Rep,Ruben Diaz,3
+Bronx,87031,State Senate,32,Rep,Ruben Diaz,9
+Bronx,87032,State Senate,32,Rep,Ruben Diaz,13
+Bronx,87033,State Senate,32,Rep,Ruben Diaz,9
+Bronx,87034,State Senate,32,Rep,Ruben Diaz,16
+Bronx,87035,State Senate,32,Rep,Ruben Diaz,8
+Bronx,87036,State Senate,32,Rep,Ruben Diaz,18
+Bronx,87037,State Senate,32,Rep,Ruben Diaz,26
+Bronx,87038,State Senate,32,Rep,Ruben Diaz,11
+Bronx,87039,State Senate,32,Rep,Ruben Diaz,19
+Bronx,87040,State Senate,32,Rep,Ruben Diaz,23
+Bronx,87041,State Senate,32,Rep,Ruben Diaz,13
+Bronx,87042,State Senate,32,Rep,Ruben Diaz,4
+Bronx,87045,State Senate,32,Rep,Ruben Diaz,11
+Bronx,87046,State Senate,32,Rep,Ruben Diaz,23
+Bronx,87047,State Senate,32,Rep,Ruben Diaz,17
+Bronx,87048,State Senate,32,Rep,Ruben Diaz,17
+Bronx,87049,State Senate,32,Rep,Ruben Diaz,21
+Bronx,87050,State Senate,32,Rep,Ruben Diaz,16
+Bronx,87051,State Senate,32,Rep,Ruben Diaz,13
+Bronx,87052,State Senate,32,Rep,Ruben Diaz,10
+Bronx,87053,State Senate,32,Rep,Ruben Diaz,19
+Bronx,87054,State Senate,32,Rep,Ruben Diaz,18
+Bronx,87055,State Senate,32,Rep,Ruben Diaz,14
+Bronx,87056,State Senate,32,Rep,Ruben Diaz,15
+Bronx,87057,State Senate,32,Rep,Ruben Diaz,20
+Bronx,87058,State Senate,32,Rep,Ruben Diaz,10
+Bronx,87059,State Senate,32,Rep,Ruben Diaz,19
+Bronx,87060,State Senate,32,Rep,Ruben Diaz,7
+Bronx,87061,State Senate,32,Rep,Ruben Diaz,11
+Bronx,87062,State Senate,32,Rep,Ruben Diaz,10
+Bronx,87063,State Senate,32,Rep,Ruben Diaz,1
+Bronx,87064,State Senate,32,Rep,Ruben Diaz,0
+Bronx,87083,State Senate,32,Rep,Ruben Diaz,0
+Bronx,87084,State Senate,32,Rep,Ruben Diaz,13
+Bronx,87085,State Senate,32,Rep,Ruben Diaz,16
+Bronx,87086,State Senate,32,Rep,Ruben Diaz,0
+Bronx,87087,State Senate,32,Rep,Ruben Diaz,9
+Bronx,87088,State Senate,32,Rep,Ruben Diaz,8
+Bronx,87089,State Senate,32,Rep,Ruben Diaz,5
+Bronx,87090,State Senate,32,Rep,Ruben Diaz,2
+Bronx,87091,State Senate,32,Rep,Ruben Diaz,10
+Bronx,77050,State Senate,32,Con,Ruben Diaz,4
+Bronx,77051,State Senate,32,Con,Ruben Diaz,1
+Bronx,77052,State Senate,32,Con,Ruben Diaz,0
+Bronx,77053,State Senate,32,Con,Ruben Diaz,1
+Bronx,77054,State Senate,32,Con,Ruben Diaz,5
+Bronx,77055,State Senate,32,Con,Ruben Diaz,3
+Bronx,77056,State Senate,32,Con,Ruben Diaz,2
+Bronx,77057,State Senate,32,Con,Ruben Diaz,2
+Bronx,77058,State Senate,32,Con,Ruben Diaz,5
+Bronx,77059,State Senate,32,Con,Ruben Diaz,1
+Bronx,77060,State Senate,32,Con,Ruben Diaz,3
+Bronx,77062,State Senate,32,Con,Ruben Diaz,5
+Bronx,77063,State Senate,32,Con,Ruben Diaz,1
+Bronx,77064,State Senate,32,Con,Ruben Diaz,1
+Bronx,79006,State Senate,32,Con,Ruben Diaz,0
+Bronx,79011,State Senate,32,Con,Ruben Diaz,2
+Bronx,79012,State Senate,32,Con,Ruben Diaz,2
+Bronx,79014,State Senate,32,Con,Ruben Diaz,0
+Bronx,79015,State Senate,32,Con,Ruben Diaz,2
+Bronx,79016,State Senate,32,Con,Ruben Diaz,1
+Bronx,79017,State Senate,32,Con,Ruben Diaz,4
+Bronx,79018,State Senate,32,Con,Ruben Diaz,4
+Bronx,79019,State Senate,32,Con,Ruben Diaz,2
+Bronx,79021,State Senate,32,Con,Ruben Diaz,4
+Bronx,79022,State Senate,32,Con,Ruben Diaz,1
+Bronx,79023,State Senate,32,Con,Ruben Diaz,4
+Bronx,79024,State Senate,32,Con,Ruben Diaz,2
+Bronx,79025,State Senate,32,Con,Ruben Diaz,0
+Bronx,79026,State Senate,32,Con,Ruben Diaz,2
+Bronx,79027,State Senate,32,Con,Ruben Diaz,1
+Bronx,79028,State Senate,32,Con,Ruben Diaz,3
+Bronx,79038,State Senate,32,Con,Ruben Diaz,3
+Bronx,79039,State Senate,32,Con,Ruben Diaz,1
+Bronx,79040,State Senate,32,Con,Ruben Diaz,0
+Bronx,79041,State Senate,32,Con,Ruben Diaz,2
+Bronx,79042,State Senate,32,Con,Ruben Diaz,0
+Bronx,79043,State Senate,32,Con,Ruben Diaz,6
+Bronx,79044,State Senate,32,Con,Ruben Diaz,5
+Bronx,79045,State Senate,32,Con,Ruben Diaz,1
+Bronx,79046,State Senate,32,Con,Ruben Diaz,5
+Bronx,79047,State Senate,32,Con,Ruben Diaz,3
+Bronx,79048,State Senate,32,Con,Ruben Diaz,2
+Bronx,79049,State Senate,32,Con,Ruben Diaz,3
+Bronx,79050,State Senate,32,Con,Ruben Diaz,5
+Bronx,79051,State Senate,32,Con,Ruben Diaz,4
+Bronx,79052,State Senate,32,Con,Ruben Diaz,3
+Bronx,79053,State Senate,32,Con,Ruben Diaz,0
+Bronx,79054,State Senate,32,Con,Ruben Diaz,1
+Bronx,79055,State Senate,32,Con,Ruben Diaz,6
+Bronx,79056,State Senate,32,Con,Ruben Diaz,6
+Bronx,79057,State Senate,32,Con,Ruben Diaz,3
+Bronx,79058,State Senate,32,Con,Ruben Diaz,5
+Bronx,79059,State Senate,32,Con,Ruben Diaz,6
+Bronx,79060,State Senate,32,Con,Ruben Diaz,0
+Bronx,79061,State Senate,32,Con,Ruben Diaz,1
+Bronx,79062,State Senate,32,Con,Ruben Diaz,3
+Bronx,79063,State Senate,32,Con,Ruben Diaz,0
+Bronx,79064,State Senate,32,Con,Ruben Diaz,1
+Bronx,79065,State Senate,32,Con,Ruben Diaz,1
+Bronx,79066,State Senate,32,Con,Ruben Diaz,2
+Bronx,79068,State Senate,32,Con,Ruben Diaz,3
+Bronx,79069,State Senate,32,Con,Ruben Diaz,2
+Bronx,79070,State Senate,32,Con,Ruben Diaz,7
+Bronx,79071,State Senate,32,Con,Ruben Diaz,2
+Bronx,79072,State Senate,32,Con,Ruben Diaz,1
+Bronx,79073,State Senate,32,Con,Ruben Diaz,1
+Bronx,79075,State Senate,32,Con,Ruben Diaz,3
+Bronx,79076,State Senate,32,Con,Ruben Diaz,0
+Bronx,82029,State Senate,32,Con,Ruben Diaz,1
+Bronx,82030,State Senate,32,Con,Ruben Diaz,9
+Bronx,84036,State Senate,32,Con,Ruben Diaz,0
+Bronx,84037,State Senate,32,Con,Ruben Diaz,1
+Bronx,84038,State Senate,32,Con,Ruben Diaz,5
+Bronx,84039,State Senate,32,Con,Ruben Diaz,2
+Bronx,84048,State Senate,32,Con,Ruben Diaz,6
+Bronx,84049,State Senate,32,Con,Ruben Diaz,3
+Bronx,84050,State Senate,32,Con,Ruben Diaz,0
+Bronx,84051,State Senate,32,Con,Ruben Diaz,6
+Bronx,84052,State Senate,32,Con,Ruben Diaz,4
+Bronx,84053,State Senate,32,Con,Ruben Diaz,0
+Bronx,84074,State Senate,32,Con,Ruben Diaz,2
+Bronx,84075,State Senate,32,Con,Ruben Diaz,0
+Bronx,85014,State Senate,32,Con,Ruben Diaz,3
+Bronx,85015,State Senate,32,Con,Ruben Diaz,2
+Bronx,85016,State Senate,32,Con,Ruben Diaz,3
+Bronx,85017,State Senate,32,Con,Ruben Diaz,5
+Bronx,85018,State Senate,32,Con,Ruben Diaz,0
+Bronx,85019,State Senate,32,Con,Ruben Diaz,5
+Bronx,85020,State Senate,32,Con,Ruben Diaz,0
+Bronx,85021,State Senate,32,Con,Ruben Diaz,1
+Bronx,85022,State Senate,32,Con,Ruben Diaz,3
+Bronx,85023,State Senate,32,Con,Ruben Diaz,2
+Bronx,85024,State Senate,32,Con,Ruben Diaz,7
+Bronx,85025,State Senate,32,Con,Ruben Diaz,2
+Bronx,85026,State Senate,32,Con,Ruben Diaz,4
+Bronx,85027,State Senate,32,Con,Ruben Diaz,5
+Bronx,85029,State Senate,32,Con,Ruben Diaz,0
+Bronx,85030,State Senate,32,Con,Ruben Diaz,1
+Bronx,85031,State Senate,32,Con,Ruben Diaz,3
+Bronx,85032,State Senate,32,Con,Ruben Diaz,3
+Bronx,85033,State Senate,32,Con,Ruben Diaz,4
+Bronx,85034,State Senate,32,Con,Ruben Diaz,1
+Bronx,85039,State Senate,32,Con,Ruben Diaz,4
+Bronx,85040,State Senate,32,Con,Ruben Diaz,4
+Bronx,85041,State Senate,32,Con,Ruben Diaz,4
+Bronx,85042,State Senate,32,Con,Ruben Diaz,5
+Bronx,85043,State Senate,32,Con,Ruben Diaz,3
+Bronx,85044,State Senate,32,Con,Ruben Diaz,5
+Bronx,85045,State Senate,32,Con,Ruben Diaz,4
+Bronx,85046,State Senate,32,Con,Ruben Diaz,7
+Bronx,85047,State Senate,32,Con,Ruben Diaz,6
+Bronx,85048,State Senate,32,Con,Ruben Diaz,3
+Bronx,85049,State Senate,32,Con,Ruben Diaz,3
+Bronx,85050,State Senate,32,Con,Ruben Diaz,2
+Bronx,85051,State Senate,32,Con,Ruben Diaz,2
+Bronx,85052,State Senate,32,Con,Ruben Diaz,2
+Bronx,85053,State Senate,32,Con,Ruben Diaz,3
+Bronx,85054,State Senate,32,Con,Ruben Diaz,4
+Bronx,85055,State Senate,32,Con,Ruben Diaz,3
+Bronx,85056,State Senate,32,Con,Ruben Diaz,0
+Bronx,85057,State Senate,32,Con,Ruben Diaz,2
+Bronx,85058,State Senate,32,Con,Ruben Diaz,8
+Bronx,85059,State Senate,32,Con,Ruben Diaz,5
+Bronx,85060,State Senate,32,Con,Ruben Diaz,4
+Bronx,85061,State Senate,32,Con,Ruben Diaz,2
+Bronx,85062,State Senate,32,Con,Ruben Diaz,3
+Bronx,85063,State Senate,32,Con,Ruben Diaz,5
+Bronx,85064,State Senate,32,Con,Ruben Diaz,6
+Bronx,85065,State Senate,32,Con,Ruben Diaz,5
+Bronx,85066,State Senate,32,Con,Ruben Diaz,5
+Bronx,85067,State Senate,32,Con,Ruben Diaz,4
+Bronx,85068,State Senate,32,Con,Ruben Diaz,0
+Bronx,85069,State Senate,32,Con,Ruben Diaz,3
+Bronx,85070,State Senate,32,Con,Ruben Diaz,0
+Bronx,85071,State Senate,32,Con,Ruben Diaz,0
+Bronx,85072,State Senate,32,Con,Ruben Diaz,1
+Bronx,87002,State Senate,32,Con,Ruben Diaz,0
+Bronx,87004,State Senate,32,Con,Ruben Diaz,0
+Bronx,87005,State Senate,32,Con,Ruben Diaz,2
+Bronx,87006,State Senate,32,Con,Ruben Diaz,5
+Bronx,87007,State Senate,32,Con,Ruben Diaz,3
+Bronx,87008,State Senate,32,Con,Ruben Diaz,1
+Bronx,87009,State Senate,32,Con,Ruben Diaz,1
+Bronx,87010,State Senate,32,Con,Ruben Diaz,2
+Bronx,87011,State Senate,32,Con,Ruben Diaz,5
+Bronx,87012,State Senate,32,Con,Ruben Diaz,0
+Bronx,87013,State Senate,32,Con,Ruben Diaz,2
+Bronx,87014,State Senate,32,Con,Ruben Diaz,2
+Bronx,87022,State Senate,32,Con,Ruben Diaz,4
+Bronx,87026,State Senate,32,Con,Ruben Diaz,1
+Bronx,87027,State Senate,32,Con,Ruben Diaz,3
+Bronx,87028,State Senate,32,Con,Ruben Diaz,8
+Bronx,87029,State Senate,32,Con,Ruben Diaz,8
+Bronx,87030,State Senate,32,Con,Ruben Diaz,0
+Bronx,87031,State Senate,32,Con,Ruben Diaz,7
+Bronx,87032,State Senate,32,Con,Ruben Diaz,3
+Bronx,87033,State Senate,32,Con,Ruben Diaz,5
+Bronx,87034,State Senate,32,Con,Ruben Diaz,5
+Bronx,87035,State Senate,32,Con,Ruben Diaz,7
+Bronx,87036,State Senate,32,Con,Ruben Diaz,12
+Bronx,87037,State Senate,32,Con,Ruben Diaz,15
+Bronx,87038,State Senate,32,Con,Ruben Diaz,3
+Bronx,87039,State Senate,32,Con,Ruben Diaz,5
+Bronx,87040,State Senate,32,Con,Ruben Diaz,11
+Bronx,87041,State Senate,32,Con,Ruben Diaz,5
+Bronx,87042,State Senate,32,Con,Ruben Diaz,1
+Bronx,87045,State Senate,32,Con,Ruben Diaz,2
+Bronx,87046,State Senate,32,Con,Ruben Diaz,6
+Bronx,87047,State Senate,32,Con,Ruben Diaz,4
+Bronx,87048,State Senate,32,Con,Ruben Diaz,3
+Bronx,87049,State Senate,32,Con,Ruben Diaz,1
+Bronx,87050,State Senate,32,Con,Ruben Diaz,4
+Bronx,87051,State Senate,32,Con,Ruben Diaz,8
+Bronx,87052,State Senate,32,Con,Ruben Diaz,7
+Bronx,87053,State Senate,32,Con,Ruben Diaz,6
+Bronx,87054,State Senate,32,Con,Ruben Diaz,6
+Bronx,87055,State Senate,32,Con,Ruben Diaz,3
+Bronx,87056,State Senate,32,Con,Ruben Diaz,3
+Bronx,87057,State Senate,32,Con,Ruben Diaz,6
+Bronx,87058,State Senate,32,Con,Ruben Diaz,1
+Bronx,87059,State Senate,32,Con,Ruben Diaz,3
+Bronx,87060,State Senate,32,Con,Ruben Diaz,6
+Bronx,87061,State Senate,32,Con,Ruben Diaz,4
+Bronx,87062,State Senate,32,Con,Ruben Diaz,6
+Bronx,87063,State Senate,32,Con,Ruben Diaz,0
+Bronx,87064,State Senate,32,Con,Ruben Diaz,0
+Bronx,87083,State Senate,32,Con,Ruben Diaz,0
+Bronx,87084,State Senate,32,Con,Ruben Diaz,5
+Bronx,87085,State Senate,32,Con,Ruben Diaz,2
+Bronx,87086,State Senate,32,Con,Ruben Diaz,0
+Bronx,87087,State Senate,32,Con,Ruben Diaz,3
+Bronx,87088,State Senate,32,Con,Ruben Diaz,2
+Bronx,87089,State Senate,32,Con,Ruben Diaz,2
+Bronx,87090,State Senate,32,Con,Ruben Diaz,3
+Bronx,87091,State Senate,32,Con,Ruben Diaz,0
+Bronx,77050,State Senate,32,Ind,writein,0
+Bronx,77051,State Senate,32,Ind,writein,0
+Bronx,77052,State Senate,32,Ind,writein,0
+Bronx,77053,State Senate,32,Ind,writein,0
+Bronx,77054,State Senate,32,Ind,writein,0
+Bronx,77055,State Senate,32,Ind,writein,0
+Bronx,77056,State Senate,32,Ind,writein,0
+Bronx,77057,State Senate,32,Ind,writein,0
+Bronx,77058,State Senate,32,Ind,writein,0
+Bronx,77059,State Senate,32,Ind,writein,0
+Bronx,77060,State Senate,32,Ind,writein,0
+Bronx,77062,State Senate,32,Ind,writein,0
+Bronx,77063,State Senate,32,Ind,writein,0
+Bronx,77064,State Senate,32,Ind,writein,0
+Bronx,79006,State Senate,32,Ind,writein,0
+Bronx,79011,State Senate,32,Ind,writein,0
+Bronx,79012,State Senate,32,Ind,writein,0
+Bronx,79014,State Senate,32,Ind,writein,0
+Bronx,79015,State Senate,32,Ind,writein,0
+Bronx,79016,State Senate,32,Ind,writein,1
+Bronx,79017,State Senate,32,Ind,writein,0
+Bronx,79018,State Senate,32,Ind,writein,0
+Bronx,79019,State Senate,32,Ind,writein,0
+Bronx,79021,State Senate,32,Ind,writein,0
+Bronx,79022,State Senate,32,Ind,writein,0
+Bronx,79023,State Senate,32,Ind,writein,0
+Bronx,79024,State Senate,32,Ind,writein,0
+Bronx,79025,State Senate,32,Ind,writein,0
+Bronx,79026,State Senate,32,Ind,writein,0
+Bronx,79027,State Senate,32,Ind,writein,0
+Bronx,79028,State Senate,32,Ind,writein,0
+Bronx,79038,State Senate,32,Ind,writein,0
+Bronx,79039,State Senate,32,Ind,writein,0
+Bronx,79040,State Senate,32,Ind,writein,0
+Bronx,79041,State Senate,32,Ind,writein,0
+Bronx,79042,State Senate,32,Ind,writein,0
+Bronx,79043,State Senate,32,Ind,writein,0
+Bronx,79044,State Senate,32,Ind,writein,0
+Bronx,79045,State Senate,32,Ind,writein,0
+Bronx,79046,State Senate,32,Ind,writein,0
+Bronx,79047,State Senate,32,Ind,writein,1
+Bronx,79048,State Senate,32,Ind,writein,0
+Bronx,79049,State Senate,32,Ind,writein,0
+Bronx,79050,State Senate,32,Ind,writein,0
+Bronx,79051,State Senate,32,Ind,writein,1
+Bronx,79052,State Senate,32,Ind,writein,0
+Bronx,79053,State Senate,32,Ind,writein,0
+Bronx,79054,State Senate,32,Ind,writein,1
+Bronx,79055,State Senate,32,Ind,writein,0
+Bronx,79056,State Senate,32,Ind,writein,0
+Bronx,79057,State Senate,32,Ind,writein,0
+Bronx,79058,State Senate,32,Ind,writein,0
+Bronx,79059,State Senate,32,Ind,writein,0
+Bronx,79060,State Senate,32,Ind,writein,0
+Bronx,79061,State Senate,32,Ind,writein,0
+Bronx,79062,State Senate,32,Ind,writein,0
+Bronx,79063,State Senate,32,Ind,writein,0
+Bronx,79064,State Senate,32,Ind,writein,0
+Bronx,79065,State Senate,32,Ind,writein,0
+Bronx,79066,State Senate,32,Ind,writein,0
+Bronx,79068,State Senate,32,Ind,writein,0
+Bronx,79069,State Senate,32,Ind,writein,0
+Bronx,79070,State Senate,32,Ind,writein,0
+Bronx,79071,State Senate,32,Ind,writein,0
+Bronx,79072,State Senate,32,Ind,writein,0
+Bronx,79073,State Senate,32,Ind,writein,0
+Bronx,79075,State Senate,32,Ind,writein,0
+Bronx,79076,State Senate,32,Ind,writein,0
+Bronx,82029,State Senate,32,Ind,writein,0
+Bronx,82030,State Senate,32,Ind,writein,0
+Bronx,84036,State Senate,32,Ind,writein,0
+Bronx,84037,State Senate,32,Ind,writein,0
+Bronx,84038,State Senate,32,Ind,writein,0
+Bronx,84039,State Senate,32,Ind,writein,0
+Bronx,84048,State Senate,32,Ind,writein,0
+Bronx,84049,State Senate,32,Ind,writein,0
+Bronx,84050,State Senate,32,Ind,writein,0
+Bronx,84051,State Senate,32,Ind,writein,0
+Bronx,84052,State Senate,32,Ind,writein,1
+Bronx,84053,State Senate,32,Ind,writein,0
+Bronx,84074,State Senate,32,Ind,writein,1
+Bronx,84075,State Senate,32,Ind,writein,0
+Bronx,85014,State Senate,32,Ind,writein,0
+Bronx,85015,State Senate,32,Ind,writein,0
+Bronx,85016,State Senate,32,Ind,writein,0
+Bronx,85017,State Senate,32,Ind,writein,0
+Bronx,85018,State Senate,32,Ind,writein,0
+Bronx,85019,State Senate,32,Ind,writein,0
+Bronx,85020,State Senate,32,Ind,writein,0
+Bronx,85021,State Senate,32,Ind,writein,0
+Bronx,85022,State Senate,32,Ind,writein,0
+Bronx,85023,State Senate,32,Ind,writein,0
+Bronx,85024,State Senate,32,Ind,writein,0
+Bronx,85025,State Senate,32,Ind,writein,0
+Bronx,85026,State Senate,32,Ind,writein,0
+Bronx,85027,State Senate,32,Ind,writein,0
+Bronx,85029,State Senate,32,Ind,writein,0
+Bronx,85030,State Senate,32,Ind,writein,0
+Bronx,85031,State Senate,32,Ind,writein,0
+Bronx,85032,State Senate,32,Ind,writein,0
+Bronx,85033,State Senate,32,Ind,writein,0
+Bronx,85034,State Senate,32,Ind,writein,0
+Bronx,85039,State Senate,32,Ind,writein,0
+Bronx,85040,State Senate,32,Ind,writein,0
+Bronx,85041,State Senate,32,Ind,writein,0
+Bronx,85042,State Senate,32,Ind,writein,0
+Bronx,85043,State Senate,32,Ind,writein,0
+Bronx,85044,State Senate,32,Ind,writein,0
+Bronx,85045,State Senate,32,Ind,writein,0
+Bronx,85046,State Senate,32,Ind,writein,0
+Bronx,85047,State Senate,32,Ind,writein,0
+Bronx,85048,State Senate,32,Ind,writein,0
+Bronx,85049,State Senate,32,Ind,writein,0
+Bronx,85050,State Senate,32,Ind,writein,0
+Bronx,85051,State Senate,32,Ind,writein,1
+Bronx,85052,State Senate,32,Ind,writein,0
+Bronx,85053,State Senate,32,Ind,writein,0
+Bronx,85054,State Senate,32,Ind,writein,1
+Bronx,85055,State Senate,32,Ind,writein,0
+Bronx,85056,State Senate,32,Ind,writein,0
+Bronx,85057,State Senate,32,Ind,writein,0
+Bronx,85058,State Senate,32,Ind,writein,0
+Bronx,85059,State Senate,32,Ind,writein,0
+Bronx,85060,State Senate,32,Ind,writein,0
+Bronx,85061,State Senate,32,Ind,writein,1
+Bronx,85062,State Senate,32,Ind,writein,0
+Bronx,85063,State Senate,32,Ind,writein,0
+Bronx,85064,State Senate,32,Ind,writein,0
+Bronx,85065,State Senate,32,Ind,writein,0
+Bronx,85066,State Senate,32,Ind,writein,0
+Bronx,85067,State Senate,32,Ind,writein,0
+Bronx,85068,State Senate,32,Ind,writein,0
+Bronx,85069,State Senate,32,Ind,writein,0
+Bronx,85070,State Senate,32,Ind,writein,0
+Bronx,85071,State Senate,32,Ind,writein,0
+Bronx,85072,State Senate,32,Ind,writein,0
+Bronx,87002,State Senate,32,Ind,writein,0
+Bronx,87004,State Senate,32,Ind,writein,0
+Bronx,87005,State Senate,32,Ind,writein,0
+Bronx,87006,State Senate,32,Ind,writein,0
+Bronx,87007,State Senate,32,Ind,writein,0
+Bronx,87008,State Senate,32,Ind,writein,0
+Bronx,87009,State Senate,32,Ind,writein,1
+Bronx,87010,State Senate,32,Ind,writein,0
+Bronx,87011,State Senate,32,Ind,writein,1
+Bronx,87012,State Senate,32,Ind,writein,0
+Bronx,87013,State Senate,32,Ind,writein,0
+Bronx,87014,State Senate,32,Ind,writein,0
+Bronx,87022,State Senate,32,Ind,writein,0
+Bronx,87026,State Senate,32,Ind,writein,0
+Bronx,87027,State Senate,32,Ind,writein,0
+Bronx,87028,State Senate,32,Ind,writein,0
+Bronx,87029,State Senate,32,Ind,writein,0
+Bronx,87030,State Senate,32,Ind,writein,0
+Bronx,87031,State Senate,32,Ind,writein,0
+Bronx,87032,State Senate,32,Ind,writein,0
+Bronx,87033,State Senate,32,Ind,writein,0
+Bronx,87034,State Senate,32,Ind,writein,0
+Bronx,87035,State Senate,32,Ind,writein,0
+Bronx,87036,State Senate,32,Ind,writein,0
+Bronx,87037,State Senate,32,Ind,writein,1
+Bronx,87038,State Senate,32,Ind,writein,0
+Bronx,87039,State Senate,32,Ind,writein,0
+Bronx,87040,State Senate,32,Ind,writein,1
+Bronx,87041,State Senate,32,Ind,writein,1
+Bronx,87042,State Senate,32,Ind,writein,0
+Bronx,87045,State Senate,32,Ind,writein,0
+Bronx,87046,State Senate,32,Ind,writein,0
+Bronx,87047,State Senate,32,Ind,writein,0
+Bronx,87048,State Senate,32,Ind,writein,0
+Bronx,87049,State Senate,32,Ind,writein,1
+Bronx,87050,State Senate,32,Ind,writein,0
+Bronx,87051,State Senate,32,Ind,writein,0
+Bronx,87052,State Senate,32,Ind,writein,0
+Bronx,87053,State Senate,32,Ind,writein,0
+Bronx,87054,State Senate,32,Ind,writein,0
+Bronx,87055,State Senate,32,Ind,writein,1
+Bronx,87056,State Senate,32,Ind,writein,0
+Bronx,87057,State Senate,32,Ind,writein,1
+Bronx,87058,State Senate,32,Ind,writein,1
+Bronx,87059,State Senate,32,Ind,writein,0
+Bronx,87060,State Senate,32,Ind,writein,0
+Bronx,87061,State Senate,32,Ind,writein,0
+Bronx,87062,State Senate,32,Ind,writein,0
+Bronx,87063,State Senate,32,Ind,writein,0
+Bronx,87064,State Senate,32,Ind,writein,0
+Bronx,87083,State Senate,32,Ind,writein,0
+Bronx,87084,State Senate,32,Ind,writein,0
+Bronx,87085,State Senate,32,Ind,writein,0
+Bronx,87086,State Senate,32,Ind,writein,0
+Bronx,87087,State Senate,32,Ind,writein,0
+Bronx,87088,State Senate,32,Ind,writein,0
+Bronx,87089,State Senate,32,Ind,writein,0
+Bronx,87090,State Senate,32,Ind,writein,0
+Bronx,87091,State Senate,32,Ind,writein,0
+Bronx,77029,State Senate,33,Dem,Gustavo Rivera,203
+Bronx,77030,State Senate,33,Dem,Gustavo Rivera,287
+Bronx,77033,State Senate,33,Dem,Gustavo Rivera,83
+Bronx,77037,State Senate,33,Dem,Gustavo Rivera,622
+Bronx,77038,State Senate,33,Dem,Gustavo Rivera,409
+Bronx,77039,State Senate,33,Dem,Gustavo Rivera,395
+Bronx,77042,State Senate,33,Dem,Gustavo Rivera,299
+Bronx,77043,State Senate,33,Dem,Gustavo Rivera,557
+Bronx,77044,State Senate,33,Dem,Gustavo Rivera,429
+Bronx,77045,State Senate,33,Dem,Gustavo Rivera,552
+Bronx,78001,State Senate,33,Dem,Gustavo Rivera,503
+Bronx,78002,State Senate,33,Dem,Gustavo Rivera,482
+Bronx,78003,State Senate,33,Dem,Gustavo Rivera,183
+Bronx,78004,State Senate,33,Dem,Gustavo Rivera,490
+Bronx,78005,State Senate,33,Dem,Gustavo Rivera,423
+Bronx,78006,State Senate,33,Dem,Gustavo Rivera,490
+Bronx,78008,State Senate,33,Dem,Gustavo Rivera,298
+Bronx,78009,State Senate,33,Dem,Gustavo Rivera,443
+Bronx,78010,State Senate,33,Dem,Gustavo Rivera,478
+Bronx,78011,State Senate,33,Dem,Gustavo Rivera,461
+Bronx,78012,State Senate,33,Dem,Gustavo Rivera,472
+Bronx,78013,State Senate,33,Dem,Gustavo Rivera,483
+Bronx,78014,State Senate,33,Dem,Gustavo Rivera,294
+Bronx,78015,State Senate,33,Dem,Gustavo Rivera,241
+Bronx,78017,State Senate,33,Dem,Gustavo Rivera,361
+Bronx,78018,State Senate,33,Dem,Gustavo Rivera,205
+Bronx,78019,State Senate,33,Dem,Gustavo Rivera,339
+Bronx,78020,State Senate,33,Dem,Gustavo Rivera,362
+Bronx,78021,State Senate,33,Dem,Gustavo Rivera,494
+Bronx,78022,State Senate,33,Dem,Gustavo Rivera,445
+Bronx,78023,State Senate,33,Dem,Gustavo Rivera,445
+Bronx,78024,State Senate,33,Dem,Gustavo Rivera,469
+Bronx,78025,State Senate,33,Dem,Gustavo Rivera,396
+Bronx,78026,State Senate,33,Dem,Gustavo Rivera,335
+Bronx,78027,State Senate,33,Dem,Gustavo Rivera,332
+Bronx,78028,State Senate,33,Dem,Gustavo Rivera,500
+Bronx,78029,State Senate,33,Dem,Gustavo Rivera,332
+Bronx,78043,State Senate,33,Dem,Gustavo Rivera,123
+Bronx,78044,State Senate,33,Dem,Gustavo Rivera,508
+Bronx,78045,State Senate,33,Dem,Gustavo Rivera,505
+Bronx,78046,State Senate,33,Dem,Gustavo Rivera,474
+Bronx,78047,State Senate,33,Dem,Gustavo Rivera,374
+Bronx,78048,State Senate,33,Dem,Gustavo Rivera,505
+Bronx,78049,State Senate,33,Dem,Gustavo Rivera,445
+Bronx,78050,State Senate,33,Dem,Gustavo Rivera,427
+Bronx,78051,State Senate,33,Dem,Gustavo Rivera,464
+Bronx,78052,State Senate,33,Dem,Gustavo Rivera,456
+Bronx,78053,State Senate,33,Dem,Gustavo Rivera,398
+Bronx,78054,State Senate,33,Dem,Gustavo Rivera,274
+Bronx,78056,State Senate,33,Dem,Gustavo Rivera,2
+Bronx,79001,State Senate,33,Dem,Gustavo Rivera,464
+Bronx,79002,State Senate,33,Dem,Gustavo Rivera,328
+Bronx,79003,State Senate,33,Dem,Gustavo Rivera,468
+Bronx,79004,State Senate,33,Dem,Gustavo Rivera,444
+Bronx,79005,State Senate,33,Dem,Gustavo Rivera,482
+Bronx,79007,State Senate,33,Dem,Gustavo Rivera,360
+Bronx,79008,State Senate,33,Dem,Gustavo Rivera,246
+Bronx,79009,State Senate,33,Dem,Gustavo Rivera,334
+Bronx,79010,State Senate,33,Dem,Gustavo Rivera,310
+Bronx,79013,State Senate,33,Dem,Gustavo Rivera,407
+Bronx,79020,State Senate,33,Dem,Gustavo Rivera,300
+Bronx,79029,State Senate,33,Dem,Gustavo Rivera,197
+Bronx,79030,State Senate,33,Dem,Gustavo Rivera,605
+Bronx,79031,State Senate,33,Dem,Gustavo Rivera,430
+Bronx,79032,State Senate,33,Dem,Gustavo Rivera,362
+Bronx,79033,State Senate,33,Dem,Gustavo Rivera,343
+Bronx,79034,State Senate,33,Dem,Gustavo Rivera,528
+Bronx,79035,State Senate,33,Dem,Gustavo Rivera,462
+Bronx,79036,State Senate,33,Dem,Gustavo Rivera,442
+Bronx,79037,State Senate,33,Dem,Gustavo Rivera,633
+Bronx,79074,State Senate,33,Dem,Gustavo Rivera,72
+Bronx,80009,State Senate,33,Dem,Gustavo Rivera,180
+Bronx,80010,State Senate,33,Dem,Gustavo Rivera,236
+Bronx,80011,State Senate,33,Dem,Gustavo Rivera,77
+Bronx,80012,State Senate,33,Dem,Gustavo Rivera,168
+Bronx,80013,State Senate,33,Dem,Gustavo Rivera,287
+Bronx,80014,State Senate,33,Dem,Gustavo Rivera,146
+Bronx,80015,State Senate,33,Dem,Gustavo Rivera,30
+Bronx,81001,State Senate,33,Dem,Gustavo Rivera,344
+Bronx,81002,State Senate,33,Dem,Gustavo Rivera,305
+Bronx,81003,State Senate,33,Dem,Gustavo Rivera,118
+Bronx,81004,State Senate,33,Dem,Gustavo Rivera,475
+Bronx,81005,State Senate,33,Dem,Gustavo Rivera,443
+Bronx,81006,State Senate,33,Dem,Gustavo Rivera,392
+Bronx,81007,State Senate,33,Dem,Gustavo Rivera,466
+Bronx,81008,State Senate,33,Dem,Gustavo Rivera,207
+Bronx,81009,State Senate,33,Dem,Gustavo Rivera,303
+Bronx,81011,State Senate,33,Dem,Gustavo Rivera,7
+Bronx,81038,State Senate,33,Dem,Gustavo Rivera,476
+Bronx,81039,State Senate,33,Dem,Gustavo Rivera,233
+Bronx,81040,State Senate,33,Dem,Gustavo Rivera,450
+Bronx,81045,State Senate,33,Dem,Gustavo Rivera,73
+Bronx,81046,State Senate,33,Dem,Gustavo Rivera,151
+Bronx,81108,State Senate,33,Dem,Gustavo Rivera,126
+Bronx,86008,State Senate,33,Dem,Gustavo Rivera,333
+Bronx,86009,State Senate,33,Dem,Gustavo Rivera,427
+Bronx,86010,State Senate,33,Dem,Gustavo Rivera,293
+Bronx,86011,State Senate,33,Dem,Gustavo Rivera,630
+Bronx,86012,State Senate,33,Dem,Gustavo Rivera,408
+Bronx,86013,State Senate,33,Dem,Gustavo Rivera,358
+Bronx,86014,State Senate,33,Dem,Gustavo Rivera,535
+Bronx,86015,State Senate,33,Dem,Gustavo Rivera,403
+Bronx,86016,State Senate,33,Dem,Gustavo Rivera,390
+Bronx,86017,State Senate,33,Dem,Gustavo Rivera,371
+Bronx,86018,State Senate,33,Dem,Gustavo Rivera,387
+Bronx,86019,State Senate,33,Dem,Gustavo Rivera,556
+Bronx,86020,State Senate,33,Dem,Gustavo Rivera,438
+Bronx,86021,State Senate,33,Dem,Gustavo Rivera,1
+Bronx,86022,State Senate,33,Dem,Gustavo Rivera,463
+Bronx,86023,State Senate,33,Dem,Gustavo Rivera,501
+Bronx,86024,State Senate,33,Dem,Gustavo Rivera,449
+Bronx,86025,State Senate,33,Dem,Gustavo Rivera,494
+Bronx,86026,State Senate,33,Dem,Gustavo Rivera,575
+Bronx,86027,State Senate,33,Dem,Gustavo Rivera,630
+Bronx,86028,State Senate,33,Dem,Gustavo Rivera,478
+Bronx,86029,State Senate,33,Dem,Gustavo Rivera,495
+Bronx,86030,State Senate,33,Dem,Gustavo Rivera,534
+Bronx,86031,State Senate,33,Dem,Gustavo Rivera,503
+Bronx,86032,State Senate,33,Dem,Gustavo Rivera,410
+Bronx,86033,State Senate,33,Dem,Gustavo Rivera,580
+Bronx,86034,State Senate,33,Dem,Gustavo Rivera,484
+Bronx,86035,State Senate,33,Dem,Gustavo Rivera,492
+Bronx,86036,State Senate,33,Dem,Gustavo Rivera,503
+Bronx,86037,State Senate,33,Dem,Gustavo Rivera,360
+Bronx,86038,State Senate,33,Dem,Gustavo Rivera,184
+Bronx,86039,State Senate,33,Dem,Gustavo Rivera,308
+Bronx,86040,State Senate,33,Dem,Gustavo Rivera,433
+Bronx,86041,State Senate,33,Dem,Gustavo Rivera,421
+Bronx,86042,State Senate,33,Dem,Gustavo Rivera,5
+Bronx,86043,State Senate,33,Dem,Gustavo Rivera,24
+Bronx,86044,State Senate,33,Dem,Gustavo Rivera,161
+Bronx,86045,State Senate,33,Dem,Gustavo Rivera,392
+Bronx,86046,State Senate,33,Dem,Gustavo Rivera,350
+Bronx,86047,State Senate,33,Dem,Gustavo Rivera,578
+Bronx,86048,State Senate,33,Dem,Gustavo Rivera,296
+Bronx,86049,State Senate,33,Dem,Gustavo Rivera,480
+Bronx,86050,State Senate,33,Dem,Gustavo Rivera,528
+Bronx,86051,State Senate,33,Dem,Gustavo Rivera,340
+Bronx,86052,State Senate,33,Dem,Gustavo Rivera,477
+Bronx,86053,State Senate,33,Dem,Gustavo Rivera,364
+Bronx,86054,State Senate,33,Dem,Gustavo Rivera,506
+Bronx,86055,State Senate,33,Dem,Gustavo Rivera,518
+Bronx,86056,State Senate,33,Dem,Gustavo Rivera,394
+Bronx,86057,State Senate,33,Dem,Gustavo Rivera,337
+Bronx,87003,State Senate,33,Dem,Gustavo Rivera,252
+Bronx,87015,State Senate,33,Dem,Gustavo Rivera,133
+Bronx,87016,State Senate,33,Dem,Gustavo Rivera,145
+Bronx,87017,State Senate,33,Dem,Gustavo Rivera,134
+Bronx,87018,State Senate,33,Dem,Gustavo Rivera,303
+Bronx,87019,State Senate,33,Dem,Gustavo Rivera,345
+Bronx,87020,State Senate,33,Dem,Gustavo Rivera,337
+Bronx,87023,State Senate,33,Dem,Gustavo Rivera,403
+Bronx,87024,State Senate,33,Dem,Gustavo Rivera,16
+Bronx,87025,State Senate,33,Dem,Gustavo Rivera,120
+Bronx,77029,State Senate,33,WF,Gustavo Rivera,8
+Bronx,77030,State Senate,33,WF,Gustavo Rivera,5
+Bronx,77033,State Senate,33,WF,Gustavo Rivera,1
+Bronx,77037,State Senate,33,WF,Gustavo Rivera,5
+Bronx,77038,State Senate,33,WF,Gustavo Rivera,3
+Bronx,77039,State Senate,33,WF,Gustavo Rivera,7
+Bronx,77042,State Senate,33,WF,Gustavo Rivera,0
+Bronx,77043,State Senate,33,WF,Gustavo Rivera,9
+Bronx,77044,State Senate,33,WF,Gustavo Rivera,5
+Bronx,77045,State Senate,33,WF,Gustavo Rivera,9
+Bronx,78001,State Senate,33,WF,Gustavo Rivera,8
+Bronx,78002,State Senate,33,WF,Gustavo Rivera,13
+Bronx,78003,State Senate,33,WF,Gustavo Rivera,3
+Bronx,78004,State Senate,33,WF,Gustavo Rivera,6
+Bronx,78005,State Senate,33,WF,Gustavo Rivera,9
+Bronx,78006,State Senate,33,WF,Gustavo Rivera,6
+Bronx,78008,State Senate,33,WF,Gustavo Rivera,4
+Bronx,78009,State Senate,33,WF,Gustavo Rivera,15
+Bronx,78010,State Senate,33,WF,Gustavo Rivera,8
+Bronx,78011,State Senate,33,WF,Gustavo Rivera,7
+Bronx,78012,State Senate,33,WF,Gustavo Rivera,5
+Bronx,78013,State Senate,33,WF,Gustavo Rivera,4
+Bronx,78014,State Senate,33,WF,Gustavo Rivera,4
+Bronx,78015,State Senate,33,WF,Gustavo Rivera,2
+Bronx,78017,State Senate,33,WF,Gustavo Rivera,3
+Bronx,78018,State Senate,33,WF,Gustavo Rivera,2
+Bronx,78019,State Senate,33,WF,Gustavo Rivera,0
+Bronx,78020,State Senate,33,WF,Gustavo Rivera,12
+Bronx,78021,State Senate,33,WF,Gustavo Rivera,9
+Bronx,78022,State Senate,33,WF,Gustavo Rivera,7
+Bronx,78023,State Senate,33,WF,Gustavo Rivera,12
+Bronx,78024,State Senate,33,WF,Gustavo Rivera,6
+Bronx,78025,State Senate,33,WF,Gustavo Rivera,2
+Bronx,78026,State Senate,33,WF,Gustavo Rivera,8
+Bronx,78027,State Senate,33,WF,Gustavo Rivera,6
+Bronx,78028,State Senate,33,WF,Gustavo Rivera,11
+Bronx,78029,State Senate,33,WF,Gustavo Rivera,9
+Bronx,78043,State Senate,33,WF,Gustavo Rivera,1
+Bronx,78044,State Senate,33,WF,Gustavo Rivera,11
+Bronx,78045,State Senate,33,WF,Gustavo Rivera,8
+Bronx,78046,State Senate,33,WF,Gustavo Rivera,5
+Bronx,78047,State Senate,33,WF,Gustavo Rivera,6
+Bronx,78048,State Senate,33,WF,Gustavo Rivera,15
+Bronx,78049,State Senate,33,WF,Gustavo Rivera,12
+Bronx,78050,State Senate,33,WF,Gustavo Rivera,9
+Bronx,78051,State Senate,33,WF,Gustavo Rivera,7
+Bronx,78052,State Senate,33,WF,Gustavo Rivera,4
+Bronx,78053,State Senate,33,WF,Gustavo Rivera,4
+Bronx,78054,State Senate,33,WF,Gustavo Rivera,5
+Bronx,78056,State Senate,33,WF,Gustavo Rivera,0
+Bronx,79001,State Senate,33,WF,Gustavo Rivera,1
+Bronx,79002,State Senate,33,WF,Gustavo Rivera,14
+Bronx,79003,State Senate,33,WF,Gustavo Rivera,6
+Bronx,79004,State Senate,33,WF,Gustavo Rivera,4
+Bronx,79005,State Senate,33,WF,Gustavo Rivera,4
+Bronx,79007,State Senate,33,WF,Gustavo Rivera,6
+Bronx,79008,State Senate,33,WF,Gustavo Rivera,7
+Bronx,79009,State Senate,33,WF,Gustavo Rivera,14
+Bronx,79010,State Senate,33,WF,Gustavo Rivera,4
+Bronx,79013,State Senate,33,WF,Gustavo Rivera,24
+Bronx,79020,State Senate,33,WF,Gustavo Rivera,1
+Bronx,79029,State Senate,33,WF,Gustavo Rivera,2
+Bronx,79030,State Senate,33,WF,Gustavo Rivera,12
+Bronx,79031,State Senate,33,WF,Gustavo Rivera,2
+Bronx,79032,State Senate,33,WF,Gustavo Rivera,8
+Bronx,79033,State Senate,33,WF,Gustavo Rivera,4
+Bronx,79034,State Senate,33,WF,Gustavo Rivera,9
+Bronx,79035,State Senate,33,WF,Gustavo Rivera,5
+Bronx,79036,State Senate,33,WF,Gustavo Rivera,7
+Bronx,79037,State Senate,33,WF,Gustavo Rivera,5
+Bronx,79074,State Senate,33,WF,Gustavo Rivera,1
+Bronx,80009,State Senate,33,WF,Gustavo Rivera,8
+Bronx,80010,State Senate,33,WF,Gustavo Rivera,5
+Bronx,80011,State Senate,33,WF,Gustavo Rivera,6
+Bronx,80012,State Senate,33,WF,Gustavo Rivera,10
+Bronx,80013,State Senate,33,WF,Gustavo Rivera,5
+Bronx,80014,State Senate,33,WF,Gustavo Rivera,3
+Bronx,80015,State Senate,33,WF,Gustavo Rivera,0
+Bronx,81001,State Senate,33,WF,Gustavo Rivera,1
+Bronx,81002,State Senate,33,WF,Gustavo Rivera,6
+Bronx,81003,State Senate,33,WF,Gustavo Rivera,0
+Bronx,81004,State Senate,33,WF,Gustavo Rivera,10
+Bronx,81005,State Senate,33,WF,Gustavo Rivera,8
+Bronx,81006,State Senate,33,WF,Gustavo Rivera,16
+Bronx,81007,State Senate,33,WF,Gustavo Rivera,7
+Bronx,81008,State Senate,33,WF,Gustavo Rivera,4
+Bronx,81009,State Senate,33,WF,Gustavo Rivera,4
+Bronx,81011,State Senate,33,WF,Gustavo Rivera,1
+Bronx,81038,State Senate,33,WF,Gustavo Rivera,12
+Bronx,81039,State Senate,33,WF,Gustavo Rivera,7
+Bronx,81040,State Senate,33,WF,Gustavo Rivera,13
+Bronx,81045,State Senate,33,WF,Gustavo Rivera,0
+Bronx,81046,State Senate,33,WF,Gustavo Rivera,5
+Bronx,81108,State Senate,33,WF,Gustavo Rivera,3
+Bronx,86008,State Senate,33,WF,Gustavo Rivera,6
+Bronx,86009,State Senate,33,WF,Gustavo Rivera,4
+Bronx,86010,State Senate,33,WF,Gustavo Rivera,1
+Bronx,86011,State Senate,33,WF,Gustavo Rivera,12
+Bronx,86012,State Senate,33,WF,Gustavo Rivera,7
+Bronx,86013,State Senate,33,WF,Gustavo Rivera,5
+Bronx,86014,State Senate,33,WF,Gustavo Rivera,14
+Bronx,86015,State Senate,33,WF,Gustavo Rivera,5
+Bronx,86016,State Senate,33,WF,Gustavo Rivera,5
+Bronx,86017,State Senate,33,WF,Gustavo Rivera,15
+Bronx,86018,State Senate,33,WF,Gustavo Rivera,2
+Bronx,86019,State Senate,33,WF,Gustavo Rivera,7
+Bronx,86020,State Senate,33,WF,Gustavo Rivera,7
+Bronx,86021,State Senate,33,WF,Gustavo Rivera,0
+Bronx,86022,State Senate,33,WF,Gustavo Rivera,5
+Bronx,86023,State Senate,33,WF,Gustavo Rivera,8
+Bronx,86024,State Senate,33,WF,Gustavo Rivera,4
+Bronx,86025,State Senate,33,WF,Gustavo Rivera,5
+Bronx,86026,State Senate,33,WF,Gustavo Rivera,0
+Bronx,86027,State Senate,33,WF,Gustavo Rivera,7
+Bronx,86028,State Senate,33,WF,Gustavo Rivera,8
+Bronx,86029,State Senate,33,WF,Gustavo Rivera,3
+Bronx,86030,State Senate,33,WF,Gustavo Rivera,6
+Bronx,86031,State Senate,33,WF,Gustavo Rivera,7
+Bronx,86032,State Senate,33,WF,Gustavo Rivera,2
+Bronx,86033,State Senate,33,WF,Gustavo Rivera,11
+Bronx,86034,State Senate,33,WF,Gustavo Rivera,6
+Bronx,86035,State Senate,33,WF,Gustavo Rivera,5
+Bronx,86036,State Senate,33,WF,Gustavo Rivera,9
+Bronx,86037,State Senate,33,WF,Gustavo Rivera,6
+Bronx,86038,State Senate,33,WF,Gustavo Rivera,0
+Bronx,86039,State Senate,33,WF,Gustavo Rivera,4
+Bronx,86040,State Senate,33,WF,Gustavo Rivera,14
+Bronx,86041,State Senate,33,WF,Gustavo Rivera,7
+Bronx,86042,State Senate,33,WF,Gustavo Rivera,0
+Bronx,86043,State Senate,33,WF,Gustavo Rivera,0
+Bronx,86044,State Senate,33,WF,Gustavo Rivera,6
+Bronx,86045,State Senate,33,WF,Gustavo Rivera,4
+Bronx,86046,State Senate,33,WF,Gustavo Rivera,7
+Bronx,86047,State Senate,33,WF,Gustavo Rivera,7
+Bronx,86048,State Senate,33,WF,Gustavo Rivera,6
+Bronx,86049,State Senate,33,WF,Gustavo Rivera,12
+Bronx,86050,State Senate,33,WF,Gustavo Rivera,7
+Bronx,86051,State Senate,33,WF,Gustavo Rivera,6
+Bronx,86052,State Senate,33,WF,Gustavo Rivera,3
+Bronx,86053,State Senate,33,WF,Gustavo Rivera,7
+Bronx,86054,State Senate,33,WF,Gustavo Rivera,6
+Bronx,86055,State Senate,33,WF,Gustavo Rivera,9
+Bronx,86056,State Senate,33,WF,Gustavo Rivera,12
+Bronx,86057,State Senate,33,WF,Gustavo Rivera,1
+Bronx,87003,State Senate,33,WF,Gustavo Rivera,3
+Bronx,87015,State Senate,33,WF,Gustavo Rivera,5
+Bronx,87016,State Senate,33,WF,Gustavo Rivera,4
+Bronx,87017,State Senate,33,WF,Gustavo Rivera,2
+Bronx,87018,State Senate,33,WF,Gustavo Rivera,7
+Bronx,87019,State Senate,33,WF,Gustavo Rivera,9
+Bronx,87020,State Senate,33,WF,Gustavo Rivera,7
+Bronx,87023,State Senate,33,WF,Gustavo Rivera,8
+Bronx,87024,State Senate,33,WF,Gustavo Rivera,3
+Bronx,87025,State Senate,33,WF,Gustavo Rivera,3
+Bronx,77029,State Senate,33,Rep,Michael Waters,3
+Bronx,77030,State Senate,33,Rep,Michael Waters,2
+Bronx,77033,State Senate,33,Rep,Michael Waters,0
+Bronx,77037,State Senate,33,Rep,Michael Waters,8
+Bronx,77038,State Senate,33,Rep,Michael Waters,12
+Bronx,77039,State Senate,33,Rep,Michael Waters,9
+Bronx,77042,State Senate,33,Rep,Michael Waters,3
+Bronx,77043,State Senate,33,Rep,Michael Waters,8
+Bronx,77044,State Senate,33,Rep,Michael Waters,6
+Bronx,77045,State Senate,33,Rep,Michael Waters,13
+Bronx,78001,State Senate,33,Rep,Michael Waters,6
+Bronx,78002,State Senate,33,Rep,Michael Waters,7
+Bronx,78003,State Senate,33,Rep,Michael Waters,14
+Bronx,78004,State Senate,33,Rep,Michael Waters,21
+Bronx,78005,State Senate,33,Rep,Michael Waters,24
+Bronx,78006,State Senate,33,Rep,Michael Waters,35
+Bronx,78008,State Senate,33,Rep,Michael Waters,27
+Bronx,78009,State Senate,33,Rep,Michael Waters,34
+Bronx,78010,State Senate,33,Rep,Michael Waters,8
+Bronx,78011,State Senate,33,Rep,Michael Waters,9
+Bronx,78012,State Senate,33,Rep,Michael Waters,16
+Bronx,78013,State Senate,33,Rep,Michael Waters,14
+Bronx,78014,State Senate,33,Rep,Michael Waters,10
+Bronx,78015,State Senate,33,Rep,Michael Waters,12
+Bronx,78017,State Senate,33,Rep,Michael Waters,3
+Bronx,78018,State Senate,33,Rep,Michael Waters,10
+Bronx,78019,State Senate,33,Rep,Michael Waters,17
+Bronx,78020,State Senate,33,Rep,Michael Waters,16
+Bronx,78021,State Senate,33,Rep,Michael Waters,9
+Bronx,78022,State Senate,33,Rep,Michael Waters,18
+Bronx,78023,State Senate,33,Rep,Michael Waters,16
+Bronx,78024,State Senate,33,Rep,Michael Waters,15
+Bronx,78025,State Senate,33,Rep,Michael Waters,10
+Bronx,78026,State Senate,33,Rep,Michael Waters,10
+Bronx,78027,State Senate,33,Rep,Michael Waters,8
+Bronx,78028,State Senate,33,Rep,Michael Waters,33
+Bronx,78029,State Senate,33,Rep,Michael Waters,8
+Bronx,78043,State Senate,33,Rep,Michael Waters,5
+Bronx,78044,State Senate,33,Rep,Michael Waters,26
+Bronx,78045,State Senate,33,Rep,Michael Waters,21
+Bronx,78046,State Senate,33,Rep,Michael Waters,23
+Bronx,78047,State Senate,33,Rep,Michael Waters,11
+Bronx,78048,State Senate,33,Rep,Michael Waters,30
+Bronx,78049,State Senate,33,Rep,Michael Waters,19
+Bronx,78050,State Senate,33,Rep,Michael Waters,18
+Bronx,78051,State Senate,33,Rep,Michael Waters,14
+Bronx,78052,State Senate,33,Rep,Michael Waters,13
+Bronx,78053,State Senate,33,Rep,Michael Waters,14
+Bronx,78054,State Senate,33,Rep,Michael Waters,12
+Bronx,78056,State Senate,33,Rep,Michael Waters,0
+Bronx,79001,State Senate,33,Rep,Michael Waters,16
+Bronx,79002,State Senate,33,Rep,Michael Waters,8
+Bronx,79003,State Senate,33,Rep,Michael Waters,6
+Bronx,79004,State Senate,33,Rep,Michael Waters,12
+Bronx,79005,State Senate,33,Rep,Michael Waters,8
+Bronx,79007,State Senate,33,Rep,Michael Waters,5
+Bronx,79008,State Senate,33,Rep,Michael Waters,4
+Bronx,79009,State Senate,33,Rep,Michael Waters,4
+Bronx,79010,State Senate,33,Rep,Michael Waters,5
+Bronx,79013,State Senate,33,Rep,Michael Waters,6
+Bronx,79020,State Senate,33,Rep,Michael Waters,6
+Bronx,79029,State Senate,33,Rep,Michael Waters,2
+Bronx,79030,State Senate,33,Rep,Michael Waters,9
+Bronx,79031,State Senate,33,Rep,Michael Waters,3
+Bronx,79032,State Senate,33,Rep,Michael Waters,9
+Bronx,79033,State Senate,33,Rep,Michael Waters,8
+Bronx,79034,State Senate,33,Rep,Michael Waters,10
+Bronx,79035,State Senate,33,Rep,Michael Waters,7
+Bronx,79036,State Senate,33,Rep,Michael Waters,1
+Bronx,79037,State Senate,33,Rep,Michael Waters,7
+Bronx,79074,State Senate,33,Rep,Michael Waters,0
+Bronx,80009,State Senate,33,Rep,Michael Waters,16
+Bronx,80010,State Senate,33,Rep,Michael Waters,43
+Bronx,80011,State Senate,33,Rep,Michael Waters,8
+Bronx,80012,State Senate,33,Rep,Michael Waters,14
+Bronx,80013,State Senate,33,Rep,Michael Waters,47
+Bronx,80014,State Senate,33,Rep,Michael Waters,17
+Bronx,80015,State Senate,33,Rep,Michael Waters,1
+Bronx,81001,State Senate,33,Rep,Michael Waters,18
+Bronx,81002,State Senate,33,Rep,Michael Waters,34
+Bronx,81003,State Senate,33,Rep,Michael Waters,10
+Bronx,81004,State Senate,33,Rep,Michael Waters,36
+Bronx,81005,State Senate,33,Rep,Michael Waters,25
+Bronx,81006,State Senate,33,Rep,Michael Waters,36
+Bronx,81007,State Senate,33,Rep,Michael Waters,27
+Bronx,81008,State Senate,33,Rep,Michael Waters,9
+Bronx,81009,State Senate,33,Rep,Michael Waters,5
+Bronx,81011,State Senate,33,Rep,Michael Waters,0
+Bronx,81038,State Senate,33,Rep,Michael Waters,21
+Bronx,81039,State Senate,33,Rep,Michael Waters,19
+Bronx,81040,State Senate,33,Rep,Michael Waters,25
+Bronx,81045,State Senate,33,Rep,Michael Waters,10
+Bronx,81046,State Senate,33,Rep,Michael Waters,15
+Bronx,81108,State Senate,33,Rep,Michael Waters,24
+Bronx,86008,State Senate,33,Rep,Michael Waters,3
+Bronx,86009,State Senate,33,Rep,Michael Waters,11
+Bronx,86010,State Senate,33,Rep,Michael Waters,6
+Bronx,86011,State Senate,33,Rep,Michael Waters,16
+Bronx,86012,State Senate,33,Rep,Michael Waters,20
+Bronx,86013,State Senate,33,Rep,Michael Waters,8
+Bronx,86014,State Senate,33,Rep,Michael Waters,9
+Bronx,86015,State Senate,33,Rep,Michael Waters,10
+Bronx,86016,State Senate,33,Rep,Michael Waters,15
+Bronx,86017,State Senate,33,Rep,Michael Waters,16
+Bronx,86018,State Senate,33,Rep,Michael Waters,8
+Bronx,86019,State Senate,33,Rep,Michael Waters,14
+Bronx,86020,State Senate,33,Rep,Michael Waters,17
+Bronx,86021,State Senate,33,Rep,Michael Waters,0
+Bronx,86022,State Senate,33,Rep,Michael Waters,16
+Bronx,86023,State Senate,33,Rep,Michael Waters,12
+Bronx,86024,State Senate,33,Rep,Michael Waters,13
+Bronx,86025,State Senate,33,Rep,Michael Waters,19
+Bronx,86026,State Senate,33,Rep,Michael Waters,15
+Bronx,86027,State Senate,33,Rep,Michael Waters,19
+Bronx,86028,State Senate,33,Rep,Michael Waters,7
+Bronx,86029,State Senate,33,Rep,Michael Waters,17
+Bronx,86030,State Senate,33,Rep,Michael Waters,21
+Bronx,86031,State Senate,33,Rep,Michael Waters,17
+Bronx,86032,State Senate,33,Rep,Michael Waters,11
+Bronx,86033,State Senate,33,Rep,Michael Waters,8
+Bronx,86034,State Senate,33,Rep,Michael Waters,5
+Bronx,86035,State Senate,33,Rep,Michael Waters,12
+Bronx,86036,State Senate,33,Rep,Michael Waters,11
+Bronx,86037,State Senate,33,Rep,Michael Waters,8
+Bronx,86038,State Senate,33,Rep,Michael Waters,1
+Bronx,86039,State Senate,33,Rep,Michael Waters,12
+Bronx,86040,State Senate,33,Rep,Michael Waters,9
+Bronx,86041,State Senate,33,Rep,Michael Waters,4
+Bronx,86042,State Senate,33,Rep,Michael Waters,0
+Bronx,86043,State Senate,33,Rep,Michael Waters,1
+Bronx,86044,State Senate,33,Rep,Michael Waters,1
+Bronx,86045,State Senate,33,Rep,Michael Waters,7
+Bronx,86046,State Senate,33,Rep,Michael Waters,8
+Bronx,86047,State Senate,33,Rep,Michael Waters,8
+Bronx,86048,State Senate,33,Rep,Michael Waters,3
+Bronx,86049,State Senate,33,Rep,Michael Waters,10
+Bronx,86050,State Senate,33,Rep,Michael Waters,7
+Bronx,86051,State Senate,33,Rep,Michael Waters,5
+Bronx,86052,State Senate,33,Rep,Michael Waters,12
+Bronx,86053,State Senate,33,Rep,Michael Waters,11
+Bronx,86054,State Senate,33,Rep,Michael Waters,6
+Bronx,86055,State Senate,33,Rep,Michael Waters,9
+Bronx,86056,State Senate,33,Rep,Michael Waters,8
+Bronx,86057,State Senate,33,Rep,Michael Waters,5
+Bronx,87003,State Senate,33,Rep,Michael Waters,5
+Bronx,87015,State Senate,33,Rep,Michael Waters,2
+Bronx,87016,State Senate,33,Rep,Michael Waters,6
+Bronx,87017,State Senate,33,Rep,Michael Waters,7
+Bronx,87018,State Senate,33,Rep,Michael Waters,14
+Bronx,87019,State Senate,33,Rep,Michael Waters,14
+Bronx,87020,State Senate,33,Rep,Michael Waters,31
+Bronx,87023,State Senate,33,Rep,Michael Waters,21
+Bronx,87024,State Senate,33,Rep,Michael Waters,8
+Bronx,87025,State Senate,33,Rep,Michael Waters,9
+Bronx,77029,State Senate,33,Con,Michael Waters,1
+Bronx,77030,State Senate,33,Con,Michael Waters,1
+Bronx,77033,State Senate,33,Con,Michael Waters,0
+Bronx,77037,State Senate,33,Con,Michael Waters,3
+Bronx,77038,State Senate,33,Con,Michael Waters,3
+Bronx,77039,State Senate,33,Con,Michael Waters,6
+Bronx,77042,State Senate,33,Con,Michael Waters,2
+Bronx,77043,State Senate,33,Con,Michael Waters,1
+Bronx,77044,State Senate,33,Con,Michael Waters,1
+Bronx,77045,State Senate,33,Con,Michael Waters,3
+Bronx,78001,State Senate,33,Con,Michael Waters,3
+Bronx,78002,State Senate,33,Con,Michael Waters,0
+Bronx,78003,State Senate,33,Con,Michael Waters,5
+Bronx,78004,State Senate,33,Con,Michael Waters,4
+Bronx,78005,State Senate,33,Con,Michael Waters,3
+Bronx,78006,State Senate,33,Con,Michael Waters,2
+Bronx,78008,State Senate,33,Con,Michael Waters,12
+Bronx,78009,State Senate,33,Con,Michael Waters,5
+Bronx,78010,State Senate,33,Con,Michael Waters,9
+Bronx,78011,State Senate,33,Con,Michael Waters,0
+Bronx,78012,State Senate,33,Con,Michael Waters,7
+Bronx,78013,State Senate,33,Con,Michael Waters,5
+Bronx,78014,State Senate,33,Con,Michael Waters,2
+Bronx,78015,State Senate,33,Con,Michael Waters,1
+Bronx,78017,State Senate,33,Con,Michael Waters,1
+Bronx,78018,State Senate,33,Con,Michael Waters,1
+Bronx,78019,State Senate,33,Con,Michael Waters,1
+Bronx,78020,State Senate,33,Con,Michael Waters,5
+Bronx,78021,State Senate,33,Con,Michael Waters,4
+Bronx,78022,State Senate,33,Con,Michael Waters,2
+Bronx,78023,State Senate,33,Con,Michael Waters,3
+Bronx,78024,State Senate,33,Con,Michael Waters,6
+Bronx,78025,State Senate,33,Con,Michael Waters,2
+Bronx,78026,State Senate,33,Con,Michael Waters,1
+Bronx,78027,State Senate,33,Con,Michael Waters,3
+Bronx,78028,State Senate,33,Con,Michael Waters,3
+Bronx,78029,State Senate,33,Con,Michael Waters,2
+Bronx,78043,State Senate,33,Con,Michael Waters,0
+Bronx,78044,State Senate,33,Con,Michael Waters,2
+Bronx,78045,State Senate,33,Con,Michael Waters,6
+Bronx,78046,State Senate,33,Con,Michael Waters,4
+Bronx,78047,State Senate,33,Con,Michael Waters,4
+Bronx,78048,State Senate,33,Con,Michael Waters,10
+Bronx,78049,State Senate,33,Con,Michael Waters,4
+Bronx,78050,State Senate,33,Con,Michael Waters,3
+Bronx,78051,State Senate,33,Con,Michael Waters,1
+Bronx,78052,State Senate,33,Con,Michael Waters,2
+Bronx,78053,State Senate,33,Con,Michael Waters,2
+Bronx,78054,State Senate,33,Con,Michael Waters,2
+Bronx,78056,State Senate,33,Con,Michael Waters,0
+Bronx,79001,State Senate,33,Con,Michael Waters,2
+Bronx,79002,State Senate,33,Con,Michael Waters,2
+Bronx,79003,State Senate,33,Con,Michael Waters,4
+Bronx,79004,State Senate,33,Con,Michael Waters,2
+Bronx,79005,State Senate,33,Con,Michael Waters,3
+Bronx,79007,State Senate,33,Con,Michael Waters,2
+Bronx,79008,State Senate,33,Con,Michael Waters,2
+Bronx,79009,State Senate,33,Con,Michael Waters,6
+Bronx,79010,State Senate,33,Con,Michael Waters,3
+Bronx,79013,State Senate,33,Con,Michael Waters,1
+Bronx,79020,State Senate,33,Con,Michael Waters,0
+Bronx,79029,State Senate,33,Con,Michael Waters,0
+Bronx,79030,State Senate,33,Con,Michael Waters,2
+Bronx,79031,State Senate,33,Con,Michael Waters,2
+Bronx,79032,State Senate,33,Con,Michael Waters,1
+Bronx,79033,State Senate,33,Con,Michael Waters,1
+Bronx,79034,State Senate,33,Con,Michael Waters,5
+Bronx,79035,State Senate,33,Con,Michael Waters,1
+Bronx,79036,State Senate,33,Con,Michael Waters,1
+Bronx,79037,State Senate,33,Con,Michael Waters,1
+Bronx,79074,State Senate,33,Con,Michael Waters,0
+Bronx,80009,State Senate,33,Con,Michael Waters,2
+Bronx,80010,State Senate,33,Con,Michael Waters,8
+Bronx,80011,State Senate,33,Con,Michael Waters,2
+Bronx,80012,State Senate,33,Con,Michael Waters,2
+Bronx,80013,State Senate,33,Con,Michael Waters,6
+Bronx,80014,State Senate,33,Con,Michael Waters,3
+Bronx,80015,State Senate,33,Con,Michael Waters,0
+Bronx,81001,State Senate,33,Con,Michael Waters,3
+Bronx,81002,State Senate,33,Con,Michael Waters,5
+Bronx,81003,State Senate,33,Con,Michael Waters,0
+Bronx,81004,State Senate,33,Con,Michael Waters,7
+Bronx,81005,State Senate,33,Con,Michael Waters,1
+Bronx,81006,State Senate,33,Con,Michael Waters,1
+Bronx,81007,State Senate,33,Con,Michael Waters,6
+Bronx,81008,State Senate,33,Con,Michael Waters,0
+Bronx,81009,State Senate,33,Con,Michael Waters,4
+Bronx,81011,State Senate,33,Con,Michael Waters,0
+Bronx,81038,State Senate,33,Con,Michael Waters,7
+Bronx,81039,State Senate,33,Con,Michael Waters,7
+Bronx,81040,State Senate,33,Con,Michael Waters,4
+Bronx,81045,State Senate,33,Con,Michael Waters,3
+Bronx,81046,State Senate,33,Con,Michael Waters,1
+Bronx,81108,State Senate,33,Con,Michael Waters,4
+Bronx,86008,State Senate,33,Con,Michael Waters,2
+Bronx,86009,State Senate,33,Con,Michael Waters,1
+Bronx,86010,State Senate,33,Con,Michael Waters,1
+Bronx,86011,State Senate,33,Con,Michael Waters,1
+Bronx,86012,State Senate,33,Con,Michael Waters,12
+Bronx,86013,State Senate,33,Con,Michael Waters,4
+Bronx,86014,State Senate,33,Con,Michael Waters,4
+Bronx,86015,State Senate,33,Con,Michael Waters,0
+Bronx,86016,State Senate,33,Con,Michael Waters,7
+Bronx,86017,State Senate,33,Con,Michael Waters,5
+Bronx,86018,State Senate,33,Con,Michael Waters,0
+Bronx,86019,State Senate,33,Con,Michael Waters,4
+Bronx,86020,State Senate,33,Con,Michael Waters,4
+Bronx,86021,State Senate,33,Con,Michael Waters,0
+Bronx,86022,State Senate,33,Con,Michael Waters,2
+Bronx,86023,State Senate,33,Con,Michael Waters,2
+Bronx,86024,State Senate,33,Con,Michael Waters,2
+Bronx,86025,State Senate,33,Con,Michael Waters,2
+Bronx,86026,State Senate,33,Con,Michael Waters,2
+Bronx,86027,State Senate,33,Con,Michael Waters,6
+Bronx,86028,State Senate,33,Con,Michael Waters,2
+Bronx,86029,State Senate,33,Con,Michael Waters,6
+Bronx,86030,State Senate,33,Con,Michael Waters,2
+Bronx,86031,State Senate,33,Con,Michael Waters,4
+Bronx,86032,State Senate,33,Con,Michael Waters,4
+Bronx,86033,State Senate,33,Con,Michael Waters,1
+Bronx,86034,State Senate,33,Con,Michael Waters,1
+Bronx,86035,State Senate,33,Con,Michael Waters,2
+Bronx,86036,State Senate,33,Con,Michael Waters,1
+Bronx,86037,State Senate,33,Con,Michael Waters,2
+Bronx,86038,State Senate,33,Con,Michael Waters,0
+Bronx,86039,State Senate,33,Con,Michael Waters,1
+Bronx,86040,State Senate,33,Con,Michael Waters,4
+Bronx,86041,State Senate,33,Con,Michael Waters,1
+Bronx,86042,State Senate,33,Con,Michael Waters,0
+Bronx,86043,State Senate,33,Con,Michael Waters,0
+Bronx,86044,State Senate,33,Con,Michael Waters,1
+Bronx,86045,State Senate,33,Con,Michael Waters,0
+Bronx,86046,State Senate,33,Con,Michael Waters,3
+Bronx,86047,State Senate,33,Con,Michael Waters,5
+Bronx,86048,State Senate,33,Con,Michael Waters,2
+Bronx,86049,State Senate,33,Con,Michael Waters,2
+Bronx,86050,State Senate,33,Con,Michael Waters,4
+Bronx,86051,State Senate,33,Con,Michael Waters,1
+Bronx,86052,State Senate,33,Con,Michael Waters,2
+Bronx,86053,State Senate,33,Con,Michael Waters,1
+Bronx,86054,State Senate,33,Con,Michael Waters,3
+Bronx,86055,State Senate,33,Con,Michael Waters,4
+Bronx,86056,State Senate,33,Con,Michael Waters,3
+Bronx,86057,State Senate,33,Con,Michael Waters,1
+Bronx,87003,State Senate,33,Con,Michael Waters,0
+Bronx,87015,State Senate,33,Con,Michael Waters,0
+Bronx,87016,State Senate,33,Con,Michael Waters,1
+Bronx,87017,State Senate,33,Con,Michael Waters,2
+Bronx,87018,State Senate,33,Con,Michael Waters,3
+Bronx,87019,State Senate,33,Con,Michael Waters,1
+Bronx,87020,State Senate,33,Con,Michael Waters,4
+Bronx,87023,State Senate,33,Con,Michael Waters,6
+Bronx,87024,State Senate,33,Con,Michael Waters,0
+Bronx,87025,State Senate,33,Con,Michael Waters,1
+Bronx,77029,State Senate,33,Ind,writein,0
+Bronx,77030,State Senate,33,Ind,writein,0
+Bronx,77033,State Senate,33,Ind,writein,0
+Bronx,77037,State Senate,33,Ind,writein,0
+Bronx,77038,State Senate,33,Ind,writein,0
+Bronx,77039,State Senate,33,Ind,writein,0
+Bronx,77042,State Senate,33,Ind,writein,0
+Bronx,77043,State Senate,33,Ind,writein,0
+Bronx,77044,State Senate,33,Ind,writein,0
+Bronx,77045,State Senate,33,Ind,writein,0
+Bronx,78001,State Senate,33,Ind,writein,0
+Bronx,78002,State Senate,33,Ind,writein,0
+Bronx,78003,State Senate,33,Ind,writein,0
+Bronx,78004,State Senate,33,Ind,writein,0
+Bronx,78005,State Senate,33,Ind,writein,0
+Bronx,78006,State Senate,33,Ind,writein,0
+Bronx,78008,State Senate,33,Ind,writein,3
+Bronx,78009,State Senate,33,Ind,writein,0
+Bronx,78010,State Senate,33,Ind,writein,0
+Bronx,78011,State Senate,33,Ind,writein,0
+Bronx,78012,State Senate,33,Ind,writein,0
+Bronx,78013,State Senate,33,Ind,writein,0
+Bronx,78014,State Senate,33,Ind,writein,0
+Bronx,78015,State Senate,33,Ind,writein,0
+Bronx,78017,State Senate,33,Ind,writein,0
+Bronx,78018,State Senate,33,Ind,writein,0
+Bronx,78019,State Senate,33,Ind,writein,0
+Bronx,78020,State Senate,33,Ind,writein,0
+Bronx,78021,State Senate,33,Ind,writein,0
+Bronx,78022,State Senate,33,Ind,writein,0
+Bronx,78023,State Senate,33,Ind,writein,1
+Bronx,78024,State Senate,33,Ind,writein,1
+Bronx,78025,State Senate,33,Ind,writein,0
+Bronx,78026,State Senate,33,Ind,writein,1
+Bronx,78027,State Senate,33,Ind,writein,0
+Bronx,78028,State Senate,33,Ind,writein,1
+Bronx,78029,State Senate,33,Ind,writein,0
+Bronx,78043,State Senate,33,Ind,writein,0
+Bronx,78044,State Senate,33,Ind,writein,0
+Bronx,78045,State Senate,33,Ind,writein,0
+Bronx,78046,State Senate,33,Ind,writein,0
+Bronx,78047,State Senate,33,Ind,writein,0
+Bronx,78048,State Senate,33,Ind,writein,2
+Bronx,78049,State Senate,33,Ind,writein,1
+Bronx,78050,State Senate,33,Ind,writein,1
+Bronx,78051,State Senate,33,Ind,writein,0
+Bronx,78052,State Senate,33,Ind,writein,0
+Bronx,78053,State Senate,33,Ind,writein,0
+Bronx,78054,State Senate,33,Ind,writein,0
+Bronx,78056,State Senate,33,Ind,writein,0
+Bronx,79001,State Senate,33,Ind,writein,1
+Bronx,79002,State Senate,33,Ind,writein,0
+Bronx,79003,State Senate,33,Ind,writein,0
+Bronx,79004,State Senate,33,Ind,writein,0
+Bronx,79005,State Senate,33,Ind,writein,0
+Bronx,79007,State Senate,33,Ind,writein,0
+Bronx,79008,State Senate,33,Ind,writein,0
+Bronx,79009,State Senate,33,Ind,writein,0
+Bronx,79010,State Senate,33,Ind,writein,0
+Bronx,79013,State Senate,33,Ind,writein,0
+Bronx,79020,State Senate,33,Ind,writein,0
+Bronx,79029,State Senate,33,Ind,writein,0
+Bronx,79030,State Senate,33,Ind,writein,0
+Bronx,79031,State Senate,33,Ind,writein,0
+Bronx,79032,State Senate,33,Ind,writein,0
+Bronx,79033,State Senate,33,Ind,writein,0
+Bronx,79034,State Senate,33,Ind,writein,0
+Bronx,79035,State Senate,33,Ind,writein,0
+Bronx,79036,State Senate,33,Ind,writein,0
+Bronx,79037,State Senate,33,Ind,writein,0
+Bronx,79074,State Senate,33,Ind,writein,0
+Bronx,80009,State Senate,33,Ind,writein,0
+Bronx,80010,State Senate,33,Ind,writein,0
+Bronx,80011,State Senate,33,Ind,writein,0
+Bronx,80012,State Senate,33,Ind,writein,0
+Bronx,80013,State Senate,33,Ind,writein,0
+Bronx,80014,State Senate,33,Ind,writein,0
+Bronx,80015,State Senate,33,Ind,writein,0
+Bronx,81001,State Senate,33,Ind,writein,0
+Bronx,81002,State Senate,33,Ind,writein,0
+Bronx,81003,State Senate,33,Ind,writein,0
+Bronx,81004,State Senate,33,Ind,writein,0
+Bronx,81005,State Senate,33,Ind,writein,0
+Bronx,81006,State Senate,33,Ind,writein,1
+Bronx,81007,State Senate,33,Ind,writein,0
+Bronx,81008,State Senate,33,Ind,writein,0
+Bronx,81009,State Senate,33,Ind,writein,0
+Bronx,81011,State Senate,33,Ind,writein,0
+Bronx,81038,State Senate,33,Ind,writein,0
+Bronx,81039,State Senate,33,Ind,writein,0
+Bronx,81040,State Senate,33,Ind,writein,0
+Bronx,81045,State Senate,33,Ind,writein,0
+Bronx,81046,State Senate,33,Ind,writein,0
+Bronx,81108,State Senate,33,Ind,writein,0
+Bronx,86008,State Senate,33,Ind,writein,0
+Bronx,86009,State Senate,33,Ind,writein,0
+Bronx,86010,State Senate,33,Ind,writein,0
+Bronx,86011,State Senate,33,Ind,writein,0
+Bronx,86012,State Senate,33,Ind,writein,0
+Bronx,86013,State Senate,33,Ind,writein,0
+Bronx,86014,State Senate,33,Ind,writein,0
+Bronx,86015,State Senate,33,Ind,writein,0
+Bronx,86016,State Senate,33,Ind,writein,0
+Bronx,86017,State Senate,33,Ind,writein,0
+Bronx,86018,State Senate,33,Ind,writein,0
+Bronx,86019,State Senate,33,Ind,writein,0
+Bronx,86020,State Senate,33,Ind,writein,0
+Bronx,86021,State Senate,33,Ind,writein,0
+Bronx,86022,State Senate,33,Ind,writein,0
+Bronx,86023,State Senate,33,Ind,writein,0
+Bronx,86024,State Senate,33,Ind,writein,0
+Bronx,86025,State Senate,33,Ind,writein,0
+Bronx,86026,State Senate,33,Ind,writein,0
+Bronx,86027,State Senate,33,Ind,writein,0
+Bronx,86028,State Senate,33,Ind,writein,0
+Bronx,86029,State Senate,33,Ind,writein,0
+Bronx,86030,State Senate,33,Ind,writein,0
+Bronx,86031,State Senate,33,Ind,writein,0
+Bronx,86032,State Senate,33,Ind,writein,0
+Bronx,86033,State Senate,33,Ind,writein,0
+Bronx,86034,State Senate,33,Ind,writein,0
+Bronx,86035,State Senate,33,Ind,writein,0
+Bronx,86036,State Senate,33,Ind,writein,0
+Bronx,86037,State Senate,33,Ind,writein,0
+Bronx,86038,State Senate,33,Ind,writein,0
+Bronx,86039,State Senate,33,Ind,writein,0
+Bronx,86040,State Senate,33,Ind,writein,0
+Bronx,86041,State Senate,33,Ind,writein,0
+Bronx,86042,State Senate,33,Ind,writein,0
+Bronx,86043,State Senate,33,Ind,writein,0
+Bronx,86044,State Senate,33,Ind,writein,0
+Bronx,86045,State Senate,33,Ind,writein,0
+Bronx,86046,State Senate,33,Ind,writein,0
+Bronx,86047,State Senate,33,Ind,writein,1
+Bronx,86048,State Senate,33,Ind,writein,0
+Bronx,86049,State Senate,33,Ind,writein,0
+Bronx,86050,State Senate,33,Ind,writein,0
+Bronx,86051,State Senate,33,Ind,writein,0
+Bronx,86052,State Senate,33,Ind,writein,0
+Bronx,86053,State Senate,33,Ind,writein,0
+Bronx,86054,State Senate,33,Ind,writein,0
+Bronx,86055,State Senate,33,Ind,writein,0
+Bronx,86056,State Senate,33,Ind,writein,0
+Bronx,86057,State Senate,33,Ind,writein,0
+Bronx,87003,State Senate,33,Ind,writein,0
+Bronx,87015,State Senate,33,Ind,writein,0
+Bronx,87016,State Senate,33,Ind,writein,0
+Bronx,87017,State Senate,33,Ind,writein,0
+Bronx,87018,State Senate,33,Ind,writein,0
+Bronx,87019,State Senate,33,Ind,writein,0
+Bronx,87020,State Senate,33,Ind,writein,1
+Bronx,87023,State Senate,33,Ind,writein,0
+Bronx,87024,State Senate,33,Ind,writein,0
+Bronx,87025,State Senate,33,Ind,writein,0
+Bronx,78007,State Senate,34,Green,Carl Lundgren,3
+Bronx,78016,State Senate,34,Green,Carl Lundgren,3
+Bronx,78030,State Senate,34,Green,Carl Lundgren,6
+Bronx,78031,State Senate,34,Green,Carl Lundgren,11
+Bronx,78036,State Senate,34,Green,Carl Lundgren,5
+Bronx,78037,State Senate,34,Green,Carl Lundgren,0
+Bronx,78040,State Senate,34,Green,Carl Lundgren,8
+Bronx,78041,State Senate,34,Green,Carl Lundgren,6
+Bronx,78055,State Senate,34,Green,Carl Lundgren,4
+Bronx,78058,State Senate,34,Green,Carl Lundgren,1
+Bronx,80001,State Senate,34,Green,Carl Lundgren,1
+Bronx,80002,State Senate,34,Green,Carl Lundgren,14
+Bronx,80003,State Senate,34,Green,Carl Lundgren,5
+Bronx,80004,State Senate,34,Green,Carl Lundgren,4
+Bronx,80005,State Senate,34,Green,Carl Lundgren,2
+Bronx,80006,State Senate,34,Green,Carl Lundgren,7
+Bronx,80007,State Senate,34,Green,Carl Lundgren,3
+Bronx,80008,State Senate,34,Green,Carl Lundgren,4
+Bronx,80016,State Senate,34,Green,Carl Lundgren,9
+Bronx,80017,State Senate,34,Green,Carl Lundgren,1
+Bronx,80018,State Senate,34,Green,Carl Lundgren,6
+Bronx,80019,State Senate,34,Green,Carl Lundgren,2
+Bronx,80020,State Senate,34,Green,Carl Lundgren,7
+Bronx,80021,State Senate,34,Green,Carl Lundgren,8
+Bronx,80022,State Senate,34,Green,Carl Lundgren,4
+Bronx,80023,State Senate,34,Green,Carl Lundgren,7
+Bronx,80024,State Senate,34,Green,Carl Lundgren,12
+Bronx,80025,State Senate,34,Green,Carl Lundgren,7
+Bronx,80026,State Senate,34,Green,Carl Lundgren,3
+Bronx,80027,State Senate,34,Green,Carl Lundgren,2
+Bronx,80028,State Senate,34,Green,Carl Lundgren,6
+Bronx,80029,State Senate,34,Green,Carl Lundgren,2
+Bronx,80030,State Senate,34,Green,Carl Lundgren,6
+Bronx,80031,State Senate,34,Green,Carl Lundgren,4
+Bronx,80032,State Senate,34,Green,Carl Lundgren,5
+Bronx,80033,State Senate,34,Green,Carl Lundgren,6
+Bronx,80034,State Senate,34,Green,Carl Lundgren,5
+Bronx,80035,State Senate,34,Green,Carl Lundgren,2
+Bronx,80036,State Senate,34,Green,Carl Lundgren,7
+Bronx,80037,State Senate,34,Green,Carl Lundgren,3
+Bronx,80038,State Senate,34,Green,Carl Lundgren,2
+Bronx,80039,State Senate,34,Green,Carl Lundgren,6
+Bronx,80040,State Senate,34,Green,Carl Lundgren,2
+Bronx,80041,State Senate,34,Green,Carl Lundgren,3
+Bronx,80042,State Senate,34,Green,Carl Lundgren,2
+Bronx,80043,State Senate,34,Green,Carl Lundgren,5
+Bronx,80044,State Senate,34,Green,Carl Lundgren,0
+Bronx,80045,State Senate,34,Green,Carl Lundgren,2
+Bronx,80046,State Senate,34,Green,Carl Lundgren,4
+Bronx,80047,State Senate,34,Green,Carl Lundgren,2
+Bronx,80048,State Senate,34,Green,Carl Lundgren,3
+Bronx,80049,State Senate,34,Green,Carl Lundgren,0
+Bronx,80050,State Senate,34,Green,Carl Lundgren,4
+Bronx,80051,State Senate,34,Green,Carl Lundgren,3
+Bronx,80066,State Senate,34,Green,Carl Lundgren,1
+Bronx,80067,State Senate,34,Green,Carl Lundgren,10
+Bronx,80068,State Senate,34,Green,Carl Lundgren,5
+Bronx,80069,State Senate,34,Green,Carl Lundgren,1
+Bronx,81010,State Senate,34,Green,Carl Lundgren,5
+Bronx,81012,State Senate,34,Green,Carl Lundgren,3
+Bronx,81013,State Senate,34,Green,Carl Lundgren,12
+Bronx,81014,State Senate,34,Green,Carl Lundgren,7
+Bronx,81015,State Senate,34,Green,Carl Lundgren,11
+Bronx,81016,State Senate,34,Green,Carl Lundgren,0
+Bronx,81025,State Senate,34,Green,Carl Lundgren,5
+Bronx,81026,State Senate,34,Green,Carl Lundgren,3
+Bronx,81027,State Senate,34,Green,Carl Lundgren,6
+Bronx,81028,State Senate,34,Green,Carl Lundgren,7
+Bronx,81029,State Senate,34,Green,Carl Lundgren,10
+Bronx,81030,State Senate,34,Green,Carl Lundgren,11
+Bronx,81031,State Senate,34,Green,Carl Lundgren,2
+Bronx,81032,State Senate,34,Green,Carl Lundgren,5
+Bronx,81033,State Senate,34,Green,Carl Lundgren,7
+Bronx,81034,State Senate,34,Green,Carl Lundgren,11
+Bronx,81035,State Senate,34,Green,Carl Lundgren,6
+Bronx,81036,State Senate,34,Green,Carl Lundgren,30
+Bronx,81037,State Senate,34,Green,Carl Lundgren,6
+Bronx,81041,State Senate,34,Green,Carl Lundgren,15
+Bronx,81042,State Senate,34,Green,Carl Lundgren,1
+Bronx,81043,State Senate,34,Green,Carl Lundgren,4
+Bronx,81044,State Senate,34,Green,Carl Lundgren,8
+Bronx,81047,State Senate,34,Green,Carl Lundgren,4
+Bronx,81048,State Senate,34,Green,Carl Lundgren,19
+Bronx,81049,State Senate,34,Green,Carl Lundgren,21
+Bronx,81050,State Senate,34,Green,Carl Lundgren,14
+Bronx,81051,State Senate,34,Green,Carl Lundgren,10
+Bronx,81052,State Senate,34,Green,Carl Lundgren,2
+Bronx,81053,State Senate,34,Green,Carl Lundgren,4
+Bronx,81054,State Senate,34,Green,Carl Lundgren,14
+Bronx,81055,State Senate,34,Green,Carl Lundgren,5
+Bronx,81056,State Senate,34,Green,Carl Lundgren,9
+Bronx,81057,State Senate,34,Green,Carl Lundgren,9
+Bronx,81058,State Senate,34,Green,Carl Lundgren,3
+Bronx,81059,State Senate,34,Green,Carl Lundgren,12
+Bronx,81060,State Senate,34,Green,Carl Lundgren,5
+Bronx,81061,State Senate,34,Green,Carl Lundgren,3
+Bronx,81062,State Senate,34,Green,Carl Lundgren,15
+Bronx,81063,State Senate,34,Green,Carl Lundgren,12
+Bronx,81064,State Senate,34,Green,Carl Lundgren,10
+Bronx,81065,State Senate,34,Green,Carl Lundgren,12
+Bronx,81066,State Senate,34,Green,Carl Lundgren,6
+Bronx,81067,State Senate,34,Green,Carl Lundgren,7
+Bronx,81068,State Senate,34,Green,Carl Lundgren,18
+Bronx,81069,State Senate,34,Green,Carl Lundgren,10
+Bronx,81070,State Senate,34,Green,Carl Lundgren,5
+Bronx,81071,State Senate,34,Green,Carl Lundgren,11
+Bronx,81072,State Senate,34,Green,Carl Lundgren,18
+Bronx,81073,State Senate,34,Green,Carl Lundgren,3
+Bronx,81074,State Senate,34,Green,Carl Lundgren,13
+Bronx,81075,State Senate,34,Green,Carl Lundgren,12
+Bronx,81076,State Senate,34,Green,Carl Lundgren,9
+Bronx,81077,State Senate,34,Green,Carl Lundgren,12
+Bronx,81078,State Senate,34,Green,Carl Lundgren,17
+Bronx,81079,State Senate,34,Green,Carl Lundgren,6
+Bronx,81080,State Senate,34,Green,Carl Lundgren,15
+Bronx,81081,State Senate,34,Green,Carl Lundgren,11
+Bronx,81082,State Senate,34,Green,Carl Lundgren,5
+Bronx,81083,State Senate,34,Green,Carl Lundgren,4
+Bronx,81084,State Senate,34,Green,Carl Lundgren,9
+Bronx,81085,State Senate,34,Green,Carl Lundgren,5
+Bronx,81086,State Senate,34,Green,Carl Lundgren,10
+Bronx,81087,State Senate,34,Green,Carl Lundgren,4
+Bronx,81088,State Senate,34,Green,Carl Lundgren,5
+Bronx,81089,State Senate,34,Green,Carl Lundgren,13
+Bronx,81090,State Senate,34,Green,Carl Lundgren,15
+Bronx,81091,State Senate,34,Green,Carl Lundgren,1
+Bronx,81104,State Senate,34,Green,Carl Lundgren,0
+Bronx,82001,State Senate,34,Green,Carl Lundgren,3
+Bronx,82002,State Senate,34,Green,Carl Lundgren,3
+Bronx,82003,State Senate,34,Green,Carl Lundgren,0
+Bronx,82004,State Senate,34,Green,Carl Lundgren,5
+Bronx,82005,State Senate,34,Green,Carl Lundgren,2
+Bronx,82006,State Senate,34,Green,Carl Lundgren,3
+Bronx,82007,State Senate,34,Green,Carl Lundgren,2
+Bronx,82008,State Senate,34,Green,Carl Lundgren,5
+Bronx,82009,State Senate,34,Green,Carl Lundgren,3
+Bronx,82010,State Senate,34,Green,Carl Lundgren,5
+Bronx,82011,State Senate,34,Green,Carl Lundgren,3
+Bronx,82012,State Senate,34,Green,Carl Lundgren,1
+Bronx,82013,State Senate,34,Green,Carl Lundgren,1
+Bronx,82014,State Senate,34,Green,Carl Lundgren,1
+Bronx,82015,State Senate,34,Green,Carl Lundgren,2
+Bronx,82016,State Senate,34,Green,Carl Lundgren,5
+Bronx,82017,State Senate,34,Green,Carl Lundgren,6
+Bronx,82018,State Senate,34,Green,Carl Lundgren,0
+Bronx,82019,State Senate,34,Green,Carl Lundgren,2
+Bronx,82020,State Senate,34,Green,Carl Lundgren,3
+Bronx,82021,State Senate,34,Green,Carl Lundgren,1
+Bronx,82022,State Senate,34,Green,Carl Lundgren,2
+Bronx,82023,State Senate,34,Green,Carl Lundgren,4
+Bronx,82024,State Senate,34,Green,Carl Lundgren,8
+Bronx,82025,State Senate,34,Green,Carl Lundgren,3
+Bronx,82026,State Senate,34,Green,Carl Lundgren,2
+Bronx,82027,State Senate,34,Green,Carl Lundgren,0
+Bronx,82028,State Senate,34,Green,Carl Lundgren,3
+Bronx,82031,State Senate,34,Green,Carl Lundgren,7
+Bronx,82032,State Senate,34,Green,Carl Lundgren,4
+Bronx,82033,State Senate,34,Green,Carl Lundgren,6
+Bronx,82034,State Senate,34,Green,Carl Lundgren,2
+Bronx,82035,State Senate,34,Green,Carl Lundgren,3
+Bronx,82036,State Senate,34,Green,Carl Lundgren,5
+Bronx,82037,State Senate,34,Green,Carl Lundgren,0
+Bronx,82038,State Senate,34,Green,Carl Lundgren,4
+Bronx,82039,State Senate,34,Green,Carl Lundgren,5
+Bronx,82040,State Senate,34,Green,Carl Lundgren,2
+Bronx,82041,State Senate,34,Green,Carl Lundgren,5
+Bronx,82042,State Senate,34,Green,Carl Lundgren,1
+Bronx,82043,State Senate,34,Green,Carl Lundgren,2
+Bronx,82044,State Senate,34,Green,Carl Lundgren,3
+Bronx,82045,State Senate,34,Green,Carl Lundgren,6
+Bronx,82046,State Senate,34,Green,Carl Lundgren,7
+Bronx,82047,State Senate,34,Green,Carl Lundgren,7
+Bronx,82048,State Senate,34,Green,Carl Lundgren,3
+Bronx,82049,State Senate,34,Green,Carl Lundgren,7
+Bronx,82050,State Senate,34,Green,Carl Lundgren,0
+Bronx,82051,State Senate,34,Green,Carl Lundgren,5
+Bronx,82052,State Senate,34,Green,Carl Lundgren,4
+Bronx,82053,State Senate,34,Green,Carl Lundgren,7
+Bronx,82055,State Senate,34,Green,Carl Lundgren,2
+Bronx,82056,State Senate,34,Green,Carl Lundgren,9
+Bronx,82057,State Senate,34,Green,Carl Lundgren,7
+Bronx,82058,State Senate,34,Green,Carl Lundgren,7
+Bronx,82059,State Senate,34,Green,Carl Lundgren,1
+Bronx,82060,State Senate,34,Green,Carl Lundgren,11
+Bronx,82061,State Senate,34,Green,Carl Lundgren,16
+Bronx,82062,State Senate,34,Green,Carl Lundgren,11
+Bronx,82063,State Senate,34,Green,Carl Lundgren,10
+Bronx,82064,State Senate,34,Green,Carl Lundgren,5
+Bronx,82106,State Senate,34,Green,Carl Lundgren,1
+Bronx,82107,State Senate,34,Green,Carl Lundgren,0
+Bronx,83068,State Senate,34,Green,Carl Lundgren,0
+Bronx,84073,State Senate,34,Green,Carl Lundgren,0
+Bronx,84077,State Senate,34,Green,Carl Lundgren,2
+Bronx,84078,State Senate,34,Green,Carl Lundgren,0
+Bronx,85001,State Senate,34,Green,Carl Lundgren,4
+Bronx,85002,State Senate,34,Green,Carl Lundgren,6
+Bronx,85003,State Senate,34,Green,Carl Lundgren,6
+Bronx,85004,State Senate,34,Green,Carl Lundgren,1
+Bronx,85005,State Senate,34,Green,Carl Lundgren,3
+Bronx,85006,State Senate,34,Green,Carl Lundgren,0
+Bronx,85007,State Senate,34,Green,Carl Lundgren,2
+Bronx,85008,State Senate,34,Green,Carl Lundgren,3
+Bronx,85009,State Senate,34,Green,Carl Lundgren,0
+Bronx,85010,State Senate,34,Green,Carl Lundgren,2
+Bronx,85011,State Senate,34,Green,Carl Lundgren,2
+Bronx,85012,State Senate,34,Green,Carl Lundgren,4
+Bronx,85028,State Senate,34,Green,Carl Lundgren,0
+Bronx,85037,State Senate,34,Green,Carl Lundgren,1
+Bronx,85038,State Senate,34,Green,Carl Lundgren,1
+Bronx,85076,State Senate,34,Green,Carl Lundgren,0
+Bronx,87044,State Senate,34,Green,Carl Lundgren,2
+Bronx,87065,State Senate,34,Green,Carl Lundgren,1
+Bronx,87066,State Senate,34,Green,Carl Lundgren,4
+Bronx,87067,State Senate,34,Green,Carl Lundgren,2
+Bronx,87068,State Senate,34,Green,Carl Lundgren,6
+Bronx,87069,State Senate,34,Green,Carl Lundgren,2
+Bronx,87072,State Senate,34,Green,Carl Lundgren,3
+Bronx,87073,State Senate,34,Green,Carl Lundgren,1
+Bronx,87074,State Senate,34,Green,Carl Lundgren,7
+Bronx,87075,State Senate,34,Green,Carl Lundgren,0
+Bronx,87076,State Senate,34,Green,Carl Lundgren,4
+Bronx,87077,State Senate,34,Green,Carl Lundgren,3
+Bronx,87078,State Senate,34,Green,Carl Lundgren,2
+Bronx,87079,State Senate,34,Green,Carl Lundgren,0
+Bronx,87080,State Senate,34,Green,Carl Lundgren,4
+Bronx,87081,State Senate,34,Green,Carl Lundgren,4
+Bronx,87082,State Senate,34,Green,Carl Lundgren,1
+Bronx,78007,State Senate,34,Con,Elizabeth Perri,6
+Bronx,78016,State Senate,34,Con,Elizabeth Perri,5
+Bronx,78030,State Senate,34,Con,Elizabeth Perri,14
+Bronx,78031,State Senate,34,Con,Elizabeth Perri,7
+Bronx,78036,State Senate,34,Con,Elizabeth Perri,6
+Bronx,78037,State Senate,34,Con,Elizabeth Perri,1
+Bronx,78040,State Senate,34,Con,Elizabeth Perri,15
+Bronx,78041,State Senate,34,Con,Elizabeth Perri,20
+Bronx,78055,State Senate,34,Con,Elizabeth Perri,17
+Bronx,78058,State Senate,34,Con,Elizabeth Perri,1
+Bronx,80001,State Senate,34,Con,Elizabeth Perri,9
+Bronx,80002,State Senate,34,Con,Elizabeth Perri,6
+Bronx,80003,State Senate,34,Con,Elizabeth Perri,20
+Bronx,80004,State Senate,34,Con,Elizabeth Perri,18
+Bronx,80005,State Senate,34,Con,Elizabeth Perri,16
+Bronx,80006,State Senate,34,Con,Elizabeth Perri,20
+Bronx,80007,State Senate,34,Con,Elizabeth Perri,14
+Bronx,80008,State Senate,34,Con,Elizabeth Perri,8
+Bronx,80016,State Senate,34,Con,Elizabeth Perri,15
+Bronx,80017,State Senate,34,Con,Elizabeth Perri,3
+Bronx,80018,State Senate,34,Con,Elizabeth Perri,16
+Bronx,80019,State Senate,34,Con,Elizabeth Perri,11
+Bronx,80020,State Senate,34,Con,Elizabeth Perri,12
+Bronx,80021,State Senate,34,Con,Elizabeth Perri,9
+Bronx,80022,State Senate,34,Con,Elizabeth Perri,8
+Bronx,80023,State Senate,34,Con,Elizabeth Perri,11
+Bronx,80024,State Senate,34,Con,Elizabeth Perri,12
+Bronx,80025,State Senate,34,Con,Elizabeth Perri,7
+Bronx,80026,State Senate,34,Con,Elizabeth Perri,16
+Bronx,80027,State Senate,34,Con,Elizabeth Perri,8
+Bronx,80028,State Senate,34,Con,Elizabeth Perri,14
+Bronx,80029,State Senate,34,Con,Elizabeth Perri,11
+Bronx,80030,State Senate,34,Con,Elizabeth Perri,27
+Bronx,80031,State Senate,34,Con,Elizabeth Perri,33
+Bronx,80032,State Senate,34,Con,Elizabeth Perri,22
+Bronx,80033,State Senate,34,Con,Elizabeth Perri,29
+Bronx,80034,State Senate,34,Con,Elizabeth Perri,21
+Bronx,80035,State Senate,34,Con,Elizabeth Perri,16
+Bronx,80036,State Senate,34,Con,Elizabeth Perri,19
+Bronx,80037,State Senate,34,Con,Elizabeth Perri,25
+Bronx,80038,State Senate,34,Con,Elizabeth Perri,12
+Bronx,80039,State Senate,34,Con,Elizabeth Perri,14
+Bronx,80040,State Senate,34,Con,Elizabeth Perri,6
+Bronx,80041,State Senate,34,Con,Elizabeth Perri,6
+Bronx,80042,State Senate,34,Con,Elizabeth Perri,2
+Bronx,80043,State Senate,34,Con,Elizabeth Perri,11
+Bronx,80044,State Senate,34,Con,Elizabeth Perri,9
+Bronx,80045,State Senate,34,Con,Elizabeth Perri,6
+Bronx,80046,State Senate,34,Con,Elizabeth Perri,10
+Bronx,80047,State Senate,34,Con,Elizabeth Perri,5
+Bronx,80048,State Senate,34,Con,Elizabeth Perri,6
+Bronx,80049,State Senate,34,Con,Elizabeth Perri,0
+Bronx,80050,State Senate,34,Con,Elizabeth Perri,9
+Bronx,80051,State Senate,34,Con,Elizabeth Perri,11
+Bronx,80066,State Senate,34,Con,Elizabeth Perri,13
+Bronx,80067,State Senate,34,Con,Elizabeth Perri,13
+Bronx,80068,State Senate,34,Con,Elizabeth Perri,23
+Bronx,80069,State Senate,34,Con,Elizabeth Perri,6
+Bronx,81010,State Senate,34,Con,Elizabeth Perri,3
+Bronx,81012,State Senate,34,Con,Elizabeth Perri,19
+Bronx,81013,State Senate,34,Con,Elizabeth Perri,14
+Bronx,81014,State Senate,34,Con,Elizabeth Perri,15
+Bronx,81015,State Senate,34,Con,Elizabeth Perri,14
+Bronx,81016,State Senate,34,Con,Elizabeth Perri,4
+Bronx,81025,State Senate,34,Con,Elizabeth Perri,22
+Bronx,81026,State Senate,34,Con,Elizabeth Perri,19
+Bronx,81027,State Senate,34,Con,Elizabeth Perri,28
+Bronx,81028,State Senate,34,Con,Elizabeth Perri,35
+Bronx,81029,State Senate,34,Con,Elizabeth Perri,19
+Bronx,81030,State Senate,34,Con,Elizabeth Perri,41
+Bronx,81031,State Senate,34,Con,Elizabeth Perri,34
+Bronx,81032,State Senate,34,Con,Elizabeth Perri,26
+Bronx,81033,State Senate,34,Con,Elizabeth Perri,21
+Bronx,81034,State Senate,34,Con,Elizabeth Perri,18
+Bronx,81035,State Senate,34,Con,Elizabeth Perri,11
+Bronx,81036,State Senate,34,Con,Elizabeth Perri,25
+Bronx,81037,State Senate,34,Con,Elizabeth Perri,14
+Bronx,81041,State Senate,34,Con,Elizabeth Perri,18
+Bronx,81042,State Senate,34,Con,Elizabeth Perri,1
+Bronx,81043,State Senate,34,Con,Elizabeth Perri,14
+Bronx,81044,State Senate,34,Con,Elizabeth Perri,12
+Bronx,81047,State Senate,34,Con,Elizabeth Perri,2
+Bronx,81048,State Senate,34,Con,Elizabeth Perri,20
+Bronx,81049,State Senate,34,Con,Elizabeth Perri,23
+Bronx,81050,State Senate,34,Con,Elizabeth Perri,19
+Bronx,81051,State Senate,34,Con,Elizabeth Perri,23
+Bronx,81052,State Senate,34,Con,Elizabeth Perri,10
+Bronx,81053,State Senate,34,Con,Elizabeth Perri,4
+Bronx,81054,State Senate,34,Con,Elizabeth Perri,28
+Bronx,81055,State Senate,34,Con,Elizabeth Perri,23
+Bronx,81056,State Senate,34,Con,Elizabeth Perri,35
+Bronx,81057,State Senate,34,Con,Elizabeth Perri,19
+Bronx,81058,State Senate,34,Con,Elizabeth Perri,7
+Bronx,81059,State Senate,34,Con,Elizabeth Perri,36
+Bronx,81060,State Senate,34,Con,Elizabeth Perri,47
+Bronx,81061,State Senate,34,Con,Elizabeth Perri,15
+Bronx,81062,State Senate,34,Con,Elizabeth Perri,15
+Bronx,81063,State Senate,34,Con,Elizabeth Perri,35
+Bronx,81064,State Senate,34,Con,Elizabeth Perri,23
+Bronx,81065,State Senate,34,Con,Elizabeth Perri,32
+Bronx,81066,State Senate,34,Con,Elizabeth Perri,15
+Bronx,81067,State Senate,34,Con,Elizabeth Perri,12
+Bronx,81068,State Senate,34,Con,Elizabeth Perri,32
+Bronx,81069,State Senate,34,Con,Elizabeth Perri,19
+Bronx,81070,State Senate,34,Con,Elizabeth Perri,11
+Bronx,81071,State Senate,34,Con,Elizabeth Perri,11
+Bronx,81072,State Senate,34,Con,Elizabeth Perri,17
+Bronx,81073,State Senate,34,Con,Elizabeth Perri,14
+Bronx,81074,State Senate,34,Con,Elizabeth Perri,14
+Bronx,81075,State Senate,34,Con,Elizabeth Perri,15
+Bronx,81076,State Senate,34,Con,Elizabeth Perri,8
+Bronx,81077,State Senate,34,Con,Elizabeth Perri,19
+Bronx,81078,State Senate,34,Con,Elizabeth Perri,25
+Bronx,81079,State Senate,34,Con,Elizabeth Perri,20
+Bronx,81080,State Senate,34,Con,Elizabeth Perri,25
+Bronx,81081,State Senate,34,Con,Elizabeth Perri,5
+Bronx,81082,State Senate,34,Con,Elizabeth Perri,17
+Bronx,81083,State Senate,34,Con,Elizabeth Perri,9
+Bronx,81084,State Senate,34,Con,Elizabeth Perri,24
+Bronx,81085,State Senate,34,Con,Elizabeth Perri,13
+Bronx,81086,State Senate,34,Con,Elizabeth Perri,13
+Bronx,81087,State Senate,34,Con,Elizabeth Perri,14
+Bronx,81088,State Senate,34,Con,Elizabeth Perri,26
+Bronx,81089,State Senate,34,Con,Elizabeth Perri,7
+Bronx,81090,State Senate,34,Con,Elizabeth Perri,10
+Bronx,81091,State Senate,34,Con,Elizabeth Perri,0
+Bronx,81104,State Senate,34,Con,Elizabeth Perri,0
+Bronx,82001,State Senate,34,Con,Elizabeth Perri,42
+Bronx,82002,State Senate,34,Con,Elizabeth Perri,50
+Bronx,82003,State Senate,34,Con,Elizabeth Perri,22
+Bronx,82004,State Senate,34,Con,Elizabeth Perri,23
+Bronx,82005,State Senate,34,Con,Elizabeth Perri,19
+Bronx,82006,State Senate,34,Con,Elizabeth Perri,28
+Bronx,82007,State Senate,34,Con,Elizabeth Perri,31
+Bronx,82008,State Senate,34,Con,Elizabeth Perri,8
+Bronx,82009,State Senate,34,Con,Elizabeth Perri,10
+Bronx,82010,State Senate,34,Con,Elizabeth Perri,30
+Bronx,82011,State Senate,34,Con,Elizabeth Perri,17
+Bronx,82012,State Senate,34,Con,Elizabeth Perri,3
+Bronx,82013,State Senate,34,Con,Elizabeth Perri,3
+Bronx,82014,State Senate,34,Con,Elizabeth Perri,6
+Bronx,82015,State Senate,34,Con,Elizabeth Perri,2
+Bronx,82016,State Senate,34,Con,Elizabeth Perri,11
+Bronx,82017,State Senate,34,Con,Elizabeth Perri,25
+Bronx,82018,State Senate,34,Con,Elizabeth Perri,7
+Bronx,82019,State Senate,34,Con,Elizabeth Perri,23
+Bronx,82020,State Senate,34,Con,Elizabeth Perri,20
+Bronx,82021,State Senate,34,Con,Elizabeth Perri,16
+Bronx,82022,State Senate,34,Con,Elizabeth Perri,19
+Bronx,82023,State Senate,34,Con,Elizabeth Perri,4
+Bronx,82024,State Senate,34,Con,Elizabeth Perri,13
+Bronx,82025,State Senate,34,Con,Elizabeth Perri,30
+Bronx,82026,State Senate,34,Con,Elizabeth Perri,2
+Bronx,82027,State Senate,34,Con,Elizabeth Perri,3
+Bronx,82028,State Senate,34,Con,Elizabeth Perri,7
+Bronx,82031,State Senate,34,Con,Elizabeth Perri,17
+Bronx,82032,State Senate,34,Con,Elizabeth Perri,23
+Bronx,82033,State Senate,34,Con,Elizabeth Perri,14
+Bronx,82034,State Senate,34,Con,Elizabeth Perri,17
+Bronx,82035,State Senate,34,Con,Elizabeth Perri,33
+Bronx,82036,State Senate,34,Con,Elizabeth Perri,22
+Bronx,82037,State Senate,34,Con,Elizabeth Perri,17
+Bronx,82038,State Senate,34,Con,Elizabeth Perri,27
+Bronx,82039,State Senate,34,Con,Elizabeth Perri,31
+Bronx,82040,State Senate,34,Con,Elizabeth Perri,30
+Bronx,82041,State Senate,34,Con,Elizabeth Perri,26
+Bronx,82042,State Senate,34,Con,Elizabeth Perri,10
+Bronx,82043,State Senate,34,Con,Elizabeth Perri,24
+Bronx,82044,State Senate,34,Con,Elizabeth Perri,25
+Bronx,82045,State Senate,34,Con,Elizabeth Perri,26
+Bronx,82046,State Senate,34,Con,Elizabeth Perri,37
+Bronx,82047,State Senate,34,Con,Elizabeth Perri,35
+Bronx,82048,State Senate,34,Con,Elizabeth Perri,39
+Bronx,82049,State Senate,34,Con,Elizabeth Perri,41
+Bronx,82050,State Senate,34,Con,Elizabeth Perri,7
+Bronx,82051,State Senate,34,Con,Elizabeth Perri,19
+Bronx,82052,State Senate,34,Con,Elizabeth Perri,30
+Bronx,82053,State Senate,34,Con,Elizabeth Perri,26
+Bronx,82055,State Senate,34,Con,Elizabeth Perri,15
+Bronx,82056,State Senate,34,Con,Elizabeth Perri,36
+Bronx,82057,State Senate,34,Con,Elizabeth Perri,24
+Bronx,82058,State Senate,34,Con,Elizabeth Perri,21
+Bronx,82059,State Senate,34,Con,Elizabeth Perri,2
+Bronx,82060,State Senate,34,Con,Elizabeth Perri,26
+Bronx,82061,State Senate,34,Con,Elizabeth Perri,28
+Bronx,82062,State Senate,34,Con,Elizabeth Perri,25
+Bronx,82063,State Senate,34,Con,Elizabeth Perri,16
+Bronx,82064,State Senate,34,Con,Elizabeth Perri,14
+Bronx,82106,State Senate,34,Con,Elizabeth Perri,1
+Bronx,82107,State Senate,34,Con,Elizabeth Perri,7
+Bronx,83068,State Senate,34,Con,Elizabeth Perri,0
+Bronx,84073,State Senate,34,Con,Elizabeth Perri,1
+Bronx,84077,State Senate,34,Con,Elizabeth Perri,8
+Bronx,84078,State Senate,34,Con,Elizabeth Perri,0
+Bronx,85001,State Senate,34,Con,Elizabeth Perri,9
+Bronx,85002,State Senate,34,Con,Elizabeth Perri,12
+Bronx,85003,State Senate,34,Con,Elizabeth Perri,15
+Bronx,85004,State Senate,34,Con,Elizabeth Perri,11
+Bronx,85005,State Senate,34,Con,Elizabeth Perri,10
+Bronx,85006,State Senate,34,Con,Elizabeth Perri,6
+Bronx,85007,State Senate,34,Con,Elizabeth Perri,10
+Bronx,85008,State Senate,34,Con,Elizabeth Perri,9
+Bronx,85009,State Senate,34,Con,Elizabeth Perri,5
+Bronx,85010,State Senate,34,Con,Elizabeth Perri,4
+Bronx,85011,State Senate,34,Con,Elizabeth Perri,7
+Bronx,85012,State Senate,34,Con,Elizabeth Perri,3
+Bronx,85028,State Senate,34,Con,Elizabeth Perri,1
+Bronx,85037,State Senate,34,Con,Elizabeth Perri,7
+Bronx,85038,State Senate,34,Con,Elizabeth Perri,8
+Bronx,85076,State Senate,34,Con,Elizabeth Perri,1
+Bronx,87044,State Senate,34,Con,Elizabeth Perri,1
+Bronx,87065,State Senate,34,Con,Elizabeth Perri,7
+Bronx,87066,State Senate,34,Con,Elizabeth Perri,4
+Bronx,87067,State Senate,34,Con,Elizabeth Perri,1
+Bronx,87068,State Senate,34,Con,Elizabeth Perri,7
+Bronx,87069,State Senate,34,Con,Elizabeth Perri,11
+Bronx,87072,State Senate,34,Con,Elizabeth Perri,6
+Bronx,87073,State Senate,34,Con,Elizabeth Perri,0
+Bronx,87074,State Senate,34,Con,Elizabeth Perri,8
+Bronx,87075,State Senate,34,Con,Elizabeth Perri,11
+Bronx,87076,State Senate,34,Con,Elizabeth Perri,17
+Bronx,87077,State Senate,34,Con,Elizabeth Perri,11
+Bronx,87078,State Senate,34,Con,Elizabeth Perri,9
+Bronx,87079,State Senate,34,Con,Elizabeth Perri,0
+Bronx,87080,State Senate,34,Con,Elizabeth Perri,11
+Bronx,87081,State Senate,34,Con,Elizabeth Perri,9
+Bronx,87082,State Senate,34,Con,Elizabeth Perri,7
+Bronx,78007,State Senate,34,Dem,Jeffrey Klein,87
+Bronx,78016,State Senate,34,Dem,Jeffrey Klein,283
+Bronx,78030,State Senate,34,Dem,Jeffrey Klein,456
+Bronx,78031,State Senate,34,Dem,Jeffrey Klein,498
+Bronx,78036,State Senate,34,Dem,Jeffrey Klein,340
+Bronx,78037,State Senate,34,Dem,Jeffrey Klein,38
+Bronx,78040,State Senate,34,Dem,Jeffrey Klein,269
+Bronx,78041,State Senate,34,Dem,Jeffrey Klein,631
+Bronx,78055,State Senate,34,Dem,Jeffrey Klein,112
+Bronx,78058,State Senate,34,Dem,Jeffrey Klein,14
+Bronx,80001,State Senate,34,Dem,Jeffrey Klein,184
+Bronx,80002,State Senate,34,Dem,Jeffrey Klein,122
+Bronx,80003,State Senate,34,Dem,Jeffrey Klein,130
+Bronx,80004,State Senate,34,Dem,Jeffrey Klein,150
+Bronx,80005,State Senate,34,Dem,Jeffrey Klein,96
+Bronx,80006,State Senate,34,Dem,Jeffrey Klein,158
+Bronx,80007,State Senate,34,Dem,Jeffrey Klein,193
+Bronx,80008,State Senate,34,Dem,Jeffrey Klein,182
+Bronx,80016,State Senate,34,Dem,Jeffrey Klein,451
+Bronx,80017,State Senate,34,Dem,Jeffrey Klein,399
+Bronx,80018,State Senate,34,Dem,Jeffrey Klein,172
+Bronx,80019,State Senate,34,Dem,Jeffrey Klein,106
+Bronx,80020,State Senate,34,Dem,Jeffrey Klein,281
+Bronx,80021,State Senate,34,Dem,Jeffrey Klein,392
+Bronx,80022,State Senate,34,Dem,Jeffrey Klein,243
+Bronx,80023,State Senate,34,Dem,Jeffrey Klein,419
+Bronx,80024,State Senate,34,Dem,Jeffrey Klein,573
+Bronx,80025,State Senate,34,Dem,Jeffrey Klein,371
+Bronx,80026,State Senate,34,Dem,Jeffrey Klein,263
+Bronx,80027,State Senate,34,Dem,Jeffrey Klein,179
+Bronx,80028,State Senate,34,Dem,Jeffrey Klein,198
+Bronx,80029,State Senate,34,Dem,Jeffrey Klein,76
+Bronx,80030,State Senate,34,Dem,Jeffrey Klein,223
+Bronx,80031,State Senate,34,Dem,Jeffrey Klein,314
+Bronx,80032,State Senate,34,Dem,Jeffrey Klein,197
+Bronx,80033,State Senate,34,Dem,Jeffrey Klein,186
+Bronx,80034,State Senate,34,Dem,Jeffrey Klein,276
+Bronx,80035,State Senate,34,Dem,Jeffrey Klein,222
+Bronx,80036,State Senate,34,Dem,Jeffrey Klein,372
+Bronx,80037,State Senate,34,Dem,Jeffrey Klein,119
+Bronx,80038,State Senate,34,Dem,Jeffrey Klein,209
+Bronx,80039,State Senate,34,Dem,Jeffrey Klein,239
+Bronx,80040,State Senate,34,Dem,Jeffrey Klein,252
+Bronx,80041,State Senate,34,Dem,Jeffrey Klein,544
+Bronx,80042,State Senate,34,Dem,Jeffrey Klein,336
+Bronx,80043,State Senate,34,Dem,Jeffrey Klein,247
+Bronx,80044,State Senate,34,Dem,Jeffrey Klein,188
+Bronx,80045,State Senate,34,Dem,Jeffrey Klein,274
+Bronx,80046,State Senate,34,Dem,Jeffrey Klein,301
+Bronx,80047,State Senate,34,Dem,Jeffrey Klein,269
+Bronx,80048,State Senate,34,Dem,Jeffrey Klein,228
+Bronx,80049,State Senate,34,Dem,Jeffrey Klein,47
+Bronx,80050,State Senate,34,Dem,Jeffrey Klein,420
+Bronx,80051,State Senate,34,Dem,Jeffrey Klein,150
+Bronx,80066,State Senate,34,Dem,Jeffrey Klein,155
+Bronx,80067,State Senate,34,Dem,Jeffrey Klein,297
+Bronx,80068,State Senate,34,Dem,Jeffrey Klein,327
+Bronx,80069,State Senate,34,Dem,Jeffrey Klein,158
+Bronx,81010,State Senate,34,Dem,Jeffrey Klein,72
+Bronx,81012,State Senate,34,Dem,Jeffrey Klein,200
+Bronx,81013,State Senate,34,Dem,Jeffrey Klein,405
+Bronx,81014,State Senate,34,Dem,Jeffrey Klein,371
+Bronx,81015,State Senate,34,Dem,Jeffrey Klein,369
+Bronx,81016,State Senate,34,Dem,Jeffrey Klein,24
+Bronx,81025,State Senate,34,Dem,Jeffrey Klein,161
+Bronx,81026,State Senate,34,Dem,Jeffrey Klein,117
+Bronx,81027,State Senate,34,Dem,Jeffrey Klein,142
+Bronx,81028,State Senate,34,Dem,Jeffrey Klein,128
+Bronx,81029,State Senate,34,Dem,Jeffrey Klein,117
+Bronx,81030,State Senate,34,Dem,Jeffrey Klein,158
+Bronx,81031,State Senate,34,Dem,Jeffrey Klein,129
+Bronx,81032,State Senate,34,Dem,Jeffrey Klein,104
+Bronx,81033,State Senate,34,Dem,Jeffrey Klein,497
+Bronx,81034,State Senate,34,Dem,Jeffrey Klein,387
+Bronx,81035,State Senate,34,Dem,Jeffrey Klein,356
+Bronx,81036,State Senate,34,Dem,Jeffrey Klein,605
+Bronx,81037,State Senate,34,Dem,Jeffrey Klein,351
+Bronx,81041,State Senate,34,Dem,Jeffrey Klein,387
+Bronx,81042,State Senate,34,Dem,Jeffrey Klein,5
+Bronx,81043,State Senate,34,Dem,Jeffrey Klein,253
+Bronx,81044,State Senate,34,Dem,Jeffrey Klein,171
+Bronx,81047,State Senate,34,Dem,Jeffrey Klein,78
+Bronx,81048,State Senate,34,Dem,Jeffrey Klein,238
+Bronx,81049,State Senate,34,Dem,Jeffrey Klein,236
+Bronx,81050,State Senate,34,Dem,Jeffrey Klein,307
+Bronx,81051,State Senate,34,Dem,Jeffrey Klein,239
+Bronx,81052,State Senate,34,Dem,Jeffrey Klein,129
+Bronx,81053,State Senate,34,Dem,Jeffrey Klein,95
+Bronx,81054,State Senate,34,Dem,Jeffrey Klein,338
+Bronx,81055,State Senate,34,Dem,Jeffrey Klein,383
+Bronx,81056,State Senate,34,Dem,Jeffrey Klein,327
+Bronx,81057,State Senate,34,Dem,Jeffrey Klein,175
+Bronx,81058,State Senate,34,Dem,Jeffrey Klein,257
+Bronx,81059,State Senate,34,Dem,Jeffrey Klein,173
+Bronx,81060,State Senate,34,Dem,Jeffrey Klein,239
+Bronx,81061,State Senate,34,Dem,Jeffrey Klein,150
+Bronx,81062,State Senate,34,Dem,Jeffrey Klein,308
+Bronx,81063,State Senate,34,Dem,Jeffrey Klein,267
+Bronx,81064,State Senate,34,Dem,Jeffrey Klein,548
+Bronx,81065,State Senate,34,Dem,Jeffrey Klein,338
+Bronx,81066,State Senate,34,Dem,Jeffrey Klein,169
+Bronx,81067,State Senate,34,Dem,Jeffrey Klein,210
+Bronx,81068,State Senate,34,Dem,Jeffrey Klein,411
+Bronx,81069,State Senate,34,Dem,Jeffrey Klein,450
+Bronx,81070,State Senate,34,Dem,Jeffrey Klein,233
+Bronx,81071,State Senate,34,Dem,Jeffrey Klein,409
+Bronx,81072,State Senate,34,Dem,Jeffrey Klein,333
+Bronx,81073,State Senate,34,Dem,Jeffrey Klein,277
+Bronx,81074,State Senate,34,Dem,Jeffrey Klein,287
+Bronx,81075,State Senate,34,Dem,Jeffrey Klein,298
+Bronx,81076,State Senate,34,Dem,Jeffrey Klein,318
+Bronx,81077,State Senate,34,Dem,Jeffrey Klein,322
+Bronx,81078,State Senate,34,Dem,Jeffrey Klein,488
+Bronx,81079,State Senate,34,Dem,Jeffrey Klein,283
+Bronx,81080,State Senate,34,Dem,Jeffrey Klein,401
+Bronx,81081,State Senate,34,Dem,Jeffrey Klein,289
+Bronx,81082,State Senate,34,Dem,Jeffrey Klein,271
+Bronx,81083,State Senate,34,Dem,Jeffrey Klein,304
+Bronx,81084,State Senate,34,Dem,Jeffrey Klein,423
+Bronx,81085,State Senate,34,Dem,Jeffrey Klein,212
+Bronx,81086,State Senate,34,Dem,Jeffrey Klein,298
+Bronx,81087,State Senate,34,Dem,Jeffrey Klein,281
+Bronx,81088,State Senate,34,Dem,Jeffrey Klein,225
+Bronx,81089,State Senate,34,Dem,Jeffrey Klein,262
+Bronx,81090,State Senate,34,Dem,Jeffrey Klein,296
+Bronx,81091,State Senate,34,Dem,Jeffrey Klein,213
+Bronx,81104,State Senate,34,Dem,Jeffrey Klein,42
+Bronx,82001,State Senate,34,Dem,Jeffrey Klein,200
+Bronx,82002,State Senate,34,Dem,Jeffrey Klein,206
+Bronx,82003,State Senate,34,Dem,Jeffrey Klein,124
+Bronx,82004,State Senate,34,Dem,Jeffrey Klein,228
+Bronx,82005,State Senate,34,Dem,Jeffrey Klein,308
+Bronx,82006,State Senate,34,Dem,Jeffrey Klein,229
+Bronx,82007,State Senate,34,Dem,Jeffrey Klein,211
+Bronx,82008,State Senate,34,Dem,Jeffrey Klein,393
+Bronx,82009,State Senate,34,Dem,Jeffrey Klein,213
+Bronx,82010,State Senate,34,Dem,Jeffrey Klein,396
+Bronx,82011,State Senate,34,Dem,Jeffrey Klein,327
+Bronx,82012,State Senate,34,Dem,Jeffrey Klein,282
+Bronx,82013,State Senate,34,Dem,Jeffrey Klein,387
+Bronx,82014,State Senate,34,Dem,Jeffrey Klein,157
+Bronx,82015,State Senate,34,Dem,Jeffrey Klein,426
+Bronx,82016,State Senate,34,Dem,Jeffrey Klein,247
+Bronx,82017,State Senate,34,Dem,Jeffrey Klein,316
+Bronx,82018,State Senate,34,Dem,Jeffrey Klein,189
+Bronx,82019,State Senate,34,Dem,Jeffrey Klein,168
+Bronx,82020,State Senate,34,Dem,Jeffrey Klein,179
+Bronx,82021,State Senate,34,Dem,Jeffrey Klein,180
+Bronx,82022,State Senate,34,Dem,Jeffrey Klein,290
+Bronx,82023,State Senate,34,Dem,Jeffrey Klein,320
+Bronx,82024,State Senate,34,Dem,Jeffrey Klein,349
+Bronx,82025,State Senate,34,Dem,Jeffrey Klein,254
+Bronx,82026,State Senate,34,Dem,Jeffrey Klein,55
+Bronx,82027,State Senate,34,Dem,Jeffrey Klein,186
+Bronx,82028,State Senate,34,Dem,Jeffrey Klein,341
+Bronx,82031,State Senate,34,Dem,Jeffrey Klein,524
+Bronx,82032,State Senate,34,Dem,Jeffrey Klein,293
+Bronx,82033,State Senate,34,Dem,Jeffrey Klein,239
+Bronx,82034,State Senate,34,Dem,Jeffrey Klein,198
+Bronx,82035,State Senate,34,Dem,Jeffrey Klein,302
+Bronx,82036,State Senate,34,Dem,Jeffrey Klein,345
+Bronx,82037,State Senate,34,Dem,Jeffrey Klein,261
+Bronx,82038,State Senate,34,Dem,Jeffrey Klein,267
+Bronx,82039,State Senate,34,Dem,Jeffrey Klein,327
+Bronx,82040,State Senate,34,Dem,Jeffrey Klein,195
+Bronx,82041,State Senate,34,Dem,Jeffrey Klein,226
+Bronx,82042,State Senate,34,Dem,Jeffrey Klein,127
+Bronx,82043,State Senate,34,Dem,Jeffrey Klein,172
+Bronx,82044,State Senate,34,Dem,Jeffrey Klein,187
+Bronx,82045,State Senate,34,Dem,Jeffrey Klein,155
+Bronx,82046,State Senate,34,Dem,Jeffrey Klein,178
+Bronx,82047,State Senate,34,Dem,Jeffrey Klein,170
+Bronx,82048,State Senate,34,Dem,Jeffrey Klein,190
+Bronx,82049,State Senate,34,Dem,Jeffrey Klein,231
+Bronx,82050,State Senate,34,Dem,Jeffrey Klein,179
+Bronx,82051,State Senate,34,Dem,Jeffrey Klein,290
+Bronx,82052,State Senate,34,Dem,Jeffrey Klein,279
+Bronx,82053,State Senate,34,Dem,Jeffrey Klein,217
+Bronx,82055,State Senate,34,Dem,Jeffrey Klein,159
+Bronx,82056,State Senate,34,Dem,Jeffrey Klein,352
+Bronx,82057,State Senate,34,Dem,Jeffrey Klein,284
+Bronx,82058,State Senate,34,Dem,Jeffrey Klein,201
+Bronx,82059,State Senate,34,Dem,Jeffrey Klein,13
+Bronx,82060,State Senate,34,Dem,Jeffrey Klein,207
+Bronx,82061,State Senate,34,Dem,Jeffrey Klein,268
+Bronx,82062,State Senate,34,Dem,Jeffrey Klein,235
+Bronx,82063,State Senate,34,Dem,Jeffrey Klein,193
+Bronx,82064,State Senate,34,Dem,Jeffrey Klein,153
+Bronx,82106,State Senate,34,Dem,Jeffrey Klein,103
+Bronx,82107,State Senate,34,Dem,Jeffrey Klein,86
+Bronx,83068,State Senate,34,Dem,Jeffrey Klein,1
+Bronx,84073,State Senate,34,Dem,Jeffrey Klein,68
+Bronx,84077,State Senate,34,Dem,Jeffrey Klein,271
+Bronx,84078,State Senate,34,Dem,Jeffrey Klein,21
+Bronx,85001,State Senate,34,Dem,Jeffrey Klein,360
+Bronx,85002,State Senate,34,Dem,Jeffrey Klein,327
+Bronx,85003,State Senate,34,Dem,Jeffrey Klein,440
+Bronx,85004,State Senate,34,Dem,Jeffrey Klein,337
+Bronx,85005,State Senate,34,Dem,Jeffrey Klein,419
+Bronx,85006,State Senate,34,Dem,Jeffrey Klein,231
+Bronx,85007,State Senate,34,Dem,Jeffrey Klein,311
+Bronx,85008,State Senate,34,Dem,Jeffrey Klein,453
+Bronx,85009,State Senate,34,Dem,Jeffrey Klein,266
+Bronx,85010,State Senate,34,Dem,Jeffrey Klein,343
+Bronx,85011,State Senate,34,Dem,Jeffrey Klein,376
+Bronx,85012,State Senate,34,Dem,Jeffrey Klein,390
+Bronx,85028,State Senate,34,Dem,Jeffrey Klein,48
+Bronx,85037,State Senate,34,Dem,Jeffrey Klein,407
+Bronx,85038,State Senate,34,Dem,Jeffrey Klein,274
+Bronx,85076,State Senate,34,Dem,Jeffrey Klein,35
+Bronx,87044,State Senate,34,Dem,Jeffrey Klein,81
+Bronx,87065,State Senate,34,Dem,Jeffrey Klein,215
+Bronx,87066,State Senate,34,Dem,Jeffrey Klein,233
+Bronx,87067,State Senate,34,Dem,Jeffrey Klein,225
+Bronx,87068,State Senate,34,Dem,Jeffrey Klein,428
+Bronx,87069,State Senate,34,Dem,Jeffrey Klein,316
+Bronx,87072,State Senate,34,Dem,Jeffrey Klein,221
+Bronx,87073,State Senate,34,Dem,Jeffrey Klein,27
+Bronx,87074,State Senate,34,Dem,Jeffrey Klein,374
+Bronx,87075,State Senate,34,Dem,Jeffrey Klein,297
+Bronx,87076,State Senate,34,Dem,Jeffrey Klein,288
+Bronx,87077,State Senate,34,Dem,Jeffrey Klein,359
+Bronx,87078,State Senate,34,Dem,Jeffrey Klein,420
+Bronx,87079,State Senate,34,Dem,Jeffrey Klein,23
+Bronx,87080,State Senate,34,Dem,Jeffrey Klein,277
+Bronx,87081,State Senate,34,Dem,Jeffrey Klein,329
+Bronx,87082,State Senate,34,Dem,Jeffrey Klein,359
+Bronx,78007,State Senate,34,Rep,Jeffrey Klein,15
+Bronx,78016,State Senate,34,Rep,Jeffrey Klein,18
+Bronx,78030,State Senate,34,Rep,Jeffrey Klein,33
+Bronx,78031,State Senate,34,Rep,Jeffrey Klein,31
+Bronx,78036,State Senate,34,Rep,Jeffrey Klein,9
+Bronx,78037,State Senate,34,Rep,Jeffrey Klein,3
+Bronx,78040,State Senate,34,Rep,Jeffrey Klein,33
+Bronx,78041,State Senate,34,Rep,Jeffrey Klein,75
+Bronx,78055,State Senate,34,Rep,Jeffrey Klein,21
+Bronx,78058,State Senate,34,Rep,Jeffrey Klein,3
+Bronx,80001,State Senate,34,Rep,Jeffrey Klein,35
+Bronx,80002,State Senate,34,Rep,Jeffrey Klein,26
+Bronx,80003,State Senate,34,Rep,Jeffrey Klein,172
+Bronx,80004,State Senate,34,Rep,Jeffrey Klein,82
+Bronx,80005,State Senate,34,Rep,Jeffrey Klein,55
+Bronx,80006,State Senate,34,Rep,Jeffrey Klein,55
+Bronx,80007,State Senate,34,Rep,Jeffrey Klein,52
+Bronx,80008,State Senate,34,Rep,Jeffrey Klein,50
+Bronx,80016,State Senate,34,Rep,Jeffrey Klein,37
+Bronx,80017,State Senate,34,Rep,Jeffrey Klein,20
+Bronx,80018,State Senate,34,Rep,Jeffrey Klein,82
+Bronx,80019,State Senate,34,Rep,Jeffrey Klein,74
+Bronx,80020,State Senate,34,Rep,Jeffrey Klein,54
+Bronx,80021,State Senate,34,Rep,Jeffrey Klein,39
+Bronx,80022,State Senate,34,Rep,Jeffrey Klein,17
+Bronx,80023,State Senate,34,Rep,Jeffrey Klein,49
+Bronx,80024,State Senate,34,Rep,Jeffrey Klein,39
+Bronx,80025,State Senate,34,Rep,Jeffrey Klein,21
+Bronx,80026,State Senate,34,Rep,Jeffrey Klein,28
+Bronx,80027,State Senate,34,Rep,Jeffrey Klein,48
+Bronx,80028,State Senate,34,Rep,Jeffrey Klein,70
+Bronx,80029,State Senate,34,Rep,Jeffrey Klein,31
+Bronx,80030,State Senate,34,Rep,Jeffrey Klein,117
+Bronx,80031,State Senate,34,Rep,Jeffrey Klein,135
+Bronx,80032,State Senate,34,Rep,Jeffrey Klein,103
+Bronx,80033,State Senate,34,Rep,Jeffrey Klein,83
+Bronx,80034,State Senate,34,Rep,Jeffrey Klein,106
+Bronx,80035,State Senate,34,Rep,Jeffrey Klein,99
+Bronx,80036,State Senate,34,Rep,Jeffrey Klein,92
+Bronx,80037,State Senate,34,Rep,Jeffrey Klein,47
+Bronx,80038,State Senate,34,Rep,Jeffrey Klein,44
+Bronx,80039,State Senate,34,Rep,Jeffrey Klein,54
+Bronx,80040,State Senate,34,Rep,Jeffrey Klein,7
+Bronx,80041,State Senate,34,Rep,Jeffrey Klein,33
+Bronx,80042,State Senate,34,Rep,Jeffrey Klein,16
+Bronx,80043,State Senate,34,Rep,Jeffrey Klein,21
+Bronx,80044,State Senate,34,Rep,Jeffrey Klein,33
+Bronx,80045,State Senate,34,Rep,Jeffrey Klein,45
+Bronx,80046,State Senate,34,Rep,Jeffrey Klein,18
+Bronx,80047,State Senate,34,Rep,Jeffrey Klein,22
+Bronx,80048,State Senate,34,Rep,Jeffrey Klein,24
+Bronx,80049,State Senate,34,Rep,Jeffrey Klein,1
+Bronx,80050,State Senate,34,Rep,Jeffrey Klein,25
+Bronx,80051,State Senate,34,Rep,Jeffrey Klein,39
+Bronx,80066,State Senate,34,Rep,Jeffrey Klein,68
+Bronx,80067,State Senate,34,Rep,Jeffrey Klein,65
+Bronx,80068,State Senate,34,Rep,Jeffrey Klein,91
+Bronx,80069,State Senate,34,Rep,Jeffrey Klein,9
+Bronx,81010,State Senate,34,Rep,Jeffrey Klein,7
+Bronx,81012,State Senate,34,Rep,Jeffrey Klein,19
+Bronx,81013,State Senate,34,Rep,Jeffrey Klein,35
+Bronx,81014,State Senate,34,Rep,Jeffrey Klein,35
+Bronx,81015,State Senate,34,Rep,Jeffrey Klein,47
+Bronx,81016,State Senate,34,Rep,Jeffrey Klein,22
+Bronx,81025,State Senate,34,Rep,Jeffrey Klein,76
+Bronx,81026,State Senate,34,Rep,Jeffrey Klein,43
+Bronx,81027,State Senate,34,Rep,Jeffrey Klein,70
+Bronx,81028,State Senate,34,Rep,Jeffrey Klein,103
+Bronx,81029,State Senate,34,Rep,Jeffrey Klein,55
+Bronx,81030,State Senate,34,Rep,Jeffrey Klein,99
+Bronx,81031,State Senate,34,Rep,Jeffrey Klein,79
+Bronx,81032,State Senate,34,Rep,Jeffrey Klein,86
+Bronx,81033,State Senate,34,Rep,Jeffrey Klein,54
+Bronx,81034,State Senate,34,Rep,Jeffrey Klein,59
+Bronx,81035,State Senate,34,Rep,Jeffrey Klein,56
+Bronx,81036,State Senate,34,Rep,Jeffrey Klein,59
+Bronx,81037,State Senate,34,Rep,Jeffrey Klein,51
+Bronx,81041,State Senate,34,Rep,Jeffrey Klein,83
+Bronx,81042,State Senate,34,Rep,Jeffrey Klein,0
+Bronx,81043,State Senate,34,Rep,Jeffrey Klein,31
+Bronx,81044,State Senate,34,Rep,Jeffrey Klein,40
+Bronx,81047,State Senate,34,Rep,Jeffrey Klein,27
+Bronx,81048,State Senate,34,Rep,Jeffrey Klein,52
+Bronx,81049,State Senate,34,Rep,Jeffrey Klein,56
+Bronx,81050,State Senate,34,Rep,Jeffrey Klein,45
+Bronx,81051,State Senate,34,Rep,Jeffrey Klein,39
+Bronx,81052,State Senate,34,Rep,Jeffrey Klein,23
+Bronx,81053,State Senate,34,Rep,Jeffrey Klein,52
+Bronx,81054,State Senate,34,Rep,Jeffrey Klein,40
+Bronx,81055,State Senate,34,Rep,Jeffrey Klein,83
+Bronx,81056,State Senate,34,Rep,Jeffrey Klein,54
+Bronx,81057,State Senate,34,Rep,Jeffrey Klein,51
+Bronx,81058,State Senate,34,Rep,Jeffrey Klein,38
+Bronx,81059,State Senate,34,Rep,Jeffrey Klein,56
+Bronx,81060,State Senate,34,Rep,Jeffrey Klein,89
+Bronx,81061,State Senate,34,Rep,Jeffrey Klein,40
+Bronx,81062,State Senate,34,Rep,Jeffrey Klein,46
+Bronx,81063,State Senate,34,Rep,Jeffrey Klein,90
+Bronx,81064,State Senate,34,Rep,Jeffrey Klein,71
+Bronx,81065,State Senate,34,Rep,Jeffrey Klein,91
+Bronx,81066,State Senate,34,Rep,Jeffrey Klein,58
+Bronx,81067,State Senate,34,Rep,Jeffrey Klein,46
+Bronx,81068,State Senate,34,Rep,Jeffrey Klein,123
+Bronx,81069,State Senate,34,Rep,Jeffrey Klein,71
+Bronx,81070,State Senate,34,Rep,Jeffrey Klein,45
+Bronx,81071,State Senate,34,Rep,Jeffrey Klein,97
+Bronx,81072,State Senate,34,Rep,Jeffrey Klein,74
+Bronx,81073,State Senate,34,Rep,Jeffrey Klein,75
+Bronx,81074,State Senate,34,Rep,Jeffrey Klein,74
+Bronx,81075,State Senate,34,Rep,Jeffrey Klein,55
+Bronx,81076,State Senate,34,Rep,Jeffrey Klein,49
+Bronx,81077,State Senate,34,Rep,Jeffrey Klein,50
+Bronx,81078,State Senate,34,Rep,Jeffrey Klein,88
+Bronx,81079,State Senate,34,Rep,Jeffrey Klein,94
+Bronx,81080,State Senate,34,Rep,Jeffrey Klein,62
+Bronx,81081,State Senate,34,Rep,Jeffrey Klein,34
+Bronx,81082,State Senate,34,Rep,Jeffrey Klein,49
+Bronx,81083,State Senate,34,Rep,Jeffrey Klein,54
+Bronx,81084,State Senate,34,Rep,Jeffrey Klein,71
+Bronx,81085,State Senate,34,Rep,Jeffrey Klein,53
+Bronx,81086,State Senate,34,Rep,Jeffrey Klein,65
+Bronx,81087,State Senate,34,Rep,Jeffrey Klein,50
+Bronx,81088,State Senate,34,Rep,Jeffrey Klein,71
+Bronx,81089,State Senate,34,Rep,Jeffrey Klein,33
+Bronx,81090,State Senate,34,Rep,Jeffrey Klein,41
+Bronx,81091,State Senate,34,Rep,Jeffrey Klein,21
+Bronx,81104,State Senate,34,Rep,Jeffrey Klein,3
+Bronx,82001,State Senate,34,Rep,Jeffrey Klein,191
+Bronx,82002,State Senate,34,Rep,Jeffrey Klein,169
+Bronx,82003,State Senate,34,Rep,Jeffrey Klein,108
+Bronx,82004,State Senate,34,Rep,Jeffrey Klein,160
+Bronx,82005,State Senate,34,Rep,Jeffrey Klein,143
+Bronx,82006,State Senate,34,Rep,Jeffrey Klein,91
+Bronx,82007,State Senate,34,Rep,Jeffrey Klein,126
+Bronx,82008,State Senate,34,Rep,Jeffrey Klein,62
+Bronx,82009,State Senate,34,Rep,Jeffrey Klein,65
+Bronx,82010,State Senate,34,Rep,Jeffrey Klein,88
+Bronx,82011,State Senate,34,Rep,Jeffrey Klein,55
+Bronx,82012,State Senate,34,Rep,Jeffrey Klein,5
+Bronx,82013,State Senate,34,Rep,Jeffrey Klein,10
+Bronx,82014,State Senate,34,Rep,Jeffrey Klein,4
+Bronx,82015,State Senate,34,Rep,Jeffrey Klein,15
+Bronx,82016,State Senate,34,Rep,Jeffrey Klein,62
+Bronx,82017,State Senate,34,Rep,Jeffrey Klein,116
+Bronx,82018,State Senate,34,Rep,Jeffrey Klein,29
+Bronx,82019,State Senate,34,Rep,Jeffrey Klein,69
+Bronx,82020,State Senate,34,Rep,Jeffrey Klein,104
+Bronx,82021,State Senate,34,Rep,Jeffrey Klein,55
+Bronx,82022,State Senate,34,Rep,Jeffrey Klein,70
+Bronx,82023,State Senate,34,Rep,Jeffrey Klein,15
+Bronx,82024,State Senate,34,Rep,Jeffrey Klein,77
+Bronx,82025,State Senate,34,Rep,Jeffrey Klein,76
+Bronx,82026,State Senate,34,Rep,Jeffrey Klein,1
+Bronx,82027,State Senate,34,Rep,Jeffrey Klein,9
+Bronx,82028,State Senate,34,Rep,Jeffrey Klein,33
+Bronx,82031,State Senate,34,Rep,Jeffrey Klein,38
+Bronx,82032,State Senate,34,Rep,Jeffrey Klein,97
+Bronx,82033,State Senate,34,Rep,Jeffrey Klein,109
+Bronx,82034,State Senate,34,Rep,Jeffrey Klein,74
+Bronx,82035,State Senate,34,Rep,Jeffrey Klein,129
+Bronx,82036,State Senate,34,Rep,Jeffrey Klein,139
+Bronx,82037,State Senate,34,Rep,Jeffrey Klein,59
+Bronx,82038,State Senate,34,Rep,Jeffrey Klein,60
+Bronx,82039,State Senate,34,Rep,Jeffrey Klein,99
+Bronx,82040,State Senate,34,Rep,Jeffrey Klein,116
+Bronx,82041,State Senate,34,Rep,Jeffrey Klein,135
+Bronx,82042,State Senate,34,Rep,Jeffrey Klein,79
+Bronx,82043,State Senate,34,Rep,Jeffrey Klein,123
+Bronx,82044,State Senate,34,Rep,Jeffrey Klein,136
+Bronx,82045,State Senate,34,Rep,Jeffrey Klein,135
+Bronx,82046,State Senate,34,Rep,Jeffrey Klein,143
+Bronx,82047,State Senate,34,Rep,Jeffrey Klein,142
+Bronx,82048,State Senate,34,Rep,Jeffrey Klein,136
+Bronx,82049,State Senate,34,Rep,Jeffrey Klein,227
+Bronx,82050,State Senate,34,Rep,Jeffrey Klein,52
+Bronx,82051,State Senate,34,Rep,Jeffrey Klein,57
+Bronx,82052,State Senate,34,Rep,Jeffrey Klein,101
+Bronx,82053,State Senate,34,Rep,Jeffrey Klein,48
+Bronx,82055,State Senate,34,Rep,Jeffrey Klein,88
+Bronx,82056,State Senate,34,Rep,Jeffrey Klein,158
+Bronx,82057,State Senate,34,Rep,Jeffrey Klein,132
+Bronx,82058,State Senate,34,Rep,Jeffrey Klein,131
+Bronx,82059,State Senate,34,Rep,Jeffrey Klein,7
+Bronx,82060,State Senate,34,Rep,Jeffrey Klein,145
+Bronx,82061,State Senate,34,Rep,Jeffrey Klein,157
+Bronx,82062,State Senate,34,Rep,Jeffrey Klein,125
+Bronx,82063,State Senate,34,Rep,Jeffrey Klein,115
+Bronx,82064,State Senate,34,Rep,Jeffrey Klein,20
+Bronx,82106,State Senate,34,Rep,Jeffrey Klein,16
+Bronx,82107,State Senate,34,Rep,Jeffrey Klein,38
+Bronx,83068,State Senate,34,Rep,Jeffrey Klein,0
+Bronx,84073,State Senate,34,Rep,Jeffrey Klein,1
+Bronx,84077,State Senate,34,Rep,Jeffrey Klein,2
+Bronx,84078,State Senate,34,Rep,Jeffrey Klein,3
+Bronx,85001,State Senate,34,Rep,Jeffrey Klein,14
+Bronx,85002,State Senate,34,Rep,Jeffrey Klein,17
+Bronx,85003,State Senate,34,Rep,Jeffrey Klein,28
+Bronx,85004,State Senate,34,Rep,Jeffrey Klein,16
+Bronx,85005,State Senate,34,Rep,Jeffrey Klein,19
+Bronx,85006,State Senate,34,Rep,Jeffrey Klein,10
+Bronx,85007,State Senate,34,Rep,Jeffrey Klein,26
+Bronx,85008,State Senate,34,Rep,Jeffrey Klein,17
+Bronx,85009,State Senate,34,Rep,Jeffrey Klein,9
+Bronx,85010,State Senate,34,Rep,Jeffrey Klein,5
+Bronx,85011,State Senate,34,Rep,Jeffrey Klein,1
+Bronx,85012,State Senate,34,Rep,Jeffrey Klein,8
+Bronx,85028,State Senate,34,Rep,Jeffrey Klein,3
+Bronx,85037,State Senate,34,Rep,Jeffrey Klein,5
+Bronx,85038,State Senate,34,Rep,Jeffrey Klein,7
+Bronx,85076,State Senate,34,Rep,Jeffrey Klein,1
+Bronx,87044,State Senate,34,Rep,Jeffrey Klein,10
+Bronx,87065,State Senate,34,Rep,Jeffrey Klein,23
+Bronx,87066,State Senate,34,Rep,Jeffrey Klein,14
+Bronx,87067,State Senate,34,Rep,Jeffrey Klein,11
+Bronx,87068,State Senate,34,Rep,Jeffrey Klein,34
+Bronx,87069,State Senate,34,Rep,Jeffrey Klein,19
+Bronx,87072,State Senate,34,Rep,Jeffrey Klein,25
+Bronx,87073,State Senate,34,Rep,Jeffrey Klein,1
+Bronx,87074,State Senate,34,Rep,Jeffrey Klein,33
+Bronx,87075,State Senate,34,Rep,Jeffrey Klein,22
+Bronx,87076,State Senate,34,Rep,Jeffrey Klein,31
+Bronx,87077,State Senate,34,Rep,Jeffrey Klein,15
+Bronx,87078,State Senate,34,Rep,Jeffrey Klein,23
+Bronx,87079,State Senate,34,Rep,Jeffrey Klein,0
+Bronx,87080,State Senate,34,Rep,Jeffrey Klein,12
+Bronx,87081,State Senate,34,Rep,Jeffrey Klein,17
+Bronx,87082,State Senate,34,Rep,Jeffrey Klein,13
+Bronx,78007,State Senate,34,WF,Jeffrey Klein,4
+Bronx,78016,State Senate,34,WF,Jeffrey Klein,4
+Bronx,78030,State Senate,34,WF,Jeffrey Klein,13
+Bronx,78031,State Senate,34,WF,Jeffrey Klein,6
+Bronx,78036,State Senate,34,WF,Jeffrey Klein,6
+Bronx,78037,State Senate,34,WF,Jeffrey Klein,2
+Bronx,78040,State Senate,34,WF,Jeffrey Klein,10
+Bronx,78041,State Senate,34,WF,Jeffrey Klein,13
+Bronx,78055,State Senate,34,WF,Jeffrey Klein,2
+Bronx,78058,State Senate,34,WF,Jeffrey Klein,1
+Bronx,80001,State Senate,34,WF,Jeffrey Klein,6
+Bronx,80002,State Senate,34,WF,Jeffrey Klein,2
+Bronx,80003,State Senate,34,WF,Jeffrey Klein,14
+Bronx,80004,State Senate,34,WF,Jeffrey Klein,5
+Bronx,80005,State Senate,34,WF,Jeffrey Klein,3
+Bronx,80006,State Senate,34,WF,Jeffrey Klein,9
+Bronx,80007,State Senate,34,WF,Jeffrey Klein,6
+Bronx,80008,State Senate,34,WF,Jeffrey Klein,12
+Bronx,80016,State Senate,34,WF,Jeffrey Klein,13
+Bronx,80017,State Senate,34,WF,Jeffrey Klein,6
+Bronx,80018,State Senate,34,WF,Jeffrey Klein,7
+Bronx,80019,State Senate,34,WF,Jeffrey Klein,6
+Bronx,80020,State Senate,34,WF,Jeffrey Klein,20
+Bronx,80021,State Senate,34,WF,Jeffrey Klein,11
+Bronx,80022,State Senate,34,WF,Jeffrey Klein,11
+Bronx,80023,State Senate,34,WF,Jeffrey Klein,11
+Bronx,80024,State Senate,34,WF,Jeffrey Klein,22
+Bronx,80025,State Senate,34,WF,Jeffrey Klein,13
+Bronx,80026,State Senate,34,WF,Jeffrey Klein,10
+Bronx,80027,State Senate,34,WF,Jeffrey Klein,4
+Bronx,80028,State Senate,34,WF,Jeffrey Klein,9
+Bronx,80029,State Senate,34,WF,Jeffrey Klein,5
+Bronx,80030,State Senate,34,WF,Jeffrey Klein,7
+Bronx,80031,State Senate,34,WF,Jeffrey Klein,9
+Bronx,80032,State Senate,34,WF,Jeffrey Klein,12
+Bronx,80033,State Senate,34,WF,Jeffrey Klein,2
+Bronx,80034,State Senate,34,WF,Jeffrey Klein,8
+Bronx,80035,State Senate,34,WF,Jeffrey Klein,4
+Bronx,80036,State Senate,34,WF,Jeffrey Klein,15
+Bronx,80037,State Senate,34,WF,Jeffrey Klein,9
+Bronx,80038,State Senate,34,WF,Jeffrey Klein,5
+Bronx,80039,State Senate,34,WF,Jeffrey Klein,13
+Bronx,80040,State Senate,34,WF,Jeffrey Klein,5
+Bronx,80041,State Senate,34,WF,Jeffrey Klein,5
+Bronx,80042,State Senate,34,WF,Jeffrey Klein,3
+Bronx,80043,State Senate,34,WF,Jeffrey Klein,7
+Bronx,80044,State Senate,34,WF,Jeffrey Klein,5
+Bronx,80045,State Senate,34,WF,Jeffrey Klein,11
+Bronx,80046,State Senate,34,WF,Jeffrey Klein,6
+Bronx,80047,State Senate,34,WF,Jeffrey Klein,12
+Bronx,80048,State Senate,34,WF,Jeffrey Klein,2
+Bronx,80049,State Senate,34,WF,Jeffrey Klein,2
+Bronx,80050,State Senate,34,WF,Jeffrey Klein,10
+Bronx,80051,State Senate,34,WF,Jeffrey Klein,4
+Bronx,80066,State Senate,34,WF,Jeffrey Klein,1
+Bronx,80067,State Senate,34,WF,Jeffrey Klein,4
+Bronx,80068,State Senate,34,WF,Jeffrey Klein,5
+Bronx,80069,State Senate,34,WF,Jeffrey Klein,6
+Bronx,81010,State Senate,34,WF,Jeffrey Klein,2
+Bronx,81012,State Senate,34,WF,Jeffrey Klein,3
+Bronx,81013,State Senate,34,WF,Jeffrey Klein,11
+Bronx,81014,State Senate,34,WF,Jeffrey Klein,15
+Bronx,81015,State Senate,34,WF,Jeffrey Klein,13
+Bronx,81016,State Senate,34,WF,Jeffrey Klein,0
+Bronx,81025,State Senate,34,WF,Jeffrey Klein,6
+Bronx,81026,State Senate,34,WF,Jeffrey Klein,4
+Bronx,81027,State Senate,34,WF,Jeffrey Klein,6
+Bronx,81028,State Senate,34,WF,Jeffrey Klein,4
+Bronx,81029,State Senate,34,WF,Jeffrey Klein,7
+Bronx,81030,State Senate,34,WF,Jeffrey Klein,8
+Bronx,81031,State Senate,34,WF,Jeffrey Klein,1
+Bronx,81032,State Senate,34,WF,Jeffrey Klein,10
+Bronx,81033,State Senate,34,WF,Jeffrey Klein,23
+Bronx,81034,State Senate,34,WF,Jeffrey Klein,24
+Bronx,81035,State Senate,34,WF,Jeffrey Klein,15
+Bronx,81036,State Senate,34,WF,Jeffrey Klein,28
+Bronx,81037,State Senate,34,WF,Jeffrey Klein,14
+Bronx,81041,State Senate,34,WF,Jeffrey Klein,14
+Bronx,81042,State Senate,34,WF,Jeffrey Klein,0
+Bronx,81043,State Senate,34,WF,Jeffrey Klein,7
+Bronx,81044,State Senate,34,WF,Jeffrey Klein,4
+Bronx,81047,State Senate,34,WF,Jeffrey Klein,5
+Bronx,81048,State Senate,34,WF,Jeffrey Klein,18
+Bronx,81049,State Senate,34,WF,Jeffrey Klein,11
+Bronx,81050,State Senate,34,WF,Jeffrey Klein,14
+Bronx,81051,State Senate,34,WF,Jeffrey Klein,17
+Bronx,81052,State Senate,34,WF,Jeffrey Klein,3
+Bronx,81053,State Senate,34,WF,Jeffrey Klein,1
+Bronx,81054,State Senate,34,WF,Jeffrey Klein,12
+Bronx,81055,State Senate,34,WF,Jeffrey Klein,14
+Bronx,81056,State Senate,34,WF,Jeffrey Klein,8
+Bronx,81057,State Senate,34,WF,Jeffrey Klein,6
+Bronx,81058,State Senate,34,WF,Jeffrey Klein,12
+Bronx,81059,State Senate,34,WF,Jeffrey Klein,12
+Bronx,81060,State Senate,34,WF,Jeffrey Klein,10
+Bronx,81061,State Senate,34,WF,Jeffrey Klein,4
+Bronx,81062,State Senate,34,WF,Jeffrey Klein,11
+Bronx,81063,State Senate,34,WF,Jeffrey Klein,9
+Bronx,81064,State Senate,34,WF,Jeffrey Klein,16
+Bronx,81065,State Senate,34,WF,Jeffrey Klein,15
+Bronx,81066,State Senate,34,WF,Jeffrey Klein,5
+Bronx,81067,State Senate,34,WF,Jeffrey Klein,12
+Bronx,81068,State Senate,34,WF,Jeffrey Klein,20
+Bronx,81069,State Senate,34,WF,Jeffrey Klein,14
+Bronx,81070,State Senate,34,WF,Jeffrey Klein,8
+Bronx,81071,State Senate,34,WF,Jeffrey Klein,12
+Bronx,81072,State Senate,34,WF,Jeffrey Klein,8
+Bronx,81073,State Senate,34,WF,Jeffrey Klein,6
+Bronx,81074,State Senate,34,WF,Jeffrey Klein,6
+Bronx,81075,State Senate,34,WF,Jeffrey Klein,15
+Bronx,81076,State Senate,34,WF,Jeffrey Klein,13
+Bronx,81077,State Senate,34,WF,Jeffrey Klein,13
+Bronx,81078,State Senate,34,WF,Jeffrey Klein,19
+Bronx,81079,State Senate,34,WF,Jeffrey Klein,6
+Bronx,81080,State Senate,34,WF,Jeffrey Klein,24
+Bronx,81081,State Senate,34,WF,Jeffrey Klein,15
+Bronx,81082,State Senate,34,WF,Jeffrey Klein,9
+Bronx,81083,State Senate,34,WF,Jeffrey Klein,15
+Bronx,81084,State Senate,34,WF,Jeffrey Klein,22
+Bronx,81085,State Senate,34,WF,Jeffrey Klein,6
+Bronx,81086,State Senate,34,WF,Jeffrey Klein,11
+Bronx,81087,State Senate,34,WF,Jeffrey Klein,8
+Bronx,81088,State Senate,34,WF,Jeffrey Klein,8
+Bronx,81089,State Senate,34,WF,Jeffrey Klein,16
+Bronx,81090,State Senate,34,WF,Jeffrey Klein,8
+Bronx,81091,State Senate,34,WF,Jeffrey Klein,0
+Bronx,81104,State Senate,34,WF,Jeffrey Klein,1
+Bronx,82001,State Senate,34,WF,Jeffrey Klein,19
+Bronx,82002,State Senate,34,WF,Jeffrey Klein,10
+Bronx,82003,State Senate,34,WF,Jeffrey Klein,10
+Bronx,82004,State Senate,34,WF,Jeffrey Klein,17
+Bronx,82005,State Senate,34,WF,Jeffrey Klein,15
+Bronx,82006,State Senate,34,WF,Jeffrey Klein,4
+Bronx,82007,State Senate,34,WF,Jeffrey Klein,11
+Bronx,82008,State Senate,34,WF,Jeffrey Klein,11
+Bronx,82009,State Senate,34,WF,Jeffrey Klein,11
+Bronx,82010,State Senate,34,WF,Jeffrey Klein,17
+Bronx,82011,State Senate,34,WF,Jeffrey Klein,10
+Bronx,82012,State Senate,34,WF,Jeffrey Klein,8
+Bronx,82013,State Senate,34,WF,Jeffrey Klein,4
+Bronx,82014,State Senate,34,WF,Jeffrey Klein,2
+Bronx,82015,State Senate,34,WF,Jeffrey Klein,5
+Bronx,82016,State Senate,34,WF,Jeffrey Klein,7
+Bronx,82017,State Senate,34,WF,Jeffrey Klein,13
+Bronx,82018,State Senate,34,WF,Jeffrey Klein,9
+Bronx,82019,State Senate,34,WF,Jeffrey Klein,9
+Bronx,82020,State Senate,34,WF,Jeffrey Klein,12
+Bronx,82021,State Senate,34,WF,Jeffrey Klein,6
+Bronx,82022,State Senate,34,WF,Jeffrey Klein,9
+Bronx,82023,State Senate,34,WF,Jeffrey Klein,6
+Bronx,82024,State Senate,34,WF,Jeffrey Klein,9
+Bronx,82025,State Senate,34,WF,Jeffrey Klein,18
+Bronx,82026,State Senate,34,WF,Jeffrey Klein,4
+Bronx,82027,State Senate,34,WF,Jeffrey Klein,2
+Bronx,82028,State Senate,34,WF,Jeffrey Klein,9
+Bronx,82031,State Senate,34,WF,Jeffrey Klein,6
+Bronx,82032,State Senate,34,WF,Jeffrey Klein,9
+Bronx,82033,State Senate,34,WF,Jeffrey Klein,13
+Bronx,82034,State Senate,34,WF,Jeffrey Klein,7
+Bronx,82035,State Senate,34,WF,Jeffrey Klein,11
+Bronx,82036,State Senate,34,WF,Jeffrey Klein,12
+Bronx,82037,State Senate,34,WF,Jeffrey Klein,7
+Bronx,82038,State Senate,34,WF,Jeffrey Klein,12
+Bronx,82039,State Senate,34,WF,Jeffrey Klein,15
+Bronx,82040,State Senate,34,WF,Jeffrey Klein,11
+Bronx,82041,State Senate,34,WF,Jeffrey Klein,8
+Bronx,82042,State Senate,34,WF,Jeffrey Klein,5
+Bronx,82043,State Senate,34,WF,Jeffrey Klein,8
+Bronx,82044,State Senate,34,WF,Jeffrey Klein,12
+Bronx,82045,State Senate,34,WF,Jeffrey Klein,8
+Bronx,82046,State Senate,34,WF,Jeffrey Klein,12
+Bronx,82047,State Senate,34,WF,Jeffrey Klein,9
+Bronx,82048,State Senate,34,WF,Jeffrey Klein,17
+Bronx,82049,State Senate,34,WF,Jeffrey Klein,13
+Bronx,82050,State Senate,34,WF,Jeffrey Klein,7
+Bronx,82051,State Senate,34,WF,Jeffrey Klein,14
+Bronx,82052,State Senate,34,WF,Jeffrey Klein,13
+Bronx,82053,State Senate,34,WF,Jeffrey Klein,7
+Bronx,82055,State Senate,34,WF,Jeffrey Klein,9
+Bronx,82056,State Senate,34,WF,Jeffrey Klein,14
+Bronx,82057,State Senate,34,WF,Jeffrey Klein,5
+Bronx,82058,State Senate,34,WF,Jeffrey Klein,12
+Bronx,82059,State Senate,34,WF,Jeffrey Klein,0
+Bronx,82060,State Senate,34,WF,Jeffrey Klein,18
+Bronx,82061,State Senate,34,WF,Jeffrey Klein,19
+Bronx,82062,State Senate,34,WF,Jeffrey Klein,9
+Bronx,82063,State Senate,34,WF,Jeffrey Klein,11
+Bronx,82064,State Senate,34,WF,Jeffrey Klein,3
+Bronx,82106,State Senate,34,WF,Jeffrey Klein,0
+Bronx,82107,State Senate,34,WF,Jeffrey Klein,2
+Bronx,83068,State Senate,34,WF,Jeffrey Klein,0
+Bronx,84073,State Senate,34,WF,Jeffrey Klein,1
+Bronx,84077,State Senate,34,WF,Jeffrey Klein,3
+Bronx,84078,State Senate,34,WF,Jeffrey Klein,1
+Bronx,85001,State Senate,34,WF,Jeffrey Klein,8
+Bronx,85002,State Senate,34,WF,Jeffrey Klein,8
+Bronx,85003,State Senate,34,WF,Jeffrey Klein,11
+Bronx,85004,State Senate,34,WF,Jeffrey Klein,6
+Bronx,85005,State Senate,34,WF,Jeffrey Klein,7
+Bronx,85006,State Senate,34,WF,Jeffrey Klein,6
+Bronx,85007,State Senate,34,WF,Jeffrey Klein,6
+Bronx,85008,State Senate,34,WF,Jeffrey Klein,6
+Bronx,85009,State Senate,34,WF,Jeffrey Klein,1
+Bronx,85010,State Senate,34,WF,Jeffrey Klein,4
+Bronx,85011,State Senate,34,WF,Jeffrey Klein,7
+Bronx,85012,State Senate,34,WF,Jeffrey Klein,6
+Bronx,85028,State Senate,34,WF,Jeffrey Klein,0
+Bronx,85037,State Senate,34,WF,Jeffrey Klein,2
+Bronx,85038,State Senate,34,WF,Jeffrey Klein,4
+Bronx,85076,State Senate,34,WF,Jeffrey Klein,1
+Bronx,87044,State Senate,34,WF,Jeffrey Klein,2
+Bronx,87065,State Senate,34,WF,Jeffrey Klein,5
+Bronx,87066,State Senate,34,WF,Jeffrey Klein,3
+Bronx,87067,State Senate,34,WF,Jeffrey Klein,1
+Bronx,87068,State Senate,34,WF,Jeffrey Klein,6
+Bronx,87069,State Senate,34,WF,Jeffrey Klein,5
+Bronx,87072,State Senate,34,WF,Jeffrey Klein,6
+Bronx,87073,State Senate,34,WF,Jeffrey Klein,3
+Bronx,87074,State Senate,34,WF,Jeffrey Klein,4
+Bronx,87075,State Senate,34,WF,Jeffrey Klein,7
+Bronx,87076,State Senate,34,WF,Jeffrey Klein,3
+Bronx,87077,State Senate,34,WF,Jeffrey Klein,8
+Bronx,87078,State Senate,34,WF,Jeffrey Klein,9
+Bronx,87079,State Senate,34,WF,Jeffrey Klein,0
+Bronx,87080,State Senate,34,WF,Jeffrey Klein,5
+Bronx,87081,State Senate,34,WF,Jeffrey Klein,7
+Bronx,87082,State Senate,34,WF,Jeffrey Klein,5
+Bronx,78007,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,78016,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,78030,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,78031,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,78036,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,78037,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,78040,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,78041,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,78055,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,78058,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,80001,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,80002,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,80003,State Senate,34,Ind,Jeffrey Klein,9
+Bronx,80004,State Senate,34,Ind,Jeffrey Klein,8
+Bronx,80005,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,80006,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,80007,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,80008,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,80016,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,80017,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,80018,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,80019,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,80020,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,80021,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,80022,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,80023,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,80024,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,80025,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,80026,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,80027,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,80028,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,80029,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,80030,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,80031,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,80032,State Senate,34,Ind,Jeffrey Klein,6
+Bronx,80033,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,80034,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,80035,State Senate,34,Ind,Jeffrey Klein,6
+Bronx,80036,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,80037,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,80038,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,80039,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,80040,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,80041,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,80042,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,80043,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,80044,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,80045,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,80046,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,80047,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,80048,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,80049,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,80050,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,80051,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,80066,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,80067,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,80068,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,80069,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,81010,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,81012,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,81013,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,81014,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,81015,State Senate,34,Ind,Jeffrey Klein,6
+Bronx,81016,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,81025,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,81026,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,81027,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,81028,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,81029,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,81030,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,81031,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,81032,State Senate,34,Ind,Jeffrey Klein,6
+Bronx,81033,State Senate,34,Ind,Jeffrey Klein,6
+Bronx,81034,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,81035,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,81036,State Senate,34,Ind,Jeffrey Klein,19
+Bronx,81037,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,81041,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,81042,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,81043,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,81044,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,81047,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,81048,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,81049,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,81050,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,81051,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,81052,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,81053,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,81054,State Senate,34,Ind,Jeffrey Klein,7
+Bronx,81055,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,81056,State Senate,34,Ind,Jeffrey Klein,7
+Bronx,81057,State Senate,34,Ind,Jeffrey Klein,9
+Bronx,81058,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,81059,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,81060,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,81061,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,81062,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,81063,State Senate,34,Ind,Jeffrey Klein,6
+Bronx,81064,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,81065,State Senate,34,Ind,Jeffrey Klein,6
+Bronx,81066,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,81067,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,81068,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,81069,State Senate,34,Ind,Jeffrey Klein,9
+Bronx,81070,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,81071,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,81072,State Senate,34,Ind,Jeffrey Klein,7
+Bronx,81073,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,81074,State Senate,34,Ind,Jeffrey Klein,7
+Bronx,81075,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,81076,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,81077,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,81078,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,81079,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,81080,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,81081,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,81082,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,81083,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,81084,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,81085,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,81086,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,81087,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,81088,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,81089,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,81090,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,81091,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,81104,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,82001,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,82002,State Senate,34,Ind,Jeffrey Klein,6
+Bronx,82003,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,82004,State Senate,34,Ind,Jeffrey Klein,9
+Bronx,82005,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,82006,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,82007,State Senate,34,Ind,Jeffrey Klein,8
+Bronx,82008,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,82009,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,82010,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,82011,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,82012,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,82013,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,82014,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,82015,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,82016,State Senate,34,Ind,Jeffrey Klein,6
+Bronx,82017,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,82018,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,82019,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,82020,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,82021,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,82022,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,82023,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,82024,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,82025,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,82026,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,82027,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,82028,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,82031,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,82032,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,82033,State Senate,34,Ind,Jeffrey Klein,6
+Bronx,82034,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,82035,State Senate,34,Ind,Jeffrey Klein,9
+Bronx,82036,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,82037,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,82038,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,82039,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,82040,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,82041,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,82042,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,82043,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,82044,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,82045,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,82046,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,82047,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,82048,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,82049,State Senate,34,Ind,Jeffrey Klein,6
+Bronx,82050,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,82051,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,82052,State Senate,34,Ind,Jeffrey Klein,6
+Bronx,82053,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,82055,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,82056,State Senate,34,Ind,Jeffrey Klein,8
+Bronx,82057,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,82058,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,82059,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,82060,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,82061,State Senate,34,Ind,Jeffrey Klein,9
+Bronx,82062,State Senate,34,Ind,Jeffrey Klein,10
+Bronx,82063,State Senate,34,Ind,Jeffrey Klein,11
+Bronx,82064,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,82106,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,82107,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,83068,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,84073,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,84077,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,84078,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,85001,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,85002,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,85003,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,85004,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,85005,State Senate,34,Ind,Jeffrey Klein,3
+Bronx,85006,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,85007,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,85008,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,85009,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,85010,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,85011,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,85012,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,85028,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,85037,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,85038,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,85076,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,87044,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,87065,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,87066,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,87067,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,87068,State Senate,34,Ind,Jeffrey Klein,5
+Bronx,87069,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,87072,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,87073,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,87074,State Senate,34,Ind,Jeffrey Klein,0
+Bronx,87075,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,87076,State Senate,34,Ind,Jeffrey Klein,4
+Bronx,87077,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,87078,State Senate,34,Ind,Jeffrey Klein,2
+Bronx,87079,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,87080,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,87081,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,87082,State Senate,34,Ind,Jeffrey Klein,1
+Bronx,78007,State Senate,34,Ind,writein,0
+Bronx,78016,State Senate,34,Ind,writein,0
+Bronx,78030,State Senate,34,Ind,writein,0
+Bronx,78031,State Senate,34,Ind,writein,0
+Bronx,78036,State Senate,34,Ind,writein,0
+Bronx,78037,State Senate,34,Ind,writein,0
+Bronx,78040,State Senate,34,Ind,writein,0
+Bronx,78041,State Senate,34,Ind,writein,0
+Bronx,78055,State Senate,34,Ind,writein,0
+Bronx,78058,State Senate,34,Ind,writein,0
+Bronx,80001,State Senate,34,Ind,writein,0
+Bronx,80002,State Senate,34,Ind,writein,0
+Bronx,80003,State Senate,34,Ind,writein,1
+Bronx,80004,State Senate,34,Ind,writein,0
+Bronx,80005,State Senate,34,Ind,writein,0
+Bronx,80006,State Senate,34,Ind,writein,0
+Bronx,80007,State Senate,34,Ind,writein,0
+Bronx,80008,State Senate,34,Ind,writein,0
+Bronx,80016,State Senate,34,Ind,writein,0
+Bronx,80017,State Senate,34,Ind,writein,0
+Bronx,80018,State Senate,34,Ind,writein,0
+Bronx,80019,State Senate,34,Ind,writein,0
+Bronx,80020,State Senate,34,Ind,writein,0
+Bronx,80021,State Senate,34,Ind,writein,0
+Bronx,80022,State Senate,34,Ind,writein,0
+Bronx,80023,State Senate,34,Ind,writein,0
+Bronx,80024,State Senate,34,Ind,writein,0
+Bronx,80025,State Senate,34,Ind,writein,0
+Bronx,80026,State Senate,34,Ind,writein,0
+Bronx,80027,State Senate,34,Ind,writein,0
+Bronx,80028,State Senate,34,Ind,writein,0
+Bronx,80029,State Senate,34,Ind,writein,0
+Bronx,80030,State Senate,34,Ind,writein,1
+Bronx,80031,State Senate,34,Ind,writein,0
+Bronx,80032,State Senate,34,Ind,writein,0
+Bronx,80033,State Senate,34,Ind,writein,0
+Bronx,80034,State Senate,34,Ind,writein,0
+Bronx,80035,State Senate,34,Ind,writein,0
+Bronx,80036,State Senate,34,Ind,writein,0
+Bronx,80037,State Senate,34,Ind,writein,0
+Bronx,80038,State Senate,34,Ind,writein,0
+Bronx,80039,State Senate,34,Ind,writein,0
+Bronx,80040,State Senate,34,Ind,writein,0
+Bronx,80041,State Senate,34,Ind,writein,0
+Bronx,80042,State Senate,34,Ind,writein,0
+Bronx,80043,State Senate,34,Ind,writein,0
+Bronx,80044,State Senate,34,Ind,writein,0
+Bronx,80045,State Senate,34,Ind,writein,0
+Bronx,80046,State Senate,34,Ind,writein,0
+Bronx,80047,State Senate,34,Ind,writein,1
+Bronx,80048,State Senate,34,Ind,writein,0
+Bronx,80049,State Senate,34,Ind,writein,0
+Bronx,80050,State Senate,34,Ind,writein,0
+Bronx,80051,State Senate,34,Ind,writein,0
+Bronx,80066,State Senate,34,Ind,writein,0
+Bronx,80067,State Senate,34,Ind,writein,0
+Bronx,80068,State Senate,34,Ind,writein,0
+Bronx,80069,State Senate,34,Ind,writein,1
+Bronx,81010,State Senate,34,Ind,writein,1
+Bronx,81012,State Senate,34,Ind,writein,0
+Bronx,81013,State Senate,34,Ind,writein,1
+Bronx,81014,State Senate,34,Ind,writein,0
+Bronx,81015,State Senate,34,Ind,writein,2
+Bronx,81016,State Senate,34,Ind,writein,0
+Bronx,81025,State Senate,34,Ind,writein,1
+Bronx,81026,State Senate,34,Ind,writein,1
+Bronx,81027,State Senate,34,Ind,writein,0
+Bronx,81028,State Senate,34,Ind,writein,0
+Bronx,81029,State Senate,34,Ind,writein,0
+Bronx,81030,State Senate,34,Ind,writein,0
+Bronx,81031,State Senate,34,Ind,writein,1
+Bronx,81032,State Senate,34,Ind,writein,0
+Bronx,81033,State Senate,34,Ind,writein,0
+Bronx,81034,State Senate,34,Ind,writein,4
+Bronx,81035,State Senate,34,Ind,writein,0
+Bronx,81036,State Senate,34,Ind,writein,5
+Bronx,81037,State Senate,34,Ind,writein,1
+Bronx,81041,State Senate,34,Ind,writein,0
+Bronx,81042,State Senate,34,Ind,writein,0
+Bronx,81043,State Senate,34,Ind,writein,0
+Bronx,81044,State Senate,34,Ind,writein,0
+Bronx,81047,State Senate,34,Ind,writein,0
+Bronx,81048,State Senate,34,Ind,writein,0
+Bronx,81049,State Senate,34,Ind,writein,1
+Bronx,81050,State Senate,34,Ind,writein,0
+Bronx,81051,State Senate,34,Ind,writein,1
+Bronx,81052,State Senate,34,Ind,writein,1
+Bronx,81053,State Senate,34,Ind,writein,0
+Bronx,81054,State Senate,34,Ind,writein,0
+Bronx,81055,State Senate,34,Ind,writein,0
+Bronx,81056,State Senate,34,Ind,writein,1
+Bronx,81057,State Senate,34,Ind,writein,0
+Bronx,81058,State Senate,34,Ind,writein,0
+Bronx,81059,State Senate,34,Ind,writein,0
+Bronx,81060,State Senate,34,Ind,writein,0
+Bronx,81061,State Senate,34,Ind,writein,0
+Bronx,81062,State Senate,34,Ind,writein,0
+Bronx,81063,State Senate,34,Ind,writein,0
+Bronx,81064,State Senate,34,Ind,writein,0
+Bronx,81065,State Senate,34,Ind,writein,0
+Bronx,81066,State Senate,34,Ind,writein,0
+Bronx,81067,State Senate,34,Ind,writein,0
+Bronx,81068,State Senate,34,Ind,writein,0
+Bronx,81069,State Senate,34,Ind,writein,1
+Bronx,81070,State Senate,34,Ind,writein,0
+Bronx,81071,State Senate,34,Ind,writein,0
+Bronx,81072,State Senate,34,Ind,writein,0
+Bronx,81073,State Senate,34,Ind,writein,1
+Bronx,81074,State Senate,34,Ind,writein,1
+Bronx,81075,State Senate,34,Ind,writein,0
+Bronx,81076,State Senate,34,Ind,writein,0
+Bronx,81077,State Senate,34,Ind,writein,2
+Bronx,81078,State Senate,34,Ind,writein,0
+Bronx,81079,State Senate,34,Ind,writein,0
+Bronx,81080,State Senate,34,Ind,writein,0
+Bronx,81081,State Senate,34,Ind,writein,0
+Bronx,81082,State Senate,34,Ind,writein,0
+Bronx,81083,State Senate,34,Ind,writein,0
+Bronx,81084,State Senate,34,Ind,writein,3
+Bronx,81085,State Senate,34,Ind,writein,1
+Bronx,81086,State Senate,34,Ind,writein,1
+Bronx,81087,State Senate,34,Ind,writein,0
+Bronx,81088,State Senate,34,Ind,writein,1
+Bronx,81089,State Senate,34,Ind,writein,0
+Bronx,81090,State Senate,34,Ind,writein,0
+Bronx,81091,State Senate,34,Ind,writein,0
+Bronx,81104,State Senate,34,Ind,writein,0
+Bronx,82001,State Senate,34,Ind,writein,0
+Bronx,82002,State Senate,34,Ind,writein,0
+Bronx,82003,State Senate,34,Ind,writein,0
+Bronx,82004,State Senate,34,Ind,writein,0
+Bronx,82005,State Senate,34,Ind,writein,0
+Bronx,82006,State Senate,34,Ind,writein,0
+Bronx,82007,State Senate,34,Ind,writein,0
+Bronx,82008,State Senate,34,Ind,writein,0
+Bronx,82009,State Senate,34,Ind,writein,0
+Bronx,82010,State Senate,34,Ind,writein,0
+Bronx,82011,State Senate,34,Ind,writein,0
+Bronx,82012,State Senate,34,Ind,writein,0
+Bronx,82013,State Senate,34,Ind,writein,0
+Bronx,82014,State Senate,34,Ind,writein,0
+Bronx,82015,State Senate,34,Ind,writein,0
+Bronx,82016,State Senate,34,Ind,writein,0
+Bronx,82017,State Senate,34,Ind,writein,1
+Bronx,82018,State Senate,34,Ind,writein,0
+Bronx,82019,State Senate,34,Ind,writein,0
+Bronx,82020,State Senate,34,Ind,writein,0
+Bronx,82021,State Senate,34,Ind,writein,0
+Bronx,82022,State Senate,34,Ind,writein,0
+Bronx,82023,State Senate,34,Ind,writein,0
+Bronx,82024,State Senate,34,Ind,writein,0
+Bronx,82025,State Senate,34,Ind,writein,0
+Bronx,82026,State Senate,34,Ind,writein,0
+Bronx,82027,State Senate,34,Ind,writein,0
+Bronx,82028,State Senate,34,Ind,writein,0
+Bronx,82031,State Senate,34,Ind,writein,0
+Bronx,82032,State Senate,34,Ind,writein,1
+Bronx,82033,State Senate,34,Ind,writein,0
+Bronx,82034,State Senate,34,Ind,writein,0
+Bronx,82035,State Senate,34,Ind,writein,0
+Bronx,82036,State Senate,34,Ind,writein,0
+Bronx,82037,State Senate,34,Ind,writein,0
+Bronx,82038,State Senate,34,Ind,writein,1
+Bronx,82039,State Senate,34,Ind,writein,0
+Bronx,82040,State Senate,34,Ind,writein,0
+Bronx,82041,State Senate,34,Ind,writein,0
+Bronx,82042,State Senate,34,Ind,writein,0
+Bronx,82043,State Senate,34,Ind,writein,0
+Bronx,82044,State Senate,34,Ind,writein,0
+Bronx,82045,State Senate,34,Ind,writein,0
+Bronx,82046,State Senate,34,Ind,writein,0
+Bronx,82047,State Senate,34,Ind,writein,0
+Bronx,82048,State Senate,34,Ind,writein,0
+Bronx,82049,State Senate,34,Ind,writein,0
+Bronx,82050,State Senate,34,Ind,writein,0
+Bronx,82051,State Senate,34,Ind,writein,1
+Bronx,82052,State Senate,34,Ind,writein,0
+Bronx,82053,State Senate,34,Ind,writein,0
+Bronx,82055,State Senate,34,Ind,writein,0
+Bronx,82056,State Senate,34,Ind,writein,0
+Bronx,82057,State Senate,34,Ind,writein,0
+Bronx,82058,State Senate,34,Ind,writein,0
+Bronx,82059,State Senate,34,Ind,writein,0
+Bronx,82060,State Senate,34,Ind,writein,1
+Bronx,82061,State Senate,34,Ind,writein,1
+Bronx,82062,State Senate,34,Ind,writein,0
+Bronx,82063,State Senate,34,Ind,writein,0
+Bronx,82064,State Senate,34,Ind,writein,0
+Bronx,82106,State Senate,34,Ind,writein,0
+Bronx,82107,State Senate,34,Ind,writein,0
+Bronx,83068,State Senate,34,Ind,writein,0
+Bronx,84073,State Senate,34,Ind,writein,0
+Bronx,84077,State Senate,34,Ind,writein,0
+Bronx,84078,State Senate,34,Ind,writein,0
+Bronx,85001,State Senate,34,Ind,writein,0
+Bronx,85002,State Senate,34,Ind,writein,0
+Bronx,85003,State Senate,34,Ind,writein,0
+Bronx,85004,State Senate,34,Ind,writein,0
+Bronx,85005,State Senate,34,Ind,writein,0
+Bronx,85006,State Senate,34,Ind,writein,0
+Bronx,85007,State Senate,34,Ind,writein,0
+Bronx,85008,State Senate,34,Ind,writein,0
+Bronx,85009,State Senate,34,Ind,writein,0
+Bronx,85010,State Senate,34,Ind,writein,0
+Bronx,85011,State Senate,34,Ind,writein,0
+Bronx,85012,State Senate,34,Ind,writein,0
+Bronx,85028,State Senate,34,Ind,writein,0
+Bronx,85037,State Senate,34,Ind,writein,0
+Bronx,85038,State Senate,34,Ind,writein,0
+Bronx,85076,State Senate,34,Ind,writein,0
+Bronx,87044,State Senate,34,Ind,writein,0
+Bronx,87065,State Senate,34,Ind,writein,0
+Bronx,87066,State Senate,34,Ind,writein,0
+Bronx,87067,State Senate,34,Ind,writein,0
+Bronx,87068,State Senate,34,Ind,writein,0
+Bronx,87069,State Senate,34,Ind,writein,0
+Bronx,87072,State Senate,34,Ind,writein,0
+Bronx,87073,State Senate,34,Ind,writein,0
+Bronx,87074,State Senate,34,Ind,writein,0
+Bronx,87075,State Senate,34,Ind,writein,0
+Bronx,87076,State Senate,34,Ind,writein,0
+Bronx,87077,State Senate,34,Ind,writein,0
+Bronx,87078,State Senate,34,Ind,writein,0
+Bronx,87079,State Senate,34,Ind,writein,0
+Bronx,87080,State Senate,34,Ind,writein,0
+Bronx,87081,State Senate,34,Ind,writein,0
+Bronx,87082,State Senate,34,Ind,writein,0
+Bronx,78032,State Senate,36,Con,Robert Diamond,28
+Bronx,78033,State Senate,36,Con,Robert Diamond,33
+Bronx,78034,State Senate,36,Con,Robert Diamond,19
+Bronx,78035,State Senate,36,Con,Robert Diamond,6
+Bronx,80052,State Senate,36,Con,Robert Diamond,9
+Bronx,80053,State Senate,36,Con,Robert Diamond,14
+Bronx,80054,State Senate,36,Con,Robert Diamond,0
+Bronx,80055,State Senate,36,Con,Robert Diamond,11
+Bronx,80056,State Senate,36,Con,Robert Diamond,4
+Bronx,80057,State Senate,36,Con,Robert Diamond,13
+Bronx,80058,State Senate,36,Con,Robert Diamond,15
+Bronx,80059,State Senate,36,Con,Robert Diamond,4
+Bronx,80060,State Senate,36,Con,Robert Diamond,9
+Bronx,80061,State Senate,36,Con,Robert Diamond,2
+Bronx,80062,State Senate,36,Con,Robert Diamond,14
+Bronx,80063,State Senate,36,Con,Robert Diamond,9
+Bronx,80064,State Senate,36,Con,Robert Diamond,0
+Bronx,80065,State Senate,36,Con,Robert Diamond,1
+Bronx,80070,State Senate,36,Con,Robert Diamond,23
+Bronx,80071,State Senate,36,Con,Robert Diamond,14
+Bronx,80072,State Senate,36,Con,Robert Diamond,1
+Bronx,80073,State Senate,36,Con,Robert Diamond,9
+Bronx,80075,State Senate,36,Con,Robert Diamond,0
+Bronx,80076,State Senate,36,Con,Robert Diamond,0
+Bronx,80077,State Senate,36,Con,Robert Diamond,11
+Bronx,80078,State Senate,36,Con,Robert Diamond,18
+Bronx,80079,State Senate,36,Con,Robert Diamond,20
+Bronx,80080,State Senate,36,Con,Robert Diamond,6
+Bronx,80081,State Senate,36,Con,Robert Diamond,14
+Bronx,80082,State Senate,36,Con,Robert Diamond,11
+Bronx,80083,State Senate,36,Con,Robert Diamond,30
+Bronx,80084,State Senate,36,Con,Robert Diamond,14
+Bronx,80085,State Senate,36,Con,Robert Diamond,15
+Bronx,80086,State Senate,36,Con,Robert Diamond,10
+Bronx,80087,State Senate,36,Con,Robert Diamond,6
+Bronx,80089,State Senate,36,Con,Robert Diamond,7
+Bronx,80090,State Senate,36,Con,Robert Diamond,0
+Bronx,80091,State Senate,36,Con,Robert Diamond,14
+Bronx,80092,State Senate,36,Con,Robert Diamond,1
+Bronx,80093,State Senate,36,Con,Robert Diamond,2
+Bronx,80094,State Senate,36,Con,Robert Diamond,14
+Bronx,81017,State Senate,36,Con,Robert Diamond,6
+Bronx,81018,State Senate,36,Con,Robert Diamond,4
+Bronx,81019,State Senate,36,Con,Robert Diamond,9
+Bronx,81020,State Senate,36,Con,Robert Diamond,24
+Bronx,81021,State Senate,36,Con,Robert Diamond,10
+Bronx,81022,State Senate,36,Con,Robert Diamond,4
+Bronx,81023,State Senate,36,Con,Robert Diamond,11
+Bronx,81024,State Senate,36,Con,Robert Diamond,1
+Bronx,81092,State Senate,36,Con,Robert Diamond,1
+Bronx,81093,State Senate,36,Con,Robert Diamond,4
+Bronx,81094,State Senate,36,Con,Robert Diamond,18
+Bronx,81095,State Senate,36,Con,Robert Diamond,12
+Bronx,81096,State Senate,36,Con,Robert Diamond,14
+Bronx,81097,State Senate,36,Con,Robert Diamond,11
+Bronx,81098,State Senate,36,Con,Robert Diamond,19
+Bronx,81099,State Senate,36,Con,Robert Diamond,27
+Bronx,81100,State Senate,36,Con,Robert Diamond,9
+Bronx,81102,State Senate,36,Con,Robert Diamond,2
+Bronx,82054,State Senate,36,Con,Robert Diamond,2
+Bronx,82065,State Senate,36,Con,Robert Diamond,13
+Bronx,82066,State Senate,36,Con,Robert Diamond,7
+Bronx,82067,State Senate,36,Con,Robert Diamond,9
+Bronx,82068,State Senate,36,Con,Robert Diamond,9
+Bronx,82069,State Senate,36,Con,Robert Diamond,12
+Bronx,82070,State Senate,36,Con,Robert Diamond,8
+Bronx,82071,State Senate,36,Con,Robert Diamond,4
+Bronx,82072,State Senate,36,Con,Robert Diamond,10
+Bronx,82073,State Senate,36,Con,Robert Diamond,8
+Bronx,82074,State Senate,36,Con,Robert Diamond,12
+Bronx,82075,State Senate,36,Con,Robert Diamond,5
+Bronx,82076,State Senate,36,Con,Robert Diamond,2
+Bronx,82077,State Senate,36,Con,Robert Diamond,14
+Bronx,82078,State Senate,36,Con,Robert Diamond,7
+Bronx,82079,State Senate,36,Con,Robert Diamond,13
+Bronx,82080,State Senate,36,Con,Robert Diamond,6
+Bronx,82081,State Senate,36,Con,Robert Diamond,8
+Bronx,82082,State Senate,36,Con,Robert Diamond,7
+Bronx,82083,State Senate,36,Con,Robert Diamond,3
+Bronx,82084,State Senate,36,Con,Robert Diamond,4
+Bronx,82085,State Senate,36,Con,Robert Diamond,9
+Bronx,82086,State Senate,36,Con,Robert Diamond,8
+Bronx,82087,State Senate,36,Con,Robert Diamond,5
+Bronx,82088,State Senate,36,Con,Robert Diamond,11
+Bronx,82089,State Senate,36,Con,Robert Diamond,8
+Bronx,82090,State Senate,36,Con,Robert Diamond,5
+Bronx,82091,State Senate,36,Con,Robert Diamond,10
+Bronx,82092,State Senate,36,Con,Robert Diamond,12
+Bronx,82093,State Senate,36,Con,Robert Diamond,11
+Bronx,82094,State Senate,36,Con,Robert Diamond,11
+Bronx,82095,State Senate,36,Con,Robert Diamond,16
+Bronx,82096,State Senate,36,Con,Robert Diamond,3
+Bronx,82097,State Senate,36,Con,Robert Diamond,10
+Bronx,82098,State Senate,36,Con,Robert Diamond,18
+Bronx,82099,State Senate,36,Con,Robert Diamond,4
+Bronx,82100,State Senate,36,Con,Robert Diamond,5
+Bronx,82101,State Senate,36,Con,Robert Diamond,9
+Bronx,82102,State Senate,36,Con,Robert Diamond,4
+Bronx,82103,State Senate,36,Con,Robert Diamond,6
+Bronx,82104,State Senate,36,Con,Robert Diamond,5
+Bronx,82105,State Senate,36,Con,Robert Diamond,11
+Bronx,82117,State Senate,36,Con,Robert Diamond,0
+Bronx,83001,State Senate,36,Con,Robert Diamond,11
+Bronx,83002,State Senate,36,Con,Robert Diamond,2
+Bronx,83003,State Senate,36,Con,Robert Diamond,5
+Bronx,83004,State Senate,36,Con,Robert Diamond,4
+Bronx,83005,State Senate,36,Con,Robert Diamond,4
+Bronx,83006,State Senate,36,Con,Robert Diamond,4
+Bronx,83007,State Senate,36,Con,Robert Diamond,6
+Bronx,83008,State Senate,36,Con,Robert Diamond,2
+Bronx,83009,State Senate,36,Con,Robert Diamond,2
+Bronx,83010,State Senate,36,Con,Robert Diamond,6
+Bronx,83011,State Senate,36,Con,Robert Diamond,4
+Bronx,83013,State Senate,36,Con,Robert Diamond,5
+Bronx,83014,State Senate,36,Con,Robert Diamond,6
+Bronx,83015,State Senate,36,Con,Robert Diamond,6
+Bronx,83016,State Senate,36,Con,Robert Diamond,3
+Bronx,83017,State Senate,36,Con,Robert Diamond,7
+Bronx,83018,State Senate,36,Con,Robert Diamond,1
+Bronx,83019,State Senate,36,Con,Robert Diamond,2
+Bronx,83020,State Senate,36,Con,Robert Diamond,4
+Bronx,83021,State Senate,36,Con,Robert Diamond,6
+Bronx,83022,State Senate,36,Con,Robert Diamond,13
+Bronx,83023,State Senate,36,Con,Robert Diamond,6
+Bronx,83024,State Senate,36,Con,Robert Diamond,1
+Bronx,83025,State Senate,36,Con,Robert Diamond,5
+Bronx,83026,State Senate,36,Con,Robert Diamond,9
+Bronx,83027,State Senate,36,Con,Robert Diamond,9
+Bronx,83028,State Senate,36,Con,Robert Diamond,5
+Bronx,83029,State Senate,36,Con,Robert Diamond,8
+Bronx,83030,State Senate,36,Con,Robert Diamond,5
+Bronx,83031,State Senate,36,Con,Robert Diamond,7
+Bronx,83032,State Senate,36,Con,Robert Diamond,9
+Bronx,83033,State Senate,36,Con,Robert Diamond,5
+Bronx,83034,State Senate,36,Con,Robert Diamond,3
+Bronx,83035,State Senate,36,Con,Robert Diamond,3
+Bronx,83036,State Senate,36,Con,Robert Diamond,5
+Bronx,83037,State Senate,36,Con,Robert Diamond,3
+Bronx,83038,State Senate,36,Con,Robert Diamond,3
+Bronx,83039,State Senate,36,Con,Robert Diamond,5
+Bronx,83040,State Senate,36,Con,Robert Diamond,2
+Bronx,83041,State Senate,36,Con,Robert Diamond,5
+Bronx,83042,State Senate,36,Con,Robert Diamond,4
+Bronx,83043,State Senate,36,Con,Robert Diamond,1
+Bronx,83044,State Senate,36,Con,Robert Diamond,4
+Bronx,83045,State Senate,36,Con,Robert Diamond,3
+Bronx,83046,State Senate,36,Con,Robert Diamond,11
+Bronx,83047,State Senate,36,Con,Robert Diamond,5
+Bronx,83048,State Senate,36,Con,Robert Diamond,2
+Bronx,83049,State Senate,36,Con,Robert Diamond,6
+Bronx,83050,State Senate,36,Con,Robert Diamond,5
+Bronx,83051,State Senate,36,Con,Robert Diamond,4
+Bronx,83052,State Senate,36,Con,Robert Diamond,12
+Bronx,83053,State Senate,36,Con,Robert Diamond,0
+Bronx,83054,State Senate,36,Con,Robert Diamond,3
+Bronx,83055,State Senate,36,Con,Robert Diamond,6
+Bronx,83056,State Senate,36,Con,Robert Diamond,5
+Bronx,83057,State Senate,36,Con,Robert Diamond,6
+Bronx,83058,State Senate,36,Con,Robert Diamond,2
+Bronx,83059,State Senate,36,Con,Robert Diamond,5
+Bronx,83060,State Senate,36,Con,Robert Diamond,4
+Bronx,83061,State Senate,36,Con,Robert Diamond,1
+Bronx,83062,State Senate,36,Con,Robert Diamond,2
+Bronx,83063,State Senate,36,Con,Robert Diamond,4
+Bronx,83064,State Senate,36,Con,Robert Diamond,7
+Bronx,83065,State Senate,36,Con,Robert Diamond,5
+Bronx,83066,State Senate,36,Con,Robert Diamond,5
+Bronx,83067,State Senate,36,Con,Robert Diamond,13
+Bronx,83069,State Senate,36,Con,Robert Diamond,14
+Bronx,83070,State Senate,36,Con,Robert Diamond,7
+Bronx,83071,State Senate,36,Con,Robert Diamond,11
+Bronx,83072,State Senate,36,Con,Robert Diamond,7
+Bronx,83073,State Senate,36,Con,Robert Diamond,3
+Bronx,83074,State Senate,36,Con,Robert Diamond,12
+Bronx,83075,State Senate,36,Con,Robert Diamond,6
+Bronx,83076,State Senate,36,Con,Robert Diamond,11
+Bronx,83077,State Senate,36,Con,Robert Diamond,7
+Bronx,83078,State Senate,36,Con,Robert Diamond,2
+Bronx,83079,State Senate,36,Con,Robert Diamond,4
+Bronx,83080,State Senate,36,Con,Robert Diamond,2
+Bronx,83081,State Senate,36,Con,Robert Diamond,5
+Bronx,83082,State Senate,36,Con,Robert Diamond,9
+Bronx,83083,State Senate,36,Con,Robert Diamond,7
+Bronx,83084,State Senate,36,Con,Robert Diamond,2
+Bronx,83085,State Senate,36,Con,Robert Diamond,2
+Bronx,83086,State Senate,36,Con,Robert Diamond,6
+Bronx,83087,State Senate,36,Con,Robert Diamond,0
+Bronx,78032,State Senate,36,Dem,Ruth Haskell-Thompson,500
+Bronx,78033,State Senate,36,Dem,Ruth Haskell-Thompson,548
+Bronx,78034,State Senate,36,Dem,Ruth Haskell-Thompson,287
+Bronx,78035,State Senate,36,Dem,Ruth Haskell-Thompson,124
+Bronx,80052,State Senate,36,Dem,Ruth Haskell-Thompson,383
+Bronx,80053,State Senate,36,Dem,Ruth Haskell-Thompson,285
+Bronx,80054,State Senate,36,Dem,Ruth Haskell-Thompson,15
+Bronx,80055,State Senate,36,Dem,Ruth Haskell-Thompson,251
+Bronx,80056,State Senate,36,Dem,Ruth Haskell-Thompson,22
+Bronx,80057,State Senate,36,Dem,Ruth Haskell-Thompson,191
+Bronx,80058,State Senate,36,Dem,Ruth Haskell-Thompson,259
+Bronx,80059,State Senate,36,Dem,Ruth Haskell-Thompson,75
+Bronx,80060,State Senate,36,Dem,Ruth Haskell-Thompson,488
+Bronx,80061,State Senate,36,Dem,Ruth Haskell-Thompson,279
+Bronx,80062,State Senate,36,Dem,Ruth Haskell-Thompson,356
+Bronx,80063,State Senate,36,Dem,Ruth Haskell-Thompson,456
+Bronx,80064,State Senate,36,Dem,Ruth Haskell-Thompson,113
+Bronx,80065,State Senate,36,Dem,Ruth Haskell-Thompson,52
+Bronx,80070,State Senate,36,Dem,Ruth Haskell-Thompson,410
+Bronx,80071,State Senate,36,Dem,Ruth Haskell-Thompson,260
+Bronx,80072,State Senate,36,Dem,Ruth Haskell-Thompson,46
+Bronx,80073,State Senate,36,Dem,Ruth Haskell-Thompson,184
+Bronx,80075,State Senate,36,Dem,Ruth Haskell-Thompson,7
+Bronx,80076,State Senate,36,Dem,Ruth Haskell-Thompson,8
+Bronx,80077,State Senate,36,Dem,Ruth Haskell-Thompson,521
+Bronx,80078,State Senate,36,Dem,Ruth Haskell-Thompson,456
+Bronx,80079,State Senate,36,Dem,Ruth Haskell-Thompson,431
+Bronx,80080,State Senate,36,Dem,Ruth Haskell-Thompson,305
+Bronx,80081,State Senate,36,Dem,Ruth Haskell-Thompson,417
+Bronx,80082,State Senate,36,Dem,Ruth Haskell-Thompson,184
+Bronx,80083,State Senate,36,Dem,Ruth Haskell-Thompson,519
+Bronx,80084,State Senate,36,Dem,Ruth Haskell-Thompson,213
+Bronx,80085,State Senate,36,Dem,Ruth Haskell-Thompson,534
+Bronx,80086,State Senate,36,Dem,Ruth Haskell-Thompson,445
+Bronx,80087,State Senate,36,Dem,Ruth Haskell-Thompson,199
+Bronx,80089,State Senate,36,Dem,Ruth Haskell-Thompson,119
+Bronx,80090,State Senate,36,Dem,Ruth Haskell-Thompson,443
+Bronx,80091,State Senate,36,Dem,Ruth Haskell-Thompson,221
+Bronx,80092,State Senate,36,Dem,Ruth Haskell-Thompson,483
+Bronx,80093,State Senate,36,Dem,Ruth Haskell-Thompson,572
+Bronx,80094,State Senate,36,Dem,Ruth Haskell-Thompson,581
+Bronx,81017,State Senate,36,Dem,Ruth Haskell-Thompson,357
+Bronx,81018,State Senate,36,Dem,Ruth Haskell-Thompson,296
+Bronx,81019,State Senate,36,Dem,Ruth Haskell-Thompson,385
+Bronx,81020,State Senate,36,Dem,Ruth Haskell-Thompson,511
+Bronx,81021,State Senate,36,Dem,Ruth Haskell-Thompson,491
+Bronx,81022,State Senate,36,Dem,Ruth Haskell-Thompson,358
+Bronx,81023,State Senate,36,Dem,Ruth Haskell-Thompson,533
+Bronx,81024,State Senate,36,Dem,Ruth Haskell-Thompson,354
+Bronx,81092,State Senate,36,Dem,Ruth Haskell-Thompson,250
+Bronx,81093,State Senate,36,Dem,Ruth Haskell-Thompson,409
+Bronx,81094,State Senate,36,Dem,Ruth Haskell-Thompson,310
+Bronx,81095,State Senate,36,Dem,Ruth Haskell-Thompson,160
+Bronx,81096,State Senate,36,Dem,Ruth Haskell-Thompson,259
+Bronx,81097,State Senate,36,Dem,Ruth Haskell-Thompson,357
+Bronx,81098,State Senate,36,Dem,Ruth Haskell-Thompson,320
+Bronx,81099,State Senate,36,Dem,Ruth Haskell-Thompson,461
+Bronx,81100,State Senate,36,Dem,Ruth Haskell-Thompson,287
+Bronx,81102,State Senate,36,Dem,Ruth Haskell-Thompson,106
+Bronx,82054,State Senate,36,Dem,Ruth Haskell-Thompson,55
+Bronx,82065,State Senate,36,Dem,Ruth Haskell-Thompson,348
+Bronx,82066,State Senate,36,Dem,Ruth Haskell-Thompson,351
+Bronx,82067,State Senate,36,Dem,Ruth Haskell-Thompson,440
+Bronx,82068,State Senate,36,Dem,Ruth Haskell-Thompson,324
+Bronx,82069,State Senate,36,Dem,Ruth Haskell-Thompson,359
+Bronx,82070,State Senate,36,Dem,Ruth Haskell-Thompson,305
+Bronx,82071,State Senate,36,Dem,Ruth Haskell-Thompson,360
+Bronx,82072,State Senate,36,Dem,Ruth Haskell-Thompson,393
+Bronx,82073,State Senate,36,Dem,Ruth Haskell-Thompson,330
+Bronx,82074,State Senate,36,Dem,Ruth Haskell-Thompson,289
+Bronx,82075,State Senate,36,Dem,Ruth Haskell-Thompson,308
+Bronx,82076,State Senate,36,Dem,Ruth Haskell-Thompson,356
+Bronx,82077,State Senate,36,Dem,Ruth Haskell-Thompson,416
+Bronx,82078,State Senate,36,Dem,Ruth Haskell-Thompson,386
+Bronx,82079,State Senate,36,Dem,Ruth Haskell-Thompson,405
+Bronx,82080,State Senate,36,Dem,Ruth Haskell-Thompson,361
+Bronx,82081,State Senate,36,Dem,Ruth Haskell-Thompson,379
+Bronx,82082,State Senate,36,Dem,Ruth Haskell-Thompson,221
+Bronx,82083,State Senate,36,Dem,Ruth Haskell-Thompson,272
+Bronx,82084,State Senate,36,Dem,Ruth Haskell-Thompson,313
+Bronx,82085,State Senate,36,Dem,Ruth Haskell-Thompson,316
+Bronx,82086,State Senate,36,Dem,Ruth Haskell-Thompson,320
+Bronx,82087,State Senate,36,Dem,Ruth Haskell-Thompson,329
+Bronx,82088,State Senate,36,Dem,Ruth Haskell-Thompson,378
+Bronx,82089,State Senate,36,Dem,Ruth Haskell-Thompson,385
+Bronx,82090,State Senate,36,Dem,Ruth Haskell-Thompson,353
+Bronx,82091,State Senate,36,Dem,Ruth Haskell-Thompson,361
+Bronx,82092,State Senate,36,Dem,Ruth Haskell-Thompson,457
+Bronx,82093,State Senate,36,Dem,Ruth Haskell-Thompson,349
+Bronx,82094,State Senate,36,Dem,Ruth Haskell-Thompson,366
+Bronx,82095,State Senate,36,Dem,Ruth Haskell-Thompson,331
+Bronx,82096,State Senate,36,Dem,Ruth Haskell-Thompson,305
+Bronx,82097,State Senate,36,Dem,Ruth Haskell-Thompson,377
+Bronx,82098,State Senate,36,Dem,Ruth Haskell-Thompson,425
+Bronx,82099,State Senate,36,Dem,Ruth Haskell-Thompson,425
+Bronx,82100,State Senate,36,Dem,Ruth Haskell-Thompson,367
+Bronx,82101,State Senate,36,Dem,Ruth Haskell-Thompson,355
+Bronx,82102,State Senate,36,Dem,Ruth Haskell-Thompson,302
+Bronx,82103,State Senate,36,Dem,Ruth Haskell-Thompson,302
+Bronx,82104,State Senate,36,Dem,Ruth Haskell-Thompson,410
+Bronx,82105,State Senate,36,Dem,Ruth Haskell-Thompson,380
+Bronx,82117,State Senate,36,Dem,Ruth Haskell-Thompson,33
+Bronx,83001,State Senate,36,Dem,Ruth Haskell-Thompson,573
+Bronx,83002,State Senate,36,Dem,Ruth Haskell-Thompson,66
+Bronx,83003,State Senate,36,Dem,Ruth Haskell-Thompson,310
+Bronx,83004,State Senate,36,Dem,Ruth Haskell-Thompson,195
+Bronx,83005,State Senate,36,Dem,Ruth Haskell-Thompson,102
+Bronx,83006,State Senate,36,Dem,Ruth Haskell-Thompson,432
+Bronx,83007,State Senate,36,Dem,Ruth Haskell-Thompson,478
+Bronx,83008,State Senate,36,Dem,Ruth Haskell-Thompson,324
+Bronx,83009,State Senate,36,Dem,Ruth Haskell-Thompson,381
+Bronx,83010,State Senate,36,Dem,Ruth Haskell-Thompson,647
+Bronx,83011,State Senate,36,Dem,Ruth Haskell-Thompson,479
+Bronx,83013,State Senate,36,Dem,Ruth Haskell-Thompson,546
+Bronx,83014,State Senate,36,Dem,Ruth Haskell-Thompson,679
+Bronx,83015,State Senate,36,Dem,Ruth Haskell-Thompson,586
+Bronx,83016,State Senate,36,Dem,Ruth Haskell-Thompson,536
+Bronx,83017,State Senate,36,Dem,Ruth Haskell-Thompson,468
+Bronx,83018,State Senate,36,Dem,Ruth Haskell-Thompson,472
+Bronx,83019,State Senate,36,Dem,Ruth Haskell-Thompson,402
+Bronx,83020,State Senate,36,Dem,Ruth Haskell-Thompson,370
+Bronx,83021,State Senate,36,Dem,Ruth Haskell-Thompson,408
+Bronx,83022,State Senate,36,Dem,Ruth Haskell-Thompson,426
+Bronx,83023,State Senate,36,Dem,Ruth Haskell-Thompson,419
+Bronx,83024,State Senate,36,Dem,Ruth Haskell-Thompson,195
+Bronx,83025,State Senate,36,Dem,Ruth Haskell-Thompson,313
+Bronx,83026,State Senate,36,Dem,Ruth Haskell-Thompson,271
+Bronx,83027,State Senate,36,Dem,Ruth Haskell-Thompson,453
+Bronx,83028,State Senate,36,Dem,Ruth Haskell-Thompson,643
+Bronx,83029,State Senate,36,Dem,Ruth Haskell-Thompson,307
+Bronx,83030,State Senate,36,Dem,Ruth Haskell-Thompson,388
+Bronx,83031,State Senate,36,Dem,Ruth Haskell-Thompson,520
+Bronx,83032,State Senate,36,Dem,Ruth Haskell-Thompson,477
+Bronx,83033,State Senate,36,Dem,Ruth Haskell-Thompson,461
+Bronx,83034,State Senate,36,Dem,Ruth Haskell-Thompson,462
+Bronx,83035,State Senate,36,Dem,Ruth Haskell-Thompson,333
+Bronx,83036,State Senate,36,Dem,Ruth Haskell-Thompson,208
+Bronx,83037,State Senate,36,Dem,Ruth Haskell-Thompson,374
+Bronx,83038,State Senate,36,Dem,Ruth Haskell-Thompson,410
+Bronx,83039,State Senate,36,Dem,Ruth Haskell-Thompson,384
+Bronx,83040,State Senate,36,Dem,Ruth Haskell-Thompson,341
+Bronx,83041,State Senate,36,Dem,Ruth Haskell-Thompson,344
+Bronx,83042,State Senate,36,Dem,Ruth Haskell-Thompson,433
+Bronx,83043,State Senate,36,Dem,Ruth Haskell-Thompson,413
+Bronx,83044,State Senate,36,Dem,Ruth Haskell-Thompson,490
+Bronx,83045,State Senate,36,Dem,Ruth Haskell-Thompson,509
+Bronx,83046,State Senate,36,Dem,Ruth Haskell-Thompson,389
+Bronx,83047,State Senate,36,Dem,Ruth Haskell-Thompson,395
+Bronx,83048,State Senate,36,Dem,Ruth Haskell-Thompson,366
+Bronx,83049,State Senate,36,Dem,Ruth Haskell-Thompson,393
+Bronx,83050,State Senate,36,Dem,Ruth Haskell-Thompson,386
+Bronx,83051,State Senate,36,Dem,Ruth Haskell-Thompson,387
+Bronx,83052,State Senate,36,Dem,Ruth Haskell-Thompson,416
+Bronx,83053,State Senate,36,Dem,Ruth Haskell-Thompson,404
+Bronx,83054,State Senate,36,Dem,Ruth Haskell-Thompson,347
+Bronx,83055,State Senate,36,Dem,Ruth Haskell-Thompson,492
+Bronx,83056,State Senate,36,Dem,Ruth Haskell-Thompson,491
+Bronx,83057,State Senate,36,Dem,Ruth Haskell-Thompson,468
+Bronx,83058,State Senate,36,Dem,Ruth Haskell-Thompson,339
+Bronx,83059,State Senate,36,Dem,Ruth Haskell-Thompson,485
+Bronx,83060,State Senate,36,Dem,Ruth Haskell-Thompson,209
+Bronx,83061,State Senate,36,Dem,Ruth Haskell-Thompson,339
+Bronx,83062,State Senate,36,Dem,Ruth Haskell-Thompson,283
+Bronx,83063,State Senate,36,Dem,Ruth Haskell-Thompson,284
+Bronx,83064,State Senate,36,Dem,Ruth Haskell-Thompson,389
+Bronx,83065,State Senate,36,Dem,Ruth Haskell-Thompson,347
+Bronx,83066,State Senate,36,Dem,Ruth Haskell-Thompson,510
+Bronx,83067,State Senate,36,Dem,Ruth Haskell-Thompson,607
+Bronx,83069,State Senate,36,Dem,Ruth Haskell-Thompson,661
+Bronx,83070,State Senate,36,Dem,Ruth Haskell-Thompson,508
+Bronx,83071,State Senate,36,Dem,Ruth Haskell-Thompson,524
+Bronx,83072,State Senate,36,Dem,Ruth Haskell-Thompson,361
+Bronx,83073,State Senate,36,Dem,Ruth Haskell-Thompson,495
+Bronx,83074,State Senate,36,Dem,Ruth Haskell-Thompson,475
+Bronx,83075,State Senate,36,Dem,Ruth Haskell-Thompson,511
+Bronx,83076,State Senate,36,Dem,Ruth Haskell-Thompson,495
+Bronx,83077,State Senate,36,Dem,Ruth Haskell-Thompson,447
+Bronx,83078,State Senate,36,Dem,Ruth Haskell-Thompson,357
+Bronx,83079,State Senate,36,Dem,Ruth Haskell-Thompson,404
+Bronx,83080,State Senate,36,Dem,Ruth Haskell-Thompson,441
+Bronx,83081,State Senate,36,Dem,Ruth Haskell-Thompson,547
+Bronx,83082,State Senate,36,Dem,Ruth Haskell-Thompson,645
+Bronx,83083,State Senate,36,Dem,Ruth Haskell-Thompson,438
+Bronx,83084,State Senate,36,Dem,Ruth Haskell-Thompson,16
+Bronx,83085,State Senate,36,Dem,Ruth Haskell-Thompson,202
+Bronx,83086,State Senate,36,Dem,Ruth Haskell-Thompson,234
+Bronx,83087,State Senate,36,Dem,Ruth Haskell-Thompson,55
+Bronx,78032,State Senate,36,Ind,writein,0
+Bronx,78033,State Senate,36,Ind,writein,0
+Bronx,78034,State Senate,36,Ind,writein,1
+Bronx,78035,State Senate,36,Ind,writein,0
+Bronx,80052,State Senate,36,Ind,writein,0
+Bronx,80053,State Senate,36,Ind,writein,0
+Bronx,80054,State Senate,36,Ind,writein,0
+Bronx,80055,State Senate,36,Ind,writein,0
+Bronx,80056,State Senate,36,Ind,writein,0
+Bronx,80057,State Senate,36,Ind,writein,0
+Bronx,80058,State Senate,36,Ind,writein,0
+Bronx,80059,State Senate,36,Ind,writein,0
+Bronx,80060,State Senate,36,Ind,writein,0
+Bronx,80061,State Senate,36,Ind,writein,0
+Bronx,80062,State Senate,36,Ind,writein,1
+Bronx,80063,State Senate,36,Ind,writein,0
+Bronx,80064,State Senate,36,Ind,writein,0
+Bronx,80065,State Senate,36,Ind,writein,1
+Bronx,80070,State Senate,36,Ind,writein,0
+Bronx,80071,State Senate,36,Ind,writein,0
+Bronx,80072,State Senate,36,Ind,writein,0
+Bronx,80073,State Senate,36,Ind,writein,0
+Bronx,80075,State Senate,36,Ind,writein,0
+Bronx,80076,State Senate,36,Ind,writein,0
+Bronx,80077,State Senate,36,Ind,writein,0
+Bronx,80078,State Senate,36,Ind,writein,0
+Bronx,80079,State Senate,36,Ind,writein,0
+Bronx,80080,State Senate,36,Ind,writein,0
+Bronx,80081,State Senate,36,Ind,writein,0
+Bronx,80082,State Senate,36,Ind,writein,0
+Bronx,80083,State Senate,36,Ind,writein,1
+Bronx,80084,State Senate,36,Ind,writein,0
+Bronx,80085,State Senate,36,Ind,writein,0
+Bronx,80086,State Senate,36,Ind,writein,0
+Bronx,80087,State Senate,36,Ind,writein,0
+Bronx,80089,State Senate,36,Ind,writein,1
+Bronx,80090,State Senate,36,Ind,writein,0
+Bronx,80091,State Senate,36,Ind,writein,1
+Bronx,80092,State Senate,36,Ind,writein,0
+Bronx,80093,State Senate,36,Ind,writein,0
+Bronx,80094,State Senate,36,Ind,writein,1
+Bronx,81017,State Senate,36,Ind,writein,1
+Bronx,81018,State Senate,36,Ind,writein,0
+Bronx,81019,State Senate,36,Ind,writein,0
+Bronx,81020,State Senate,36,Ind,writein,0
+Bronx,81021,State Senate,36,Ind,writein,1
+Bronx,81022,State Senate,36,Ind,writein,0
+Bronx,81023,State Senate,36,Ind,writein,0
+Bronx,81024,State Senate,36,Ind,writein,0
+Bronx,81092,State Senate,36,Ind,writein,0
+Bronx,81093,State Senate,36,Ind,writein,0
+Bronx,81094,State Senate,36,Ind,writein,0
+Bronx,81095,State Senate,36,Ind,writein,0
+Bronx,81096,State Senate,36,Ind,writein,0
+Bronx,81097,State Senate,36,Ind,writein,0
+Bronx,81098,State Senate,36,Ind,writein,0
+Bronx,81099,State Senate,36,Ind,writein,2
+Bronx,81100,State Senate,36,Ind,writein,0
+Bronx,81102,State Senate,36,Ind,writein,0
+Bronx,82054,State Senate,36,Ind,writein,0
+Bronx,82065,State Senate,36,Ind,writein,0
+Bronx,82066,State Senate,36,Ind,writein,0
+Bronx,82067,State Senate,36,Ind,writein,0
+Bronx,82068,State Senate,36,Ind,writein,0
+Bronx,82069,State Senate,36,Ind,writein,0
+Bronx,82070,State Senate,36,Ind,writein,1
+Bronx,82071,State Senate,36,Ind,writein,0
+Bronx,82072,State Senate,36,Ind,writein,0
+Bronx,82073,State Senate,36,Ind,writein,0
+Bronx,82074,State Senate,36,Ind,writein,0
+Bronx,82075,State Senate,36,Ind,writein,0
+Bronx,82076,State Senate,36,Ind,writein,0
+Bronx,82077,State Senate,36,Ind,writein,0
+Bronx,82078,State Senate,36,Ind,writein,0
+Bronx,82079,State Senate,36,Ind,writein,0
+Bronx,82080,State Senate,36,Ind,writein,0
+Bronx,82081,State Senate,36,Ind,writein,0
+Bronx,82082,State Senate,36,Ind,writein,0
+Bronx,82083,State Senate,36,Ind,writein,0
+Bronx,82084,State Senate,36,Ind,writein,0
+Bronx,82085,State Senate,36,Ind,writein,0
+Bronx,82086,State Senate,36,Ind,writein,0
+Bronx,82087,State Senate,36,Ind,writein,0
+Bronx,82088,State Senate,36,Ind,writein,0
+Bronx,82089,State Senate,36,Ind,writein,0
+Bronx,82090,State Senate,36,Ind,writein,0
+Bronx,82091,State Senate,36,Ind,writein,0
+Bronx,82092,State Senate,36,Ind,writein,0
+Bronx,82093,State Senate,36,Ind,writein,0
+Bronx,82094,State Senate,36,Ind,writein,0
+Bronx,82095,State Senate,36,Ind,writein,1
+Bronx,82096,State Senate,36,Ind,writein,0
+Bronx,82097,State Senate,36,Ind,writein,0
+Bronx,82098,State Senate,36,Ind,writein,0
+Bronx,82099,State Senate,36,Ind,writein,0
+Bronx,82100,State Senate,36,Ind,writein,0
+Bronx,82101,State Senate,36,Ind,writein,0
+Bronx,82102,State Senate,36,Ind,writein,0
+Bronx,82103,State Senate,36,Ind,writein,0
+Bronx,82104,State Senate,36,Ind,writein,0
+Bronx,82105,State Senate,36,Ind,writein,0
+Bronx,82117,State Senate,36,Ind,writein,0
+Bronx,83001,State Senate,36,Ind,writein,0
+Bronx,83002,State Senate,36,Ind,writein,0
+Bronx,83003,State Senate,36,Ind,writein,0
+Bronx,83004,State Senate,36,Ind,writein,0
+Bronx,83005,State Senate,36,Ind,writein,0
+Bronx,83006,State Senate,36,Ind,writein,0
+Bronx,83007,State Senate,36,Ind,writein,0
+Bronx,83008,State Senate,36,Ind,writein,0
+Bronx,83009,State Senate,36,Ind,writein,0
+Bronx,83010,State Senate,36,Ind,writein,0
+Bronx,83011,State Senate,36,Ind,writein,0
+Bronx,83013,State Senate,36,Ind,writein,0
+Bronx,83014,State Senate,36,Ind,writein,0
+Bronx,83015,State Senate,36,Ind,writein,0
+Bronx,83016,State Senate,36,Ind,writein,0
+Bronx,83017,State Senate,36,Ind,writein,0
+Bronx,83018,State Senate,36,Ind,writein,0
+Bronx,83019,State Senate,36,Ind,writein,0
+Bronx,83020,State Senate,36,Ind,writein,0
+Bronx,83021,State Senate,36,Ind,writein,0
+Bronx,83022,State Senate,36,Ind,writein,0
+Bronx,83023,State Senate,36,Ind,writein,0
+Bronx,83024,State Senate,36,Ind,writein,0
+Bronx,83025,State Senate,36,Ind,writein,0
+Bronx,83026,State Senate,36,Ind,writein,0
+Bronx,83027,State Senate,36,Ind,writein,0
+Bronx,83028,State Senate,36,Ind,writein,0
+Bronx,83029,State Senate,36,Ind,writein,0
+Bronx,83030,State Senate,36,Ind,writein,0
+Bronx,83031,State Senate,36,Ind,writein,0
+Bronx,83032,State Senate,36,Ind,writein,0
+Bronx,83033,State Senate,36,Ind,writein,0
+Bronx,83034,State Senate,36,Ind,writein,0
+Bronx,83035,State Senate,36,Ind,writein,0
+Bronx,83036,State Senate,36,Ind,writein,0
+Bronx,83037,State Senate,36,Ind,writein,0
+Bronx,83038,State Senate,36,Ind,writein,0
+Bronx,83039,State Senate,36,Ind,writein,0
+Bronx,83040,State Senate,36,Ind,writein,0
+Bronx,83041,State Senate,36,Ind,writein,0
+Bronx,83042,State Senate,36,Ind,writein,0
+Bronx,83043,State Senate,36,Ind,writein,0
+Bronx,83044,State Senate,36,Ind,writein,0
+Bronx,83045,State Senate,36,Ind,writein,0
+Bronx,83046,State Senate,36,Ind,writein,0
+Bronx,83047,State Senate,36,Ind,writein,0
+Bronx,83048,State Senate,36,Ind,writein,0
+Bronx,83049,State Senate,36,Ind,writein,0
+Bronx,83050,State Senate,36,Ind,writein,0
+Bronx,83051,State Senate,36,Ind,writein,0
+Bronx,83052,State Senate,36,Ind,writein,0
+Bronx,83053,State Senate,36,Ind,writein,0
+Bronx,83054,State Senate,36,Ind,writein,0
+Bronx,83055,State Senate,36,Ind,writein,0
+Bronx,83056,State Senate,36,Ind,writein,0
+Bronx,83057,State Senate,36,Ind,writein,0
+Bronx,83058,State Senate,36,Ind,writein,0
+Bronx,83059,State Senate,36,Ind,writein,0
+Bronx,83060,State Senate,36,Ind,writein,2
+Bronx,83061,State Senate,36,Ind,writein,0
+Bronx,83062,State Senate,36,Ind,writein,0
+Bronx,83063,State Senate,36,Ind,writein,0
+Bronx,83064,State Senate,36,Ind,writein,0
+Bronx,83065,State Senate,36,Ind,writein,0
+Bronx,83066,State Senate,36,Ind,writein,0
+Bronx,83067,State Senate,36,Ind,writein,0
+Bronx,83069,State Senate,36,Ind,writein,1
+Bronx,83070,State Senate,36,Ind,writein,1
+Bronx,83071,State Senate,36,Ind,writein,0
+Bronx,83072,State Senate,36,Ind,writein,0
+Bronx,83073,State Senate,36,Ind,writein,0
+Bronx,83074,State Senate,36,Ind,writein,0
+Bronx,83075,State Senate,36,Ind,writein,0
+Bronx,83076,State Senate,36,Ind,writein,0
+Bronx,83077,State Senate,36,Ind,writein,0
+Bronx,83078,State Senate,36,Ind,writein,0
+Bronx,83079,State Senate,36,Ind,writein,0
+Bronx,83080,State Senate,36,Ind,writein,0
+Bronx,83081,State Senate,36,Ind,writein,0
+Bronx,83082,State Senate,36,Ind,writein,0
+Bronx,83083,State Senate,36,Ind,writein,0
+Bronx,83084,State Senate,36,Ind,writein,0
+Bronx,83085,State Senate,36,Ind,writein,0
+Bronx,83086,State Senate,36,Ind,writein,0
+Bronx,83087,State Senate,36,Ind,writein,0
 Bronx,77023,U.S. House,13,Dem,Charles Rangel,451
 Bronx,77024,U.S. House,13,Dem,Charles Rangel,410
 Bronx,77025,U.S. House,13,Dem,Charles Rangel,545

--- a/2012/counties/20121106__ny__general__kings__precinct.csv
+++ b/2012/counties/20121106__ny__general__kings__precinct.csv
@@ -6849,7884 +6849,7884 @@ Kings,64091,State Assembly,064,Con,Nicole Malliotakis,27
 Kings,64091,State Assembly,064,WF,John Mancuso,8
 Kings,64091,State Assembly,064,Ind,Nicole Malliotakis,11
 Kings,64091,State Assembly,064,Ind,writein,0
-Kings,41001,State Senate,SD17,SC,Abraham Tischler,4
-Kings,41002,State Senate,SD17,SC,Abraham Tischler,1
-Kings,41003,State Senate,SD17,SC,Abraham Tischler,0
-Kings,41004,State Senate,SD17,SC,Abraham Tischler,0
-Kings,41005,State Senate,SD17,SC,Abraham Tischler,6
-Kings,41006,State Senate,SD17,SC,Abraham Tischler,5
-Kings,41007,State Senate,SD17,SC,Abraham Tischler,6
-Kings,41008,State Senate,SD17,SC,Abraham Tischler,1
-Kings,41009,State Senate,SD17,SC,Abraham Tischler,2
-Kings,41010,State Senate,SD17,SC,Abraham Tischler,2
-Kings,41011,State Senate,SD17,SC,Abraham Tischler,2
-Kings,41012,State Senate,SD17,SC,Abraham Tischler,2
-Kings,41024,State Senate,SD17,SC,Abraham Tischler,0
-Kings,41050,State Senate,SD17,SC,Abraham Tischler,1
-Kings,41051,State Senate,SD17,SC,Abraham Tischler,0
-Kings,41052,State Senate,SD17,SC,Abraham Tischler,0
-Kings,41058,State Senate,SD17,SC,Abraham Tischler,1
-Kings,41059,State Senate,SD17,SC,Abraham Tischler,1
-Kings,42034,State Senate,SD17,SC,Abraham Tischler,6
-Kings,42035,State Senate,SD17,SC,Abraham Tischler,3
-Kings,42036,State Senate,SD17,SC,Abraham Tischler,9
-Kings,42037,State Senate,SD17,SC,Abraham Tischler,3
-Kings,42038,State Senate,SD17,SC,Abraham Tischler,4
-Kings,42061,State Senate,SD17,SC,Abraham Tischler,2
-Kings,42062,State Senate,SD17,SC,Abraham Tischler,3
-Kings,42063,State Senate,SD17,SC,Abraham Tischler,2
-Kings,42064,State Senate,SD17,SC,Abraham Tischler,1
-Kings,42065,State Senate,SD17,SC,Abraham Tischler,4
-Kings,42066,State Senate,SD17,SC,Abraham Tischler,1
-Kings,42067,State Senate,SD17,SC,Abraham Tischler,2
-Kings,44001,State Senate,SD17,SC,Abraham Tischler,5
-Kings,44002,State Senate,SD17,SC,Abraham Tischler,8
-Kings,44003,State Senate,SD17,SC,Abraham Tischler,3
-Kings,44004,State Senate,SD17,SC,Abraham Tischler,3
-Kings,44005,State Senate,SD17,SC,Abraham Tischler,2
-Kings,44006,State Senate,SD17,SC,Abraham Tischler,6
-Kings,44007,State Senate,SD17,SC,Abraham Tischler,9
-Kings,44008,State Senate,SD17,SC,Abraham Tischler,4
-Kings,44010,State Senate,SD17,SC,Abraham Tischler,0
-Kings,44013,State Senate,SD17,SC,Abraham Tischler,1
-Kings,44021,State Senate,SD17,SC,Abraham Tischler,0
-Kings,44023,State Senate,SD17,SC,Abraham Tischler,2
-Kings,44024,State Senate,SD17,SC,Abraham Tischler,3
-Kings,44025,State Senate,SD17,SC,Abraham Tischler,4
-Kings,44026,State Senate,SD17,SC,Abraham Tischler,7
-Kings,44027,State Senate,SD17,SC,Abraham Tischler,4
-Kings,44028,State Senate,SD17,SC,Abraham Tischler,2
-Kings,44029,State Senate,SD17,SC,Abraham Tischler,5
-Kings,44030,State Senate,SD17,SC,Abraham Tischler,6
-Kings,44031,State Senate,SD17,SC,Abraham Tischler,13
-Kings,44032,State Senate,SD17,SC,Abraham Tischler,1
-Kings,44033,State Senate,SD17,SC,Abraham Tischler,6
-Kings,44035,State Senate,SD17,SC,Abraham Tischler,8
-Kings,44038,State Senate,SD17,SC,Abraham Tischler,10
-Kings,44039,State Senate,SD17,SC,Abraham Tischler,2
-Kings,44041,State Senate,SD17,SC,Abraham Tischler,0
-Kings,44042,State Senate,SD17,SC,Abraham Tischler,7
-Kings,44043,State Senate,SD17,SC,Abraham Tischler,8
-Kings,44044,State Senate,SD17,SC,Abraham Tischler,13
-Kings,44045,State Senate,SD17,SC,Abraham Tischler,6
-Kings,45001,State Senate,SD17,SC,Abraham Tischler,4
-Kings,45002,State Senate,SD17,SC,Abraham Tischler,7
-Kings,45003,State Senate,SD17,SC,Abraham Tischler,1
-Kings,45004,State Senate,SD17,SC,Abraham Tischler,5
-Kings,45005,State Senate,SD17,SC,Abraham Tischler,4
-Kings,45007,State Senate,SD17,SC,Abraham Tischler,0
-Kings,45010,State Senate,SD17,SC,Abraham Tischler,0
-Kings,45011,State Senate,SD17,SC,Abraham Tischler,4
-Kings,45012,State Senate,SD17,SC,Abraham Tischler,2
-Kings,45013,State Senate,SD17,SC,Abraham Tischler,2
-Kings,45014,State Senate,SD17,SC,Abraham Tischler,3
-Kings,45018,State Senate,SD17,SC,Abraham Tischler,0
-Kings,45023,State Senate,SD17,SC,Abraham Tischler,1
-Kings,45024,State Senate,SD17,SC,Abraham Tischler,4
-Kings,45029,State Senate,SD17,SC,Abraham Tischler,1
-Kings,45030,State Senate,SD17,SC,Abraham Tischler,4
-Kings,45038,State Senate,SD17,SC,Abraham Tischler,1
-Kings,45039,State Senate,SD17,SC,Abraham Tischler,1
-Kings,47023,State Senate,SD17,SC,Abraham Tischler,2
-Kings,47024,State Senate,SD17,SC,Abraham Tischler,2
-Kings,47025,State Senate,SD17,SC,Abraham Tischler,7
-Kings,47026,State Senate,SD17,SC,Abraham Tischler,0
-Kings,47027,State Senate,SD17,SC,Abraham Tischler,2
-Kings,47028,State Senate,SD17,SC,Abraham Tischler,5
-Kings,47029,State Senate,SD17,SC,Abraham Tischler,3
-Kings,47030,State Senate,SD17,SC,Abraham Tischler,0
-Kings,47031,State Senate,SD17,SC,Abraham Tischler,2
-Kings,47032,State Senate,SD17,SC,Abraham Tischler,0
-Kings,47033,State Senate,SD17,SC,Abraham Tischler,2
-Kings,48001,State Senate,SD17,SC,Abraham Tischler,0
-Kings,48002,State Senate,SD17,SC,Abraham Tischler,1
-Kings,48003,State Senate,SD17,SC,Abraham Tischler,6
-Kings,48004,State Senate,SD17,SC,Abraham Tischler,4
-Kings,48005,State Senate,SD17,SC,Abraham Tischler,1
-Kings,48006,State Senate,SD17,SC,Abraham Tischler,2
-Kings,48007,State Senate,SD17,SC,Abraham Tischler,5
-Kings,48008,State Senate,SD17,SC,Abraham Tischler,2
-Kings,48009,State Senate,SD17,SC,Abraham Tischler,5
-Kings,48010,State Senate,SD17,SC,Abraham Tischler,3
-Kings,48011,State Senate,SD17,SC,Abraham Tischler,7
-Kings,48012,State Senate,SD17,SC,Abraham Tischler,5
-Kings,48013,State Senate,SD17,SC,Abraham Tischler,3
-Kings,48014,State Senate,SD17,SC,Abraham Tischler,4
-Kings,48015,State Senate,SD17,SC,Abraham Tischler,0
-Kings,48016,State Senate,SD17,SC,Abraham Tischler,4
-Kings,48017,State Senate,SD17,SC,Abraham Tischler,3
-Kings,48018,State Senate,SD17,SC,Abraham Tischler,4
-Kings,48019,State Senate,SD17,SC,Abraham Tischler,6
-Kings,48020,State Senate,SD17,SC,Abraham Tischler,2
-Kings,48021,State Senate,SD17,SC,Abraham Tischler,3
-Kings,48022,State Senate,SD17,SC,Abraham Tischler,1
-Kings,48023,State Senate,SD17,SC,Abraham Tischler,1
-Kings,48024,State Senate,SD17,SC,Abraham Tischler,2
-Kings,48025,State Senate,SD17,SC,Abraham Tischler,7
-Kings,48026,State Senate,SD17,SC,Abraham Tischler,1
-Kings,48027,State Senate,SD17,SC,Abraham Tischler,2
-Kings,48028,State Senate,SD17,SC,Abraham Tischler,2
-Kings,48029,State Senate,SD17,SC,Abraham Tischler,4
-Kings,48030,State Senate,SD17,SC,Abraham Tischler,0
-Kings,48031,State Senate,SD17,SC,Abraham Tischler,1
-Kings,48032,State Senate,SD17,SC,Abraham Tischler,5
-Kings,48033,State Senate,SD17,SC,Abraham Tischler,1
-Kings,48036,State Senate,SD17,SC,Abraham Tischler,1
-Kings,48038,State Senate,SD17,SC,Abraham Tischler,1
-Kings,48039,State Senate,SD17,SC,Abraham Tischler,1
-Kings,48040,State Senate,SD17,SC,Abraham Tischler,2
-Kings,48041,State Senate,SD17,SC,Abraham Tischler,1
-Kings,48042,State Senate,SD17,SC,Abraham Tischler,4
-Kings,48043,State Senate,SD17,SC,Abraham Tischler,7
-Kings,48044,State Senate,SD17,SC,Abraham Tischler,2
-Kings,48045,State Senate,SD17,SC,Abraham Tischler,1
-Kings,48049,State Senate,SD17,SC,Abraham Tischler,0
-Kings,48054,State Senate,SD17,SC,Abraham Tischler,4
-Kings,48055,State Senate,SD17,SC,Abraham Tischler,6
-Kings,48056,State Senate,SD17,SC,Abraham Tischler,2
-Kings,48057,State Senate,SD17,SC,Abraham Tischler,5
-Kings,48058,State Senate,SD17,SC,Abraham Tischler,5
-Kings,48060,State Senate,SD17,SC,Abraham Tischler,5
-Kings,48061,State Senate,SD17,SC,Abraham Tischler,4
-Kings,48062,State Senate,SD17,SC,Abraham Tischler,11
-Kings,48063,State Senate,SD17,SC,Abraham Tischler,2
-Kings,48064,State Senate,SD17,SC,Abraham Tischler,4
-Kings,48065,State Senate,SD17,SC,Abraham Tischler,4
-Kings,48066,State Senate,SD17,SC,Abraham Tischler,1
-Kings,48067,State Senate,SD17,SC,Abraham Tischler,2
-Kings,49006,State Senate,SD17,SC,Abraham Tischler,0
-Kings,49007,State Senate,SD17,SC,Abraham Tischler,1
-Kings,49008,State Senate,SD17,SC,Abraham Tischler,6
-Kings,49009,State Senate,SD17,SC,Abraham Tischler,4
-Kings,49010,State Senate,SD17,SC,Abraham Tischler,6
-Kings,49011,State Senate,SD17,SC,Abraham Tischler,0
-Kings,49012,State Senate,SD17,SC,Abraham Tischler,2
-Kings,49013,State Senate,SD17,SC,Abraham Tischler,1
-Kings,49030,State Senate,SD17,SC,Abraham Tischler,3
-Kings,49031,State Senate,SD17,SC,Abraham Tischler,2
-Kings,49032,State Senate,SD17,SC,Abraham Tischler,0
-Kings,49033,State Senate,SD17,SC,Abraham Tischler,1
-Kings,49042,State Senate,SD17,SC,Abraham Tischler,4
-Kings,49043,State Senate,SD17,SC,Abraham Tischler,4
-Kings,51001,State Senate,SD17,SC,Abraham Tischler,11
-Kings,51002,State Senate,SD17,SC,Abraham Tischler,6
-Kings,51003,State Senate,SD17,SC,Abraham Tischler,3
-Kings,51004,State Senate,SD17,SC,Abraham Tischler,1
-Kings,51005,State Senate,SD17,SC,Abraham Tischler,3
-Kings,51006,State Senate,SD17,SC,Abraham Tischler,1
-Kings,51014,State Senate,SD17,SC,Abraham Tischler,2
-Kings,51015,State Senate,SD17,SC,Abraham Tischler,4
-Kings,51016,State Senate,SD17,SC,Abraham Tischler,4
-Kings,51017,State Senate,SD17,SC,Abraham Tischler,1
-Kings,51018,State Senate,SD17,SC,Abraham Tischler,0
-Kings,41001,State Senate,SD17,Rep,David Storobin,203
-Kings,41002,State Senate,SD17,Rep,David Storobin,208
-Kings,41003,State Senate,SD17,Rep,David Storobin,116
-Kings,41004,State Senate,SD17,Rep,David Storobin,181
-Kings,41005,State Senate,SD17,Rep,David Storobin,246
-Kings,41006,State Senate,SD17,Rep,David Storobin,165
-Kings,41007,State Senate,SD17,Rep,David Storobin,192
-Kings,41008,State Senate,SD17,Rep,David Storobin,282
-Kings,41009,State Senate,SD17,Rep,David Storobin,212
-Kings,41010,State Senate,SD17,Rep,David Storobin,143
-Kings,41011,State Senate,SD17,Rep,David Storobin,55
-Kings,41012,State Senate,SD17,Rep,David Storobin,132
-Kings,41024,State Senate,SD17,Rep,David Storobin,20
-Kings,41050,State Senate,SD17,Rep,David Storobin,131
-Kings,41051,State Senate,SD17,Rep,David Storobin,14
-Kings,41052,State Senate,SD17,Rep,David Storobin,45
-Kings,41058,State Senate,SD17,Rep,David Storobin,251
-Kings,41059,State Senate,SD17,Rep,David Storobin,200
-Kings,42034,State Senate,SD17,Rep,David Storobin,30
-Kings,42035,State Senate,SD17,Rep,David Storobin,13
-Kings,42036,State Senate,SD17,Rep,David Storobin,110
-Kings,42037,State Senate,SD17,Rep,David Storobin,5
-Kings,42038,State Senate,SD17,Rep,David Storobin,139
-Kings,42061,State Senate,SD17,Rep,David Storobin,143
-Kings,42062,State Senate,SD17,Rep,David Storobin,133
-Kings,42063,State Senate,SD17,Rep,David Storobin,73
-Kings,42064,State Senate,SD17,Rep,David Storobin,122
-Kings,42065,State Senate,SD17,Rep,David Storobin,146
-Kings,42066,State Senate,SD17,Rep,David Storobin,183
-Kings,42067,State Senate,SD17,Rep,David Storobin,47
-Kings,44001,State Senate,SD17,Rep,David Storobin,162
-Kings,44002,State Senate,SD17,Rep,David Storobin,126
-Kings,44003,State Senate,SD17,Rep,David Storobin,129
-Kings,44004,State Senate,SD17,Rep,David Storobin,111
-Kings,44005,State Senate,SD17,Rep,David Storobin,88
-Kings,44006,State Senate,SD17,Rep,David Storobin,69
-Kings,44007,State Senate,SD17,Rep,David Storobin,84
-Kings,44008,State Senate,SD17,Rep,David Storobin,44
-Kings,44010,State Senate,SD17,Rep,David Storobin,0
-Kings,44013,State Senate,SD17,Rep,David Storobin,30
-Kings,44021,State Senate,SD17,Rep,David Storobin,29
-Kings,44023,State Senate,SD17,Rep,David Storobin,75
-Kings,44024,State Senate,SD17,Rep,David Storobin,136
-Kings,44025,State Senate,SD17,Rep,David Storobin,264
-Kings,44026,State Senate,SD17,Rep,David Storobin,215
-Kings,44027,State Senate,SD17,Rep,David Storobin,148
-Kings,44028,State Senate,SD17,Rep,David Storobin,119
-Kings,44029,State Senate,SD17,Rep,David Storobin,115
-Kings,44030,State Senate,SD17,Rep,David Storobin,143
-Kings,44031,State Senate,SD17,Rep,David Storobin,72
-Kings,44032,State Senate,SD17,Rep,David Storobin,5
-Kings,44033,State Senate,SD17,Rep,David Storobin,55
-Kings,44035,State Senate,SD17,Rep,David Storobin,41
-Kings,44038,State Senate,SD17,Rep,David Storobin,43
-Kings,44039,State Senate,SD17,Rep,David Storobin,30
-Kings,44041,State Senate,SD17,Rep,David Storobin,35
-Kings,44042,State Senate,SD17,Rep,David Storobin,137
-Kings,44043,State Senate,SD17,Rep,David Storobin,83
-Kings,44044,State Senate,SD17,Rep,David Storobin,90
-Kings,44045,State Senate,SD17,Rep,David Storobin,99
-Kings,45001,State Senate,SD17,Rep,David Storobin,193
-Kings,45002,State Senate,SD17,Rep,David Storobin,200
-Kings,45003,State Senate,SD17,Rep,David Storobin,196
-Kings,45004,State Senate,SD17,Rep,David Storobin,168
-Kings,45005,State Senate,SD17,Rep,David Storobin,155
-Kings,45007,State Senate,SD17,Rep,David Storobin,11
-Kings,45010,State Senate,SD17,Rep,David Storobin,66
-Kings,45011,State Senate,SD17,Rep,David Storobin,181
-Kings,45012,State Senate,SD17,Rep,David Storobin,226
-Kings,45013,State Senate,SD17,Rep,David Storobin,191
-Kings,45014,State Senate,SD17,Rep,David Storobin,216
-Kings,45018,State Senate,SD17,Rep,David Storobin,9
-Kings,45023,State Senate,SD17,Rep,David Storobin,190
-Kings,45024,State Senate,SD17,Rep,David Storobin,188
-Kings,45029,State Senate,SD17,Rep,David Storobin,87
-Kings,45030,State Senate,SD17,Rep,David Storobin,190
-Kings,45038,State Senate,SD17,Rep,David Storobin,63
-Kings,45039,State Senate,SD17,Rep,David Storobin,13
-Kings,47023,State Senate,SD17,Rep,David Storobin,176
-Kings,47024,State Senate,SD17,Rep,David Storobin,182
-Kings,47025,State Senate,SD17,Rep,David Storobin,123
-Kings,47026,State Senate,SD17,Rep,David Storobin,176
-Kings,47027,State Senate,SD17,Rep,David Storobin,117
-Kings,47028,State Senate,SD17,Rep,David Storobin,167
-Kings,47029,State Senate,SD17,Rep,David Storobin,207
-Kings,47030,State Senate,SD17,Rep,David Storobin,4
-Kings,47031,State Senate,SD17,Rep,David Storobin,110
-Kings,47032,State Senate,SD17,Rep,David Storobin,25
-Kings,47033,State Senate,SD17,Rep,David Storobin,40
-Kings,48001,State Senate,SD17,Rep,David Storobin,20
-Kings,48002,State Senate,SD17,Rep,David Storobin,37
-Kings,48003,State Senate,SD17,Rep,David Storobin,172
-Kings,48004,State Senate,SD17,Rep,David Storobin,171
-Kings,48005,State Senate,SD17,Rep,David Storobin,122
-Kings,48006,State Senate,SD17,Rep,David Storobin,161
-Kings,48007,State Senate,SD17,Rep,David Storobin,139
-Kings,48008,State Senate,SD17,Rep,David Storobin,3
-Kings,48009,State Senate,SD17,Rep,David Storobin,169
-Kings,48010,State Senate,SD17,Rep,David Storobin,173
-Kings,48011,State Senate,SD17,Rep,David Storobin,142
-Kings,48012,State Senate,SD17,Rep,David Storobin,165
-Kings,48013,State Senate,SD17,Rep,David Storobin,130
-Kings,48014,State Senate,SD17,Rep,David Storobin,188
-Kings,48015,State Senate,SD17,Rep,David Storobin,15
-Kings,48016,State Senate,SD17,Rep,David Storobin,174
-Kings,48017,State Senate,SD17,Rep,David Storobin,207
-Kings,48018,State Senate,SD17,Rep,David Storobin,205
-Kings,48019,State Senate,SD17,Rep,David Storobin,141
-Kings,48020,State Senate,SD17,Rep,David Storobin,195
-Kings,48021,State Senate,SD17,Rep,David Storobin,174
-Kings,48022,State Senate,SD17,Rep,David Storobin,216
-Kings,48023,State Senate,SD17,Rep,David Storobin,164
-Kings,48024,State Senate,SD17,Rep,David Storobin,158
-Kings,48025,State Senate,SD17,Rep,David Storobin,157
-Kings,48026,State Senate,SD17,Rep,David Storobin,139
-Kings,48027,State Senate,SD17,Rep,David Storobin,103
-Kings,48028,State Senate,SD17,Rep,David Storobin,199
-Kings,48029,State Senate,SD17,Rep,David Storobin,192
-Kings,48030,State Senate,SD17,Rep,David Storobin,139
-Kings,48031,State Senate,SD17,Rep,David Storobin,47
-Kings,48032,State Senate,SD17,Rep,David Storobin,205
-Kings,48033,State Senate,SD17,Rep,David Storobin,83
-Kings,48036,State Senate,SD17,Rep,David Storobin,150
-Kings,48038,State Senate,SD17,Rep,David Storobin,55
-Kings,48039,State Senate,SD17,Rep,David Storobin,96
-Kings,48040,State Senate,SD17,Rep,David Storobin,151
-Kings,48041,State Senate,SD17,Rep,David Storobin,47
-Kings,48042,State Senate,SD17,Rep,David Storobin,117
-Kings,48043,State Senate,SD17,Rep,David Storobin,180
-Kings,48044,State Senate,SD17,Rep,David Storobin,83
-Kings,48045,State Senate,SD17,Rep,David Storobin,64
-Kings,48049,State Senate,SD17,Rep,David Storobin,27
-Kings,48054,State Senate,SD17,Rep,David Storobin,132
-Kings,48055,State Senate,SD17,Rep,David Storobin,267
-Kings,48056,State Senate,SD17,Rep,David Storobin,153
-Kings,48057,State Senate,SD17,Rep,David Storobin,138
-Kings,48058,State Senate,SD17,Rep,David Storobin,159
-Kings,48060,State Senate,SD17,Rep,David Storobin,196
-Kings,48061,State Senate,SD17,Rep,David Storobin,152
-Kings,48062,State Senate,SD17,Rep,David Storobin,139
-Kings,48063,State Senate,SD17,Rep,David Storobin,97
-Kings,48064,State Senate,SD17,Rep,David Storobin,137
-Kings,48065,State Senate,SD17,Rep,David Storobin,63
-Kings,48066,State Senate,SD17,Rep,David Storobin,81
-Kings,48067,State Senate,SD17,Rep,David Storobin,59
-Kings,49006,State Senate,SD17,Rep,David Storobin,18
-Kings,49007,State Senate,SD17,Rep,David Storobin,21
-Kings,49008,State Senate,SD17,Rep,David Storobin,76
-Kings,49009,State Senate,SD17,Rep,David Storobin,39
-Kings,49010,State Senate,SD17,Rep,David Storobin,50
-Kings,49011,State Senate,SD17,Rep,David Storobin,20
-Kings,49012,State Senate,SD17,Rep,David Storobin,12
-Kings,49013,State Senate,SD17,Rep,David Storobin,12
-Kings,49030,State Senate,SD17,Rep,David Storobin,64
-Kings,49031,State Senate,SD17,Rep,David Storobin,59
-Kings,49032,State Senate,SD17,Rep,David Storobin,14
-Kings,49033,State Senate,SD17,Rep,David Storobin,32
-Kings,49042,State Senate,SD17,Rep,David Storobin,108
-Kings,49043,State Senate,SD17,Rep,David Storobin,121
-Kings,51001,State Senate,SD17,Rep,David Storobin,62
-Kings,51002,State Senate,SD17,Rep,David Storobin,48
-Kings,51003,State Senate,SD17,Rep,David Storobin,46
-Kings,51004,State Senate,SD17,Rep,David Storobin,66
-Kings,51005,State Senate,SD17,Rep,David Storobin,38
-Kings,51006,State Senate,SD17,Rep,David Storobin,40
-Kings,51014,State Senate,SD17,Rep,David Storobin,20
-Kings,51015,State Senate,SD17,Rep,David Storobin,149
-Kings,51016,State Senate,SD17,Rep,David Storobin,128
-Kings,51017,State Senate,SD17,Rep,David Storobin,46
-Kings,51018,State Senate,SD17,Rep,David Storobin,47
-Kings,41001,State Senate,SD17,Dem,Simcha Felder,246
-Kings,41002,State Senate,SD17,Dem,Simcha Felder,260
-Kings,41003,State Senate,SD17,Dem,Simcha Felder,91
-Kings,41004,State Senate,SD17,Dem,Simcha Felder,165
-Kings,41005,State Senate,SD17,Dem,Simcha Felder,233
-Kings,41006,State Senate,SD17,Dem,Simcha Felder,154
-Kings,41007,State Senate,SD17,Dem,Simcha Felder,228
-Kings,41008,State Senate,SD17,Dem,Simcha Felder,191
-Kings,41009,State Senate,SD17,Dem,Simcha Felder,188
-Kings,41010,State Senate,SD17,Dem,Simcha Felder,136
-Kings,41011,State Senate,SD17,Dem,Simcha Felder,94
-Kings,41012,State Senate,SD17,Dem,Simcha Felder,135
-Kings,41024,State Senate,SD17,Dem,Simcha Felder,51
-Kings,41050,State Senate,SD17,Dem,Simcha Felder,265
-Kings,41051,State Senate,SD17,Dem,Simcha Felder,100
-Kings,41052,State Senate,SD17,Dem,Simcha Felder,183
-Kings,41058,State Senate,SD17,Dem,Simcha Felder,290
-Kings,41059,State Senate,SD17,Dem,Simcha Felder,194
-Kings,42034,State Senate,SD17,Dem,Simcha Felder,225
-Kings,42035,State Senate,SD17,Dem,Simcha Felder,66
-Kings,42036,State Senate,SD17,Dem,Simcha Felder,391
-Kings,42037,State Senate,SD17,Dem,Simcha Felder,92
-Kings,42038,State Senate,SD17,Dem,Simcha Felder,200
-Kings,42061,State Senate,SD17,Dem,Simcha Felder,248
-Kings,42062,State Senate,SD17,Dem,Simcha Felder,216
-Kings,42063,State Senate,SD17,Dem,Simcha Felder,131
-Kings,42064,State Senate,SD17,Dem,Simcha Felder,294
-Kings,42065,State Senate,SD17,Dem,Simcha Felder,281
-Kings,42066,State Senate,SD17,Dem,Simcha Felder,256
-Kings,42067,State Senate,SD17,Dem,Simcha Felder,108
-Kings,44001,State Senate,SD17,Dem,Simcha Felder,270
-Kings,44002,State Senate,SD17,Dem,Simcha Felder,294
-Kings,44003,State Senate,SD17,Dem,Simcha Felder,234
-Kings,44004,State Senate,SD17,Dem,Simcha Felder,299
-Kings,44005,State Senate,SD17,Dem,Simcha Felder,310
-Kings,44006,State Senate,SD17,Dem,Simcha Felder,311
-Kings,44007,State Senate,SD17,Dem,Simcha Felder,412
-Kings,44008,State Senate,SD17,Dem,Simcha Felder,222
-Kings,44010,State Senate,SD17,Dem,Simcha Felder,0
-Kings,44013,State Senate,SD17,Dem,Simcha Felder,74
-Kings,44021,State Senate,SD17,Dem,Simcha Felder,52
-Kings,44023,State Senate,SD17,Dem,Simcha Felder,185
-Kings,44024,State Senate,SD17,Dem,Simcha Felder,406
-Kings,44025,State Senate,SD17,Dem,Simcha Felder,329
-Kings,44026,State Senate,SD17,Dem,Simcha Felder,290
-Kings,44027,State Senate,SD17,Dem,Simcha Felder,238
-Kings,44028,State Senate,SD17,Dem,Simcha Felder,342
-Kings,44029,State Senate,SD17,Dem,Simcha Felder,322
-Kings,44030,State Senate,SD17,Dem,Simcha Felder,271
-Kings,44031,State Senate,SD17,Dem,Simcha Felder,402
-Kings,44032,State Senate,SD17,Dem,Simcha Felder,65
-Kings,44033,State Senate,SD17,Dem,Simcha Felder,368
-Kings,44035,State Senate,SD17,Dem,Simcha Felder,371
-Kings,44038,State Senate,SD17,Dem,Simcha Felder,362
-Kings,44039,State Senate,SD17,Dem,Simcha Felder,268
-Kings,44041,State Senate,SD17,Dem,Simcha Felder,103
-Kings,44042,State Senate,SD17,Dem,Simcha Felder,305
-Kings,44043,State Senate,SD17,Dem,Simcha Felder,270
-Kings,44044,State Senate,SD17,Dem,Simcha Felder,363
-Kings,44045,State Senate,SD17,Dem,Simcha Felder,353
-Kings,45001,State Senate,SD17,Dem,Simcha Felder,301
-Kings,45002,State Senate,SD17,Dem,Simcha Felder,262
-Kings,45003,State Senate,SD17,Dem,Simcha Felder,190
-Kings,45004,State Senate,SD17,Dem,Simcha Felder,211
-Kings,45005,State Senate,SD17,Dem,Simcha Felder,128
-Kings,45007,State Senate,SD17,Dem,Simcha Felder,15
-Kings,45010,State Senate,SD17,Dem,Simcha Felder,91
-Kings,45011,State Senate,SD17,Dem,Simcha Felder,209
-Kings,45012,State Senate,SD17,Dem,Simcha Felder,193
-Kings,45013,State Senate,SD17,Dem,Simcha Felder,199
-Kings,45014,State Senate,SD17,Dem,Simcha Felder,196
-Kings,45018,State Senate,SD17,Dem,Simcha Felder,19
-Kings,45023,State Senate,SD17,Dem,Simcha Felder,226
-Kings,45024,State Senate,SD17,Dem,Simcha Felder,244
-Kings,45029,State Senate,SD17,Dem,Simcha Felder,93
-Kings,45030,State Senate,SD17,Dem,Simcha Felder,203
-Kings,45038,State Senate,SD17,Dem,Simcha Felder,91
-Kings,45039,State Senate,SD17,Dem,Simcha Felder,9
-Kings,47023,State Senate,SD17,Dem,Simcha Felder,168
-Kings,47024,State Senate,SD17,Dem,Simcha Felder,212
-Kings,47025,State Senate,SD17,Dem,Simcha Felder,236
-Kings,47026,State Senate,SD17,Dem,Simcha Felder,179
-Kings,47027,State Senate,SD17,Dem,Simcha Felder,210
-Kings,47028,State Senate,SD17,Dem,Simcha Felder,207
-Kings,47029,State Senate,SD17,Dem,Simcha Felder,188
-Kings,47030,State Senate,SD17,Dem,Simcha Felder,12
-Kings,47031,State Senate,SD17,Dem,Simcha Felder,198
-Kings,47032,State Senate,SD17,Dem,Simcha Felder,71
-Kings,47033,State Senate,SD17,Dem,Simcha Felder,76
-Kings,48001,State Senate,SD17,Dem,Simcha Felder,34
-Kings,48002,State Senate,SD17,Dem,Simcha Felder,55
-Kings,48003,State Senate,SD17,Dem,Simcha Felder,170
-Kings,48004,State Senate,SD17,Dem,Simcha Felder,242
-Kings,48005,State Senate,SD17,Dem,Simcha Felder,234
-Kings,48006,State Senate,SD17,Dem,Simcha Felder,128
-Kings,48007,State Senate,SD17,Dem,Simcha Felder,170
-Kings,48008,State Senate,SD17,Dem,Simcha Felder,16
-Kings,48009,State Senate,SD17,Dem,Simcha Felder,178
-Kings,48010,State Senate,SD17,Dem,Simcha Felder,216
-Kings,48011,State Senate,SD17,Dem,Simcha Felder,266
-Kings,48012,State Senate,SD17,Dem,Simcha Felder,233
-Kings,48013,State Senate,SD17,Dem,Simcha Felder,227
-Kings,48014,State Senate,SD17,Dem,Simcha Felder,173
-Kings,48015,State Senate,SD17,Dem,Simcha Felder,24
-Kings,48016,State Senate,SD17,Dem,Simcha Felder,184
-Kings,48017,State Senate,SD17,Dem,Simcha Felder,218
-Kings,48018,State Senate,SD17,Dem,Simcha Felder,213
-Kings,48019,State Senate,SD17,Dem,Simcha Felder,285
-Kings,48020,State Senate,SD17,Dem,Simcha Felder,260
-Kings,48021,State Senate,SD17,Dem,Simcha Felder,213
-Kings,48022,State Senate,SD17,Dem,Simcha Felder,279
-Kings,48023,State Senate,SD17,Dem,Simcha Felder,217
-Kings,48024,State Senate,SD17,Dem,Simcha Felder,218
-Kings,48025,State Senate,SD17,Dem,Simcha Felder,269
-Kings,48026,State Senate,SD17,Dem,Simcha Felder,227
-Kings,48027,State Senate,SD17,Dem,Simcha Felder,258
-Kings,48028,State Senate,SD17,Dem,Simcha Felder,242
-Kings,48029,State Senate,SD17,Dem,Simcha Felder,222
-Kings,48030,State Senate,SD17,Dem,Simcha Felder,235
-Kings,48031,State Senate,SD17,Dem,Simcha Felder,98
-Kings,48032,State Senate,SD17,Dem,Simcha Felder,195
-Kings,48033,State Senate,SD17,Dem,Simcha Felder,126
-Kings,48036,State Senate,SD17,Dem,Simcha Felder,190
-Kings,48038,State Senate,SD17,Dem,Simcha Felder,81
-Kings,48039,State Senate,SD17,Dem,Simcha Felder,99
-Kings,48040,State Senate,SD17,Dem,Simcha Felder,220
-Kings,48041,State Senate,SD17,Dem,Simcha Felder,95
-Kings,48042,State Senate,SD17,Dem,Simcha Felder,152
-Kings,48043,State Senate,SD17,Dem,Simcha Felder,258
-Kings,48044,State Senate,SD17,Dem,Simcha Felder,133
-Kings,48045,State Senate,SD17,Dem,Simcha Felder,89
-Kings,48049,State Senate,SD17,Dem,Simcha Felder,71
-Kings,48054,State Senate,SD17,Dem,Simcha Felder,101
-Kings,48055,State Senate,SD17,Dem,Simcha Felder,228
-Kings,48056,State Senate,SD17,Dem,Simcha Felder,273
-Kings,48057,State Senate,SD17,Dem,Simcha Felder,183
-Kings,48058,State Senate,SD17,Dem,Simcha Felder,266
-Kings,48060,State Senate,SD17,Dem,Simcha Felder,283
-Kings,48061,State Senate,SD17,Dem,Simcha Felder,236
-Kings,48062,State Senate,SD17,Dem,Simcha Felder,299
-Kings,48063,State Senate,SD17,Dem,Simcha Felder,301
-Kings,48064,State Senate,SD17,Dem,Simcha Felder,206
-Kings,48065,State Senate,SD17,Dem,Simcha Felder,130
-Kings,48066,State Senate,SD17,Dem,Simcha Felder,141
-Kings,48067,State Senate,SD17,Dem,Simcha Felder,59
-Kings,49006,State Senate,SD17,Dem,Simcha Felder,69
-Kings,49007,State Senate,SD17,Dem,Simcha Felder,47
-Kings,49008,State Senate,SD17,Dem,Simcha Felder,203
-Kings,49009,State Senate,SD17,Dem,Simcha Felder,171
-Kings,49010,State Senate,SD17,Dem,Simcha Felder,194
-Kings,49011,State Senate,SD17,Dem,Simcha Felder,61
-Kings,49012,State Senate,SD17,Dem,Simcha Felder,60
-Kings,49013,State Senate,SD17,Dem,Simcha Felder,51
-Kings,49030,State Senate,SD17,Dem,Simcha Felder,93
-Kings,49031,State Senate,SD17,Dem,Simcha Felder,44
-Kings,49032,State Senate,SD17,Dem,Simcha Felder,47
-Kings,49033,State Senate,SD17,Dem,Simcha Felder,38
-Kings,49042,State Senate,SD17,Dem,Simcha Felder,233
-Kings,49043,State Senate,SD17,Dem,Simcha Felder,174
-Kings,51001,State Senate,SD17,Dem,Simcha Felder,387
-Kings,51002,State Senate,SD17,Dem,Simcha Felder,263
-Kings,51003,State Senate,SD17,Dem,Simcha Felder,382
-Kings,51004,State Senate,SD17,Dem,Simcha Felder,342
-Kings,51005,State Senate,SD17,Dem,Simcha Felder,294
-Kings,51006,State Senate,SD17,Dem,Simcha Felder,231
-Kings,51014,State Senate,SD17,Dem,Simcha Felder,61
-Kings,51015,State Senate,SD17,Dem,Simcha Felder,272
-Kings,51016,State Senate,SD17,Dem,Simcha Felder,221
-Kings,51017,State Senate,SD17,Dem,Simcha Felder,115
-Kings,51018,State Senate,SD17,Dem,Simcha Felder,63
-Kings,41001,State Senate,SD17,Con,Simcha Felder,56
-Kings,41002,State Senate,SD17,Con,Simcha Felder,37
-Kings,41003,State Senate,SD17,Con,Simcha Felder,4
-Kings,41004,State Senate,SD17,Con,Simcha Felder,20
-Kings,41005,State Senate,SD17,Con,Simcha Felder,52
-Kings,41006,State Senate,SD17,Con,Simcha Felder,27
-Kings,41007,State Senate,SD17,Con,Simcha Felder,30
-Kings,41008,State Senate,SD17,Con,Simcha Felder,21
-Kings,41009,State Senate,SD17,Con,Simcha Felder,36
-Kings,41010,State Senate,SD17,Con,Simcha Felder,8
-Kings,41011,State Senate,SD17,Con,Simcha Felder,8
-Kings,41012,State Senate,SD17,Con,Simcha Felder,38
-Kings,41024,State Senate,SD17,Con,Simcha Felder,4
-Kings,41050,State Senate,SD17,Con,Simcha Felder,67
-Kings,41051,State Senate,SD17,Con,Simcha Felder,10
-Kings,41052,State Senate,SD17,Con,Simcha Felder,35
-Kings,41058,State Senate,SD17,Con,Simcha Felder,72
-Kings,41059,State Senate,SD17,Con,Simcha Felder,44
-Kings,42034,State Senate,SD17,Con,Simcha Felder,6
-Kings,42035,State Senate,SD17,Con,Simcha Felder,3
-Kings,42036,State Senate,SD17,Con,Simcha Felder,72
-Kings,42037,State Senate,SD17,Con,Simcha Felder,4
-Kings,42038,State Senate,SD17,Con,Simcha Felder,96
-Kings,42061,State Senate,SD17,Con,Simcha Felder,62
-Kings,42062,State Senate,SD17,Con,Simcha Felder,131
-Kings,42063,State Senate,SD17,Con,Simcha Felder,26
-Kings,42064,State Senate,SD17,Con,Simcha Felder,100
-Kings,42065,State Senate,SD17,Con,Simcha Felder,112
-Kings,42066,State Senate,SD17,Con,Simcha Felder,83
-Kings,42067,State Senate,SD17,Con,Simcha Felder,10
-Kings,44001,State Senate,SD17,Con,Simcha Felder,96
-Kings,44002,State Senate,SD17,Con,Simcha Felder,133
-Kings,44003,State Senate,SD17,Con,Simcha Felder,130
-Kings,44004,State Senate,SD17,Con,Simcha Felder,84
-Kings,44005,State Senate,SD17,Con,Simcha Felder,59
-Kings,44006,State Senate,SD17,Con,Simcha Felder,40
-Kings,44007,State Senate,SD17,Con,Simcha Felder,21
-Kings,44008,State Senate,SD17,Con,Simcha Felder,25
-Kings,44010,State Senate,SD17,Con,Simcha Felder,0
-Kings,44013,State Senate,SD17,Con,Simcha Felder,18
-Kings,44021,State Senate,SD17,Con,Simcha Felder,17
-Kings,44023,State Senate,SD17,Con,Simcha Felder,50
-Kings,44024,State Senate,SD17,Con,Simcha Felder,98
-Kings,44025,State Senate,SD17,Con,Simcha Felder,96
-Kings,44026,State Senate,SD17,Con,Simcha Felder,38
-Kings,44027,State Senate,SD17,Con,Simcha Felder,68
-Kings,44028,State Senate,SD17,Con,Simcha Felder,18
-Kings,44029,State Senate,SD17,Con,Simcha Felder,17
-Kings,44030,State Senate,SD17,Con,Simcha Felder,26
-Kings,44031,State Senate,SD17,Con,Simcha Felder,15
-Kings,44032,State Senate,SD17,Con,Simcha Felder,5
-Kings,44033,State Senate,SD17,Con,Simcha Felder,8
-Kings,44035,State Senate,SD17,Con,Simcha Felder,19
-Kings,44038,State Senate,SD17,Con,Simcha Felder,6
-Kings,44039,State Senate,SD17,Con,Simcha Felder,5
-Kings,44041,State Senate,SD17,Con,Simcha Felder,29
-Kings,44042,State Senate,SD17,Con,Simcha Felder,60
-Kings,44043,State Senate,SD17,Con,Simcha Felder,37
-Kings,44044,State Senate,SD17,Con,Simcha Felder,32
-Kings,44045,State Senate,SD17,Con,Simcha Felder,11
-Kings,45001,State Senate,SD17,Con,Simcha Felder,88
-Kings,45002,State Senate,SD17,Con,Simcha Felder,45
-Kings,45003,State Senate,SD17,Con,Simcha Felder,73
-Kings,45004,State Senate,SD17,Con,Simcha Felder,46
-Kings,45005,State Senate,SD17,Con,Simcha Felder,44
-Kings,45007,State Senate,SD17,Con,Simcha Felder,2
-Kings,45010,State Senate,SD17,Con,Simcha Felder,35
-Kings,45011,State Senate,SD17,Con,Simcha Felder,18
-Kings,45012,State Senate,SD17,Con,Simcha Felder,18
-Kings,45013,State Senate,SD17,Con,Simcha Felder,46
-Kings,45014,State Senate,SD17,Con,Simcha Felder,40
-Kings,45018,State Senate,SD17,Con,Simcha Felder,3
-Kings,45023,State Senate,SD17,Con,Simcha Felder,32
-Kings,45024,State Senate,SD17,Con,Simcha Felder,30
-Kings,45029,State Senate,SD17,Con,Simcha Felder,10
-Kings,45030,State Senate,SD17,Con,Simcha Felder,18
-Kings,45038,State Senate,SD17,Con,Simcha Felder,2
-Kings,45039,State Senate,SD17,Con,Simcha Felder,1
-Kings,47023,State Senate,SD17,Con,Simcha Felder,9
-Kings,47024,State Senate,SD17,Con,Simcha Felder,12
-Kings,47025,State Senate,SD17,Con,Simcha Felder,15
-Kings,47026,State Senate,SD17,Con,Simcha Felder,13
-Kings,47027,State Senate,SD17,Con,Simcha Felder,21
-Kings,47028,State Senate,SD17,Con,Simcha Felder,11
-Kings,47029,State Senate,SD17,Con,Simcha Felder,16
-Kings,47030,State Senate,SD17,Con,Simcha Felder,0
-Kings,47031,State Senate,SD17,Con,Simcha Felder,15
-Kings,47032,State Senate,SD17,Con,Simcha Felder,1
-Kings,47033,State Senate,SD17,Con,Simcha Felder,1
-Kings,48001,State Senate,SD17,Con,Simcha Felder,6
-Kings,48002,State Senate,SD17,Con,Simcha Felder,7
-Kings,48003,State Senate,SD17,Con,Simcha Felder,46
-Kings,48004,State Senate,SD17,Con,Simcha Felder,49
-Kings,48005,State Senate,SD17,Con,Simcha Felder,40
-Kings,48006,State Senate,SD17,Con,Simcha Felder,34
-Kings,48007,State Senate,SD17,Con,Simcha Felder,53
-Kings,48008,State Senate,SD17,Con,Simcha Felder,0
-Kings,48009,State Senate,SD17,Con,Simcha Felder,57
-Kings,48010,State Senate,SD17,Con,Simcha Felder,61
-Kings,48011,State Senate,SD17,Con,Simcha Felder,97
-Kings,48012,State Senate,SD17,Con,Simcha Felder,82
-Kings,48013,State Senate,SD17,Con,Simcha Felder,60
-Kings,48014,State Senate,SD17,Con,Simcha Felder,56
-Kings,48015,State Senate,SD17,Con,Simcha Felder,3
-Kings,48016,State Senate,SD17,Con,Simcha Felder,57
-Kings,48017,State Senate,SD17,Con,Simcha Felder,73
-Kings,48018,State Senate,SD17,Con,Simcha Felder,69
-Kings,48019,State Senate,SD17,Con,Simcha Felder,72
-Kings,48020,State Senate,SD17,Con,Simcha Felder,80
-Kings,48021,State Senate,SD17,Con,Simcha Felder,69
-Kings,48022,State Senate,SD17,Con,Simcha Felder,80
-Kings,48023,State Senate,SD17,Con,Simcha Felder,68
-Kings,48024,State Senate,SD17,Con,Simcha Felder,83
-Kings,48025,State Senate,SD17,Con,Simcha Felder,78
-Kings,48026,State Senate,SD17,Con,Simcha Felder,89
-Kings,48027,State Senate,SD17,Con,Simcha Felder,107
-Kings,48028,State Senate,SD17,Con,Simcha Felder,75
-Kings,48029,State Senate,SD17,Con,Simcha Felder,76
-Kings,48030,State Senate,SD17,Con,Simcha Felder,93
-Kings,48031,State Senate,SD17,Con,Simcha Felder,33
-Kings,48032,State Senate,SD17,Con,Simcha Felder,51
-Kings,48033,State Senate,SD17,Con,Simcha Felder,28
-Kings,48036,State Senate,SD17,Con,Simcha Felder,14
-Kings,48038,State Senate,SD17,Con,Simcha Felder,17
-Kings,48039,State Senate,SD17,Con,Simcha Felder,20
-Kings,48040,State Senate,SD17,Con,Simcha Felder,52
-Kings,48041,State Senate,SD17,Con,Simcha Felder,15
-Kings,48042,State Senate,SD17,Con,Simcha Felder,25
-Kings,48043,State Senate,SD17,Con,Simcha Felder,6
-Kings,48044,State Senate,SD17,Con,Simcha Felder,6
-Kings,48045,State Senate,SD17,Con,Simcha Felder,20
-Kings,48049,State Senate,SD17,Con,Simcha Felder,8
-Kings,48054,State Senate,SD17,Con,Simcha Felder,30
-Kings,48055,State Senate,SD17,Con,Simcha Felder,21
-Kings,48056,State Senate,SD17,Con,Simcha Felder,60
-Kings,48057,State Senate,SD17,Con,Simcha Felder,39
-Kings,48058,State Senate,SD17,Con,Simcha Felder,60
-Kings,48060,State Senate,SD17,Con,Simcha Felder,81
-Kings,48061,State Senate,SD17,Con,Simcha Felder,51
-Kings,48062,State Senate,SD17,Con,Simcha Felder,42
-Kings,48063,State Senate,SD17,Con,Simcha Felder,20
-Kings,48064,State Senate,SD17,Con,Simcha Felder,36
-Kings,48065,State Senate,SD17,Con,Simcha Felder,20
-Kings,48066,State Senate,SD17,Con,Simcha Felder,29
-Kings,48067,State Senate,SD17,Con,Simcha Felder,21
-Kings,49006,State Senate,SD17,Con,Simcha Felder,7
-Kings,49007,State Senate,SD17,Con,Simcha Felder,2
-Kings,49008,State Senate,SD17,Con,Simcha Felder,19
-Kings,49009,State Senate,SD17,Con,Simcha Felder,15
-Kings,49010,State Senate,SD17,Con,Simcha Felder,9
-Kings,49011,State Senate,SD17,Con,Simcha Felder,2
-Kings,49012,State Senate,SD17,Con,Simcha Felder,1
-Kings,49013,State Senate,SD17,Con,Simcha Felder,3
-Kings,49030,State Senate,SD17,Con,Simcha Felder,10
-Kings,49031,State Senate,SD17,Con,Simcha Felder,6
-Kings,49032,State Senate,SD17,Con,Simcha Felder,5
-Kings,49033,State Senate,SD17,Con,Simcha Felder,13
-Kings,49042,State Senate,SD17,Con,Simcha Felder,7
-Kings,49043,State Senate,SD17,Con,Simcha Felder,23
-Kings,51001,State Senate,SD17,Con,Simcha Felder,11
-Kings,51002,State Senate,SD17,Con,Simcha Felder,10
-Kings,51003,State Senate,SD17,Con,Simcha Felder,9
-Kings,51004,State Senate,SD17,Con,Simcha Felder,11
-Kings,51005,State Senate,SD17,Con,Simcha Felder,6
-Kings,51006,State Senate,SD17,Con,Simcha Felder,14
-Kings,51014,State Senate,SD17,Con,Simcha Felder,5
-Kings,51015,State Senate,SD17,Con,Simcha Felder,48
-Kings,51016,State Senate,SD17,Con,Simcha Felder,51
-Kings,51017,State Senate,SD17,Con,Simcha Felder,15
-Kings,51018,State Senate,SD17,Con,Simcha Felder,12
-Kings,41001,State Senate,SD17,WF,Simcha Felder,1
-Kings,41002,State Senate,SD17,WF,Simcha Felder,1
-Kings,41003,State Senate,SD17,WF,Simcha Felder,0
-Kings,41004,State Senate,SD17,WF,Simcha Felder,4
-Kings,41005,State Senate,SD17,WF,Simcha Felder,2
-Kings,41006,State Senate,SD17,WF,Simcha Felder,0
-Kings,41007,State Senate,SD17,WF,Simcha Felder,4
-Kings,41008,State Senate,SD17,WF,Simcha Felder,4
-Kings,41009,State Senate,SD17,WF,Simcha Felder,5
-Kings,41010,State Senate,SD17,WF,Simcha Felder,0
-Kings,41011,State Senate,SD17,WF,Simcha Felder,0
-Kings,41012,State Senate,SD17,WF,Simcha Felder,2
-Kings,41024,State Senate,SD17,WF,Simcha Felder,0
-Kings,41050,State Senate,SD17,WF,Simcha Felder,4
-Kings,41051,State Senate,SD17,WF,Simcha Felder,1
-Kings,41052,State Senate,SD17,WF,Simcha Felder,0
-Kings,41058,State Senate,SD17,WF,Simcha Felder,2
-Kings,41059,State Senate,SD17,WF,Simcha Felder,1
-Kings,42034,State Senate,SD17,WF,Simcha Felder,2
-Kings,42035,State Senate,SD17,WF,Simcha Felder,1
-Kings,42036,State Senate,SD17,WF,Simcha Felder,6
-Kings,42037,State Senate,SD17,WF,Simcha Felder,2
-Kings,42038,State Senate,SD17,WF,Simcha Felder,4
-Kings,42061,State Senate,SD17,WF,Simcha Felder,4
-Kings,42062,State Senate,SD17,WF,Simcha Felder,3
-Kings,42063,State Senate,SD17,WF,Simcha Felder,0
-Kings,42064,State Senate,SD17,WF,Simcha Felder,4
-Kings,42065,State Senate,SD17,WF,Simcha Felder,5
-Kings,42066,State Senate,SD17,WF,Simcha Felder,3
-Kings,42067,State Senate,SD17,WF,Simcha Felder,1
-Kings,44001,State Senate,SD17,WF,Simcha Felder,0
-Kings,44002,State Senate,SD17,WF,Simcha Felder,4
-Kings,44003,State Senate,SD17,WF,Simcha Felder,4
-Kings,44004,State Senate,SD17,WF,Simcha Felder,3
-Kings,44005,State Senate,SD17,WF,Simcha Felder,2
-Kings,44006,State Senate,SD17,WF,Simcha Felder,2
-Kings,44007,State Senate,SD17,WF,Simcha Felder,3
-Kings,44008,State Senate,SD17,WF,Simcha Felder,1
-Kings,44010,State Senate,SD17,WF,Simcha Felder,0
-Kings,44013,State Senate,SD17,WF,Simcha Felder,1
-Kings,44021,State Senate,SD17,WF,Simcha Felder,0
-Kings,44023,State Senate,SD17,WF,Simcha Felder,0
-Kings,44024,State Senate,SD17,WF,Simcha Felder,2
-Kings,44025,State Senate,SD17,WF,Simcha Felder,2
-Kings,44026,State Senate,SD17,WF,Simcha Felder,1
-Kings,44027,State Senate,SD17,WF,Simcha Felder,4
-Kings,44028,State Senate,SD17,WF,Simcha Felder,3
-Kings,44029,State Senate,SD17,WF,Simcha Felder,4
-Kings,44030,State Senate,SD17,WF,Simcha Felder,2
-Kings,44031,State Senate,SD17,WF,Simcha Felder,1
-Kings,44032,State Senate,SD17,WF,Simcha Felder,1
-Kings,44033,State Senate,SD17,WF,Simcha Felder,4
-Kings,44035,State Senate,SD17,WF,Simcha Felder,1
-Kings,44038,State Senate,SD17,WF,Simcha Felder,4
-Kings,44039,State Senate,SD17,WF,Simcha Felder,3
-Kings,44041,State Senate,SD17,WF,Simcha Felder,0
-Kings,44042,State Senate,SD17,WF,Simcha Felder,5
-Kings,44043,State Senate,SD17,WF,Simcha Felder,2
-Kings,44044,State Senate,SD17,WF,Simcha Felder,2
-Kings,44045,State Senate,SD17,WF,Simcha Felder,2
-Kings,45001,State Senate,SD17,WF,Simcha Felder,13
-Kings,45002,State Senate,SD17,WF,Simcha Felder,5
-Kings,45003,State Senate,SD17,WF,Simcha Felder,5
-Kings,45004,State Senate,SD17,WF,Simcha Felder,3
-Kings,45005,State Senate,SD17,WF,Simcha Felder,3
-Kings,45007,State Senate,SD17,WF,Simcha Felder,0
-Kings,45010,State Senate,SD17,WF,Simcha Felder,0
-Kings,45011,State Senate,SD17,WF,Simcha Felder,1
-Kings,45012,State Senate,SD17,WF,Simcha Felder,2
-Kings,45013,State Senate,SD17,WF,Simcha Felder,2
-Kings,45014,State Senate,SD17,WF,Simcha Felder,2
-Kings,45018,State Senate,SD17,WF,Simcha Felder,0
-Kings,45023,State Senate,SD17,WF,Simcha Felder,3
-Kings,45024,State Senate,SD17,WF,Simcha Felder,2
-Kings,45029,State Senate,SD17,WF,Simcha Felder,0
-Kings,45030,State Senate,SD17,WF,Simcha Felder,2
-Kings,45038,State Senate,SD17,WF,Simcha Felder,1
-Kings,45039,State Senate,SD17,WF,Simcha Felder,1
-Kings,47023,State Senate,SD17,WF,Simcha Felder,2
-Kings,47024,State Senate,SD17,WF,Simcha Felder,2
-Kings,47025,State Senate,SD17,WF,Simcha Felder,1
-Kings,47026,State Senate,SD17,WF,Simcha Felder,3
-Kings,47027,State Senate,SD17,WF,Simcha Felder,2
-Kings,47028,State Senate,SD17,WF,Simcha Felder,4
-Kings,47029,State Senate,SD17,WF,Simcha Felder,1
-Kings,47030,State Senate,SD17,WF,Simcha Felder,2
-Kings,47031,State Senate,SD17,WF,Simcha Felder,2
-Kings,47032,State Senate,SD17,WF,Simcha Felder,0
-Kings,47033,State Senate,SD17,WF,Simcha Felder,1
-Kings,48001,State Senate,SD17,WF,Simcha Felder,0
-Kings,48002,State Senate,SD17,WF,Simcha Felder,4
-Kings,48003,State Senate,SD17,WF,Simcha Felder,2
-Kings,48004,State Senate,SD17,WF,Simcha Felder,2
-Kings,48005,State Senate,SD17,WF,Simcha Felder,3
-Kings,48006,State Senate,SD17,WF,Simcha Felder,1
-Kings,48007,State Senate,SD17,WF,Simcha Felder,2
-Kings,48008,State Senate,SD17,WF,Simcha Felder,0
-Kings,48009,State Senate,SD17,WF,Simcha Felder,3
-Kings,48010,State Senate,SD17,WF,Simcha Felder,1
-Kings,48011,State Senate,SD17,WF,Simcha Felder,3
-Kings,48012,State Senate,SD17,WF,Simcha Felder,6
-Kings,48013,State Senate,SD17,WF,Simcha Felder,1
-Kings,48014,State Senate,SD17,WF,Simcha Felder,1
-Kings,48015,State Senate,SD17,WF,Simcha Felder,1
-Kings,48016,State Senate,SD17,WF,Simcha Felder,2
-Kings,48017,State Senate,SD17,WF,Simcha Felder,5
-Kings,48018,State Senate,SD17,WF,Simcha Felder,4
-Kings,48019,State Senate,SD17,WF,Simcha Felder,1
-Kings,48020,State Senate,SD17,WF,Simcha Felder,3
-Kings,48021,State Senate,SD17,WF,Simcha Felder,2
-Kings,48022,State Senate,SD17,WF,Simcha Felder,0
-Kings,48023,State Senate,SD17,WF,Simcha Felder,1
-Kings,48024,State Senate,SD17,WF,Simcha Felder,1
-Kings,48025,State Senate,SD17,WF,Simcha Felder,6
-Kings,48026,State Senate,SD17,WF,Simcha Felder,3
-Kings,48027,State Senate,SD17,WF,Simcha Felder,4
-Kings,48028,State Senate,SD17,WF,Simcha Felder,5
-Kings,48029,State Senate,SD17,WF,Simcha Felder,3
-Kings,48030,State Senate,SD17,WF,Simcha Felder,1
-Kings,48031,State Senate,SD17,WF,Simcha Felder,0
-Kings,48032,State Senate,SD17,WF,Simcha Felder,6
-Kings,48033,State Senate,SD17,WF,Simcha Felder,4
-Kings,48036,State Senate,SD17,WF,Simcha Felder,2
-Kings,48038,State Senate,SD17,WF,Simcha Felder,1
-Kings,48039,State Senate,SD17,WF,Simcha Felder,1
-Kings,48040,State Senate,SD17,WF,Simcha Felder,3
-Kings,48041,State Senate,SD17,WF,Simcha Felder,1
-Kings,48042,State Senate,SD17,WF,Simcha Felder,5
-Kings,48043,State Senate,SD17,WF,Simcha Felder,6
-Kings,48044,State Senate,SD17,WF,Simcha Felder,4
-Kings,48045,State Senate,SD17,WF,Simcha Felder,3
-Kings,48049,State Senate,SD17,WF,Simcha Felder,0
-Kings,48054,State Senate,SD17,WF,Simcha Felder,2
-Kings,48055,State Senate,SD17,WF,Simcha Felder,6
-Kings,48056,State Senate,SD17,WF,Simcha Felder,1
-Kings,48057,State Senate,SD17,WF,Simcha Felder,0
-Kings,48058,State Senate,SD17,WF,Simcha Felder,4
-Kings,48060,State Senate,SD17,WF,Simcha Felder,4
-Kings,48061,State Senate,SD17,WF,Simcha Felder,9
-Kings,48062,State Senate,SD17,WF,Simcha Felder,2
-Kings,48063,State Senate,SD17,WF,Simcha Felder,2
-Kings,48064,State Senate,SD17,WF,Simcha Felder,1
-Kings,48065,State Senate,SD17,WF,Simcha Felder,1
-Kings,48066,State Senate,SD17,WF,Simcha Felder,2
-Kings,48067,State Senate,SD17,WF,Simcha Felder,0
-Kings,49006,State Senate,SD17,WF,Simcha Felder,0
-Kings,49007,State Senate,SD17,WF,Simcha Felder,0
-Kings,49008,State Senate,SD17,WF,Simcha Felder,1
-Kings,49009,State Senate,SD17,WF,Simcha Felder,2
-Kings,49010,State Senate,SD17,WF,Simcha Felder,6
-Kings,49011,State Senate,SD17,WF,Simcha Felder,3
-Kings,49012,State Senate,SD17,WF,Simcha Felder,0
-Kings,49013,State Senate,SD17,WF,Simcha Felder,2
-Kings,49030,State Senate,SD17,WF,Simcha Felder,2
-Kings,49031,State Senate,SD17,WF,Simcha Felder,0
-Kings,49032,State Senate,SD17,WF,Simcha Felder,1
-Kings,49033,State Senate,SD17,WF,Simcha Felder,0
-Kings,49042,State Senate,SD17,WF,Simcha Felder,1
-Kings,49043,State Senate,SD17,WF,Simcha Felder,1
-Kings,51001,State Senate,SD17,WF,Simcha Felder,1
-Kings,51002,State Senate,SD17,WF,Simcha Felder,2
-Kings,51003,State Senate,SD17,WF,Simcha Felder,2
-Kings,51004,State Senate,SD17,WF,Simcha Felder,1
-Kings,51005,State Senate,SD17,WF,Simcha Felder,3
-Kings,51006,State Senate,SD17,WF,Simcha Felder,2
-Kings,51014,State Senate,SD17,WF,Simcha Felder,0
-Kings,51015,State Senate,SD17,WF,Simcha Felder,5
-Kings,51016,State Senate,SD17,WF,Simcha Felder,1
-Kings,51017,State Senate,SD17,WF,Simcha Felder,1
-Kings,51018,State Senate,SD17,WF,Simcha Felder,1
-Kings,41001,State Senate,SD17,Ind,writein,0
-Kings,41002,State Senate,SD17,Ind,writein,1
-Kings,41003,State Senate,SD17,Ind,writein,2
-Kings,41004,State Senate,SD17,Ind,writein,0
-Kings,41005,State Senate,SD17,Ind,writein,0
-Kings,41006,State Senate,SD17,Ind,writein,0
-Kings,41007,State Senate,SD17,Ind,writein,2
-Kings,41008,State Senate,SD17,Ind,writein,1
-Kings,41009,State Senate,SD17,Ind,writein,2
-Kings,41010,State Senate,SD17,Ind,writein,1
-Kings,41011,State Senate,SD17,Ind,writein,1
-Kings,41012,State Senate,SD17,Ind,writein,0
-Kings,41024,State Senate,SD17,Ind,writein,0
-Kings,41050,State Senate,SD17,Ind,writein,0
-Kings,41051,State Senate,SD17,Ind,writein,0
-Kings,41052,State Senate,SD17,Ind,writein,0
-Kings,41058,State Senate,SD17,Ind,writein,0
-Kings,41059,State Senate,SD17,Ind,writein,3
-Kings,42034,State Senate,SD17,Ind,writein,7
-Kings,42035,State Senate,SD17,Ind,writein,1
-Kings,42036,State Senate,SD17,Ind,writein,3
-Kings,42037,State Senate,SD17,Ind,writein,2
-Kings,42038,State Senate,SD17,Ind,writein,1
-Kings,42061,State Senate,SD17,Ind,writein,3
-Kings,42062,State Senate,SD17,Ind,writein,0
-Kings,42063,State Senate,SD17,Ind,writein,3
-Kings,42064,State Senate,SD17,Ind,writein,0
-Kings,42065,State Senate,SD17,Ind,writein,0
-Kings,42066,State Senate,SD17,Ind,writein,1
-Kings,42067,State Senate,SD17,Ind,writein,0
-Kings,44001,State Senate,SD17,Ind,writein,1
-Kings,44002,State Senate,SD17,Ind,writein,0
-Kings,44003,State Senate,SD17,Ind,writein,0
-Kings,44004,State Senate,SD17,Ind,writein,1
-Kings,44005,State Senate,SD17,Ind,writein,1
-Kings,44006,State Senate,SD17,Ind,writein,1
-Kings,44007,State Senate,SD17,Ind,writein,3
-Kings,44008,State Senate,SD17,Ind,writein,1
-Kings,44010,State Senate,SD17,Ind,writein,0
-Kings,44013,State Senate,SD17,Ind,writein,0
-Kings,44021,State Senate,SD17,Ind,writein,0
-Kings,44023,State Senate,SD17,Ind,writein,0
-Kings,44024,State Senate,SD17,Ind,writein,3
-Kings,44025,State Senate,SD17,Ind,writein,0
-Kings,44026,State Senate,SD17,Ind,writein,0
-Kings,44027,State Senate,SD17,Ind,writein,2
-Kings,44028,State Senate,SD17,Ind,writein,4
-Kings,44029,State Senate,SD17,Ind,writein,2
-Kings,44030,State Senate,SD17,Ind,writein,0
-Kings,44031,State Senate,SD17,Ind,writein,6
-Kings,44032,State Senate,SD17,Ind,writein,0
-Kings,44033,State Senate,SD17,Ind,writein,5
-Kings,44035,State Senate,SD17,Ind,writein,9
-Kings,44038,State Senate,SD17,Ind,writein,0
-Kings,44039,State Senate,SD17,Ind,writein,4
-Kings,44041,State Senate,SD17,Ind,writein,0
-Kings,44042,State Senate,SD17,Ind,writein,8
-Kings,44043,State Senate,SD17,Ind,writein,4
-Kings,44044,State Senate,SD17,Ind,writein,8
-Kings,44045,State Senate,SD17,Ind,writein,2
-Kings,45001,State Senate,SD17,Ind,writein,0
-Kings,45002,State Senate,SD17,Ind,writein,2
-Kings,45003,State Senate,SD17,Ind,writein,0
-Kings,45004,State Senate,SD17,Ind,writein,0
-Kings,45005,State Senate,SD17,Ind,writein,1
-Kings,45007,State Senate,SD17,Ind,writein,0
-Kings,45010,State Senate,SD17,Ind,writein,0
-Kings,45011,State Senate,SD17,Ind,writein,0
-Kings,45012,State Senate,SD17,Ind,writein,1
-Kings,45013,State Senate,SD17,Ind,writein,3
-Kings,45014,State Senate,SD17,Ind,writein,1
-Kings,45018,State Senate,SD17,Ind,writein,0
-Kings,45023,State Senate,SD17,Ind,writein,0
-Kings,45024,State Senate,SD17,Ind,writein,0
-Kings,45029,State Senate,SD17,Ind,writein,1
-Kings,45030,State Senate,SD17,Ind,writein,0
-Kings,45038,State Senate,SD17,Ind,writein,1
-Kings,45039,State Senate,SD17,Ind,writein,0
-Kings,47023,State Senate,SD17,Ind,writein,0
-Kings,47024,State Senate,SD17,Ind,writein,0
-Kings,47025,State Senate,SD17,Ind,writein,0
-Kings,47026,State Senate,SD17,Ind,writein,1
-Kings,47027,State Senate,SD17,Ind,writein,1
-Kings,47028,State Senate,SD17,Ind,writein,0
-Kings,47029,State Senate,SD17,Ind,writein,0
-Kings,47030,State Senate,SD17,Ind,writein,0
-Kings,47031,State Senate,SD17,Ind,writein,0
-Kings,47032,State Senate,SD17,Ind,writein,0
-Kings,47033,State Senate,SD17,Ind,writein,0
-Kings,48001,State Senate,SD17,Ind,writein,0
-Kings,48002,State Senate,SD17,Ind,writein,0
-Kings,48003,State Senate,SD17,Ind,writein,1
-Kings,48004,State Senate,SD17,Ind,writein,1
-Kings,48005,State Senate,SD17,Ind,writein,2
-Kings,48006,State Senate,SD17,Ind,writein,0
-Kings,48007,State Senate,SD17,Ind,writein,0
-Kings,48008,State Senate,SD17,Ind,writein,0
-Kings,48009,State Senate,SD17,Ind,writein,1
-Kings,48010,State Senate,SD17,Ind,writein,1
-Kings,48011,State Senate,SD17,Ind,writein,0
-Kings,48012,State Senate,SD17,Ind,writein,0
-Kings,48013,State Senate,SD17,Ind,writein,0
-Kings,48014,State Senate,SD17,Ind,writein,0
-Kings,48015,State Senate,SD17,Ind,writein,0
-Kings,48016,State Senate,SD17,Ind,writein,1
-Kings,48017,State Senate,SD17,Ind,writein,0
-Kings,48018,State Senate,SD17,Ind,writein,2
-Kings,48019,State Senate,SD17,Ind,writein,0
-Kings,48020,State Senate,SD17,Ind,writein,0
-Kings,48021,State Senate,SD17,Ind,writein,0
-Kings,48022,State Senate,SD17,Ind,writein,2
-Kings,48023,State Senate,SD17,Ind,writein,1
-Kings,48024,State Senate,SD17,Ind,writein,0
-Kings,48025,State Senate,SD17,Ind,writein,0
-Kings,48026,State Senate,SD17,Ind,writein,3
-Kings,48027,State Senate,SD17,Ind,writein,0
-Kings,48028,State Senate,SD17,Ind,writein,1
-Kings,48029,State Senate,SD17,Ind,writein,0
-Kings,48030,State Senate,SD17,Ind,writein,0
-Kings,48031,State Senate,SD17,Ind,writein,0
-Kings,48032,State Senate,SD17,Ind,writein,0
-Kings,48033,State Senate,SD17,Ind,writein,1
-Kings,48036,State Senate,SD17,Ind,writein,0
-Kings,48038,State Senate,SD17,Ind,writein,0
-Kings,48039,State Senate,SD17,Ind,writein,0
-Kings,48040,State Senate,SD17,Ind,writein,1
-Kings,48041,State Senate,SD17,Ind,writein,0
-Kings,48042,State Senate,SD17,Ind,writein,0
-Kings,48043,State Senate,SD17,Ind,writein,0
-Kings,48044,State Senate,SD17,Ind,writein,0
-Kings,48045,State Senate,SD17,Ind,writein,1
-Kings,48049,State Senate,SD17,Ind,writein,0
-Kings,48054,State Senate,SD17,Ind,writein,0
-Kings,48055,State Senate,SD17,Ind,writein,2
-Kings,48056,State Senate,SD17,Ind,writein,0
-Kings,48057,State Senate,SD17,Ind,writein,0
-Kings,48058,State Senate,SD17,Ind,writein,0
-Kings,48060,State Senate,SD17,Ind,writein,0
-Kings,48061,State Senate,SD17,Ind,writein,0
-Kings,48062,State Senate,SD17,Ind,writein,1
-Kings,48063,State Senate,SD17,Ind,writein,0
-Kings,48064,State Senate,SD17,Ind,writein,0
-Kings,48065,State Senate,SD17,Ind,writein,3
-Kings,48066,State Senate,SD17,Ind,writein,0
-Kings,48067,State Senate,SD17,Ind,writein,0
-Kings,49006,State Senate,SD17,Ind,writein,0
-Kings,49007,State Senate,SD17,Ind,writein,0
-Kings,49008,State Senate,SD17,Ind,writein,0
-Kings,49009,State Senate,SD17,Ind,writein,0
-Kings,49010,State Senate,SD17,Ind,writein,0
-Kings,49011,State Senate,SD17,Ind,writein,0
-Kings,49012,State Senate,SD17,Ind,writein,0
-Kings,49013,State Senate,SD17,Ind,writein,0
-Kings,49030,State Senate,SD17,Ind,writein,0
-Kings,49031,State Senate,SD17,Ind,writein,3
-Kings,49032,State Senate,SD17,Ind,writein,0
-Kings,49033,State Senate,SD17,Ind,writein,0
-Kings,49042,State Senate,SD17,Ind,writein,0
-Kings,49043,State Senate,SD17,Ind,writein,0
-Kings,51001,State Senate,SD17,Ind,writein,4
-Kings,51002,State Senate,SD17,Ind,writein,2
-Kings,51003,State Senate,SD17,Ind,writein,2
-Kings,51004,State Senate,SD17,Ind,writein,3
-Kings,51005,State Senate,SD17,Ind,writein,1
-Kings,51006,State Senate,SD17,Ind,writein,0
-Kings,51014,State Senate,SD17,Ind,writein,0
-Kings,51015,State Senate,SD17,Ind,writein,3
-Kings,51016,State Senate,SD17,Ind,writein,0
-Kings,51017,State Senate,SD17,Ind,writein,1
-Kings,51018,State Senate,SD17,Ind,writein,0
-Kings,50001,State Senate,SD18,Dem,Martin Dilan,47
-Kings,50003,State Senate,SD18,Dem,Martin Dilan,254
-Kings,50004,State Senate,SD18,Dem,Martin Dilan,79
-Kings,50005,State Senate,SD18,Dem,Martin Dilan,468
-Kings,50006,State Senate,SD18,Dem,Martin Dilan,425
-Kings,50007,State Senate,SD18,Dem,Martin Dilan,495
-Kings,50008,State Senate,SD18,Dem,Martin Dilan,389
-Kings,50009,State Senate,SD18,Dem,Martin Dilan,355
-Kings,50010,State Senate,SD18,Dem,Martin Dilan,95
-Kings,50012,State Senate,SD18,Dem,Martin Dilan,405
-Kings,50015,State Senate,SD18,Dem,Martin Dilan,188
-Kings,50016,State Senate,SD18,Dem,Martin Dilan,396
-Kings,50017,State Senate,SD18,Dem,Martin Dilan,423
-Kings,50018,State Senate,SD18,Dem,Martin Dilan,324
-Kings,50019,State Senate,SD18,Dem,Martin Dilan,560
-Kings,50020,State Senate,SD18,Dem,Martin Dilan,412
-Kings,50021,State Senate,SD18,Dem,Martin Dilan,405
-Kings,50022,State Senate,SD18,Dem,Martin Dilan,258
-Kings,50025,State Senate,SD18,Dem,Martin Dilan,92
-Kings,50043,State Senate,SD18,Dem,Martin Dilan,280
-Kings,50044,State Senate,SD18,Dem,Martin Dilan,584
-Kings,50045,State Senate,SD18,Dem,Martin Dilan,117
-Kings,50046,State Senate,SD18,Dem,Martin Dilan,363
-Kings,50049,State Senate,SD18,Dem,Martin Dilan,474
-Kings,50050,State Senate,SD18,Dem,Martin Dilan,336
-Kings,50051,State Senate,SD18,Dem,Martin Dilan,342
-Kings,50052,State Senate,SD18,Dem,Martin Dilan,467
-Kings,50053,State Senate,SD18,Dem,Martin Dilan,212
-Kings,50054,State Senate,SD18,Dem,Martin Dilan,216
-Kings,50056,State Senate,SD18,Dem,Martin Dilan,124
-Kings,50057,State Senate,SD18,Dem,Martin Dilan,192
-Kings,50058,State Senate,SD18,Dem,Martin Dilan,160
-Kings,50059,State Senate,SD18,Dem,Martin Dilan,293
-Kings,50060,State Senate,SD18,Dem,Martin Dilan,293
-Kings,50061,State Senate,SD18,Dem,Martin Dilan,209
-Kings,50062,State Senate,SD18,Dem,Martin Dilan,352
-Kings,50063,State Senate,SD18,Dem,Martin Dilan,158
-Kings,50081,State Senate,SD18,Dem,Martin Dilan,68
-Kings,53001,State Senate,SD18,Dem,Martin Dilan,453
-Kings,53002,State Senate,SD18,Dem,Martin Dilan,314
-Kings,53003,State Senate,SD18,Dem,Martin Dilan,399
-Kings,53004,State Senate,SD18,Dem,Martin Dilan,336
-Kings,53005,State Senate,SD18,Dem,Martin Dilan,375
-Kings,53006,State Senate,SD18,Dem,Martin Dilan,44
-Kings,53007,State Senate,SD18,Dem,Martin Dilan,347
-Kings,53008,State Senate,SD18,Dem,Martin Dilan,328
-Kings,53009,State Senate,SD18,Dem,Martin Dilan,354
-Kings,53010,State Senate,SD18,Dem,Martin Dilan,447
-Kings,53011,State Senate,SD18,Dem,Martin Dilan,394
-Kings,53012,State Senate,SD18,Dem,Martin Dilan,355
-Kings,53013,State Senate,SD18,Dem,Martin Dilan,181
-Kings,53015,State Senate,SD18,Dem,Martin Dilan,395
-Kings,53016,State Senate,SD18,Dem,Martin Dilan,401
-Kings,53017,State Senate,SD18,Dem,Martin Dilan,519
-Kings,53018,State Senate,SD18,Dem,Martin Dilan,329
-Kings,53019,State Senate,SD18,Dem,Martin Dilan,489
-Kings,53020,State Senate,SD18,Dem,Martin Dilan,430
-Kings,53021,State Senate,SD18,Dem,Martin Dilan,464
-Kings,53022,State Senate,SD18,Dem,Martin Dilan,412
-Kings,53023,State Senate,SD18,Dem,Martin Dilan,287
-Kings,53024,State Senate,SD18,Dem,Martin Dilan,492
-Kings,53025,State Senate,SD18,Dem,Martin Dilan,503
-Kings,53026,State Senate,SD18,Dem,Martin Dilan,267
-Kings,53027,State Senate,SD18,Dem,Martin Dilan,314
-Kings,53028,State Senate,SD18,Dem,Martin Dilan,387
-Kings,53029,State Senate,SD18,Dem,Martin Dilan,238
-Kings,53030,State Senate,SD18,Dem,Martin Dilan,506
-Kings,53031,State Senate,SD18,Dem,Martin Dilan,406
-Kings,53032,State Senate,SD18,Dem,Martin Dilan,400
-Kings,53033,State Senate,SD18,Dem,Martin Dilan,425
-Kings,53034,State Senate,SD18,Dem,Martin Dilan,319
-Kings,53035,State Senate,SD18,Dem,Martin Dilan,454
-Kings,53036,State Senate,SD18,Dem,Martin Dilan,470
-Kings,53037,State Senate,SD18,Dem,Martin Dilan,236
-Kings,53038,State Senate,SD18,Dem,Martin Dilan,144
-Kings,53039,State Senate,SD18,Dem,Martin Dilan,288
-Kings,53040,State Senate,SD18,Dem,Martin Dilan,246
-Kings,53041,State Senate,SD18,Dem,Martin Dilan,380
-Kings,53042,State Senate,SD18,Dem,Martin Dilan,354
-Kings,53043,State Senate,SD18,Dem,Martin Dilan,334
-Kings,53044,State Senate,SD18,Dem,Martin Dilan,400
-Kings,53045,State Senate,SD18,Dem,Martin Dilan,412
-Kings,53046,State Senate,SD18,Dem,Martin Dilan,400
-Kings,53047,State Senate,SD18,Dem,Martin Dilan,472
-Kings,53048,State Senate,SD18,Dem,Martin Dilan,386
-Kings,53050,State Senate,SD18,Dem,Martin Dilan,46
-Kings,53052,State Senate,SD18,Dem,Martin Dilan,27
-Kings,53053,State Senate,SD18,Dem,Martin Dilan,318
-Kings,53054,State Senate,SD18,Dem,Martin Dilan,311
-Kings,53055,State Senate,SD18,Dem,Martin Dilan,271
-Kings,53056,State Senate,SD18,Dem,Martin Dilan,575
-Kings,53057,State Senate,SD18,Dem,Martin Dilan,462
-Kings,53058,State Senate,SD18,Dem,Martin Dilan,285
-Kings,53059,State Senate,SD18,Dem,Martin Dilan,457
-Kings,53060,State Senate,SD18,Dem,Martin Dilan,564
-Kings,53061,State Senate,SD18,Dem,Martin Dilan,394
-Kings,53062,State Senate,SD18,Dem,Martin Dilan,127
-Kings,53063,State Senate,SD18,Dem,Martin Dilan,476
-Kings,53064,State Senate,SD18,Dem,Martin Dilan,339
-Kings,53065,State Senate,SD18,Dem,Martin Dilan,246
-Kings,53066,State Senate,SD18,Dem,Martin Dilan,376
-Kings,53067,State Senate,SD18,Dem,Martin Dilan,370
-Kings,53068,State Senate,SD18,Dem,Martin Dilan,350
-Kings,53069,State Senate,SD18,Dem,Martin Dilan,253
-Kings,53070,State Senate,SD18,Dem,Martin Dilan,465
-Kings,53071,State Senate,SD18,Dem,Martin Dilan,313
-Kings,53072,State Senate,SD18,Dem,Martin Dilan,367
-Kings,53073,State Senate,SD18,Dem,Martin Dilan,440
-Kings,53074,State Senate,SD18,Dem,Martin Dilan,285
-Kings,53075,State Senate,SD18,Dem,Martin Dilan,264
-Kings,53076,State Senate,SD18,Dem,Martin Dilan,278
-Kings,53077,State Senate,SD18,Dem,Martin Dilan,318
-Kings,53079,State Senate,SD18,Dem,Martin Dilan,181
-Kings,53080,State Senate,SD18,Dem,Martin Dilan,415
-Kings,53082,State Senate,SD18,Dem,Martin Dilan,163
-Kings,53083,State Senate,SD18,Dem,Martin Dilan,178
-Kings,54001,State Senate,SD18,Dem,Martin Dilan,125
-Kings,54007,State Senate,SD18,Dem,Martin Dilan,458
-Kings,54008,State Senate,SD18,Dem,Martin Dilan,469
-Kings,54009,State Senate,SD18,Dem,Martin Dilan,256
-Kings,54010,State Senate,SD18,Dem,Martin Dilan,507
-Kings,54011,State Senate,SD18,Dem,Martin Dilan,543
-Kings,54012,State Senate,SD18,Dem,Martin Dilan,251
-Kings,54013,State Senate,SD18,Dem,Martin Dilan,401
-Kings,54014,State Senate,SD18,Dem,Martin Dilan,43
-Kings,54016,State Senate,SD18,Dem,Martin Dilan,35
-Kings,54017,State Senate,SD18,Dem,Martin Dilan,75
-Kings,54018,State Senate,SD18,Dem,Martin Dilan,27
-Kings,54019,State Senate,SD18,Dem,Martin Dilan,523
-Kings,54020,State Senate,SD18,Dem,Martin Dilan,436
-Kings,54021,State Senate,SD18,Dem,Martin Dilan,312
-Kings,54022,State Senate,SD18,Dem,Martin Dilan,388
-Kings,54023,State Senate,SD18,Dem,Martin Dilan,332
-Kings,54024,State Senate,SD18,Dem,Martin Dilan,249
-Kings,54025,State Senate,SD18,Dem,Martin Dilan,206
-Kings,54027,State Senate,SD18,Dem,Martin Dilan,352
-Kings,54028,State Senate,SD18,Dem,Martin Dilan,353
-Kings,54029,State Senate,SD18,Dem,Martin Dilan,417
-Kings,54030,State Senate,SD18,Dem,Martin Dilan,406
-Kings,54031,State Senate,SD18,Dem,Martin Dilan,147
-Kings,54032,State Senate,SD18,Dem,Martin Dilan,391
-Kings,54033,State Senate,SD18,Dem,Martin Dilan,374
-Kings,54034,State Senate,SD18,Dem,Martin Dilan,468
-Kings,54035,State Senate,SD18,Dem,Martin Dilan,440
-Kings,54036,State Senate,SD18,Dem,Martin Dilan,462
-Kings,54037,State Senate,SD18,Dem,Martin Dilan,433
-Kings,54038,State Senate,SD18,Dem,Martin Dilan,367
-Kings,54039,State Senate,SD18,Dem,Martin Dilan,449
-Kings,54040,State Senate,SD18,Dem,Martin Dilan,94
-Kings,54041,State Senate,SD18,Dem,Martin Dilan,371
-Kings,54042,State Senate,SD18,Dem,Martin Dilan,422
-Kings,54043,State Senate,SD18,Dem,Martin Dilan,437
-Kings,54044,State Senate,SD18,Dem,Martin Dilan,377
-Kings,54045,State Senate,SD18,Dem,Martin Dilan,443
-Kings,54046,State Senate,SD18,Dem,Martin Dilan,470
-Kings,54047,State Senate,SD18,Dem,Martin Dilan,348
-Kings,54048,State Senate,SD18,Dem,Martin Dilan,376
-Kings,54049,State Senate,SD18,Dem,Martin Dilan,467
-Kings,54050,State Senate,SD18,Dem,Martin Dilan,450
-Kings,54051,State Senate,SD18,Dem,Martin Dilan,396
-Kings,54052,State Senate,SD18,Dem,Martin Dilan,261
-Kings,54053,State Senate,SD18,Dem,Martin Dilan,251
-Kings,54054,State Senate,SD18,Dem,Martin Dilan,363
-Kings,54055,State Senate,SD18,Dem,Martin Dilan,362
-Kings,54056,State Senate,SD18,Dem,Martin Dilan,411
-Kings,54057,State Senate,SD18,Dem,Martin Dilan,390
-Kings,54058,State Senate,SD18,Dem,Martin Dilan,453
-Kings,54059,State Senate,SD18,Dem,Martin Dilan,400
-Kings,54060,State Senate,SD18,Dem,Martin Dilan,501
-Kings,54061,State Senate,SD18,Dem,Martin Dilan,484
-Kings,54062,State Senate,SD18,Dem,Martin Dilan,437
-Kings,54063,State Senate,SD18,Dem,Martin Dilan,454
-Kings,54064,State Senate,SD18,Dem,Martin Dilan,504
-Kings,54065,State Senate,SD18,Dem,Martin Dilan,411
-Kings,54066,State Senate,SD18,Dem,Martin Dilan,160
-Kings,54067,State Senate,SD18,Dem,Martin Dilan,368
-Kings,54068,State Senate,SD18,Dem,Martin Dilan,485
-Kings,54069,State Senate,SD18,Dem,Martin Dilan,360
-Kings,54070,State Senate,SD18,Dem,Martin Dilan,241
-Kings,54073,State Senate,SD18,Dem,Martin Dilan,326
-Kings,54074,State Senate,SD18,Dem,Martin Dilan,52
-Kings,54078,State Senate,SD18,Dem,Martin Dilan,1
-Kings,55003,State Senate,SD18,Dem,Martin Dilan,83
-Kings,55006,State Senate,SD18,Dem,Martin Dilan,235
-Kings,55007,State Senate,SD18,Dem,Martin Dilan,444
-Kings,55014,State Senate,SD18,Dem,Martin Dilan,368
-Kings,55015,State Senate,SD18,Dem,Martin Dilan,26
-Kings,55016,State Senate,SD18,Dem,Martin Dilan,415
-Kings,55026,State Senate,SD18,Dem,Martin Dilan,97
-Kings,55041,State Senate,SD18,Dem,Martin Dilan,195
-Kings,55045,State Senate,SD18,Dem,Martin Dilan,332
-Kings,55046,State Senate,SD18,Dem,Martin Dilan,378
-Kings,55050,State Senate,SD18,Dem,Martin Dilan,103
-Kings,55051,State Senate,SD18,Dem,Martin Dilan,59
-Kings,56001,State Senate,SD18,Dem,Martin Dilan,469
-Kings,56002,State Senate,SD18,Dem,Martin Dilan,315
-Kings,56003,State Senate,SD18,Dem,Martin Dilan,303
-Kings,56004,State Senate,SD18,Dem,Martin Dilan,363
-Kings,56006,State Senate,SD18,Dem,Martin Dilan,344
-Kings,56007,State Senate,SD18,Dem,Martin Dilan,446
-Kings,56008,State Senate,SD18,Dem,Martin Dilan,486
-Kings,56009,State Senate,SD18,Dem,Martin Dilan,280
-Kings,56010,State Senate,SD18,Dem,Martin Dilan,534
-Kings,56011,State Senate,SD18,Dem,Martin Dilan,376
-Kings,56017,State Senate,SD18,Dem,Martin Dilan,347
-Kings,56020,State Senate,SD18,Dem,Martin Dilan,256
-Kings,60004,State Senate,SD18,Dem,Martin Dilan,77
-Kings,60006,State Senate,SD18,Dem,Martin Dilan,138
-Kings,60010,State Senate,SD18,Dem,Martin Dilan,190
-Kings,60011,State Senate,SD18,Dem,Martin Dilan,60
-Kings,60013,State Senate,SD18,Dem,Martin Dilan,56
-Kings,60016,State Senate,SD18,Dem,Martin Dilan,238
-Kings,60018,State Senate,SD18,Dem,Martin Dilan,362
-Kings,60019,State Senate,SD18,Dem,Martin Dilan,217
-Kings,60020,State Senate,SD18,Dem,Martin Dilan,79
-Kings,50001,State Senate,SD18,Rep,Michael Freeman-Saulsberry,1
-Kings,50003,State Senate,SD18,Rep,Michael Freeman-Saulsberry,17
-Kings,50004,State Senate,SD18,Rep,Michael Freeman-Saulsberry,3
-Kings,50005,State Senate,SD18,Rep,Michael Freeman-Saulsberry,36
-Kings,50006,State Senate,SD18,Rep,Michael Freeman-Saulsberry,34
-Kings,50007,State Senate,SD18,Rep,Michael Freeman-Saulsberry,51
-Kings,50008,State Senate,SD18,Rep,Michael Freeman-Saulsberry,34
-Kings,50009,State Senate,SD18,Rep,Michael Freeman-Saulsberry,49
-Kings,50010,State Senate,SD18,Rep,Michael Freeman-Saulsberry,8
-Kings,50012,State Senate,SD18,Rep,Michael Freeman-Saulsberry,58
-Kings,50015,State Senate,SD18,Rep,Michael Freeman-Saulsberry,20
-Kings,50016,State Senate,SD18,Rep,Michael Freeman-Saulsberry,11
-Kings,50017,State Senate,SD18,Rep,Michael Freeman-Saulsberry,19
-Kings,50018,State Senate,SD18,Rep,Michael Freeman-Saulsberry,53
-Kings,50019,State Senate,SD18,Rep,Michael Freeman-Saulsberry,62
-Kings,50020,State Senate,SD18,Rep,Michael Freeman-Saulsberry,34
-Kings,50021,State Senate,SD18,Rep,Michael Freeman-Saulsberry,58
-Kings,50022,State Senate,SD18,Rep,Michael Freeman-Saulsberry,34
-Kings,50025,State Senate,SD18,Rep,Michael Freeman-Saulsberry,5
-Kings,50043,State Senate,SD18,Rep,Michael Freeman-Saulsberry,25
-Kings,50044,State Senate,SD18,Rep,Michael Freeman-Saulsberry,49
-Kings,50045,State Senate,SD18,Rep,Michael Freeman-Saulsberry,9
-Kings,50046,State Senate,SD18,Rep,Michael Freeman-Saulsberry,19
-Kings,50049,State Senate,SD18,Rep,Michael Freeman-Saulsberry,23
-Kings,50050,State Senate,SD18,Rep,Michael Freeman-Saulsberry,26
-Kings,50051,State Senate,SD18,Rep,Michael Freeman-Saulsberry,18
-Kings,50052,State Senate,SD18,Rep,Michael Freeman-Saulsberry,19
-Kings,50053,State Senate,SD18,Rep,Michael Freeman-Saulsberry,6
-Kings,50054,State Senate,SD18,Rep,Michael Freeman-Saulsberry,8
-Kings,50056,State Senate,SD18,Rep,Michael Freeman-Saulsberry,6
-Kings,50057,State Senate,SD18,Rep,Michael Freeman-Saulsberry,18
-Kings,50058,State Senate,SD18,Rep,Michael Freeman-Saulsberry,26
-Kings,50059,State Senate,SD18,Rep,Michael Freeman-Saulsberry,40
-Kings,50060,State Senate,SD18,Rep,Michael Freeman-Saulsberry,32
-Kings,50061,State Senate,SD18,Rep,Michael Freeman-Saulsberry,25
-Kings,50062,State Senate,SD18,Rep,Michael Freeman-Saulsberry,36
-Kings,50063,State Senate,SD18,Rep,Michael Freeman-Saulsberry,27
-Kings,50081,State Senate,SD18,Rep,Michael Freeman-Saulsberry,6
-Kings,53001,State Senate,SD18,Rep,Michael Freeman-Saulsberry,16
-Kings,53002,State Senate,SD18,Rep,Michael Freeman-Saulsberry,9
-Kings,53003,State Senate,SD18,Rep,Michael Freeman-Saulsberry,9
-Kings,53004,State Senate,SD18,Rep,Michael Freeman-Saulsberry,14
-Kings,53005,State Senate,SD18,Rep,Michael Freeman-Saulsberry,13
-Kings,53006,State Senate,SD18,Rep,Michael Freeman-Saulsberry,4
-Kings,53007,State Senate,SD18,Rep,Michael Freeman-Saulsberry,14
-Kings,53008,State Senate,SD18,Rep,Michael Freeman-Saulsberry,11
-Kings,53009,State Senate,SD18,Rep,Michael Freeman-Saulsberry,10
-Kings,53010,State Senate,SD18,Rep,Michael Freeman-Saulsberry,20
-Kings,53011,State Senate,SD18,Rep,Michael Freeman-Saulsberry,12
-Kings,53012,State Senate,SD18,Rep,Michael Freeman-Saulsberry,14
-Kings,53013,State Senate,SD18,Rep,Michael Freeman-Saulsberry,4
-Kings,53015,State Senate,SD18,Rep,Michael Freeman-Saulsberry,36
-Kings,53016,State Senate,SD18,Rep,Michael Freeman-Saulsberry,14
-Kings,53017,State Senate,SD18,Rep,Michael Freeman-Saulsberry,21
-Kings,53018,State Senate,SD18,Rep,Michael Freeman-Saulsberry,21
-Kings,53019,State Senate,SD18,Rep,Michael Freeman-Saulsberry,57
-Kings,53020,State Senate,SD18,Rep,Michael Freeman-Saulsberry,50
-Kings,53021,State Senate,SD18,Rep,Michael Freeman-Saulsberry,15
-Kings,53022,State Senate,SD18,Rep,Michael Freeman-Saulsberry,16
-Kings,53023,State Senate,SD18,Rep,Michael Freeman-Saulsberry,7
-Kings,53024,State Senate,SD18,Rep,Michael Freeman-Saulsberry,29
-Kings,53025,State Senate,SD18,Rep,Michael Freeman-Saulsberry,26
-Kings,53026,State Senate,SD18,Rep,Michael Freeman-Saulsberry,6
-Kings,53027,State Senate,SD18,Rep,Michael Freeman-Saulsberry,16
-Kings,53028,State Senate,SD18,Rep,Michael Freeman-Saulsberry,15
-Kings,53029,State Senate,SD18,Rep,Michael Freeman-Saulsberry,8
-Kings,53030,State Senate,SD18,Rep,Michael Freeman-Saulsberry,15
-Kings,53031,State Senate,SD18,Rep,Michael Freeman-Saulsberry,12
-Kings,53032,State Senate,SD18,Rep,Michael Freeman-Saulsberry,8
-Kings,53033,State Senate,SD18,Rep,Michael Freeman-Saulsberry,33
-Kings,53034,State Senate,SD18,Rep,Michael Freeman-Saulsberry,26
-Kings,53035,State Senate,SD18,Rep,Michael Freeman-Saulsberry,31
-Kings,53036,State Senate,SD18,Rep,Michael Freeman-Saulsberry,44
-Kings,53037,State Senate,SD18,Rep,Michael Freeman-Saulsberry,19
-Kings,53038,State Senate,SD18,Rep,Michael Freeman-Saulsberry,6
-Kings,53039,State Senate,SD18,Rep,Michael Freeman-Saulsberry,8
-Kings,53040,State Senate,SD18,Rep,Michael Freeman-Saulsberry,4
-Kings,53041,State Senate,SD18,Rep,Michael Freeman-Saulsberry,12
-Kings,53042,State Senate,SD18,Rep,Michael Freeman-Saulsberry,7
-Kings,53043,State Senate,SD18,Rep,Michael Freeman-Saulsberry,2
-Kings,53044,State Senate,SD18,Rep,Michael Freeman-Saulsberry,16
-Kings,53045,State Senate,SD18,Rep,Michael Freeman-Saulsberry,20
-Kings,53046,State Senate,SD18,Rep,Michael Freeman-Saulsberry,11
-Kings,53047,State Senate,SD18,Rep,Michael Freeman-Saulsberry,8
-Kings,53048,State Senate,SD18,Rep,Michael Freeman-Saulsberry,10
-Kings,53050,State Senate,SD18,Rep,Michael Freeman-Saulsberry,3
-Kings,53052,State Senate,SD18,Rep,Michael Freeman-Saulsberry,2
-Kings,53053,State Senate,SD18,Rep,Michael Freeman-Saulsberry,18
-Kings,53054,State Senate,SD18,Rep,Michael Freeman-Saulsberry,16
-Kings,53055,State Senate,SD18,Rep,Michael Freeman-Saulsberry,17
-Kings,53056,State Senate,SD18,Rep,Michael Freeman-Saulsberry,20
-Kings,53057,State Senate,SD18,Rep,Michael Freeman-Saulsberry,15
-Kings,53058,State Senate,SD18,Rep,Michael Freeman-Saulsberry,9
-Kings,53059,State Senate,SD18,Rep,Michael Freeman-Saulsberry,20
-Kings,53060,State Senate,SD18,Rep,Michael Freeman-Saulsberry,32
-Kings,53061,State Senate,SD18,Rep,Michael Freeman-Saulsberry,9
-Kings,53062,State Senate,SD18,Rep,Michael Freeman-Saulsberry,2
-Kings,53063,State Senate,SD18,Rep,Michael Freeman-Saulsberry,24
-Kings,53064,State Senate,SD18,Rep,Michael Freeman-Saulsberry,23
-Kings,53065,State Senate,SD18,Rep,Michael Freeman-Saulsberry,48
-Kings,53066,State Senate,SD18,Rep,Michael Freeman-Saulsberry,27
-Kings,53067,State Senate,SD18,Rep,Michael Freeman-Saulsberry,37
-Kings,53068,State Senate,SD18,Rep,Michael Freeman-Saulsberry,29
-Kings,53069,State Senate,SD18,Rep,Michael Freeman-Saulsberry,15
-Kings,53070,State Senate,SD18,Rep,Michael Freeman-Saulsberry,22
-Kings,53071,State Senate,SD18,Rep,Michael Freeman-Saulsberry,11
-Kings,53072,State Senate,SD18,Rep,Michael Freeman-Saulsberry,22
-Kings,53073,State Senate,SD18,Rep,Michael Freeman-Saulsberry,11
-Kings,53074,State Senate,SD18,Rep,Michael Freeman-Saulsberry,8
-Kings,53075,State Senate,SD18,Rep,Michael Freeman-Saulsberry,7
-Kings,53076,State Senate,SD18,Rep,Michael Freeman-Saulsberry,19
-Kings,53077,State Senate,SD18,Rep,Michael Freeman-Saulsberry,6
-Kings,53079,State Senate,SD18,Rep,Michael Freeman-Saulsberry,7
-Kings,53080,State Senate,SD18,Rep,Michael Freeman-Saulsberry,16
-Kings,53082,State Senate,SD18,Rep,Michael Freeman-Saulsberry,4
-Kings,53083,State Senate,SD18,Rep,Michael Freeman-Saulsberry,4
-Kings,54001,State Senate,SD18,Rep,Michael Freeman-Saulsberry,3
-Kings,54007,State Senate,SD18,Rep,Michael Freeman-Saulsberry,5
-Kings,54008,State Senate,SD18,Rep,Michael Freeman-Saulsberry,4
-Kings,54009,State Senate,SD18,Rep,Michael Freeman-Saulsberry,8
-Kings,54010,State Senate,SD18,Rep,Michael Freeman-Saulsberry,11
-Kings,54011,State Senate,SD18,Rep,Michael Freeman-Saulsberry,5
-Kings,54012,State Senate,SD18,Rep,Michael Freeman-Saulsberry,5
-Kings,54013,State Senate,SD18,Rep,Michael Freeman-Saulsberry,12
-Kings,54014,State Senate,SD18,Rep,Michael Freeman-Saulsberry,0
-Kings,54016,State Senate,SD18,Rep,Michael Freeman-Saulsberry,1
-Kings,54017,State Senate,SD18,Rep,Michael Freeman-Saulsberry,1
-Kings,54018,State Senate,SD18,Rep,Michael Freeman-Saulsberry,0
-Kings,54019,State Senate,SD18,Rep,Michael Freeman-Saulsberry,15
-Kings,54020,State Senate,SD18,Rep,Michael Freeman-Saulsberry,17
-Kings,54021,State Senate,SD18,Rep,Michael Freeman-Saulsberry,6
-Kings,54022,State Senate,SD18,Rep,Michael Freeman-Saulsberry,17
-Kings,54023,State Senate,SD18,Rep,Michael Freeman-Saulsberry,14
-Kings,54024,State Senate,SD18,Rep,Michael Freeman-Saulsberry,12
-Kings,54025,State Senate,SD18,Rep,Michael Freeman-Saulsberry,11
-Kings,54027,State Senate,SD18,Rep,Michael Freeman-Saulsberry,7
-Kings,54028,State Senate,SD18,Rep,Michael Freeman-Saulsberry,12
-Kings,54029,State Senate,SD18,Rep,Michael Freeman-Saulsberry,10
-Kings,54030,State Senate,SD18,Rep,Michael Freeman-Saulsberry,6
-Kings,54031,State Senate,SD18,Rep,Michael Freeman-Saulsberry,3
-Kings,54032,State Senate,SD18,Rep,Michael Freeman-Saulsberry,12
-Kings,54033,State Senate,SD18,Rep,Michael Freeman-Saulsberry,6
-Kings,54034,State Senate,SD18,Rep,Michael Freeman-Saulsberry,6
-Kings,54035,State Senate,SD18,Rep,Michael Freeman-Saulsberry,8
-Kings,54036,State Senate,SD18,Rep,Michael Freeman-Saulsberry,9
-Kings,54037,State Senate,SD18,Rep,Michael Freeman-Saulsberry,16
-Kings,54038,State Senate,SD18,Rep,Michael Freeman-Saulsberry,12
-Kings,54039,State Senate,SD18,Rep,Michael Freeman-Saulsberry,19
-Kings,54040,State Senate,SD18,Rep,Michael Freeman-Saulsberry,4
-Kings,54041,State Senate,SD18,Rep,Michael Freeman-Saulsberry,6
-Kings,54042,State Senate,SD18,Rep,Michael Freeman-Saulsberry,19
-Kings,54043,State Senate,SD18,Rep,Michael Freeman-Saulsberry,20
-Kings,54044,State Senate,SD18,Rep,Michael Freeman-Saulsberry,18
-Kings,54045,State Senate,SD18,Rep,Michael Freeman-Saulsberry,18
-Kings,54046,State Senate,SD18,Rep,Michael Freeman-Saulsberry,24
-Kings,54047,State Senate,SD18,Rep,Michael Freeman-Saulsberry,15
-Kings,54048,State Senate,SD18,Rep,Michael Freeman-Saulsberry,16
-Kings,54049,State Senate,SD18,Rep,Michael Freeman-Saulsberry,17
-Kings,54050,State Senate,SD18,Rep,Michael Freeman-Saulsberry,22
-Kings,54051,State Senate,SD18,Rep,Michael Freeman-Saulsberry,18
-Kings,54052,State Senate,SD18,Rep,Michael Freeman-Saulsberry,24
-Kings,54053,State Senate,SD18,Rep,Michael Freeman-Saulsberry,10
-Kings,54054,State Senate,SD18,Rep,Michael Freeman-Saulsberry,25
-Kings,54055,State Senate,SD18,Rep,Michael Freeman-Saulsberry,25
-Kings,54056,State Senate,SD18,Rep,Michael Freeman-Saulsberry,15
-Kings,54057,State Senate,SD18,Rep,Michael Freeman-Saulsberry,30
-Kings,54058,State Senate,SD18,Rep,Michael Freeman-Saulsberry,27
-Kings,54059,State Senate,SD18,Rep,Michael Freeman-Saulsberry,17
-Kings,54060,State Senate,SD18,Rep,Michael Freeman-Saulsberry,10
-Kings,54061,State Senate,SD18,Rep,Michael Freeman-Saulsberry,5
-Kings,54062,State Senate,SD18,Rep,Michael Freeman-Saulsberry,12
-Kings,54063,State Senate,SD18,Rep,Michael Freeman-Saulsberry,14
-Kings,54064,State Senate,SD18,Rep,Michael Freeman-Saulsberry,14
-Kings,54065,State Senate,SD18,Rep,Michael Freeman-Saulsberry,23
-Kings,54066,State Senate,SD18,Rep,Michael Freeman-Saulsberry,5
-Kings,54067,State Senate,SD18,Rep,Michael Freeman-Saulsberry,17
-Kings,54068,State Senate,SD18,Rep,Michael Freeman-Saulsberry,11
-Kings,54069,State Senate,SD18,Rep,Michael Freeman-Saulsberry,7
-Kings,54070,State Senate,SD18,Rep,Michael Freeman-Saulsberry,6
-Kings,54073,State Senate,SD18,Rep,Michael Freeman-Saulsberry,7
-Kings,54074,State Senate,SD18,Rep,Michael Freeman-Saulsberry,1
-Kings,54078,State Senate,SD18,Rep,Michael Freeman-Saulsberry,0
-Kings,55003,State Senate,SD18,Rep,Michael Freeman-Saulsberry,4
-Kings,55006,State Senate,SD18,Rep,Michael Freeman-Saulsberry,5
-Kings,55007,State Senate,SD18,Rep,Michael Freeman-Saulsberry,14
-Kings,55014,State Senate,SD18,Rep,Michael Freeman-Saulsberry,14
-Kings,55015,State Senate,SD18,Rep,Michael Freeman-Saulsberry,0
-Kings,55016,State Senate,SD18,Rep,Michael Freeman-Saulsberry,7
-Kings,55026,State Senate,SD18,Rep,Michael Freeman-Saulsberry,5
-Kings,55041,State Senate,SD18,Rep,Michael Freeman-Saulsberry,4
-Kings,55045,State Senate,SD18,Rep,Michael Freeman-Saulsberry,10
-Kings,55046,State Senate,SD18,Rep,Michael Freeman-Saulsberry,7
-Kings,55050,State Senate,SD18,Rep,Michael Freeman-Saulsberry,0
-Kings,55051,State Senate,SD18,Rep,Michael Freeman-Saulsberry,0
-Kings,56001,State Senate,SD18,Rep,Michael Freeman-Saulsberry,9
-Kings,56002,State Senate,SD18,Rep,Michael Freeman-Saulsberry,3
-Kings,56003,State Senate,SD18,Rep,Michael Freeman-Saulsberry,4
-Kings,56004,State Senate,SD18,Rep,Michael Freeman-Saulsberry,3
-Kings,56006,State Senate,SD18,Rep,Michael Freeman-Saulsberry,3
-Kings,56007,State Senate,SD18,Rep,Michael Freeman-Saulsberry,7
-Kings,56008,State Senate,SD18,Rep,Michael Freeman-Saulsberry,7
-Kings,56009,State Senate,SD18,Rep,Michael Freeman-Saulsberry,3
-Kings,56010,State Senate,SD18,Rep,Michael Freeman-Saulsberry,6
-Kings,56011,State Senate,SD18,Rep,Michael Freeman-Saulsberry,6
-Kings,56017,State Senate,SD18,Rep,Michael Freeman-Saulsberry,4
-Kings,56020,State Senate,SD18,Rep,Michael Freeman-Saulsberry,2
-Kings,60004,State Senate,SD18,Rep,Michael Freeman-Saulsberry,0
-Kings,60006,State Senate,SD18,Rep,Michael Freeman-Saulsberry,0
-Kings,60010,State Senate,SD18,Rep,Michael Freeman-Saulsberry,1
-Kings,60011,State Senate,SD18,Rep,Michael Freeman-Saulsberry,0
-Kings,60013,State Senate,SD18,Rep,Michael Freeman-Saulsberry,0
-Kings,60016,State Senate,SD18,Rep,Michael Freeman-Saulsberry,2
-Kings,60018,State Senate,SD18,Rep,Michael Freeman-Saulsberry,7
-Kings,60019,State Senate,SD18,Rep,Michael Freeman-Saulsberry,2
-Kings,60020,State Senate,SD18,Rep,Michael Freeman-Saulsberry,3
-Kings,50001,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,50003,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,50004,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,50005,State Senate,SD18,Con,Michael Freeman-Saulsberry,6
-Kings,50006,State Senate,SD18,Con,Michael Freeman-Saulsberry,6
-Kings,50007,State Senate,SD18,Con,Michael Freeman-Saulsberry,7
-Kings,50008,State Senate,SD18,Con,Michael Freeman-Saulsberry,10
-Kings,50009,State Senate,SD18,Con,Michael Freeman-Saulsberry,5
-Kings,50010,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,50012,State Senate,SD18,Con,Michael Freeman-Saulsberry,15
-Kings,50015,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,50016,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,50017,State Senate,SD18,Con,Michael Freeman-Saulsberry,9
-Kings,50018,State Senate,SD18,Con,Michael Freeman-Saulsberry,6
-Kings,50019,State Senate,SD18,Con,Michael Freeman-Saulsberry,7
-Kings,50020,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,50021,State Senate,SD18,Con,Michael Freeman-Saulsberry,13
-Kings,50022,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,50025,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,50043,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,50044,State Senate,SD18,Con,Michael Freeman-Saulsberry,6
-Kings,50045,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,50046,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,50049,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,50050,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,50051,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,50052,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,50053,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,50054,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,50056,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,50057,State Senate,SD18,Con,Michael Freeman-Saulsberry,8
-Kings,50058,State Senate,SD18,Con,Michael Freeman-Saulsberry,11
-Kings,50059,State Senate,SD18,Con,Michael Freeman-Saulsberry,7
-Kings,50060,State Senate,SD18,Con,Michael Freeman-Saulsberry,7
-Kings,50061,State Senate,SD18,Con,Michael Freeman-Saulsberry,9
-Kings,50062,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,50063,State Senate,SD18,Con,Michael Freeman-Saulsberry,7
-Kings,50081,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,53001,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,53002,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,53003,State Senate,SD18,Con,Michael Freeman-Saulsberry,7
-Kings,53004,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,53005,State Senate,SD18,Con,Michael Freeman-Saulsberry,6
-Kings,53006,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,53007,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,53008,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,53009,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,53010,State Senate,SD18,Con,Michael Freeman-Saulsberry,10
-Kings,53011,State Senate,SD18,Con,Michael Freeman-Saulsberry,8
-Kings,53012,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,53013,State Senate,SD18,Con,Michael Freeman-Saulsberry,6
-Kings,53015,State Senate,SD18,Con,Michael Freeman-Saulsberry,10
-Kings,53016,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,53017,State Senate,SD18,Con,Michael Freeman-Saulsberry,10
-Kings,53018,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,53019,State Senate,SD18,Con,Michael Freeman-Saulsberry,11
-Kings,53020,State Senate,SD18,Con,Michael Freeman-Saulsberry,9
-Kings,53021,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,53022,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,53023,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,53024,State Senate,SD18,Con,Michael Freeman-Saulsberry,10
-Kings,53025,State Senate,SD18,Con,Michael Freeman-Saulsberry,5
-Kings,53026,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,53027,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,53028,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,53029,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,53030,State Senate,SD18,Con,Michael Freeman-Saulsberry,8
-Kings,53031,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,53032,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,53033,State Senate,SD18,Con,Michael Freeman-Saulsberry,5
-Kings,53034,State Senate,SD18,Con,Michael Freeman-Saulsberry,10
-Kings,53035,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,53036,State Senate,SD18,Con,Michael Freeman-Saulsberry,6
-Kings,53037,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,53038,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,53039,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,53040,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,53041,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,53042,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,53043,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,53044,State Senate,SD18,Con,Michael Freeman-Saulsberry,5
-Kings,53045,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,53046,State Senate,SD18,Con,Michael Freeman-Saulsberry,5
-Kings,53047,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,53048,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,53050,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,53052,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,53053,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,53054,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,53055,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,53056,State Senate,SD18,Con,Michael Freeman-Saulsberry,6
-Kings,53057,State Senate,SD18,Con,Michael Freeman-Saulsberry,5
-Kings,53058,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,53059,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,53060,State Senate,SD18,Con,Michael Freeman-Saulsberry,8
-Kings,53061,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,53062,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,53063,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,53064,State Senate,SD18,Con,Michael Freeman-Saulsberry,7
-Kings,53065,State Senate,SD18,Con,Michael Freeman-Saulsberry,5
-Kings,53066,State Senate,SD18,Con,Michael Freeman-Saulsberry,7
-Kings,53067,State Senate,SD18,Con,Michael Freeman-Saulsberry,6
-Kings,53068,State Senate,SD18,Con,Michael Freeman-Saulsberry,9
-Kings,53069,State Senate,SD18,Con,Michael Freeman-Saulsberry,7
-Kings,53070,State Senate,SD18,Con,Michael Freeman-Saulsberry,6
-Kings,53071,State Senate,SD18,Con,Michael Freeman-Saulsberry,6
-Kings,53072,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,53073,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,53074,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,53075,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,53076,State Senate,SD18,Con,Michael Freeman-Saulsberry,5
-Kings,53077,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,53079,State Senate,SD18,Con,Michael Freeman-Saulsberry,6
-Kings,53080,State Senate,SD18,Con,Michael Freeman-Saulsberry,5
-Kings,53082,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,53083,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,54001,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,54007,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,54008,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,54009,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,54010,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,54011,State Senate,SD18,Con,Michael Freeman-Saulsberry,7
-Kings,54012,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,54013,State Senate,SD18,Con,Michael Freeman-Saulsberry,9
-Kings,54014,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,54016,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,54017,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,54018,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,54019,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,54020,State Senate,SD18,Con,Michael Freeman-Saulsberry,5
-Kings,54021,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,54022,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,54023,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,54024,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,54025,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,54027,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,54028,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,54029,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,54030,State Senate,SD18,Con,Michael Freeman-Saulsberry,7
-Kings,54031,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,54032,State Senate,SD18,Con,Michael Freeman-Saulsberry,12
-Kings,54033,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,54034,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,54035,State Senate,SD18,Con,Michael Freeman-Saulsberry,5
-Kings,54036,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,54037,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,54038,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,54039,State Senate,SD18,Con,Michael Freeman-Saulsberry,8
-Kings,54040,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,54041,State Senate,SD18,Con,Michael Freeman-Saulsberry,3
-Kings,54042,State Senate,SD18,Con,Michael Freeman-Saulsberry,5
-Kings,54043,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,54044,State Senate,SD18,Con,Michael Freeman-Saulsberry,5
-Kings,54045,State Senate,SD18,Con,Michael Freeman-Saulsberry,9
-Kings,54046,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,54047,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,54048,State Senate,SD18,Con,Michael Freeman-Saulsberry,6
-Kings,54049,State Senate,SD18,Con,Michael Freeman-Saulsberry,7
-Kings,54050,State Senate,SD18,Con,Michael Freeman-Saulsberry,9
-Kings,54051,State Senate,SD18,Con,Michael Freeman-Saulsberry,6
-Kings,54052,State Senate,SD18,Con,Michael Freeman-Saulsberry,6
-Kings,54053,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,54054,State Senate,SD18,Con,Michael Freeman-Saulsberry,13
-Kings,54055,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,54056,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,54057,State Senate,SD18,Con,Michael Freeman-Saulsberry,6
-Kings,54058,State Senate,SD18,Con,Michael Freeman-Saulsberry,6
-Kings,54059,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,54060,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,54061,State Senate,SD18,Con,Michael Freeman-Saulsberry,7
-Kings,54062,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,54063,State Senate,SD18,Con,Michael Freeman-Saulsberry,13
-Kings,54064,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,54065,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,54066,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,54067,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,54068,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,54069,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,54070,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,54073,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,54074,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,54078,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,55003,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,55006,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,55007,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,55014,State Senate,SD18,Con,Michael Freeman-Saulsberry,5
-Kings,55015,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,55016,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,55026,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,55041,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,55045,State Senate,SD18,Con,Michael Freeman-Saulsberry,5
-Kings,55046,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,55050,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,55051,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,56001,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,56002,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,56003,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,56004,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,56006,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,56007,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,56008,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,56009,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,56010,State Senate,SD18,Con,Michael Freeman-Saulsberry,5
-Kings,56011,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,56017,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,56020,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,60004,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,60006,State Senate,SD18,Con,Michael Freeman-Saulsberry,2
-Kings,60010,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,60011,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,60013,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,60016,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,60018,State Senate,SD18,Con,Michael Freeman-Saulsberry,4
-Kings,60019,State Senate,SD18,Con,Michael Freeman-Saulsberry,1
-Kings,60020,State Senate,SD18,Con,Michael Freeman-Saulsberry,0
-Kings,50001,State Senate,SD18,Ind,writein,0
-Kings,50003,State Senate,SD18,Ind,writein,0
-Kings,50004,State Senate,SD18,Ind,writein,0
-Kings,50005,State Senate,SD18,Ind,writein,1
-Kings,50006,State Senate,SD18,Ind,writein,2
-Kings,50007,State Senate,SD18,Ind,writein,3
-Kings,50008,State Senate,SD18,Ind,writein,0
-Kings,50009,State Senate,SD18,Ind,writein,0
-Kings,50010,State Senate,SD18,Ind,writein,0
-Kings,50012,State Senate,SD18,Ind,writein,0
-Kings,50015,State Senate,SD18,Ind,writein,1
-Kings,50016,State Senate,SD18,Ind,writein,0
-Kings,50017,State Senate,SD18,Ind,writein,0
-Kings,50018,State Senate,SD18,Ind,writein,2
-Kings,50019,State Senate,SD18,Ind,writein,2
-Kings,50020,State Senate,SD18,Ind,writein,2
-Kings,50021,State Senate,SD18,Ind,writein,3
-Kings,50022,State Senate,SD18,Ind,writein,1
-Kings,50025,State Senate,SD18,Ind,writein,0
-Kings,50043,State Senate,SD18,Ind,writein,0
-Kings,50044,State Senate,SD18,Ind,writein,2
-Kings,50045,State Senate,SD18,Ind,writein,0
-Kings,50046,State Senate,SD18,Ind,writein,3
-Kings,50049,State Senate,SD18,Ind,writein,2
-Kings,50050,State Senate,SD18,Ind,writein,0
-Kings,50051,State Senate,SD18,Ind,writein,0
-Kings,50052,State Senate,SD18,Ind,writein,2
-Kings,50053,State Senate,SD18,Ind,writein,1
-Kings,50054,State Senate,SD18,Ind,writein,0
-Kings,50056,State Senate,SD18,Ind,writein,0
-Kings,50057,State Senate,SD18,Ind,writein,0
-Kings,50058,State Senate,SD18,Ind,writein,0
-Kings,50059,State Senate,SD18,Ind,writein,1
-Kings,50060,State Senate,SD18,Ind,writein,0
-Kings,50061,State Senate,SD18,Ind,writein,1
-Kings,50062,State Senate,SD18,Ind,writein,1
-Kings,50063,State Senate,SD18,Ind,writein,0
-Kings,50081,State Senate,SD18,Ind,writein,0
-Kings,53001,State Senate,SD18,Ind,writein,0
-Kings,53002,State Senate,SD18,Ind,writein,1
-Kings,53003,State Senate,SD18,Ind,writein,0
-Kings,53004,State Senate,SD18,Ind,writein,2
-Kings,53005,State Senate,SD18,Ind,writein,0
-Kings,53006,State Senate,SD18,Ind,writein,0
-Kings,53007,State Senate,SD18,Ind,writein,0
-Kings,53008,State Senate,SD18,Ind,writein,1
-Kings,53009,State Senate,SD18,Ind,writein,1
-Kings,53010,State Senate,SD18,Ind,writein,1
-Kings,53011,State Senate,SD18,Ind,writein,0
-Kings,53012,State Senate,SD18,Ind,writein,2
-Kings,53013,State Senate,SD18,Ind,writein,1
-Kings,53015,State Senate,SD18,Ind,writein,0
-Kings,53016,State Senate,SD18,Ind,writein,2
-Kings,53017,State Senate,SD18,Ind,writein,2
-Kings,53018,State Senate,SD18,Ind,writein,1
-Kings,53019,State Senate,SD18,Ind,writein,1
-Kings,53020,State Senate,SD18,Ind,writein,2
-Kings,53021,State Senate,SD18,Ind,writein,0
-Kings,53022,State Senate,SD18,Ind,writein,0
-Kings,53023,State Senate,SD18,Ind,writein,3
-Kings,53024,State Senate,SD18,Ind,writein,0
-Kings,53025,State Senate,SD18,Ind,writein,0
-Kings,53026,State Senate,SD18,Ind,writein,0
-Kings,53027,State Senate,SD18,Ind,writein,0
-Kings,53028,State Senate,SD18,Ind,writein,0
-Kings,53029,State Senate,SD18,Ind,writein,0
-Kings,53030,State Senate,SD18,Ind,writein,4
-Kings,53031,State Senate,SD18,Ind,writein,0
-Kings,53032,State Senate,SD18,Ind,writein,1
-Kings,53033,State Senate,SD18,Ind,writein,0
-Kings,53034,State Senate,SD18,Ind,writein,1
-Kings,53035,State Senate,SD18,Ind,writein,3
-Kings,53036,State Senate,SD18,Ind,writein,1
-Kings,53037,State Senate,SD18,Ind,writein,0
-Kings,53038,State Senate,SD18,Ind,writein,0
-Kings,53039,State Senate,SD18,Ind,writein,2
-Kings,53040,State Senate,SD18,Ind,writein,0
-Kings,53041,State Senate,SD18,Ind,writein,0
-Kings,53042,State Senate,SD18,Ind,writein,0
-Kings,53043,State Senate,SD18,Ind,writein,0
-Kings,53044,State Senate,SD18,Ind,writein,1
-Kings,53045,State Senate,SD18,Ind,writein,1
-Kings,53046,State Senate,SD18,Ind,writein,0
-Kings,53047,State Senate,SD18,Ind,writein,3
-Kings,53048,State Senate,SD18,Ind,writein,1
-Kings,53050,State Senate,SD18,Ind,writein,0
-Kings,53052,State Senate,SD18,Ind,writein,1
-Kings,53053,State Senate,SD18,Ind,writein,1
-Kings,53054,State Senate,SD18,Ind,writein,0
-Kings,53055,State Senate,SD18,Ind,writein,1
-Kings,53056,State Senate,SD18,Ind,writein,2
-Kings,53057,State Senate,SD18,Ind,writein,4
-Kings,53058,State Senate,SD18,Ind,writein,1
-Kings,53059,State Senate,SD18,Ind,writein,0
-Kings,53060,State Senate,SD18,Ind,writein,0
-Kings,53061,State Senate,SD18,Ind,writein,1
-Kings,53062,State Senate,SD18,Ind,writein,0
-Kings,53063,State Senate,SD18,Ind,writein,2
-Kings,53064,State Senate,SD18,Ind,writein,0
-Kings,53065,State Senate,SD18,Ind,writein,0
-Kings,53066,State Senate,SD18,Ind,writein,0
-Kings,53067,State Senate,SD18,Ind,writein,0
-Kings,53068,State Senate,SD18,Ind,writein,0
-Kings,53069,State Senate,SD18,Ind,writein,1
-Kings,53070,State Senate,SD18,Ind,writein,0
-Kings,53071,State Senate,SD18,Ind,writein,0
-Kings,53072,State Senate,SD18,Ind,writein,2
-Kings,53073,State Senate,SD18,Ind,writein,0
-Kings,53074,State Senate,SD18,Ind,writein,1
-Kings,53075,State Senate,SD18,Ind,writein,0
-Kings,53076,State Senate,SD18,Ind,writein,1
-Kings,53077,State Senate,SD18,Ind,writein,2
-Kings,53079,State Senate,SD18,Ind,writein,0
-Kings,53080,State Senate,SD18,Ind,writein,1
-Kings,53082,State Senate,SD18,Ind,writein,0
-Kings,53083,State Senate,SD18,Ind,writein,0
-Kings,54001,State Senate,SD18,Ind,writein,0
-Kings,54007,State Senate,SD18,Ind,writein,1
-Kings,54008,State Senate,SD18,Ind,writein,0
-Kings,54009,State Senate,SD18,Ind,writein,0
-Kings,54010,State Senate,SD18,Ind,writein,0
-Kings,54011,State Senate,SD18,Ind,writein,0
-Kings,54012,State Senate,SD18,Ind,writein,0
-Kings,54013,State Senate,SD18,Ind,writein,0
-Kings,54014,State Senate,SD18,Ind,writein,0
-Kings,54016,State Senate,SD18,Ind,writein,0
-Kings,54017,State Senate,SD18,Ind,writein,0
-Kings,54018,State Senate,SD18,Ind,writein,0
-Kings,54019,State Senate,SD18,Ind,writein,0
-Kings,54020,State Senate,SD18,Ind,writein,0
-Kings,54021,State Senate,SD18,Ind,writein,1
-Kings,54022,State Senate,SD18,Ind,writein,0
-Kings,54023,State Senate,SD18,Ind,writein,0
-Kings,54024,State Senate,SD18,Ind,writein,0
-Kings,54025,State Senate,SD18,Ind,writein,0
-Kings,54027,State Senate,SD18,Ind,writein,0
-Kings,54028,State Senate,SD18,Ind,writein,0
-Kings,54029,State Senate,SD18,Ind,writein,0
-Kings,54030,State Senate,SD18,Ind,writein,0
-Kings,54031,State Senate,SD18,Ind,writein,0
-Kings,54032,State Senate,SD18,Ind,writein,0
-Kings,54033,State Senate,SD18,Ind,writein,1
-Kings,54034,State Senate,SD18,Ind,writein,0
-Kings,54035,State Senate,SD18,Ind,writein,0
-Kings,54036,State Senate,SD18,Ind,writein,0
-Kings,54037,State Senate,SD18,Ind,writein,0
-Kings,54038,State Senate,SD18,Ind,writein,0
-Kings,54039,State Senate,SD18,Ind,writein,0
-Kings,54040,State Senate,SD18,Ind,writein,0
-Kings,54041,State Senate,SD18,Ind,writein,1
-Kings,54042,State Senate,SD18,Ind,writein,0
-Kings,54043,State Senate,SD18,Ind,writein,0
-Kings,54044,State Senate,SD18,Ind,writein,0
-Kings,54045,State Senate,SD18,Ind,writein,0
-Kings,54046,State Senate,SD18,Ind,writein,0
-Kings,54047,State Senate,SD18,Ind,writein,0
-Kings,54048,State Senate,SD18,Ind,writein,0
-Kings,54049,State Senate,SD18,Ind,writein,0
-Kings,54050,State Senate,SD18,Ind,writein,1
-Kings,54051,State Senate,SD18,Ind,writein,0
-Kings,54052,State Senate,SD18,Ind,writein,0
-Kings,54053,State Senate,SD18,Ind,writein,0
-Kings,54054,State Senate,SD18,Ind,writein,0
-Kings,54055,State Senate,SD18,Ind,writein,1
-Kings,54056,State Senate,SD18,Ind,writein,0
-Kings,54057,State Senate,SD18,Ind,writein,1
-Kings,54058,State Senate,SD18,Ind,writein,0
-Kings,54059,State Senate,SD18,Ind,writein,0
-Kings,54060,State Senate,SD18,Ind,writein,0
-Kings,54061,State Senate,SD18,Ind,writein,0
-Kings,54062,State Senate,SD18,Ind,writein,1
-Kings,54063,State Senate,SD18,Ind,writein,1
-Kings,54064,State Senate,SD18,Ind,writein,0
-Kings,54065,State Senate,SD18,Ind,writein,0
-Kings,54066,State Senate,SD18,Ind,writein,0
-Kings,54067,State Senate,SD18,Ind,writein,0
-Kings,54068,State Senate,SD18,Ind,writein,0
-Kings,54069,State Senate,SD18,Ind,writein,0
-Kings,54070,State Senate,SD18,Ind,writein,0
-Kings,54073,State Senate,SD18,Ind,writein,0
-Kings,54074,State Senate,SD18,Ind,writein,0
-Kings,54078,State Senate,SD18,Ind,writein,0
-Kings,55003,State Senate,SD18,Ind,writein,0
-Kings,55006,State Senate,SD18,Ind,writein,0
-Kings,55007,State Senate,SD18,Ind,writein,1
-Kings,55014,State Senate,SD18,Ind,writein,0
-Kings,55015,State Senate,SD18,Ind,writein,0
-Kings,55016,State Senate,SD18,Ind,writein,0
-Kings,55026,State Senate,SD18,Ind,writein,0
-Kings,55041,State Senate,SD18,Ind,writein,0
-Kings,55045,State Senate,SD18,Ind,writein,1
-Kings,55046,State Senate,SD18,Ind,writein,0
-Kings,55050,State Senate,SD18,Ind,writein,0
-Kings,55051,State Senate,SD18,Ind,writein,0
-Kings,56001,State Senate,SD18,Ind,writein,0
-Kings,56002,State Senate,SD18,Ind,writein,0
-Kings,56003,State Senate,SD18,Ind,writein,0
-Kings,56004,State Senate,SD18,Ind,writein,0
-Kings,56006,State Senate,SD18,Ind,writein,1
-Kings,56007,State Senate,SD18,Ind,writein,0
-Kings,56008,State Senate,SD18,Ind,writein,0
-Kings,56009,State Senate,SD18,Ind,writein,0
-Kings,56010,State Senate,SD18,Ind,writein,0
-Kings,56011,State Senate,SD18,Ind,writein,0
-Kings,56017,State Senate,SD18,Ind,writein,0
-Kings,56020,State Senate,SD18,Ind,writein,0
-Kings,60004,State Senate,SD18,Ind,writein,0
-Kings,60006,State Senate,SD18,Ind,writein,0
-Kings,60010,State Senate,SD18,Ind,writein,0
-Kings,60011,State Senate,SD18,Ind,writein,0
-Kings,60013,State Senate,SD18,Ind,writein,0
-Kings,60016,State Senate,SD18,Ind,writein,0
-Kings,60018,State Senate,SD18,Ind,writein,0
-Kings,60019,State Senate,SD18,Ind,writein,0
-Kings,60020,State Senate,SD18,Ind,writein,0
-Kings,41013,State Senate,SD19,Con,Elias Weir,2
-Kings,41015,State Senate,SD19,Con,Elias Weir,7
-Kings,41019,State Senate,SD19,Con,Elias Weir,10
-Kings,41020,State Senate,SD19,Con,Elias Weir,15
-Kings,41021,State Senate,SD19,Con,Elias Weir,19
-Kings,41022,State Senate,SD19,Con,Elias Weir,19
-Kings,41025,State Senate,SD19,Con,Elias Weir,3
-Kings,41026,State Senate,SD19,Con,Elias Weir,0
-Kings,41027,State Senate,SD19,Con,Elias Weir,5
-Kings,41028,State Senate,SD19,Con,Elias Weir,4
-Kings,41029,State Senate,SD19,Con,Elias Weir,0
-Kings,41057,State Senate,SD19,Con,Elias Weir,19
-Kings,41060,State Senate,SD19,Con,Elias Weir,21
-Kings,41061,State Senate,SD19,Con,Elias Weir,30
-Kings,41062,State Senate,SD19,Con,Elias Weir,19
-Kings,41063,State Senate,SD19,Con,Elias Weir,30
-Kings,41064,State Senate,SD19,Con,Elias Weir,31
-Kings,41065,State Senate,SD19,Con,Elias Weir,3
-Kings,41066,State Senate,SD19,Con,Elias Weir,5
-Kings,41067,State Senate,SD19,Con,Elias Weir,3
-Kings,41068,State Senate,SD19,Con,Elias Weir,5
-Kings,41069,State Senate,SD19,Con,Elias Weir,8
-Kings,41070,State Senate,SD19,Con,Elias Weir,41
-Kings,41071,State Senate,SD19,Con,Elias Weir,27
-Kings,41072,State Senate,SD19,Con,Elias Weir,13
-Kings,41073,State Senate,SD19,Con,Elias Weir,16
-Kings,41074,State Senate,SD19,Con,Elias Weir,17
-Kings,41075,State Senate,SD19,Con,Elias Weir,11
-Kings,41076,State Senate,SD19,Con,Elias Weir,19
-Kings,41077,State Senate,SD19,Con,Elias Weir,19
-Kings,41078,State Senate,SD19,Con,Elias Weir,26
-Kings,41079,State Senate,SD19,Con,Elias Weir,21
-Kings,41080,State Senate,SD19,Con,Elias Weir,6
-Kings,42069,State Senate,SD19,Con,Elias Weir,4
-Kings,42070,State Senate,SD19,Con,Elias Weir,4
-Kings,45025,State Senate,SD19,Con,Elias Weir,4
-Kings,45026,State Senate,SD19,Con,Elias Weir,3
-Kings,45027,State Senate,SD19,Con,Elias Weir,9
-Kings,45028,State Senate,SD19,Con,Elias Weir,6
-Kings,45082,State Senate,SD19,Con,Elias Weir,6
-Kings,54002,State Senate,SD19,Con,Elias Weir,0
-Kings,54003,State Senate,SD19,Con,Elias Weir,3
-Kings,54004,State Senate,SD19,Con,Elias Weir,2
-Kings,54005,State Senate,SD19,Con,Elias Weir,1
-Kings,54006,State Senate,SD19,Con,Elias Weir,0
-Kings,54071,State Senate,SD19,Con,Elias Weir,1
-Kings,54072,State Senate,SD19,Con,Elias Weir,0
-Kings,55027,State Senate,SD19,Con,Elias Weir,2
-Kings,55036,State Senate,SD19,Con,Elias Weir,0
-Kings,55037,State Senate,SD19,Con,Elias Weir,1
-Kings,55038,State Senate,SD19,Con,Elias Weir,1
-Kings,55039,State Senate,SD19,Con,Elias Weir,0
-Kings,55040,State Senate,SD19,Con,Elias Weir,0
-Kings,55044,State Senate,SD19,Con,Elias Weir,0
-Kings,55047,State Senate,SD19,Con,Elias Weir,0
-Kings,55048,State Senate,SD19,Con,Elias Weir,2
-Kings,55049,State Senate,SD19,Con,Elias Weir,2
-Kings,55052,State Senate,SD19,Con,Elias Weir,2
-Kings,55055,State Senate,SD19,Con,Elias Weir,2
-Kings,55056,State Senate,SD19,Con,Elias Weir,2
-Kings,55060,State Senate,SD19,Con,Elias Weir,0
-Kings,55062,State Senate,SD19,Con,Elias Weir,2
-Kings,55063,State Senate,SD19,Con,Elias Weir,0
-Kings,55064,State Senate,SD19,Con,Elias Weir,5
-Kings,55074,State Senate,SD19,Con,Elias Weir,0
-Kings,55075,State Senate,SD19,Con,Elias Weir,0
-Kings,55077,State Senate,SD19,Con,Elias Weir,0
-Kings,55099,State Senate,SD19,Con,Elias Weir,3
-Kings,55105,State Senate,SD19,Con,Elias Weir,0
-Kings,58057,State Senate,SD19,Con,Elias Weir,0
-Kings,58058,State Senate,SD19,Con,Elias Weir,0
-Kings,58059,State Senate,SD19,Con,Elias Weir,8
-Kings,58060,State Senate,SD19,Con,Elias Weir,3
-Kings,58066,State Senate,SD19,Con,Elias Weir,1
-Kings,58067,State Senate,SD19,Con,Elias Weir,0
-Kings,58068,State Senate,SD19,Con,Elias Weir,2
-Kings,58069,State Senate,SD19,Con,Elias Weir,1
-Kings,58070,State Senate,SD19,Con,Elias Weir,3
-Kings,58071,State Senate,SD19,Con,Elias Weir,5
-Kings,58072,State Senate,SD19,Con,Elias Weir,0
-Kings,58073,State Senate,SD19,Con,Elias Weir,0
-Kings,58074,State Senate,SD19,Con,Elias Weir,1
-Kings,58075,State Senate,SD19,Con,Elias Weir,2
-Kings,58076,State Senate,SD19,Con,Elias Weir,0
-Kings,58077,State Senate,SD19,Con,Elias Weir,2
-Kings,58078,State Senate,SD19,Con,Elias Weir,2
-Kings,58079,State Senate,SD19,Con,Elias Weir,0
-Kings,59005,State Senate,SD19,Con,Elias Weir,0
-Kings,59006,State Senate,SD19,Con,Elias Weir,2
-Kings,59007,State Senate,SD19,Con,Elias Weir,3
-Kings,59008,State Senate,SD19,Con,Elias Weir,2
-Kings,59010,State Senate,SD19,Con,Elias Weir,1
-Kings,59011,State Senate,SD19,Con,Elias Weir,10
-Kings,59012,State Senate,SD19,Con,Elias Weir,7
-Kings,59013,State Senate,SD19,Con,Elias Weir,4
-Kings,59014,State Senate,SD19,Con,Elias Weir,2
-Kings,59015,State Senate,SD19,Con,Elias Weir,2
-Kings,59024,State Senate,SD19,Con,Elias Weir,7
-Kings,59026,State Senate,SD19,Con,Elias Weir,9
-Kings,59027,State Senate,SD19,Con,Elias Weir,14
-Kings,59028,State Senate,SD19,Con,Elias Weir,13
-Kings,59029,State Senate,SD19,Con,Elias Weir,10
-Kings,59030,State Senate,SD19,Con,Elias Weir,19
-Kings,59031,State Senate,SD19,Con,Elias Weir,16
-Kings,59032,State Senate,SD19,Con,Elias Weir,6
-Kings,59050,State Senate,SD19,Con,Elias Weir,9
-Kings,59051,State Senate,SD19,Con,Elias Weir,42
-Kings,59052,State Senate,SD19,Con,Elias Weir,23
-Kings,59053,State Senate,SD19,Con,Elias Weir,34
-Kings,59054,State Senate,SD19,Con,Elias Weir,17
-Kings,59055,State Senate,SD19,Con,Elias Weir,26
-Kings,59056,State Senate,SD19,Con,Elias Weir,14
-Kings,59057,State Senate,SD19,Con,Elias Weir,20
-Kings,59058,State Senate,SD19,Con,Elias Weir,35
-Kings,59059,State Senate,SD19,Con,Elias Weir,21
-Kings,59060,State Senate,SD19,Con,Elias Weir,15
-Kings,59061,State Senate,SD19,Con,Elias Weir,30
-Kings,59062,State Senate,SD19,Con,Elias Weir,14
-Kings,59063,State Senate,SD19,Con,Elias Weir,0
-Kings,59064,State Senate,SD19,Con,Elias Weir,2
-Kings,59065,State Senate,SD19,Con,Elias Weir,2
-Kings,59066,State Senate,SD19,Con,Elias Weir,5
-Kings,59067,State Senate,SD19,Con,Elias Weir,2
-Kings,59068,State Senate,SD19,Con,Elias Weir,8
-Kings,59069,State Senate,SD19,Con,Elias Weir,6
-Kings,59070,State Senate,SD19,Con,Elias Weir,7
-Kings,59071,State Senate,SD19,Con,Elias Weir,4
-Kings,59072,State Senate,SD19,Con,Elias Weir,2
-Kings,59073,State Senate,SD19,Con,Elias Weir,0
-Kings,59074,State Senate,SD19,Con,Elias Weir,4
-Kings,59075,State Senate,SD19,Con,Elias Weir,2
-Kings,59076,State Senate,SD19,Con,Elias Weir,3
-Kings,59077,State Senate,SD19,Con,Elias Weir,6
-Kings,59078,State Senate,SD19,Con,Elias Weir,4
-Kings,59079,State Senate,SD19,Con,Elias Weir,1
-Kings,59080,State Senate,SD19,Con,Elias Weir,6
-Kings,59081,State Senate,SD19,Con,Elias Weir,2
-Kings,60001,State Senate,SD19,Con,Elias Weir,2
-Kings,60002,State Senate,SD19,Con,Elias Weir,2
-Kings,60003,State Senate,SD19,Con,Elias Weir,2
-Kings,60005,State Senate,SD19,Con,Elias Weir,0
-Kings,60007,State Senate,SD19,Con,Elias Weir,0
-Kings,60008,State Senate,SD19,Con,Elias Weir,2
-Kings,60009,State Senate,SD19,Con,Elias Weir,0
-Kings,60012,State Senate,SD19,Con,Elias Weir,1
-Kings,60014,State Senate,SD19,Con,Elias Weir,3
-Kings,60015,State Senate,SD19,Con,Elias Weir,4
-Kings,60017,State Senate,SD19,Con,Elias Weir,0
-Kings,60021,State Senate,SD19,Con,Elias Weir,1
-Kings,60022,State Senate,SD19,Con,Elias Weir,1
-Kings,60023,State Senate,SD19,Con,Elias Weir,1
-Kings,60024,State Senate,SD19,Con,Elias Weir,1
-Kings,60025,State Senate,SD19,Con,Elias Weir,2
-Kings,60026,State Senate,SD19,Con,Elias Weir,1
-Kings,60027,State Senate,SD19,Con,Elias Weir,1
-Kings,60028,State Senate,SD19,Con,Elias Weir,1
-Kings,60029,State Senate,SD19,Con,Elias Weir,1
-Kings,60030,State Senate,SD19,Con,Elias Weir,4
-Kings,60031,State Senate,SD19,Con,Elias Weir,0
-Kings,60032,State Senate,SD19,Con,Elias Weir,0
-Kings,60033,State Senate,SD19,Con,Elias Weir,2
-Kings,60034,State Senate,SD19,Con,Elias Weir,2
-Kings,60035,State Senate,SD19,Con,Elias Weir,4
-Kings,60036,State Senate,SD19,Con,Elias Weir,1
-Kings,60037,State Senate,SD19,Con,Elias Weir,1
-Kings,60038,State Senate,SD19,Con,Elias Weir,0
-Kings,60039,State Senate,SD19,Con,Elias Weir,3
-Kings,60040,State Senate,SD19,Con,Elias Weir,5
-Kings,60041,State Senate,SD19,Con,Elias Weir,0
-Kings,60042,State Senate,SD19,Con,Elias Weir,1
-Kings,60043,State Senate,SD19,Con,Elias Weir,0
-Kings,60044,State Senate,SD19,Con,Elias Weir,2
-Kings,60045,State Senate,SD19,Con,Elias Weir,1
-Kings,60046,State Senate,SD19,Con,Elias Weir,3
-Kings,60047,State Senate,SD19,Con,Elias Weir,0
-Kings,60048,State Senate,SD19,Con,Elias Weir,2
-Kings,60049,State Senate,SD19,Con,Elias Weir,0
-Kings,60050,State Senate,SD19,Con,Elias Weir,0
-Kings,60051,State Senate,SD19,Con,Elias Weir,2
-Kings,60052,State Senate,SD19,Con,Elias Weir,0
-Kings,60053,State Senate,SD19,Con,Elias Weir,1
-Kings,60054,State Senate,SD19,Con,Elias Weir,2
-Kings,60055,State Senate,SD19,Con,Elias Weir,1
-Kings,60056,State Senate,SD19,Con,Elias Weir,0
-Kings,60057,State Senate,SD19,Con,Elias Weir,1
-Kings,60058,State Senate,SD19,Con,Elias Weir,2
-Kings,60059,State Senate,SD19,Con,Elias Weir,1
-Kings,60060,State Senate,SD19,Con,Elias Weir,3
-Kings,60061,State Senate,SD19,Con,Elias Weir,1
-Kings,60062,State Senate,SD19,Con,Elias Weir,0
-Kings,60063,State Senate,SD19,Con,Elias Weir,1
-Kings,60064,State Senate,SD19,Con,Elias Weir,2
-Kings,60065,State Senate,SD19,Con,Elias Weir,2
-Kings,60066,State Senate,SD19,Con,Elias Weir,3
-Kings,60067,State Senate,SD19,Con,Elias Weir,1
-Kings,60068,State Senate,SD19,Con,Elias Weir,0
-Kings,60069,State Senate,SD19,Con,Elias Weir,0
-Kings,60070,State Senate,SD19,Con,Elias Weir,0
-Kings,60071,State Senate,SD19,Con,Elias Weir,1
-Kings,60072,State Senate,SD19,Con,Elias Weir,3
-Kings,60073,State Senate,SD19,Con,Elias Weir,0
-Kings,60074,State Senate,SD19,Con,Elias Weir,2
-Kings,60075,State Senate,SD19,Con,Elias Weir,3
-Kings,60076,State Senate,SD19,Con,Elias Weir,0
-Kings,60077,State Senate,SD19,Con,Elias Weir,3
-Kings,60078,State Senate,SD19,Con,Elias Weir,3
-Kings,60079,State Senate,SD19,Con,Elias Weir,0
-Kings,60080,State Senate,SD19,Con,Elias Weir,0
-Kings,60081,State Senate,SD19,Con,Elias Weir,2
-Kings,60082,State Senate,SD19,Con,Elias Weir,4
-Kings,60083,State Senate,SD19,Con,Elias Weir,2
-Kings,60084,State Senate,SD19,Con,Elias Weir,6
-Kings,60085,State Senate,SD19,Con,Elias Weir,1
-Kings,60086,State Senate,SD19,Con,Elias Weir,1
-Kings,60087,State Senate,SD19,Con,Elias Weir,7
-Kings,60088,State Senate,SD19,Con,Elias Weir,4
-Kings,60089,State Senate,SD19,Con,Elias Weir,6
-Kings,60090,State Senate,SD19,Con,Elias Weir,3
-Kings,60091,State Senate,SD19,Con,Elias Weir,2
-Kings,41013,State Senate,SD19,Rep,Jane Neal,9
-Kings,41015,State Senate,SD19,Rep,Jane Neal,52
-Kings,41019,State Senate,SD19,Rep,Jane Neal,21
-Kings,41020,State Senate,SD19,Rep,Jane Neal,72
-Kings,41021,State Senate,SD19,Rep,Jane Neal,109
-Kings,41022,State Senate,SD19,Rep,Jane Neal,71
-Kings,41025,State Senate,SD19,Rep,Jane Neal,12
-Kings,41026,State Senate,SD19,Rep,Jane Neal,2
-Kings,41027,State Senate,SD19,Rep,Jane Neal,27
-Kings,41028,State Senate,SD19,Rep,Jane Neal,8
-Kings,41029,State Senate,SD19,Rep,Jane Neal,1
-Kings,41057,State Senate,SD19,Rep,Jane Neal,124
-Kings,41060,State Senate,SD19,Rep,Jane Neal,158
-Kings,41061,State Senate,SD19,Rep,Jane Neal,106
-Kings,41062,State Senate,SD19,Rep,Jane Neal,97
-Kings,41063,State Senate,SD19,Rep,Jane Neal,87
-Kings,41064,State Senate,SD19,Rep,Jane Neal,142
-Kings,41065,State Senate,SD19,Rep,Jane Neal,21
-Kings,41066,State Senate,SD19,Rep,Jane Neal,21
-Kings,41067,State Senate,SD19,Rep,Jane Neal,14
-Kings,41068,State Senate,SD19,Rep,Jane Neal,25
-Kings,41069,State Senate,SD19,Rep,Jane Neal,22
-Kings,41070,State Senate,SD19,Rep,Jane Neal,185
-Kings,41071,State Senate,SD19,Rep,Jane Neal,177
-Kings,41072,State Senate,SD19,Rep,Jane Neal,163
-Kings,41073,State Senate,SD19,Rep,Jane Neal,133
-Kings,41074,State Senate,SD19,Rep,Jane Neal,106
-Kings,41075,State Senate,SD19,Rep,Jane Neal,55
-Kings,41076,State Senate,SD19,Rep,Jane Neal,116
-Kings,41077,State Senate,SD19,Rep,Jane Neal,166
-Kings,41078,State Senate,SD19,Rep,Jane Neal,181
-Kings,41079,State Senate,SD19,Rep,Jane Neal,151
-Kings,41080,State Senate,SD19,Rep,Jane Neal,24
-Kings,42069,State Senate,SD19,Rep,Jane Neal,35
-Kings,42070,State Senate,SD19,Rep,Jane Neal,24
-Kings,45025,State Senate,SD19,Rep,Jane Neal,16
-Kings,45026,State Senate,SD19,Rep,Jane Neal,66
-Kings,45027,State Senate,SD19,Rep,Jane Neal,107
-Kings,45028,State Senate,SD19,Rep,Jane Neal,55
-Kings,45082,State Senate,SD19,Rep,Jane Neal,41
-Kings,54002,State Senate,SD19,Rep,Jane Neal,3
-Kings,54003,State Senate,SD19,Rep,Jane Neal,18
-Kings,54004,State Senate,SD19,Rep,Jane Neal,17
-Kings,54005,State Senate,SD19,Rep,Jane Neal,1
-Kings,54006,State Senate,SD19,Rep,Jane Neal,4
-Kings,54071,State Senate,SD19,Rep,Jane Neal,3
-Kings,54072,State Senate,SD19,Rep,Jane Neal,2
-Kings,55027,State Senate,SD19,Rep,Jane Neal,5
-Kings,55036,State Senate,SD19,Rep,Jane Neal,0
-Kings,55037,State Senate,SD19,Rep,Jane Neal,8
-Kings,55038,State Senate,SD19,Rep,Jane Neal,1
-Kings,55039,State Senate,SD19,Rep,Jane Neal,0
-Kings,55040,State Senate,SD19,Rep,Jane Neal,6
-Kings,55044,State Senate,SD19,Rep,Jane Neal,1
-Kings,55047,State Senate,SD19,Rep,Jane Neal,3
-Kings,55048,State Senate,SD19,Rep,Jane Neal,4
-Kings,55049,State Senate,SD19,Rep,Jane Neal,5
-Kings,55052,State Senate,SD19,Rep,Jane Neal,4
-Kings,55055,State Senate,SD19,Rep,Jane Neal,5
-Kings,55056,State Senate,SD19,Rep,Jane Neal,0
-Kings,55060,State Senate,SD19,Rep,Jane Neal,2
-Kings,55062,State Senate,SD19,Rep,Jane Neal,6
-Kings,55063,State Senate,SD19,Rep,Jane Neal,0
-Kings,55064,State Senate,SD19,Rep,Jane Neal,3
-Kings,55074,State Senate,SD19,Rep,Jane Neal,1
-Kings,55075,State Senate,SD19,Rep,Jane Neal,4
-Kings,55077,State Senate,SD19,Rep,Jane Neal,1
-Kings,55099,State Senate,SD19,Rep,Jane Neal,5
-Kings,55105,State Senate,SD19,Rep,Jane Neal,0
-Kings,58057,State Senate,SD19,Rep,Jane Neal,4
-Kings,58058,State Senate,SD19,Rep,Jane Neal,0
-Kings,58059,State Senate,SD19,Rep,Jane Neal,21
-Kings,58060,State Senate,SD19,Rep,Jane Neal,12
-Kings,58066,State Senate,SD19,Rep,Jane Neal,7
-Kings,58067,State Senate,SD19,Rep,Jane Neal,6
-Kings,58068,State Senate,SD19,Rep,Jane Neal,0
-Kings,58069,State Senate,SD19,Rep,Jane Neal,3
-Kings,58070,State Senate,SD19,Rep,Jane Neal,20
-Kings,58071,State Senate,SD19,Rep,Jane Neal,19
-Kings,58072,State Senate,SD19,Rep,Jane Neal,15
-Kings,58073,State Senate,SD19,Rep,Jane Neal,2
-Kings,58074,State Senate,SD19,Rep,Jane Neal,12
-Kings,58075,State Senate,SD19,Rep,Jane Neal,9
-Kings,58076,State Senate,SD19,Rep,Jane Neal,7
-Kings,58077,State Senate,SD19,Rep,Jane Neal,12
-Kings,58078,State Senate,SD19,Rep,Jane Neal,11
-Kings,58079,State Senate,SD19,Rep,Jane Neal,12
-Kings,59005,State Senate,SD19,Rep,Jane Neal,13
-Kings,59006,State Senate,SD19,Rep,Jane Neal,7
-Kings,59007,State Senate,SD19,Rep,Jane Neal,8
-Kings,59008,State Senate,SD19,Rep,Jane Neal,20
-Kings,59010,State Senate,SD19,Rep,Jane Neal,7
-Kings,59011,State Senate,SD19,Rep,Jane Neal,28
-Kings,59012,State Senate,SD19,Rep,Jane Neal,15
-Kings,59013,State Senate,SD19,Rep,Jane Neal,17
-Kings,59014,State Senate,SD19,Rep,Jane Neal,7
-Kings,59015,State Senate,SD19,Rep,Jane Neal,10
-Kings,59024,State Senate,SD19,Rep,Jane Neal,56
-Kings,59026,State Senate,SD19,Rep,Jane Neal,65
-Kings,59027,State Senate,SD19,Rep,Jane Neal,45
-Kings,59028,State Senate,SD19,Rep,Jane Neal,50
-Kings,59029,State Senate,SD19,Rep,Jane Neal,57
-Kings,59030,State Senate,SD19,Rep,Jane Neal,77
-Kings,59031,State Senate,SD19,Rep,Jane Neal,101
-Kings,59032,State Senate,SD19,Rep,Jane Neal,41
-Kings,59050,State Senate,SD19,Rep,Jane Neal,94
-Kings,59051,State Senate,SD19,Rep,Jane Neal,185
-Kings,59052,State Senate,SD19,Rep,Jane Neal,301
-Kings,59053,State Senate,SD19,Rep,Jane Neal,270
-Kings,59054,State Senate,SD19,Rep,Jane Neal,118
-Kings,59055,State Senate,SD19,Rep,Jane Neal,271
-Kings,59056,State Senate,SD19,Rep,Jane Neal,99
-Kings,59057,State Senate,SD19,Rep,Jane Neal,141
-Kings,59058,State Senate,SD19,Rep,Jane Neal,164
-Kings,59059,State Senate,SD19,Rep,Jane Neal,210
-Kings,59060,State Senate,SD19,Rep,Jane Neal,188
-Kings,59061,State Senate,SD19,Rep,Jane Neal,184
-Kings,59062,State Senate,SD19,Rep,Jane Neal,133
-Kings,59063,State Senate,SD19,Rep,Jane Neal,4
-Kings,59064,State Senate,SD19,Rep,Jane Neal,9
-Kings,59065,State Senate,SD19,Rep,Jane Neal,11
-Kings,59066,State Senate,SD19,Rep,Jane Neal,11
-Kings,59067,State Senate,SD19,Rep,Jane Neal,30
-Kings,59068,State Senate,SD19,Rep,Jane Neal,17
-Kings,59069,State Senate,SD19,Rep,Jane Neal,23
-Kings,59070,State Senate,SD19,Rep,Jane Neal,15
-Kings,59071,State Senate,SD19,Rep,Jane Neal,8
-Kings,59072,State Senate,SD19,Rep,Jane Neal,3
-Kings,59073,State Senate,SD19,Rep,Jane Neal,13
-Kings,59074,State Senate,SD19,Rep,Jane Neal,27
-Kings,59075,State Senate,SD19,Rep,Jane Neal,21
-Kings,59076,State Senate,SD19,Rep,Jane Neal,9
-Kings,59077,State Senate,SD19,Rep,Jane Neal,11
-Kings,59078,State Senate,SD19,Rep,Jane Neal,15
-Kings,59079,State Senate,SD19,Rep,Jane Neal,8
-Kings,59080,State Senate,SD19,Rep,Jane Neal,13
-Kings,59081,State Senate,SD19,Rep,Jane Neal,10
-Kings,60001,State Senate,SD19,Rep,Jane Neal,3
-Kings,60002,State Senate,SD19,Rep,Jane Neal,12
-Kings,60003,State Senate,SD19,Rep,Jane Neal,8
-Kings,60005,State Senate,SD19,Rep,Jane Neal,0
-Kings,60007,State Senate,SD19,Rep,Jane Neal,4
-Kings,60008,State Senate,SD19,Rep,Jane Neal,6
-Kings,60009,State Senate,SD19,Rep,Jane Neal,5
-Kings,60012,State Senate,SD19,Rep,Jane Neal,2
-Kings,60014,State Senate,SD19,Rep,Jane Neal,6
-Kings,60015,State Senate,SD19,Rep,Jane Neal,5
-Kings,60017,State Senate,SD19,Rep,Jane Neal,2
-Kings,60021,State Senate,SD19,Rep,Jane Neal,13
-Kings,60022,State Senate,SD19,Rep,Jane Neal,14
-Kings,60023,State Senate,SD19,Rep,Jane Neal,3
-Kings,60024,State Senate,SD19,Rep,Jane Neal,4
-Kings,60025,State Senate,SD19,Rep,Jane Neal,4
-Kings,60026,State Senate,SD19,Rep,Jane Neal,1
-Kings,60027,State Senate,SD19,Rep,Jane Neal,2
-Kings,60028,State Senate,SD19,Rep,Jane Neal,7
-Kings,60029,State Senate,SD19,Rep,Jane Neal,5
-Kings,60030,State Senate,SD19,Rep,Jane Neal,7
-Kings,60031,State Senate,SD19,Rep,Jane Neal,3
-Kings,60032,State Senate,SD19,Rep,Jane Neal,12
-Kings,60033,State Senate,SD19,Rep,Jane Neal,2
-Kings,60034,State Senate,SD19,Rep,Jane Neal,5
-Kings,60035,State Senate,SD19,Rep,Jane Neal,3
-Kings,60036,State Senate,SD19,Rep,Jane Neal,4
-Kings,60037,State Senate,SD19,Rep,Jane Neal,9
-Kings,60038,State Senate,SD19,Rep,Jane Neal,5
-Kings,60039,State Senate,SD19,Rep,Jane Neal,3
-Kings,60040,State Senate,SD19,Rep,Jane Neal,2
-Kings,60041,State Senate,SD19,Rep,Jane Neal,2
-Kings,60042,State Senate,SD19,Rep,Jane Neal,2
-Kings,60043,State Senate,SD19,Rep,Jane Neal,0
-Kings,60044,State Senate,SD19,Rep,Jane Neal,8
-Kings,60045,State Senate,SD19,Rep,Jane Neal,7
-Kings,60046,State Senate,SD19,Rep,Jane Neal,3
-Kings,60047,State Senate,SD19,Rep,Jane Neal,4
-Kings,60048,State Senate,SD19,Rep,Jane Neal,1
-Kings,60049,State Senate,SD19,Rep,Jane Neal,4
-Kings,60050,State Senate,SD19,Rep,Jane Neal,4
-Kings,60051,State Senate,SD19,Rep,Jane Neal,4
-Kings,60052,State Senate,SD19,Rep,Jane Neal,3
-Kings,60053,State Senate,SD19,Rep,Jane Neal,2
-Kings,60054,State Senate,SD19,Rep,Jane Neal,7
-Kings,60055,State Senate,SD19,Rep,Jane Neal,4
-Kings,60056,State Senate,SD19,Rep,Jane Neal,3
-Kings,60057,State Senate,SD19,Rep,Jane Neal,3
-Kings,60058,State Senate,SD19,Rep,Jane Neal,4
-Kings,60059,State Senate,SD19,Rep,Jane Neal,4
-Kings,60060,State Senate,SD19,Rep,Jane Neal,4
-Kings,60061,State Senate,SD19,Rep,Jane Neal,5
-Kings,60062,State Senate,SD19,Rep,Jane Neal,1
-Kings,60063,State Senate,SD19,Rep,Jane Neal,1
-Kings,60064,State Senate,SD19,Rep,Jane Neal,5
-Kings,60065,State Senate,SD19,Rep,Jane Neal,8
-Kings,60066,State Senate,SD19,Rep,Jane Neal,1
-Kings,60067,State Senate,SD19,Rep,Jane Neal,3
-Kings,60068,State Senate,SD19,Rep,Jane Neal,1
-Kings,60069,State Senate,SD19,Rep,Jane Neal,0
-Kings,60070,State Senate,SD19,Rep,Jane Neal,0
-Kings,60071,State Senate,SD19,Rep,Jane Neal,2
-Kings,60072,State Senate,SD19,Rep,Jane Neal,4
-Kings,60073,State Senate,SD19,Rep,Jane Neal,0
-Kings,60074,State Senate,SD19,Rep,Jane Neal,65
-Kings,60075,State Senate,SD19,Rep,Jane Neal,10
-Kings,60076,State Senate,SD19,Rep,Jane Neal,25
-Kings,60077,State Senate,SD19,Rep,Jane Neal,23
-Kings,60078,State Senate,SD19,Rep,Jane Neal,39
-Kings,60079,State Senate,SD19,Rep,Jane Neal,4
-Kings,60080,State Senate,SD19,Rep,Jane Neal,4
-Kings,60081,State Senate,SD19,Rep,Jane Neal,2
-Kings,60082,State Senate,SD19,Rep,Jane Neal,8
-Kings,60083,State Senate,SD19,Rep,Jane Neal,11
-Kings,60084,State Senate,SD19,Rep,Jane Neal,2
-Kings,60085,State Senate,SD19,Rep,Jane Neal,7
-Kings,60086,State Senate,SD19,Rep,Jane Neal,1
-Kings,60087,State Senate,SD19,Rep,Jane Neal,19
-Kings,60088,State Senate,SD19,Rep,Jane Neal,46
-Kings,60089,State Senate,SD19,Rep,Jane Neal,55
-Kings,60090,State Senate,SD19,Rep,Jane Neal,93
-Kings,60091,State Senate,SD19,Rep,Jane Neal,22
-Kings,41013,State Senate,SD19,Dem,John Sampson,6
-Kings,41015,State Senate,SD19,Dem,John Sampson,87
-Kings,41019,State Senate,SD19,Dem,John Sampson,17
-Kings,41020,State Senate,SD19,Dem,John Sampson,206
-Kings,41021,State Senate,SD19,Dem,John Sampson,261
-Kings,41022,State Senate,SD19,Dem,John Sampson,255
-Kings,41025,State Senate,SD19,Dem,John Sampson,69
-Kings,41026,State Senate,SD19,Dem,John Sampson,52
-Kings,41027,State Senate,SD19,Dem,John Sampson,225
-Kings,41028,State Senate,SD19,Dem,John Sampson,280
-Kings,41029,State Senate,SD19,Dem,John Sampson,28
-Kings,41057,State Senate,SD19,Dem,John Sampson,167
-Kings,41060,State Senate,SD19,Dem,John Sampson,260
-Kings,41061,State Senate,SD19,Dem,John Sampson,200
-Kings,41062,State Senate,SD19,Dem,John Sampson,208
-Kings,41063,State Senate,SD19,Dem,John Sampson,200
-Kings,41064,State Senate,SD19,Dem,John Sampson,338
-Kings,41065,State Senate,SD19,Dem,John Sampson,117
-Kings,41066,State Senate,SD19,Dem,John Sampson,341
-Kings,41067,State Senate,SD19,Dem,John Sampson,365
-Kings,41068,State Senate,SD19,Dem,John Sampson,323
-Kings,41069,State Senate,SD19,Dem,John Sampson,370
-Kings,41070,State Senate,SD19,Dem,John Sampson,190
-Kings,41071,State Senate,SD19,Dem,John Sampson,212
-Kings,41072,State Senate,SD19,Dem,John Sampson,182
-Kings,41073,State Senate,SD19,Dem,John Sampson,302
-Kings,41074,State Senate,SD19,Dem,John Sampson,213
-Kings,41075,State Senate,SD19,Dem,John Sampson,150
-Kings,41076,State Senate,SD19,Dem,John Sampson,210
-Kings,41077,State Senate,SD19,Dem,John Sampson,270
-Kings,41078,State Senate,SD19,Dem,John Sampson,251
-Kings,41079,State Senate,SD19,Dem,John Sampson,163
-Kings,41080,State Senate,SD19,Dem,John Sampson,22
-Kings,42069,State Senate,SD19,Dem,John Sampson,41
-Kings,42070,State Senate,SD19,Dem,John Sampson,13
-Kings,45025,State Senate,SD19,Dem,John Sampson,56
-Kings,45026,State Senate,SD19,Dem,John Sampson,138
-Kings,45027,State Senate,SD19,Dem,John Sampson,145
-Kings,45028,State Senate,SD19,Dem,John Sampson,146
-Kings,45082,State Senate,SD19,Dem,John Sampson,139
-Kings,54002,State Senate,SD19,Dem,John Sampson,164
-Kings,54003,State Senate,SD19,Dem,John Sampson,242
-Kings,54004,State Senate,SD19,Dem,John Sampson,438
-Kings,54005,State Senate,SD19,Dem,John Sampson,112
-Kings,54006,State Senate,SD19,Dem,John Sampson,89
-Kings,54071,State Senate,SD19,Dem,John Sampson,211
-Kings,54072,State Senate,SD19,Dem,John Sampson,65
-Kings,55027,State Senate,SD19,Dem,John Sampson,221
-Kings,55036,State Senate,SD19,Dem,John Sampson,25
-Kings,55037,State Senate,SD19,Dem,John Sampson,313
-Kings,55038,State Senate,SD19,Dem,John Sampson,103
-Kings,55039,State Senate,SD19,Dem,John Sampson,15
-Kings,55040,State Senate,SD19,Dem,John Sampson,86
-Kings,55044,State Senate,SD19,Dem,John Sampson,15
-Kings,55047,State Senate,SD19,Dem,John Sampson,160
-Kings,55048,State Senate,SD19,Dem,John Sampson,420
-Kings,55049,State Senate,SD19,Dem,John Sampson,243
-Kings,55052,State Senate,SD19,Dem,John Sampson,184
-Kings,55055,State Senate,SD19,Dem,John Sampson,283
-Kings,55056,State Senate,SD19,Dem,John Sampson,56
-Kings,55060,State Senate,SD19,Dem,John Sampson,101
-Kings,55062,State Senate,SD19,Dem,John Sampson,246
-Kings,55063,State Senate,SD19,Dem,John Sampson,186
-Kings,55064,State Senate,SD19,Dem,John Sampson,393
-Kings,55074,State Senate,SD19,Dem,John Sampson,377
-Kings,55075,State Senate,SD19,Dem,John Sampson,356
-Kings,55077,State Senate,SD19,Dem,John Sampson,76
-Kings,55099,State Senate,SD19,Dem,John Sampson,603
-Kings,55105,State Senate,SD19,Dem,John Sampson,3
-Kings,58057,State Senate,SD19,Dem,John Sampson,369
-Kings,58058,State Senate,SD19,Dem,John Sampson,153
-Kings,58059,State Senate,SD19,Dem,John Sampson,617
-Kings,58060,State Senate,SD19,Dem,John Sampson,456
-Kings,58066,State Senate,SD19,Dem,John Sampson,437
-Kings,58067,State Senate,SD19,Dem,John Sampson,498
-Kings,58068,State Senate,SD19,Dem,John Sampson,417
-Kings,58069,State Senate,SD19,Dem,John Sampson,135
-Kings,58070,State Senate,SD19,Dem,John Sampson,545
-Kings,58071,State Senate,SD19,Dem,John Sampson,685
-Kings,58072,State Senate,SD19,Dem,John Sampson,596
-Kings,58073,State Senate,SD19,Dem,John Sampson,247
-Kings,58074,State Senate,SD19,Dem,John Sampson,664
-Kings,58075,State Senate,SD19,Dem,John Sampson,650
-Kings,58076,State Senate,SD19,Dem,John Sampson,555
-Kings,58077,State Senate,SD19,Dem,John Sampson,579
-Kings,58078,State Senate,SD19,Dem,John Sampson,506
-Kings,58079,State Senate,SD19,Dem,John Sampson,396
-Kings,59005,State Senate,SD19,Dem,John Sampson,682
-Kings,59006,State Senate,SD19,Dem,John Sampson,713
-Kings,59007,State Senate,SD19,Dem,John Sampson,527
-Kings,59008,State Senate,SD19,Dem,John Sampson,461
-Kings,59010,State Senate,SD19,Dem,John Sampson,352
-Kings,59011,State Senate,SD19,Dem,John Sampson,557
-Kings,59012,State Senate,SD19,Dem,John Sampson,622
-Kings,59013,State Senate,SD19,Dem,John Sampson,704
-Kings,59014,State Senate,SD19,Dem,John Sampson,671
-Kings,59015,State Senate,SD19,Dem,John Sampson,784
-Kings,59024,State Senate,SD19,Dem,John Sampson,556
-Kings,59026,State Senate,SD19,Dem,John Sampson,581
-Kings,59027,State Senate,SD19,Dem,John Sampson,532
-Kings,59028,State Senate,SD19,Dem,John Sampson,446
-Kings,59029,State Senate,SD19,Dem,John Sampson,440
-Kings,59030,State Senate,SD19,Dem,John Sampson,497
-Kings,59031,State Senate,SD19,Dem,John Sampson,568
-Kings,59032,State Senate,SD19,Dem,John Sampson,262
-Kings,59050,State Senate,SD19,Dem,John Sampson,432
-Kings,59051,State Senate,SD19,Dem,John Sampson,287
-Kings,59052,State Senate,SD19,Dem,John Sampson,172
-Kings,59053,State Senate,SD19,Dem,John Sampson,168
-Kings,59054,State Senate,SD19,Dem,John Sampson,129
-Kings,59055,State Senate,SD19,Dem,John Sampson,196
-Kings,59056,State Senate,SD19,Dem,John Sampson,478
-Kings,59057,State Senate,SD19,Dem,John Sampson,383
-Kings,59058,State Senate,SD19,Dem,John Sampson,345
-Kings,59059,State Senate,SD19,Dem,John Sampson,239
-Kings,59060,State Senate,SD19,Dem,John Sampson,146
-Kings,59061,State Senate,SD19,Dem,John Sampson,133
-Kings,59062,State Senate,SD19,Dem,John Sampson,106
-Kings,59063,State Senate,SD19,Dem,John Sampson,14
-Kings,59064,State Senate,SD19,Dem,John Sampson,628
-Kings,59065,State Senate,SD19,Dem,John Sampson,620
-Kings,59066,State Senate,SD19,Dem,John Sampson,754
-Kings,59067,State Senate,SD19,Dem,John Sampson,673
-Kings,59068,State Senate,SD19,Dem,John Sampson,619
-Kings,59069,State Senate,SD19,Dem,John Sampson,726
-Kings,59070,State Senate,SD19,Dem,John Sampson,547
-Kings,59071,State Senate,SD19,Dem,John Sampson,618
-Kings,59072,State Senate,SD19,Dem,John Sampson,546
-Kings,59073,State Senate,SD19,Dem,John Sampson,647
-Kings,59074,State Senate,SD19,Dem,John Sampson,639
-Kings,59075,State Senate,SD19,Dem,John Sampson,552
-Kings,59076,State Senate,SD19,Dem,John Sampson,529
-Kings,59077,State Senate,SD19,Dem,John Sampson,509
-Kings,59078,State Senate,SD19,Dem,John Sampson,331
-Kings,59079,State Senate,SD19,Dem,John Sampson,310
-Kings,59080,State Senate,SD19,Dem,John Sampson,525
-Kings,59081,State Senate,SD19,Dem,John Sampson,410
-Kings,60001,State Senate,SD19,Dem,John Sampson,548
-Kings,60002,State Senate,SD19,Dem,John Sampson,573
-Kings,60003,State Senate,SD19,Dem,John Sampson,504
-Kings,60005,State Senate,SD19,Dem,John Sampson,56
-Kings,60007,State Senate,SD19,Dem,John Sampson,567
-Kings,60008,State Senate,SD19,Dem,John Sampson,644
-Kings,60009,State Senate,SD19,Dem,John Sampson,168
-Kings,60012,State Senate,SD19,Dem,John Sampson,69
-Kings,60014,State Senate,SD19,Dem,John Sampson,521
-Kings,60015,State Senate,SD19,Dem,John Sampson,412
-Kings,60017,State Senate,SD19,Dem,John Sampson,25
-Kings,60021,State Senate,SD19,Dem,John Sampson,470
-Kings,60022,State Senate,SD19,Dem,John Sampson,432
-Kings,60023,State Senate,SD19,Dem,John Sampson,82
-Kings,60024,State Senate,SD19,Dem,John Sampson,278
-Kings,60025,State Senate,SD19,Dem,John Sampson,319
-Kings,60026,State Senate,SD19,Dem,John Sampson,317
-Kings,60027,State Senate,SD19,Dem,John Sampson,302
-Kings,60028,State Senate,SD19,Dem,John Sampson,480
-Kings,60029,State Senate,SD19,Dem,John Sampson,427
-Kings,60030,State Senate,SD19,Dem,John Sampson,284
-Kings,60031,State Senate,SD19,Dem,John Sampson,411
-Kings,60032,State Senate,SD19,Dem,John Sampson,453
-Kings,60033,State Senate,SD19,Dem,John Sampson,412
-Kings,60034,State Senate,SD19,Dem,John Sampson,555
-Kings,60035,State Senate,SD19,Dem,John Sampson,570
-Kings,60036,State Senate,SD19,Dem,John Sampson,569
-Kings,60037,State Senate,SD19,Dem,John Sampson,574
-Kings,60038,State Senate,SD19,Dem,John Sampson,310
-Kings,60039,State Senate,SD19,Dem,John Sampson,406
-Kings,60040,State Senate,SD19,Dem,John Sampson,507
-Kings,60041,State Senate,SD19,Dem,John Sampson,549
-Kings,60042,State Senate,SD19,Dem,John Sampson,466
-Kings,60043,State Senate,SD19,Dem,John Sampson,551
-Kings,60044,State Senate,SD19,Dem,John Sampson,235
-Kings,60045,State Senate,SD19,Dem,John Sampson,547
-Kings,60046,State Senate,SD19,Dem,John Sampson,594
-Kings,60047,State Senate,SD19,Dem,John Sampson,564
-Kings,60048,State Senate,SD19,Dem,John Sampson,185
-Kings,60049,State Senate,SD19,Dem,John Sampson,459
-Kings,60050,State Senate,SD19,Dem,John Sampson,197
-Kings,60051,State Senate,SD19,Dem,John Sampson,535
-Kings,60052,State Senate,SD19,Dem,John Sampson,358
-Kings,60053,State Senate,SD19,Dem,John Sampson,437
-Kings,60054,State Senate,SD19,Dem,John Sampson,605
-Kings,60055,State Senate,SD19,Dem,John Sampson,373
-Kings,60056,State Senate,SD19,Dem,John Sampson,330
-Kings,60057,State Senate,SD19,Dem,John Sampson,610
-Kings,60058,State Senate,SD19,Dem,John Sampson,401
-Kings,60059,State Senate,SD19,Dem,John Sampson,272
-Kings,60060,State Senate,SD19,Dem,John Sampson,418
-Kings,60061,State Senate,SD19,Dem,John Sampson,295
-Kings,60062,State Senate,SD19,Dem,John Sampson,46
-Kings,60063,State Senate,SD19,Dem,John Sampson,462
-Kings,60064,State Senate,SD19,Dem,John Sampson,523
-Kings,60065,State Senate,SD19,Dem,John Sampson,559
-Kings,60066,State Senate,SD19,Dem,John Sampson,286
-Kings,60067,State Senate,SD19,Dem,John Sampson,347
-Kings,60068,State Senate,SD19,Dem,John Sampson,363
-Kings,60069,State Senate,SD19,Dem,John Sampson,106
-Kings,60070,State Senate,SD19,Dem,John Sampson,207
-Kings,60071,State Senate,SD19,Dem,John Sampson,384
-Kings,60072,State Senate,SD19,Dem,John Sampson,466
-Kings,60073,State Senate,SD19,Dem,John Sampson,394
-Kings,60074,State Senate,SD19,Dem,John Sampson,459
-Kings,60075,State Senate,SD19,Dem,John Sampson,630
-Kings,60076,State Senate,SD19,Dem,John Sampson,360
-Kings,60077,State Senate,SD19,Dem,John Sampson,397
-Kings,60078,State Senate,SD19,Dem,John Sampson,506
-Kings,60079,State Senate,SD19,Dem,John Sampson,229
-Kings,60080,State Senate,SD19,Dem,John Sampson,509
-Kings,60081,State Senate,SD19,Dem,John Sampson,428
-Kings,60082,State Senate,SD19,Dem,John Sampson,570
-Kings,60083,State Senate,SD19,Dem,John Sampson,710
-Kings,60084,State Senate,SD19,Dem,John Sampson,160
-Kings,60085,State Senate,SD19,Dem,John Sampson,337
-Kings,60086,State Senate,SD19,Dem,John Sampson,142
-Kings,60087,State Senate,SD19,Dem,John Sampson,479
-Kings,60088,State Senate,SD19,Dem,John Sampson,484
-Kings,60089,State Senate,SD19,Dem,John Sampson,533
-Kings,60090,State Senate,SD19,Dem,John Sampson,334
-Kings,60091,State Senate,SD19,Dem,John Sampson,271
-Kings,41013,State Senate,SD19,WF,John Sampson,0
-Kings,41015,State Senate,SD19,WF,John Sampson,5
-Kings,41019,State Senate,SD19,WF,John Sampson,0
-Kings,41020,State Senate,SD19,WF,John Sampson,5
-Kings,41021,State Senate,SD19,WF,John Sampson,9
-Kings,41022,State Senate,SD19,WF,John Sampson,12
-Kings,41025,State Senate,SD19,WF,John Sampson,1
-Kings,41026,State Senate,SD19,WF,John Sampson,1
-Kings,41027,State Senate,SD19,WF,John Sampson,4
-Kings,41028,State Senate,SD19,WF,John Sampson,5
-Kings,41029,State Senate,SD19,WF,John Sampson,0
-Kings,41057,State Senate,SD19,WF,John Sampson,8
-Kings,41060,State Senate,SD19,WF,John Sampson,8
-Kings,41061,State Senate,SD19,WF,John Sampson,9
-Kings,41062,State Senate,SD19,WF,John Sampson,9
-Kings,41063,State Senate,SD19,WF,John Sampson,11
-Kings,41064,State Senate,SD19,WF,John Sampson,25
-Kings,41065,State Senate,SD19,WF,John Sampson,2
-Kings,41066,State Senate,SD19,WF,John Sampson,3
-Kings,41067,State Senate,SD19,WF,John Sampson,15
-Kings,41068,State Senate,SD19,WF,John Sampson,5
-Kings,41069,State Senate,SD19,WF,John Sampson,8
-Kings,41070,State Senate,SD19,WF,John Sampson,12
-Kings,41071,State Senate,SD19,WF,John Sampson,6
-Kings,41072,State Senate,SD19,WF,John Sampson,5
-Kings,41073,State Senate,SD19,WF,John Sampson,13
-Kings,41074,State Senate,SD19,WF,John Sampson,7
-Kings,41075,State Senate,SD19,WF,John Sampson,5
-Kings,41076,State Senate,SD19,WF,John Sampson,2
-Kings,41077,State Senate,SD19,WF,John Sampson,17
-Kings,41078,State Senate,SD19,WF,John Sampson,15
-Kings,41079,State Senate,SD19,WF,John Sampson,13
-Kings,41080,State Senate,SD19,WF,John Sampson,1
-Kings,42069,State Senate,SD19,WF,John Sampson,4
-Kings,42070,State Senate,SD19,WF,John Sampson,0
-Kings,45025,State Senate,SD19,WF,John Sampson,4
-Kings,45026,State Senate,SD19,WF,John Sampson,5
-Kings,45027,State Senate,SD19,WF,John Sampson,11
-Kings,45028,State Senate,SD19,WF,John Sampson,8
-Kings,45082,State Senate,SD19,WF,John Sampson,12
-Kings,54002,State Senate,SD19,WF,John Sampson,10
-Kings,54003,State Senate,SD19,WF,John Sampson,4
-Kings,54004,State Senate,SD19,WF,John Sampson,3
-Kings,54005,State Senate,SD19,WF,John Sampson,0
-Kings,54006,State Senate,SD19,WF,John Sampson,2
-Kings,54071,State Senate,SD19,WF,John Sampson,2
-Kings,54072,State Senate,SD19,WF,John Sampson,1
-Kings,55027,State Senate,SD19,WF,John Sampson,10
-Kings,55036,State Senate,SD19,WF,John Sampson,1
-Kings,55037,State Senate,SD19,WF,John Sampson,8
-Kings,55038,State Senate,SD19,WF,John Sampson,0
-Kings,55039,State Senate,SD19,WF,John Sampson,0
-Kings,55040,State Senate,SD19,WF,John Sampson,4
-Kings,55044,State Senate,SD19,WF,John Sampson,0
-Kings,55047,State Senate,SD19,WF,John Sampson,0
-Kings,55048,State Senate,SD19,WF,John Sampson,6
-Kings,55049,State Senate,SD19,WF,John Sampson,3
-Kings,55052,State Senate,SD19,WF,John Sampson,2
-Kings,55055,State Senate,SD19,WF,John Sampson,8
-Kings,55056,State Senate,SD19,WF,John Sampson,0
-Kings,55060,State Senate,SD19,WF,John Sampson,4
-Kings,55062,State Senate,SD19,WF,John Sampson,3
-Kings,55063,State Senate,SD19,WF,John Sampson,2
-Kings,55064,State Senate,SD19,WF,John Sampson,2
-Kings,55074,State Senate,SD19,WF,John Sampson,4
-Kings,55075,State Senate,SD19,WF,John Sampson,4
-Kings,55077,State Senate,SD19,WF,John Sampson,3
-Kings,55099,State Senate,SD19,WF,John Sampson,6
-Kings,55105,State Senate,SD19,WF,John Sampson,0
-Kings,58057,State Senate,SD19,WF,John Sampson,0
-Kings,58058,State Senate,SD19,WF,John Sampson,0
-Kings,58059,State Senate,SD19,WF,John Sampson,6
-Kings,58060,State Senate,SD19,WF,John Sampson,4
-Kings,58066,State Senate,SD19,WF,John Sampson,4
-Kings,58067,State Senate,SD19,WF,John Sampson,6
-Kings,58068,State Senate,SD19,WF,John Sampson,3
-Kings,58069,State Senate,SD19,WF,John Sampson,1
-Kings,58070,State Senate,SD19,WF,John Sampson,9
-Kings,58071,State Senate,SD19,WF,John Sampson,8
-Kings,58072,State Senate,SD19,WF,John Sampson,2
-Kings,58073,State Senate,SD19,WF,John Sampson,5
-Kings,58074,State Senate,SD19,WF,John Sampson,2
-Kings,58075,State Senate,SD19,WF,John Sampson,6
-Kings,58076,State Senate,SD19,WF,John Sampson,18
-Kings,58077,State Senate,SD19,WF,John Sampson,10
-Kings,58078,State Senate,SD19,WF,John Sampson,5
-Kings,58079,State Senate,SD19,WF,John Sampson,3
-Kings,59005,State Senate,SD19,WF,John Sampson,3
-Kings,59006,State Senate,SD19,WF,John Sampson,3
-Kings,59007,State Senate,SD19,WF,John Sampson,3
-Kings,59008,State Senate,SD19,WF,John Sampson,7
-Kings,59010,State Senate,SD19,WF,John Sampson,4
-Kings,59011,State Senate,SD19,WF,John Sampson,12
-Kings,59012,State Senate,SD19,WF,John Sampson,2
-Kings,59013,State Senate,SD19,WF,John Sampson,2
-Kings,59014,State Senate,SD19,WF,John Sampson,5
-Kings,59015,State Senate,SD19,WF,John Sampson,0
-Kings,59024,State Senate,SD19,WF,John Sampson,13
-Kings,59026,State Senate,SD19,WF,John Sampson,14
-Kings,59027,State Senate,SD19,WF,John Sampson,8
-Kings,59028,State Senate,SD19,WF,John Sampson,6
-Kings,59029,State Senate,SD19,WF,John Sampson,13
-Kings,59030,State Senate,SD19,WF,John Sampson,9
-Kings,59031,State Senate,SD19,WF,John Sampson,13
-Kings,59032,State Senate,SD19,WF,John Sampson,8
-Kings,59050,State Senate,SD19,WF,John Sampson,18
-Kings,59051,State Senate,SD19,WF,John Sampson,16
-Kings,59052,State Senate,SD19,WF,John Sampson,6
-Kings,59053,State Senate,SD19,WF,John Sampson,6
-Kings,59054,State Senate,SD19,WF,John Sampson,3
-Kings,59055,State Senate,SD19,WF,John Sampson,0
-Kings,59056,State Senate,SD19,WF,John Sampson,12
-Kings,59057,State Senate,SD19,WF,John Sampson,5
-Kings,59058,State Senate,SD19,WF,John Sampson,10
-Kings,59059,State Senate,SD19,WF,John Sampson,7
-Kings,59060,State Senate,SD19,WF,John Sampson,10
-Kings,59061,State Senate,SD19,WF,John Sampson,0
-Kings,59062,State Senate,SD19,WF,John Sampson,1
-Kings,59063,State Senate,SD19,WF,John Sampson,1
-Kings,59064,State Senate,SD19,WF,John Sampson,2
-Kings,59065,State Senate,SD19,WF,John Sampson,12
-Kings,59066,State Senate,SD19,WF,John Sampson,5
-Kings,59067,State Senate,SD19,WF,John Sampson,7
-Kings,59068,State Senate,SD19,WF,John Sampson,15
-Kings,59069,State Senate,SD19,WF,John Sampson,8
-Kings,59070,State Senate,SD19,WF,John Sampson,7
-Kings,59071,State Senate,SD19,WF,John Sampson,5
-Kings,59072,State Senate,SD19,WF,John Sampson,4
-Kings,59073,State Senate,SD19,WF,John Sampson,7
-Kings,59074,State Senate,SD19,WF,John Sampson,4
-Kings,59075,State Senate,SD19,WF,John Sampson,6
-Kings,59076,State Senate,SD19,WF,John Sampson,8
-Kings,59077,State Senate,SD19,WF,John Sampson,16
-Kings,59078,State Senate,SD19,WF,John Sampson,9
-Kings,59079,State Senate,SD19,WF,John Sampson,12
-Kings,59080,State Senate,SD19,WF,John Sampson,14
-Kings,59081,State Senate,SD19,WF,John Sampson,12
-Kings,60001,State Senate,SD19,WF,John Sampson,8
-Kings,60002,State Senate,SD19,WF,John Sampson,8
-Kings,60003,State Senate,SD19,WF,John Sampson,7
-Kings,60005,State Senate,SD19,WF,John Sampson,0
-Kings,60007,State Senate,SD19,WF,John Sampson,10
-Kings,60008,State Senate,SD19,WF,John Sampson,7
-Kings,60009,State Senate,SD19,WF,John Sampson,3
-Kings,60012,State Senate,SD19,WF,John Sampson,7
-Kings,60014,State Senate,SD19,WF,John Sampson,3
-Kings,60015,State Senate,SD19,WF,John Sampson,7
-Kings,60017,State Senate,SD19,WF,John Sampson,4
-Kings,60021,State Senate,SD19,WF,John Sampson,4
-Kings,60022,State Senate,SD19,WF,John Sampson,6
-Kings,60023,State Senate,SD19,WF,John Sampson,1
-Kings,60024,State Senate,SD19,WF,John Sampson,4
-Kings,60025,State Senate,SD19,WF,John Sampson,5
-Kings,60026,State Senate,SD19,WF,John Sampson,0
-Kings,60027,State Senate,SD19,WF,John Sampson,2
-Kings,60028,State Senate,SD19,WF,John Sampson,5
-Kings,60029,State Senate,SD19,WF,John Sampson,5
-Kings,60030,State Senate,SD19,WF,John Sampson,1
-Kings,60031,State Senate,SD19,WF,John Sampson,4
-Kings,60032,State Senate,SD19,WF,John Sampson,1
-Kings,60033,State Senate,SD19,WF,John Sampson,9
-Kings,60034,State Senate,SD19,WF,John Sampson,9
-Kings,60035,State Senate,SD19,WF,John Sampson,8
-Kings,60036,State Senate,SD19,WF,John Sampson,12
-Kings,60037,State Senate,SD19,WF,John Sampson,5
-Kings,60038,State Senate,SD19,WF,John Sampson,3
-Kings,60039,State Senate,SD19,WF,John Sampson,8
-Kings,60040,State Senate,SD19,WF,John Sampson,18
-Kings,60041,State Senate,SD19,WF,John Sampson,3
-Kings,60042,State Senate,SD19,WF,John Sampson,8
-Kings,60043,State Senate,SD19,WF,John Sampson,6
-Kings,60044,State Senate,SD19,WF,John Sampson,6
-Kings,60045,State Senate,SD19,WF,John Sampson,9
-Kings,60046,State Senate,SD19,WF,John Sampson,3
-Kings,60047,State Senate,SD19,WF,John Sampson,7
-Kings,60048,State Senate,SD19,WF,John Sampson,3
-Kings,60049,State Senate,SD19,WF,John Sampson,9
-Kings,60050,State Senate,SD19,WF,John Sampson,1
-Kings,60051,State Senate,SD19,WF,John Sampson,13
-Kings,60052,State Senate,SD19,WF,John Sampson,3
-Kings,60053,State Senate,SD19,WF,John Sampson,8
-Kings,60054,State Senate,SD19,WF,John Sampson,11
-Kings,60055,State Senate,SD19,WF,John Sampson,14
-Kings,60056,State Senate,SD19,WF,John Sampson,5
-Kings,60057,State Senate,SD19,WF,John Sampson,7
-Kings,60058,State Senate,SD19,WF,John Sampson,8
-Kings,60059,State Senate,SD19,WF,John Sampson,9
-Kings,60060,State Senate,SD19,WF,John Sampson,9
-Kings,60061,State Senate,SD19,WF,John Sampson,9
-Kings,60062,State Senate,SD19,WF,John Sampson,2
-Kings,60063,State Senate,SD19,WF,John Sampson,6
-Kings,60064,State Senate,SD19,WF,John Sampson,13
-Kings,60065,State Senate,SD19,WF,John Sampson,11
-Kings,60066,State Senate,SD19,WF,John Sampson,3
-Kings,60067,State Senate,SD19,WF,John Sampson,3
-Kings,60068,State Senate,SD19,WF,John Sampson,7
-Kings,60069,State Senate,SD19,WF,John Sampson,0
-Kings,60070,State Senate,SD19,WF,John Sampson,1
-Kings,60071,State Senate,SD19,WF,John Sampson,9
-Kings,60072,State Senate,SD19,WF,John Sampson,5
-Kings,60073,State Senate,SD19,WF,John Sampson,2
-Kings,60074,State Senate,SD19,WF,John Sampson,13
-Kings,60075,State Senate,SD19,WF,John Sampson,6
-Kings,60076,State Senate,SD19,WF,John Sampson,6
-Kings,60077,State Senate,SD19,WF,John Sampson,9
-Kings,60078,State Senate,SD19,WF,John Sampson,14
-Kings,60079,State Senate,SD19,WF,John Sampson,1
-Kings,60080,State Senate,SD19,WF,John Sampson,6
-Kings,60081,State Senate,SD19,WF,John Sampson,6
-Kings,60082,State Senate,SD19,WF,John Sampson,6
-Kings,60083,State Senate,SD19,WF,John Sampson,8
-Kings,60084,State Senate,SD19,WF,John Sampson,1
-Kings,60085,State Senate,SD19,WF,John Sampson,10
-Kings,60086,State Senate,SD19,WF,John Sampson,0
-Kings,60087,State Senate,SD19,WF,John Sampson,6
-Kings,60088,State Senate,SD19,WF,John Sampson,7
-Kings,60089,State Senate,SD19,WF,John Sampson,9
-Kings,60090,State Senate,SD19,WF,John Sampson,7
-Kings,60091,State Senate,SD19,WF,John Sampson,8
-Kings,41013,State Senate,SD19,Ind,writein,0
-Kings,41015,State Senate,SD19,Ind,writein,0
-Kings,41019,State Senate,SD19,Ind,writein,0
-Kings,41020,State Senate,SD19,Ind,writein,0
-Kings,41021,State Senate,SD19,Ind,writein,1
-Kings,41022,State Senate,SD19,Ind,writein,0
-Kings,41025,State Senate,SD19,Ind,writein,0
-Kings,41026,State Senate,SD19,Ind,writein,0
-Kings,41027,State Senate,SD19,Ind,writein,1
-Kings,41028,State Senate,SD19,Ind,writein,0
-Kings,41029,State Senate,SD19,Ind,writein,0
-Kings,41057,State Senate,SD19,Ind,writein,1
-Kings,41060,State Senate,SD19,Ind,writein,0
-Kings,41061,State Senate,SD19,Ind,writein,0
-Kings,41062,State Senate,SD19,Ind,writein,0
-Kings,41063,State Senate,SD19,Ind,writein,0
-Kings,41064,State Senate,SD19,Ind,writein,0
-Kings,41065,State Senate,SD19,Ind,writein,0
-Kings,41066,State Senate,SD19,Ind,writein,0
-Kings,41067,State Senate,SD19,Ind,writein,0
-Kings,41068,State Senate,SD19,Ind,writein,0
-Kings,41069,State Senate,SD19,Ind,writein,0
-Kings,41070,State Senate,SD19,Ind,writein,0
-Kings,41071,State Senate,SD19,Ind,writein,1
-Kings,41072,State Senate,SD19,Ind,writein,0
-Kings,41073,State Senate,SD19,Ind,writein,1
-Kings,41074,State Senate,SD19,Ind,writein,0
-Kings,41075,State Senate,SD19,Ind,writein,1
-Kings,41076,State Senate,SD19,Ind,writein,0
-Kings,41077,State Senate,SD19,Ind,writein,1
-Kings,41078,State Senate,SD19,Ind,writein,1
-Kings,41079,State Senate,SD19,Ind,writein,0
-Kings,41080,State Senate,SD19,Ind,writein,0
-Kings,42069,State Senate,SD19,Ind,writein,0
-Kings,42070,State Senate,SD19,Ind,writein,1
-Kings,45025,State Senate,SD19,Ind,writein,1
-Kings,45026,State Senate,SD19,Ind,writein,0
-Kings,45027,State Senate,SD19,Ind,writein,2
-Kings,45028,State Senate,SD19,Ind,writein,2
-Kings,45082,State Senate,SD19,Ind,writein,1
-Kings,54002,State Senate,SD19,Ind,writein,0
-Kings,54003,State Senate,SD19,Ind,writein,0
-Kings,54004,State Senate,SD19,Ind,writein,0
-Kings,54005,State Senate,SD19,Ind,writein,0
-Kings,54006,State Senate,SD19,Ind,writein,0
-Kings,54071,State Senate,SD19,Ind,writein,0
-Kings,54072,State Senate,SD19,Ind,writein,0
-Kings,55027,State Senate,SD19,Ind,writein,0
-Kings,55036,State Senate,SD19,Ind,writein,0
-Kings,55037,State Senate,SD19,Ind,writein,0
-Kings,55038,State Senate,SD19,Ind,writein,0
-Kings,55039,State Senate,SD19,Ind,writein,0
-Kings,55040,State Senate,SD19,Ind,writein,0
-Kings,55044,State Senate,SD19,Ind,writein,0
-Kings,55047,State Senate,SD19,Ind,writein,0
-Kings,55048,State Senate,SD19,Ind,writein,0
-Kings,55049,State Senate,SD19,Ind,writein,0
-Kings,55052,State Senate,SD19,Ind,writein,0
-Kings,55055,State Senate,SD19,Ind,writein,0
-Kings,55056,State Senate,SD19,Ind,writein,0
-Kings,55060,State Senate,SD19,Ind,writein,0
-Kings,55062,State Senate,SD19,Ind,writein,0
-Kings,55063,State Senate,SD19,Ind,writein,1
-Kings,55064,State Senate,SD19,Ind,writein,0
-Kings,55074,State Senate,SD19,Ind,writein,0
-Kings,55075,State Senate,SD19,Ind,writein,0
-Kings,55077,State Senate,SD19,Ind,writein,0
-Kings,55099,State Senate,SD19,Ind,writein,0
-Kings,55105,State Senate,SD19,Ind,writein,0
-Kings,58057,State Senate,SD19,Ind,writein,0
-Kings,58058,State Senate,SD19,Ind,writein,0
-Kings,58059,State Senate,SD19,Ind,writein,0
-Kings,58060,State Senate,SD19,Ind,writein,0
-Kings,58066,State Senate,SD19,Ind,writein,0
-Kings,58067,State Senate,SD19,Ind,writein,0
-Kings,58068,State Senate,SD19,Ind,writein,1
-Kings,58069,State Senate,SD19,Ind,writein,0
-Kings,58070,State Senate,SD19,Ind,writein,0
-Kings,58071,State Senate,SD19,Ind,writein,0
-Kings,58072,State Senate,SD19,Ind,writein,0
-Kings,58073,State Senate,SD19,Ind,writein,0
-Kings,58074,State Senate,SD19,Ind,writein,0
-Kings,58075,State Senate,SD19,Ind,writein,0
-Kings,58076,State Senate,SD19,Ind,writein,0
-Kings,58077,State Senate,SD19,Ind,writein,0
-Kings,58078,State Senate,SD19,Ind,writein,0
-Kings,58079,State Senate,SD19,Ind,writein,0
-Kings,59005,State Senate,SD19,Ind,writein,0
-Kings,59006,State Senate,SD19,Ind,writein,0
-Kings,59007,State Senate,SD19,Ind,writein,0
-Kings,59008,State Senate,SD19,Ind,writein,0
-Kings,59010,State Senate,SD19,Ind,writein,0
-Kings,59011,State Senate,SD19,Ind,writein,0
-Kings,59012,State Senate,SD19,Ind,writein,1
-Kings,59013,State Senate,SD19,Ind,writein,0
-Kings,59014,State Senate,SD19,Ind,writein,0
-Kings,59015,State Senate,SD19,Ind,writein,0
-Kings,59024,State Senate,SD19,Ind,writein,0
-Kings,59026,State Senate,SD19,Ind,writein,0
-Kings,59027,State Senate,SD19,Ind,writein,0
-Kings,59028,State Senate,SD19,Ind,writein,0
-Kings,59029,State Senate,SD19,Ind,writein,2
-Kings,59030,State Senate,SD19,Ind,writein,0
-Kings,59031,State Senate,SD19,Ind,writein,0
-Kings,59032,State Senate,SD19,Ind,writein,0
-Kings,59050,State Senate,SD19,Ind,writein,0
-Kings,59051,State Senate,SD19,Ind,writein,0
-Kings,59052,State Senate,SD19,Ind,writein,0
-Kings,59053,State Senate,SD19,Ind,writein,1
-Kings,59054,State Senate,SD19,Ind,writein,0
-Kings,59055,State Senate,SD19,Ind,writein,0
-Kings,59056,State Senate,SD19,Ind,writein,0
-Kings,59057,State Senate,SD19,Ind,writein,0
-Kings,59058,State Senate,SD19,Ind,writein,0
-Kings,59059,State Senate,SD19,Ind,writein,0
-Kings,59060,State Senate,SD19,Ind,writein,0
-Kings,59061,State Senate,SD19,Ind,writein,0
-Kings,59062,State Senate,SD19,Ind,writein,0
-Kings,59063,State Senate,SD19,Ind,writein,0
-Kings,59064,State Senate,SD19,Ind,writein,0
-Kings,59065,State Senate,SD19,Ind,writein,0
-Kings,59066,State Senate,SD19,Ind,writein,0
-Kings,59067,State Senate,SD19,Ind,writein,0
-Kings,59068,State Senate,SD19,Ind,writein,0
-Kings,59069,State Senate,SD19,Ind,writein,0
-Kings,59070,State Senate,SD19,Ind,writein,0
-Kings,59071,State Senate,SD19,Ind,writein,0
-Kings,59072,State Senate,SD19,Ind,writein,0
-Kings,59073,State Senate,SD19,Ind,writein,0
-Kings,59074,State Senate,SD19,Ind,writein,0
-Kings,59075,State Senate,SD19,Ind,writein,0
-Kings,59076,State Senate,SD19,Ind,writein,0
-Kings,59077,State Senate,SD19,Ind,writein,0
-Kings,59078,State Senate,SD19,Ind,writein,0
-Kings,59079,State Senate,SD19,Ind,writein,0
-Kings,59080,State Senate,SD19,Ind,writein,0
-Kings,59081,State Senate,SD19,Ind,writein,0
-Kings,60001,State Senate,SD19,Ind,writein,0
-Kings,60002,State Senate,SD19,Ind,writein,0
-Kings,60003,State Senate,SD19,Ind,writein,0
-Kings,60005,State Senate,SD19,Ind,writein,0
-Kings,60007,State Senate,SD19,Ind,writein,0
-Kings,60008,State Senate,SD19,Ind,writein,1
-Kings,60009,State Senate,SD19,Ind,writein,0
-Kings,60012,State Senate,SD19,Ind,writein,0
-Kings,60014,State Senate,SD19,Ind,writein,0
-Kings,60015,State Senate,SD19,Ind,writein,0
-Kings,60017,State Senate,SD19,Ind,writein,0
-Kings,60021,State Senate,SD19,Ind,writein,0
-Kings,60022,State Senate,SD19,Ind,writein,0
-Kings,60023,State Senate,SD19,Ind,writein,0
-Kings,60024,State Senate,SD19,Ind,writein,0
-Kings,60025,State Senate,SD19,Ind,writein,0
-Kings,60026,State Senate,SD19,Ind,writein,0
-Kings,60027,State Senate,SD19,Ind,writein,0
-Kings,60028,State Senate,SD19,Ind,writein,0
-Kings,60029,State Senate,SD19,Ind,writein,0
-Kings,60030,State Senate,SD19,Ind,writein,0
-Kings,60031,State Senate,SD19,Ind,writein,0
-Kings,60032,State Senate,SD19,Ind,writein,0
-Kings,60033,State Senate,SD19,Ind,writein,0
-Kings,60034,State Senate,SD19,Ind,writein,0
-Kings,60035,State Senate,SD19,Ind,writein,0
-Kings,60036,State Senate,SD19,Ind,writein,0
-Kings,60037,State Senate,SD19,Ind,writein,0
-Kings,60038,State Senate,SD19,Ind,writein,0
-Kings,60039,State Senate,SD19,Ind,writein,0
-Kings,60040,State Senate,SD19,Ind,writein,0
-Kings,60041,State Senate,SD19,Ind,writein,0
-Kings,60042,State Senate,SD19,Ind,writein,0
-Kings,60043,State Senate,SD19,Ind,writein,0
-Kings,60044,State Senate,SD19,Ind,writein,0
-Kings,60045,State Senate,SD19,Ind,writein,0
-Kings,60046,State Senate,SD19,Ind,writein,0
-Kings,60047,State Senate,SD19,Ind,writein,0
-Kings,60048,State Senate,SD19,Ind,writein,0
-Kings,60049,State Senate,SD19,Ind,writein,0
-Kings,60050,State Senate,SD19,Ind,writein,0
-Kings,60051,State Senate,SD19,Ind,writein,0
-Kings,60052,State Senate,SD19,Ind,writein,0
-Kings,60053,State Senate,SD19,Ind,writein,0
-Kings,60054,State Senate,SD19,Ind,writein,0
-Kings,60055,State Senate,SD19,Ind,writein,0
-Kings,60056,State Senate,SD19,Ind,writein,0
-Kings,60057,State Senate,SD19,Ind,writein,0
-Kings,60058,State Senate,SD19,Ind,writein,1
-Kings,60059,State Senate,SD19,Ind,writein,0
-Kings,60060,State Senate,SD19,Ind,writein,0
-Kings,60061,State Senate,SD19,Ind,writein,0
-Kings,60062,State Senate,SD19,Ind,writein,0
-Kings,60063,State Senate,SD19,Ind,writein,0
-Kings,60064,State Senate,SD19,Ind,writein,0
-Kings,60065,State Senate,SD19,Ind,writein,0
-Kings,60066,State Senate,SD19,Ind,writein,0
-Kings,60067,State Senate,SD19,Ind,writein,0
-Kings,60068,State Senate,SD19,Ind,writein,0
-Kings,60069,State Senate,SD19,Ind,writein,0
-Kings,60070,State Senate,SD19,Ind,writein,0
-Kings,60071,State Senate,SD19,Ind,writein,0
-Kings,60072,State Senate,SD19,Ind,writein,0
-Kings,60073,State Senate,SD19,Ind,writein,0
-Kings,60074,State Senate,SD19,Ind,writein,0
-Kings,60075,State Senate,SD19,Ind,writein,0
-Kings,60076,State Senate,SD19,Ind,writein,0
-Kings,60077,State Senate,SD19,Ind,writein,0
-Kings,60078,State Senate,SD19,Ind,writein,0
-Kings,60079,State Senate,SD19,Ind,writein,0
-Kings,60080,State Senate,SD19,Ind,writein,0
-Kings,60081,State Senate,SD19,Ind,writein,0
-Kings,60082,State Senate,SD19,Ind,writein,0
-Kings,60083,State Senate,SD19,Ind,writein,0
-Kings,60084,State Senate,SD19,Ind,writein,0
-Kings,60085,State Senate,SD19,Ind,writein,0
-Kings,60086,State Senate,SD19,Ind,writein,0
-Kings,60087,State Senate,SD19,Ind,writein,0
-Kings,60088,State Senate,SD19,Ind,writein,0
-Kings,60089,State Senate,SD19,Ind,writein,0
-Kings,60090,State Senate,SD19,Ind,writein,0
-Kings,60091,State Senate,SD19,Ind,writein,0
-Kings,42068,State Senate,SD20,Con,Brian Kelly,0
-Kings,43014,State Senate,SD20,Con,Brian Kelly,1
-Kings,43015,State Senate,SD20,Con,Brian Kelly,3
-Kings,43016,State Senate,SD20,Con,Brian Kelly,0
-Kings,43017,State Senate,SD20,Con,Brian Kelly,11
-Kings,43018,State Senate,SD20,Con,Brian Kelly,1
-Kings,43019,State Senate,SD20,Con,Brian Kelly,4
-Kings,43020,State Senate,SD20,Con,Brian Kelly,3
-Kings,43021,State Senate,SD20,Con,Brian Kelly,1
-Kings,43022,State Senate,SD20,Con,Brian Kelly,0
-Kings,43023,State Senate,SD20,Con,Brian Kelly,1
-Kings,43024,State Senate,SD20,Con,Brian Kelly,2
-Kings,43025,State Senate,SD20,Con,Brian Kelly,0
-Kings,43026,State Senate,SD20,Con,Brian Kelly,2
-Kings,43027,State Senate,SD20,Con,Brian Kelly,2
-Kings,43028,State Senate,SD20,Con,Brian Kelly,1
-Kings,43029,State Senate,SD20,Con,Brian Kelly,3
-Kings,43030,State Senate,SD20,Con,Brian Kelly,2
-Kings,43031,State Senate,SD20,Con,Brian Kelly,1
-Kings,43032,State Senate,SD20,Con,Brian Kelly,1
-Kings,43033,State Senate,SD20,Con,Brian Kelly,1
-Kings,43034,State Senate,SD20,Con,Brian Kelly,1
-Kings,43035,State Senate,SD20,Con,Brian Kelly,2
-Kings,43036,State Senate,SD20,Con,Brian Kelly,3
-Kings,43037,State Senate,SD20,Con,Brian Kelly,14
-Kings,43038,State Senate,SD20,Con,Brian Kelly,16
-Kings,43039,State Senate,SD20,Con,Brian Kelly,7
-Kings,43040,State Senate,SD20,Con,Brian Kelly,58
-Kings,43041,State Senate,SD20,Con,Brian Kelly,7
-Kings,43042,State Senate,SD20,Con,Brian Kelly,1
-Kings,43043,State Senate,SD20,Con,Brian Kelly,12
-Kings,43044,State Senate,SD20,Con,Brian Kelly,2
-Kings,43052,State Senate,SD20,Con,Brian Kelly,3
-Kings,43053,State Senate,SD20,Con,Brian Kelly,10
-Kings,43054,State Senate,SD20,Con,Brian Kelly,2
-Kings,43055,State Senate,SD20,Con,Brian Kelly,2
-Kings,43056,State Senate,SD20,Con,Brian Kelly,30
-Kings,43057,State Senate,SD20,Con,Brian Kelly,52
-Kings,43058,State Senate,SD20,Con,Brian Kelly,30
-Kings,43059,State Senate,SD20,Con,Brian Kelly,25
-Kings,43060,State Senate,SD20,Con,Brian Kelly,21
-Kings,43061,State Senate,SD20,Con,Brian Kelly,2
-Kings,43062,State Senate,SD20,Con,Brian Kelly,13
-Kings,43063,State Senate,SD20,Con,Brian Kelly,27
-Kings,43064,State Senate,SD20,Con,Brian Kelly,20
-Kings,43065,State Senate,SD20,Con,Brian Kelly,4
-Kings,43066,State Senate,SD20,Con,Brian Kelly,1
-Kings,43067,State Senate,SD20,Con,Brian Kelly,6
-Kings,43068,State Senate,SD20,Con,Brian Kelly,4
-Kings,43069,State Senate,SD20,Con,Brian Kelly,0
-Kings,43070,State Senate,SD20,Con,Brian Kelly,2
-Kings,43071,State Senate,SD20,Con,Brian Kelly,1
-Kings,49001,State Senate,SD20,Con,Brian Kelly,18
-Kings,49002,State Senate,SD20,Con,Brian Kelly,13
-Kings,49003,State Senate,SD20,Con,Brian Kelly,10
-Kings,49004,State Senate,SD20,Con,Brian Kelly,29
-Kings,49005,State Senate,SD20,Con,Brian Kelly,24
-Kings,49014,State Senate,SD20,Con,Brian Kelly,0
-Kings,51020,State Senate,SD20,Con,Brian Kelly,7
-Kings,51028,State Senate,SD20,Con,Brian Kelly,4
-Kings,51029,State Senate,SD20,Con,Brian Kelly,17
-Kings,51030,State Senate,SD20,Con,Brian Kelly,14
-Kings,51031,State Senate,SD20,Con,Brian Kelly,25
-Kings,51032,State Senate,SD20,Con,Brian Kelly,10
-Kings,51033,State Senate,SD20,Con,Brian Kelly,4
-Kings,51034,State Senate,SD20,Con,Brian Kelly,4
-Kings,51035,State Senate,SD20,Con,Brian Kelly,8
-Kings,51036,State Senate,SD20,Con,Brian Kelly,8
-Kings,51037,State Senate,SD20,Con,Brian Kelly,5
-Kings,51038,State Senate,SD20,Con,Brian Kelly,22
-Kings,51039,State Senate,SD20,Con,Brian Kelly,12
-Kings,51040,State Senate,SD20,Con,Brian Kelly,13
-Kings,51041,State Senate,SD20,Con,Brian Kelly,7
-Kings,51042,State Senate,SD20,Con,Brian Kelly,9
-Kings,51043,State Senate,SD20,Con,Brian Kelly,5
-Kings,51063,State Senate,SD20,Con,Brian Kelly,21
-Kings,51064,State Senate,SD20,Con,Brian Kelly,5
-Kings,51065,State Senate,SD20,Con,Brian Kelly,7
-Kings,51066,State Senate,SD20,Con,Brian Kelly,10
-Kings,51067,State Senate,SD20,Con,Brian Kelly,8
-Kings,52064,State Senate,SD20,Con,Brian Kelly,8
-Kings,52065,State Senate,SD20,Con,Brian Kelly,8
-Kings,52066,State Senate,SD20,Con,Brian Kelly,6
-Kings,52067,State Senate,SD20,Con,Brian Kelly,3
-Kings,52072,State Senate,SD20,Con,Brian Kelly,2
-Kings,52073,State Senate,SD20,Con,Brian Kelly,9
-Kings,52074,State Senate,SD20,Con,Brian Kelly,3
-Kings,52075,State Senate,SD20,Con,Brian Kelly,3
-Kings,52079,State Senate,SD20,Con,Brian Kelly,3
-Kings,52087,State Senate,SD20,Con,Brian Kelly,5
-Kings,52088,State Senate,SD20,Con,Brian Kelly,9
-Kings,52092,State Senate,SD20,Con,Brian Kelly,0
-Kings,52093,State Senate,SD20,Con,Brian Kelly,5
-Kings,52094,State Senate,SD20,Con,Brian Kelly,5
-Kings,55035,State Senate,SD20,Con,Brian Kelly,1
-Kings,55057,State Senate,SD20,Con,Brian Kelly,1
-Kings,55058,State Senate,SD20,Con,Brian Kelly,2
-Kings,55059,State Senate,SD20,Con,Brian Kelly,4
-Kings,55061,State Senate,SD20,Con,Brian Kelly,0
-Kings,55065,State Senate,SD20,Con,Brian Kelly,4
-Kings,55066,State Senate,SD20,Con,Brian Kelly,4
-Kings,55067,State Senate,SD20,Con,Brian Kelly,3
-Kings,55068,State Senate,SD20,Con,Brian Kelly,0
-Kings,55069,State Senate,SD20,Con,Brian Kelly,6
-Kings,55070,State Senate,SD20,Con,Brian Kelly,2
-Kings,55071,State Senate,SD20,Con,Brian Kelly,2
-Kings,55072,State Senate,SD20,Con,Brian Kelly,3
-Kings,55073,State Senate,SD20,Con,Brian Kelly,0
-Kings,55076,State Senate,SD20,Con,Brian Kelly,0
-Kings,55078,State Senate,SD20,Con,Brian Kelly,1
-Kings,55079,State Senate,SD20,Con,Brian Kelly,2
-Kings,55080,State Senate,SD20,Con,Brian Kelly,0
-Kings,55081,State Senate,SD20,Con,Brian Kelly,2
-Kings,55082,State Senate,SD20,Con,Brian Kelly,1
-Kings,55083,State Senate,SD20,Con,Brian Kelly,0
-Kings,55084,State Senate,SD20,Con,Brian Kelly,2
-Kings,55085,State Senate,SD20,Con,Brian Kelly,2
-Kings,55086,State Senate,SD20,Con,Brian Kelly,1
-Kings,55087,State Senate,SD20,Con,Brian Kelly,1
-Kings,55088,State Senate,SD20,Con,Brian Kelly,1
-Kings,55089,State Senate,SD20,Con,Brian Kelly,2
-Kings,55090,State Senate,SD20,Con,Brian Kelly,4
-Kings,55091,State Senate,SD20,Con,Brian Kelly,1
-Kings,55092,State Senate,SD20,Con,Brian Kelly,4
-Kings,55093,State Senate,SD20,Con,Brian Kelly,3
-Kings,55094,State Senate,SD20,Con,Brian Kelly,1
-Kings,55095,State Senate,SD20,Con,Brian Kelly,1
-Kings,55096,State Senate,SD20,Con,Brian Kelly,1
-Kings,55097,State Senate,SD20,Con,Brian Kelly,2
-Kings,55100,State Senate,SD20,Con,Brian Kelly,4
-Kings,56073,State Senate,SD20,Con,Brian Kelly,0
-Kings,56075,State Senate,SD20,Con,Brian Kelly,1
-Kings,56076,State Senate,SD20,Con,Brian Kelly,2
-Kings,56077,State Senate,SD20,Con,Brian Kelly,7
-Kings,56078,State Senate,SD20,Con,Brian Kelly,3
-Kings,57067,State Senate,SD20,Con,Brian Kelly,3
-Kings,57068,State Senate,SD20,Con,Brian Kelly,4
-Kings,57069,State Senate,SD20,Con,Brian Kelly,5
-Kings,57070,State Senate,SD20,Con,Brian Kelly,2
-Kings,57071,State Senate,SD20,Con,Brian Kelly,3
-Kings,57072,State Senate,SD20,Con,Brian Kelly,3
-Kings,57073,State Senate,SD20,Con,Brian Kelly,1
-Kings,57074,State Senate,SD20,Con,Brian Kelly,1
-Kings,57075,State Senate,SD20,Con,Brian Kelly,4
-Kings,57076,State Senate,SD20,Con,Brian Kelly,2
-Kings,57077,State Senate,SD20,Con,Brian Kelly,0
-Kings,57078,State Senate,SD20,Con,Brian Kelly,6
-Kings,57079,State Senate,SD20,Con,Brian Kelly,3
-Kings,57080,State Senate,SD20,Con,Brian Kelly,3
-Kings,57081,State Senate,SD20,Con,Brian Kelly,3
-Kings,57082,State Senate,SD20,Con,Brian Kelly,0
-Kings,57083,State Senate,SD20,Con,Brian Kelly,1
-Kings,57084,State Senate,SD20,Con,Brian Kelly,1
-Kings,57085,State Senate,SD20,Con,Brian Kelly,1
-Kings,57088,State Senate,SD20,Con,Brian Kelly,0
-Kings,57089,State Senate,SD20,Con,Brian Kelly,0
-Kings,57090,State Senate,SD20,Con,Brian Kelly,0
-Kings,57091,State Senate,SD20,Con,Brian Kelly,0
-Kings,57092,State Senate,SD20,Con,Brian Kelly,3
-Kings,57093,State Senate,SD20,Con,Brian Kelly,0
-Kings,58001,State Senate,SD20,Con,Brian Kelly,3
-Kings,58002,State Senate,SD20,Con,Brian Kelly,2
-Kings,58003,State Senate,SD20,Con,Brian Kelly,1
-Kings,58004,State Senate,SD20,Con,Brian Kelly,3
-Kings,58005,State Senate,SD20,Con,Brian Kelly,1
-Kings,58006,State Senate,SD20,Con,Brian Kelly,0
-Kings,58007,State Senate,SD20,Con,Brian Kelly,1
-Kings,58008,State Senate,SD20,Con,Brian Kelly,1
-Kings,58009,State Senate,SD20,Con,Brian Kelly,0
-Kings,58010,State Senate,SD20,Con,Brian Kelly,1
-Kings,58011,State Senate,SD20,Con,Brian Kelly,0
-Kings,58012,State Senate,SD20,Con,Brian Kelly,0
-Kings,58013,State Senate,SD20,Con,Brian Kelly,0
-Kings,58014,State Senate,SD20,Con,Brian Kelly,1
-Kings,58015,State Senate,SD20,Con,Brian Kelly,1
-Kings,58045,State Senate,SD20,Con,Brian Kelly,0
-Kings,58046,State Senate,SD20,Con,Brian Kelly,0
-Kings,58047,State Senate,SD20,Con,Brian Kelly,1
-Kings,58048,State Senate,SD20,Con,Brian Kelly,0
-Kings,58052,State Senate,SD20,Con,Brian Kelly,0
-Kings,58053,State Senate,SD20,Con,Brian Kelly,0
-Kings,58054,State Senate,SD20,Con,Brian Kelly,0
-Kings,42068,State Senate,SD20,Dem,Eric Adams,335
-Kings,43014,State Senate,SD20,Dem,Eric Adams,504
-Kings,43015,State Senate,SD20,Dem,Eric Adams,549
-Kings,43016,State Senate,SD20,Dem,Eric Adams,626
-Kings,43017,State Senate,SD20,Dem,Eric Adams,526
-Kings,43018,State Senate,SD20,Dem,Eric Adams,629
-Kings,43019,State Senate,SD20,Dem,Eric Adams,644
-Kings,43020,State Senate,SD20,Dem,Eric Adams,514
-Kings,43021,State Senate,SD20,Dem,Eric Adams,650
-Kings,43022,State Senate,SD20,Dem,Eric Adams,570
-Kings,43023,State Senate,SD20,Dem,Eric Adams,634
-Kings,43024,State Senate,SD20,Dem,Eric Adams,609
-Kings,43025,State Senate,SD20,Dem,Eric Adams,629
-Kings,43026,State Senate,SD20,Dem,Eric Adams,537
-Kings,43027,State Senate,SD20,Dem,Eric Adams,566
-Kings,43028,State Senate,SD20,Dem,Eric Adams,543
-Kings,43029,State Senate,SD20,Dem,Eric Adams,437
-Kings,43030,State Senate,SD20,Dem,Eric Adams,411
-Kings,43031,State Senate,SD20,Dem,Eric Adams,588
-Kings,43032,State Senate,SD20,Dem,Eric Adams,506
-Kings,43033,State Senate,SD20,Dem,Eric Adams,621
-Kings,43034,State Senate,SD20,Dem,Eric Adams,574
-Kings,43035,State Senate,SD20,Dem,Eric Adams,615
-Kings,43036,State Senate,SD20,Dem,Eric Adams,566
-Kings,43037,State Senate,SD20,Dem,Eric Adams,581
-Kings,43038,State Senate,SD20,Dem,Eric Adams,575
-Kings,43039,State Senate,SD20,Dem,Eric Adams,494
-Kings,43040,State Senate,SD20,Dem,Eric Adams,347
-Kings,43041,State Senate,SD20,Dem,Eric Adams,551
-Kings,43042,State Senate,SD20,Dem,Eric Adams,371
-Kings,43043,State Senate,SD20,Dem,Eric Adams,320
-Kings,43044,State Senate,SD20,Dem,Eric Adams,551
-Kings,43052,State Senate,SD20,Dem,Eric Adams,559
-Kings,43053,State Senate,SD20,Dem,Eric Adams,499
-Kings,43054,State Senate,SD20,Dem,Eric Adams,440
-Kings,43055,State Senate,SD20,Dem,Eric Adams,239
-Kings,43056,State Senate,SD20,Dem,Eric Adams,468
-Kings,43057,State Senate,SD20,Dem,Eric Adams,290
-Kings,43058,State Senate,SD20,Dem,Eric Adams,435
-Kings,43059,State Senate,SD20,Dem,Eric Adams,460
-Kings,43060,State Senate,SD20,Dem,Eric Adams,450
-Kings,43061,State Senate,SD20,Dem,Eric Adams,574
-Kings,43062,State Senate,SD20,Dem,Eric Adams,215
-Kings,43063,State Senate,SD20,Dem,Eric Adams,207
-Kings,43064,State Senate,SD20,Dem,Eric Adams,530
-Kings,43065,State Senate,SD20,Dem,Eric Adams,414
-Kings,43066,State Senate,SD20,Dem,Eric Adams,666
-Kings,43067,State Senate,SD20,Dem,Eric Adams,560
-Kings,43068,State Senate,SD20,Dem,Eric Adams,484
-Kings,43069,State Senate,SD20,Dem,Eric Adams,547
-Kings,43070,State Senate,SD20,Dem,Eric Adams,261
-Kings,43071,State Senate,SD20,Dem,Eric Adams,452
-Kings,49001,State Senate,SD20,Dem,Eric Adams,209
-Kings,49002,State Senate,SD20,Dem,Eric Adams,201
-Kings,49003,State Senate,SD20,Dem,Eric Adams,244
-Kings,49004,State Senate,SD20,Dem,Eric Adams,200
-Kings,49005,State Senate,SD20,Dem,Eric Adams,166
-Kings,49014,State Senate,SD20,Dem,Eric Adams,3
-Kings,51020,State Senate,SD20,Dem,Eric Adams,310
-Kings,51028,State Senate,SD20,Dem,Eric Adams,32
-Kings,51029,State Senate,SD20,Dem,Eric Adams,249
-Kings,51030,State Senate,SD20,Dem,Eric Adams,243
-Kings,51031,State Senate,SD20,Dem,Eric Adams,310
-Kings,51032,State Senate,SD20,Dem,Eric Adams,347
-Kings,51033,State Senate,SD20,Dem,Eric Adams,371
-Kings,51034,State Senate,SD20,Dem,Eric Adams,298
-Kings,51035,State Senate,SD20,Dem,Eric Adams,339
-Kings,51036,State Senate,SD20,Dem,Eric Adams,301
-Kings,51037,State Senate,SD20,Dem,Eric Adams,275
-Kings,51038,State Senate,SD20,Dem,Eric Adams,409
-Kings,51039,State Senate,SD20,Dem,Eric Adams,409
-Kings,51040,State Senate,SD20,Dem,Eric Adams,387
-Kings,51041,State Senate,SD20,Dem,Eric Adams,410
-Kings,51042,State Senate,SD20,Dem,Eric Adams,374
-Kings,51043,State Senate,SD20,Dem,Eric Adams,288
-Kings,51063,State Senate,SD20,Dem,Eric Adams,249
-Kings,51064,State Senate,SD20,Dem,Eric Adams,288
-Kings,51065,State Senate,SD20,Dem,Eric Adams,241
-Kings,51066,State Senate,SD20,Dem,Eric Adams,305
-Kings,51067,State Senate,SD20,Dem,Eric Adams,342
-Kings,52064,State Senate,SD20,Dem,Eric Adams,637
-Kings,52065,State Senate,SD20,Dem,Eric Adams,496
-Kings,52066,State Senate,SD20,Dem,Eric Adams,444
-Kings,52067,State Senate,SD20,Dem,Eric Adams,332
-Kings,52072,State Senate,SD20,Dem,Eric Adams,223
-Kings,52073,State Senate,SD20,Dem,Eric Adams,715
-Kings,52074,State Senate,SD20,Dem,Eric Adams,701
-Kings,52075,State Senate,SD20,Dem,Eric Adams,429
-Kings,52079,State Senate,SD20,Dem,Eric Adams,185
-Kings,52087,State Senate,SD20,Dem,Eric Adams,568
-Kings,52088,State Senate,SD20,Dem,Eric Adams,529
-Kings,52092,State Senate,SD20,Dem,Eric Adams,9
-Kings,52093,State Senate,SD20,Dem,Eric Adams,303
-Kings,52094,State Senate,SD20,Dem,Eric Adams,269
-Kings,55035,State Senate,SD20,Dem,Eric Adams,242
-Kings,55057,State Senate,SD20,Dem,Eric Adams,437
-Kings,55058,State Senate,SD20,Dem,Eric Adams,257
-Kings,55059,State Senate,SD20,Dem,Eric Adams,405
-Kings,55061,State Senate,SD20,Dem,Eric Adams,1
-Kings,55065,State Senate,SD20,Dem,Eric Adams,439
-Kings,55066,State Senate,SD20,Dem,Eric Adams,424
-Kings,55067,State Senate,SD20,Dem,Eric Adams,364
-Kings,55068,State Senate,SD20,Dem,Eric Adams,463
-Kings,55069,State Senate,SD20,Dem,Eric Adams,363
-Kings,55070,State Senate,SD20,Dem,Eric Adams,207
-Kings,55071,State Senate,SD20,Dem,Eric Adams,249
-Kings,55072,State Senate,SD20,Dem,Eric Adams,469
-Kings,55073,State Senate,SD20,Dem,Eric Adams,4
-Kings,55076,State Senate,SD20,Dem,Eric Adams,403
-Kings,55078,State Senate,SD20,Dem,Eric Adams,692
-Kings,55079,State Senate,SD20,Dem,Eric Adams,532
-Kings,55080,State Senate,SD20,Dem,Eric Adams,214
-Kings,55081,State Senate,SD20,Dem,Eric Adams,451
-Kings,55082,State Senate,SD20,Dem,Eric Adams,641
-Kings,55083,State Senate,SD20,Dem,Eric Adams,367
-Kings,55084,State Senate,SD20,Dem,Eric Adams,330
-Kings,55085,State Senate,SD20,Dem,Eric Adams,665
-Kings,55086,State Senate,SD20,Dem,Eric Adams,227
-Kings,55087,State Senate,SD20,Dem,Eric Adams,570
-Kings,55088,State Senate,SD20,Dem,Eric Adams,459
-Kings,55089,State Senate,SD20,Dem,Eric Adams,520
-Kings,55090,State Senate,SD20,Dem,Eric Adams,523
-Kings,55091,State Senate,SD20,Dem,Eric Adams,510
-Kings,55092,State Senate,SD20,Dem,Eric Adams,439
-Kings,55093,State Senate,SD20,Dem,Eric Adams,325
-Kings,55094,State Senate,SD20,Dem,Eric Adams,436
-Kings,55095,State Senate,SD20,Dem,Eric Adams,164
-Kings,55096,State Senate,SD20,Dem,Eric Adams,218
-Kings,55097,State Senate,SD20,Dem,Eric Adams,421
-Kings,55100,State Senate,SD20,Dem,Eric Adams,253
-Kings,56073,State Senate,SD20,Dem,Eric Adams,246
-Kings,56075,State Senate,SD20,Dem,Eric Adams,280
-Kings,56076,State Senate,SD20,Dem,Eric Adams,169
-Kings,56077,State Senate,SD20,Dem,Eric Adams,595
-Kings,56078,State Senate,SD20,Dem,Eric Adams,454
-Kings,57067,State Senate,SD20,Dem,Eric Adams,601
-Kings,57068,State Senate,SD20,Dem,Eric Adams,672
-Kings,57069,State Senate,SD20,Dem,Eric Adams,579
-Kings,57070,State Senate,SD20,Dem,Eric Adams,546
-Kings,57071,State Senate,SD20,Dem,Eric Adams,377
-Kings,57072,State Senate,SD20,Dem,Eric Adams,490
-Kings,57073,State Senate,SD20,Dem,Eric Adams,269
-Kings,57074,State Senate,SD20,Dem,Eric Adams,591
-Kings,57075,State Senate,SD20,Dem,Eric Adams,588
-Kings,57076,State Senate,SD20,Dem,Eric Adams,512
-Kings,57077,State Senate,SD20,Dem,Eric Adams,222
-Kings,57078,State Senate,SD20,Dem,Eric Adams,491
-Kings,57079,State Senate,SD20,Dem,Eric Adams,519
-Kings,57080,State Senate,SD20,Dem,Eric Adams,590
-Kings,57081,State Senate,SD20,Dem,Eric Adams,495
-Kings,57082,State Senate,SD20,Dem,Eric Adams,221
-Kings,57083,State Senate,SD20,Dem,Eric Adams,467
-Kings,57084,State Senate,SD20,Dem,Eric Adams,322
-Kings,57085,State Senate,SD20,Dem,Eric Adams,711
-Kings,57088,State Senate,SD20,Dem,Eric Adams,532
-Kings,57089,State Senate,SD20,Dem,Eric Adams,461
-Kings,57090,State Senate,SD20,Dem,Eric Adams,635
-Kings,57091,State Senate,SD20,Dem,Eric Adams,548
-Kings,57092,State Senate,SD20,Dem,Eric Adams,390
-Kings,57093,State Senate,SD20,Dem,Eric Adams,367
-Kings,58001,State Senate,SD20,Dem,Eric Adams,566
-Kings,58002,State Senate,SD20,Dem,Eric Adams,503
-Kings,58003,State Senate,SD20,Dem,Eric Adams,513
-Kings,58004,State Senate,SD20,Dem,Eric Adams,586
-Kings,58005,State Senate,SD20,Dem,Eric Adams,602
-Kings,58006,State Senate,SD20,Dem,Eric Adams,538
-Kings,58007,State Senate,SD20,Dem,Eric Adams,517
-Kings,58008,State Senate,SD20,Dem,Eric Adams,627
-Kings,58009,State Senate,SD20,Dem,Eric Adams,502
-Kings,58010,State Senate,SD20,Dem,Eric Adams,524
-Kings,58011,State Senate,SD20,Dem,Eric Adams,616
-Kings,58012,State Senate,SD20,Dem,Eric Adams,565
-Kings,58013,State Senate,SD20,Dem,Eric Adams,531
-Kings,58014,State Senate,SD20,Dem,Eric Adams,320
-Kings,58015,State Senate,SD20,Dem,Eric Adams,454
-Kings,58045,State Senate,SD20,Dem,Eric Adams,461
-Kings,58046,State Senate,SD20,Dem,Eric Adams,478
-Kings,58047,State Senate,SD20,Dem,Eric Adams,457
-Kings,58048,State Senate,SD20,Dem,Eric Adams,392
-Kings,58052,State Senate,SD20,Dem,Eric Adams,632
-Kings,58053,State Senate,SD20,Dem,Eric Adams,174
-Kings,58054,State Senate,SD20,Dem,Eric Adams,308
-Kings,42068,State Senate,SD20,WF,Eric Adams,2
-Kings,43014,State Senate,SD20,WF,Eric Adams,31
-Kings,43015,State Senate,SD20,WF,Eric Adams,29
-Kings,43016,State Senate,SD20,WF,Eric Adams,8
-Kings,43017,State Senate,SD20,WF,Eric Adams,9
-Kings,43018,State Senate,SD20,WF,Eric Adams,41
-Kings,43019,State Senate,SD20,WF,Eric Adams,41
-Kings,43020,State Senate,SD20,WF,Eric Adams,41
-Kings,43021,State Senate,SD20,WF,Eric Adams,11
-Kings,43022,State Senate,SD20,WF,Eric Adams,13
-Kings,43023,State Senate,SD20,WF,Eric Adams,15
-Kings,43024,State Senate,SD20,WF,Eric Adams,26
-Kings,43025,State Senate,SD20,WF,Eric Adams,25
-Kings,43026,State Senate,SD20,WF,Eric Adams,8
-Kings,43027,State Senate,SD20,WF,Eric Adams,7
-Kings,43028,State Senate,SD20,WF,Eric Adams,4
-Kings,43029,State Senate,SD20,WF,Eric Adams,3
-Kings,43030,State Senate,SD20,WF,Eric Adams,4
-Kings,43031,State Senate,SD20,WF,Eric Adams,14
-Kings,43032,State Senate,SD20,WF,Eric Adams,4
-Kings,43033,State Senate,SD20,WF,Eric Adams,7
-Kings,43034,State Senate,SD20,WF,Eric Adams,14
-Kings,43035,State Senate,SD20,WF,Eric Adams,25
-Kings,43036,State Senate,SD20,WF,Eric Adams,25
-Kings,43037,State Senate,SD20,WF,Eric Adams,14
-Kings,43038,State Senate,SD20,WF,Eric Adams,12
-Kings,43039,State Senate,SD20,WF,Eric Adams,22
-Kings,43040,State Senate,SD20,WF,Eric Adams,7
-Kings,43041,State Senate,SD20,WF,Eric Adams,49
-Kings,43042,State Senate,SD20,WF,Eric Adams,28
-Kings,43043,State Senate,SD20,WF,Eric Adams,10
-Kings,43044,State Senate,SD20,WF,Eric Adams,24
-Kings,43052,State Senate,SD20,WF,Eric Adams,11
-Kings,43053,State Senate,SD20,WF,Eric Adams,4
-Kings,43054,State Senate,SD20,WF,Eric Adams,4
-Kings,43055,State Senate,SD20,WF,Eric Adams,2
-Kings,43056,State Senate,SD20,WF,Eric Adams,8
-Kings,43057,State Senate,SD20,WF,Eric Adams,8
-Kings,43058,State Senate,SD20,WF,Eric Adams,9
-Kings,43059,State Senate,SD20,WF,Eric Adams,14
-Kings,43060,State Senate,SD20,WF,Eric Adams,7
-Kings,43061,State Senate,SD20,WF,Eric Adams,5
-Kings,43062,State Senate,SD20,WF,Eric Adams,7
-Kings,43063,State Senate,SD20,WF,Eric Adams,9
-Kings,43064,State Senate,SD20,WF,Eric Adams,9
-Kings,43065,State Senate,SD20,WF,Eric Adams,3
-Kings,43066,State Senate,SD20,WF,Eric Adams,8
-Kings,43067,State Senate,SD20,WF,Eric Adams,2
-Kings,43068,State Senate,SD20,WF,Eric Adams,3
-Kings,43069,State Senate,SD20,WF,Eric Adams,5
-Kings,43070,State Senate,SD20,WF,Eric Adams,3
-Kings,43071,State Senate,SD20,WF,Eric Adams,5
-Kings,49001,State Senate,SD20,WF,Eric Adams,10
-Kings,49002,State Senate,SD20,WF,Eric Adams,11
-Kings,49003,State Senate,SD20,WF,Eric Adams,11
-Kings,49004,State Senate,SD20,WF,Eric Adams,12
-Kings,49005,State Senate,SD20,WF,Eric Adams,13
-Kings,49014,State Senate,SD20,WF,Eric Adams,1
-Kings,51020,State Senate,SD20,WF,Eric Adams,54
-Kings,51028,State Senate,SD20,WF,Eric Adams,4
-Kings,51029,State Senate,SD20,WF,Eric Adams,10
-Kings,51030,State Senate,SD20,WF,Eric Adams,14
-Kings,51031,State Senate,SD20,WF,Eric Adams,12
-Kings,51032,State Senate,SD20,WF,Eric Adams,21
-Kings,51033,State Senate,SD20,WF,Eric Adams,14
-Kings,51034,State Senate,SD20,WF,Eric Adams,14
-Kings,51035,State Senate,SD20,WF,Eric Adams,17
-Kings,51036,State Senate,SD20,WF,Eric Adams,33
-Kings,51037,State Senate,SD20,WF,Eric Adams,36
-Kings,51038,State Senate,SD20,WF,Eric Adams,58
-Kings,51039,State Senate,SD20,WF,Eric Adams,41
-Kings,51040,State Senate,SD20,WF,Eric Adams,43
-Kings,51041,State Senate,SD20,WF,Eric Adams,51
-Kings,51042,State Senate,SD20,WF,Eric Adams,69
-Kings,51043,State Senate,SD20,WF,Eric Adams,32
-Kings,51063,State Senate,SD20,WF,Eric Adams,14
-Kings,51064,State Senate,SD20,WF,Eric Adams,7
-Kings,51065,State Senate,SD20,WF,Eric Adams,22
-Kings,51066,State Senate,SD20,WF,Eric Adams,11
-Kings,51067,State Senate,SD20,WF,Eric Adams,11
-Kings,52064,State Senate,SD20,WF,Eric Adams,100
-Kings,52065,State Senate,SD20,WF,Eric Adams,70
-Kings,52066,State Senate,SD20,WF,Eric Adams,91
-Kings,52067,State Senate,SD20,WF,Eric Adams,61
-Kings,52072,State Senate,SD20,WF,Eric Adams,49
-Kings,52073,State Senate,SD20,WF,Eric Adams,113
-Kings,52074,State Senate,SD20,WF,Eric Adams,128
-Kings,52075,State Senate,SD20,WF,Eric Adams,80
-Kings,52079,State Senate,SD20,WF,Eric Adams,39
-Kings,52087,State Senate,SD20,WF,Eric Adams,97
-Kings,52088,State Senate,SD20,WF,Eric Adams,55
-Kings,52092,State Senate,SD20,WF,Eric Adams,3
-Kings,52093,State Senate,SD20,WF,Eric Adams,50
-Kings,52094,State Senate,SD20,WF,Eric Adams,53
-Kings,55035,State Senate,SD20,WF,Eric Adams,3
-Kings,55057,State Senate,SD20,WF,Eric Adams,4
-Kings,55058,State Senate,SD20,WF,Eric Adams,4
-Kings,55059,State Senate,SD20,WF,Eric Adams,6
-Kings,55061,State Senate,SD20,WF,Eric Adams,0
-Kings,55065,State Senate,SD20,WF,Eric Adams,9
-Kings,55066,State Senate,SD20,WF,Eric Adams,8
-Kings,55067,State Senate,SD20,WF,Eric Adams,3
-Kings,55068,State Senate,SD20,WF,Eric Adams,6
-Kings,55069,State Senate,SD20,WF,Eric Adams,7
-Kings,55070,State Senate,SD20,WF,Eric Adams,5
-Kings,55071,State Senate,SD20,WF,Eric Adams,2
-Kings,55072,State Senate,SD20,WF,Eric Adams,5
-Kings,55073,State Senate,SD20,WF,Eric Adams,1
-Kings,55076,State Senate,SD20,WF,Eric Adams,8
-Kings,55078,State Senate,SD20,WF,Eric Adams,7
-Kings,55079,State Senate,SD20,WF,Eric Adams,21
-Kings,55080,State Senate,SD20,WF,Eric Adams,4
-Kings,55081,State Senate,SD20,WF,Eric Adams,8
-Kings,55082,State Senate,SD20,WF,Eric Adams,7
-Kings,55083,State Senate,SD20,WF,Eric Adams,5
-Kings,55084,State Senate,SD20,WF,Eric Adams,7
-Kings,55085,State Senate,SD20,WF,Eric Adams,10
-Kings,55086,State Senate,SD20,WF,Eric Adams,4
-Kings,55087,State Senate,SD20,WF,Eric Adams,5
-Kings,55088,State Senate,SD20,WF,Eric Adams,1
-Kings,55089,State Senate,SD20,WF,Eric Adams,7
-Kings,55090,State Senate,SD20,WF,Eric Adams,5
-Kings,55091,State Senate,SD20,WF,Eric Adams,12
-Kings,55092,State Senate,SD20,WF,Eric Adams,2
-Kings,55093,State Senate,SD20,WF,Eric Adams,1
-Kings,55094,State Senate,SD20,WF,Eric Adams,5
-Kings,55095,State Senate,SD20,WF,Eric Adams,4
-Kings,55096,State Senate,SD20,WF,Eric Adams,2
-Kings,55097,State Senate,SD20,WF,Eric Adams,4
-Kings,55100,State Senate,SD20,WF,Eric Adams,1
-Kings,56073,State Senate,SD20,WF,Eric Adams,3
-Kings,56075,State Senate,SD20,WF,Eric Adams,2
-Kings,56076,State Senate,SD20,WF,Eric Adams,2
-Kings,56077,State Senate,SD20,WF,Eric Adams,17
-Kings,56078,State Senate,SD20,WF,Eric Adams,17
-Kings,57067,State Senate,SD20,WF,Eric Adams,58
-Kings,57068,State Senate,SD20,WF,Eric Adams,60
-Kings,57069,State Senate,SD20,WF,Eric Adams,58
-Kings,57070,State Senate,SD20,WF,Eric Adams,79
-Kings,57071,State Senate,SD20,WF,Eric Adams,68
-Kings,57072,State Senate,SD20,WF,Eric Adams,82
-Kings,57073,State Senate,SD20,WF,Eric Adams,45
-Kings,57074,State Senate,SD20,WF,Eric Adams,67
-Kings,57075,State Senate,SD20,WF,Eric Adams,75
-Kings,57076,State Senate,SD20,WF,Eric Adams,94
-Kings,57077,State Senate,SD20,WF,Eric Adams,31
-Kings,57078,State Senate,SD20,WF,Eric Adams,65
-Kings,57079,State Senate,SD20,WF,Eric Adams,50
-Kings,57080,State Senate,SD20,WF,Eric Adams,64
-Kings,57081,State Senate,SD20,WF,Eric Adams,59
-Kings,57082,State Senate,SD20,WF,Eric Adams,12
-Kings,57083,State Senate,SD20,WF,Eric Adams,15
-Kings,57084,State Senate,SD20,WF,Eric Adams,17
-Kings,57085,State Senate,SD20,WF,Eric Adams,42
-Kings,57088,State Senate,SD20,WF,Eric Adams,29
-Kings,57089,State Senate,SD20,WF,Eric Adams,17
-Kings,57090,State Senate,SD20,WF,Eric Adams,8
-Kings,57091,State Senate,SD20,WF,Eric Adams,14
-Kings,57092,State Senate,SD20,WF,Eric Adams,19
-Kings,57093,State Senate,SD20,WF,Eric Adams,9
-Kings,58001,State Senate,SD20,WF,Eric Adams,5
-Kings,58002,State Senate,SD20,WF,Eric Adams,9
-Kings,58003,State Senate,SD20,WF,Eric Adams,13
-Kings,58004,State Senate,SD20,WF,Eric Adams,6
-Kings,58005,State Senate,SD20,WF,Eric Adams,10
-Kings,58006,State Senate,SD20,WF,Eric Adams,0
-Kings,58007,State Senate,SD20,WF,Eric Adams,4
-Kings,58008,State Senate,SD20,WF,Eric Adams,9
-Kings,58009,State Senate,SD20,WF,Eric Adams,2
-Kings,58010,State Senate,SD20,WF,Eric Adams,6
-Kings,58011,State Senate,SD20,WF,Eric Adams,0
-Kings,58012,State Senate,SD20,WF,Eric Adams,3
-Kings,58013,State Senate,SD20,WF,Eric Adams,3
-Kings,58014,State Senate,SD20,WF,Eric Adams,2
-Kings,58015,State Senate,SD20,WF,Eric Adams,3
-Kings,58045,State Senate,SD20,WF,Eric Adams,3
-Kings,58046,State Senate,SD20,WF,Eric Adams,4
-Kings,58047,State Senate,SD20,WF,Eric Adams,6
-Kings,58048,State Senate,SD20,WF,Eric Adams,2
-Kings,58052,State Senate,SD20,WF,Eric Adams,8
-Kings,58053,State Senate,SD20,WF,Eric Adams,2
-Kings,58054,State Senate,SD20,WF,Eric Adams,5
-Kings,42068,State Senate,SD20,Rep,Rose Leary,3
-Kings,43014,State Senate,SD20,Rep,Rose Leary,6
-Kings,43015,State Senate,SD20,Rep,Rose Leary,13
-Kings,43016,State Senate,SD20,Rep,Rose Leary,10
-Kings,43017,State Senate,SD20,Rep,Rose Leary,17
-Kings,43018,State Senate,SD20,Rep,Rose Leary,6
-Kings,43019,State Senate,SD20,Rep,Rose Leary,7
-Kings,43020,State Senate,SD20,Rep,Rose Leary,5
-Kings,43021,State Senate,SD20,Rep,Rose Leary,6
-Kings,43022,State Senate,SD20,Rep,Rose Leary,7
-Kings,43023,State Senate,SD20,Rep,Rose Leary,3
-Kings,43024,State Senate,SD20,Rep,Rose Leary,8
-Kings,43025,State Senate,SD20,Rep,Rose Leary,7
-Kings,43026,State Senate,SD20,Rep,Rose Leary,5
-Kings,43027,State Senate,SD20,Rep,Rose Leary,4
-Kings,43028,State Senate,SD20,Rep,Rose Leary,5
-Kings,43029,State Senate,SD20,Rep,Rose Leary,18
-Kings,43030,State Senate,SD20,Rep,Rose Leary,2
-Kings,43031,State Senate,SD20,Rep,Rose Leary,10
-Kings,43032,State Senate,SD20,Rep,Rose Leary,2
-Kings,43033,State Senate,SD20,Rep,Rose Leary,5
-Kings,43034,State Senate,SD20,Rep,Rose Leary,8
-Kings,43035,State Senate,SD20,Rep,Rose Leary,23
-Kings,43036,State Senate,SD20,Rep,Rose Leary,10
-Kings,43037,State Senate,SD20,Rep,Rose Leary,17
-Kings,43038,State Senate,SD20,Rep,Rose Leary,22
-Kings,43039,State Senate,SD20,Rep,Rose Leary,22
-Kings,43040,State Senate,SD20,Rep,Rose Leary,111
-Kings,43041,State Senate,SD20,Rep,Rose Leary,4
-Kings,43042,State Senate,SD20,Rep,Rose Leary,7
-Kings,43043,State Senate,SD20,Rep,Rose Leary,25
-Kings,43044,State Senate,SD20,Rep,Rose Leary,6
-Kings,43052,State Senate,SD20,Rep,Rose Leary,9
-Kings,43053,State Senate,SD20,Rep,Rose Leary,16
-Kings,43054,State Senate,SD20,Rep,Rose Leary,30
-Kings,43055,State Senate,SD20,Rep,Rose Leary,15
-Kings,43056,State Senate,SD20,Rep,Rose Leary,40
-Kings,43057,State Senate,SD20,Rep,Rose Leary,114
-Kings,43058,State Senate,SD20,Rep,Rose Leary,76
-Kings,43059,State Senate,SD20,Rep,Rose Leary,78
-Kings,43060,State Senate,SD20,Rep,Rose Leary,82
-Kings,43061,State Senate,SD20,Rep,Rose Leary,5
-Kings,43062,State Senate,SD20,Rep,Rose Leary,58
-Kings,43063,State Senate,SD20,Rep,Rose Leary,81
-Kings,43064,State Senate,SD20,Rep,Rose Leary,44
-Kings,43065,State Senate,SD20,Rep,Rose Leary,12
-Kings,43066,State Senate,SD20,Rep,Rose Leary,2
-Kings,43067,State Senate,SD20,Rep,Rose Leary,34
-Kings,43068,State Senate,SD20,Rep,Rose Leary,20
-Kings,43069,State Senate,SD20,Rep,Rose Leary,1
-Kings,43070,State Senate,SD20,Rep,Rose Leary,3
-Kings,43071,State Senate,SD20,Rep,Rose Leary,3
-Kings,49001,State Senate,SD20,Rep,Rose Leary,27
-Kings,49002,State Senate,SD20,Rep,Rose Leary,22
-Kings,49003,State Senate,SD20,Rep,Rose Leary,31
-Kings,49004,State Senate,SD20,Rep,Rose Leary,48
-Kings,49005,State Senate,SD20,Rep,Rose Leary,42
-Kings,49014,State Senate,SD20,Rep,Rose Leary,3
-Kings,51020,State Senate,SD20,Rep,Rose Leary,25
-Kings,51028,State Senate,SD20,Rep,Rose Leary,9
-Kings,51029,State Senate,SD20,Rep,Rose Leary,40
-Kings,51030,State Senate,SD20,Rep,Rose Leary,46
-Kings,51031,State Senate,SD20,Rep,Rose Leary,39
-Kings,51032,State Senate,SD20,Rep,Rose Leary,36
-Kings,51033,State Senate,SD20,Rep,Rose Leary,25
-Kings,51034,State Senate,SD20,Rep,Rose Leary,15
-Kings,51035,State Senate,SD20,Rep,Rose Leary,15
-Kings,51036,State Senate,SD20,Rep,Rose Leary,20
-Kings,51037,State Senate,SD20,Rep,Rose Leary,26
-Kings,51038,State Senate,SD20,Rep,Rose Leary,37
-Kings,51039,State Senate,SD20,Rep,Rose Leary,16
-Kings,51040,State Senate,SD20,Rep,Rose Leary,38
-Kings,51041,State Senate,SD20,Rep,Rose Leary,39
-Kings,51042,State Senate,SD20,Rep,Rose Leary,20
-Kings,51043,State Senate,SD20,Rep,Rose Leary,12
-Kings,51063,State Senate,SD20,Rep,Rose Leary,41
-Kings,51064,State Senate,SD20,Rep,Rose Leary,26
-Kings,51065,State Senate,SD20,Rep,Rose Leary,32
-Kings,51066,State Senate,SD20,Rep,Rose Leary,23
-Kings,51067,State Senate,SD20,Rep,Rose Leary,26
-Kings,52064,State Senate,SD20,Rep,Rose Leary,34
-Kings,52065,State Senate,SD20,Rep,Rose Leary,22
-Kings,52066,State Senate,SD20,Rep,Rose Leary,35
-Kings,52067,State Senate,SD20,Rep,Rose Leary,27
-Kings,52072,State Senate,SD20,Rep,Rose Leary,12
-Kings,52073,State Senate,SD20,Rep,Rose Leary,33
-Kings,52074,State Senate,SD20,Rep,Rose Leary,24
-Kings,52075,State Senate,SD20,Rep,Rose Leary,23
-Kings,52079,State Senate,SD20,Rep,Rose Leary,12
-Kings,52087,State Senate,SD20,Rep,Rose Leary,28
-Kings,52088,State Senate,SD20,Rep,Rose Leary,35
-Kings,52092,State Senate,SD20,Rep,Rose Leary,0
-Kings,52093,State Senate,SD20,Rep,Rose Leary,20
-Kings,52094,State Senate,SD20,Rep,Rose Leary,29
-Kings,55035,State Senate,SD20,Rep,Rose Leary,0
-Kings,55057,State Senate,SD20,Rep,Rose Leary,3
-Kings,55058,State Senate,SD20,Rep,Rose Leary,2
-Kings,55059,State Senate,SD20,Rep,Rose Leary,4
-Kings,55061,State Senate,SD20,Rep,Rose Leary,1
-Kings,55065,State Senate,SD20,Rep,Rose Leary,2
-Kings,55066,State Senate,SD20,Rep,Rose Leary,13
-Kings,55067,State Senate,SD20,Rep,Rose Leary,4
-Kings,55068,State Senate,SD20,Rep,Rose Leary,2
-Kings,55069,State Senate,SD20,Rep,Rose Leary,4
-Kings,55070,State Senate,SD20,Rep,Rose Leary,5
-Kings,55071,State Senate,SD20,Rep,Rose Leary,2
-Kings,55072,State Senate,SD20,Rep,Rose Leary,9
-Kings,55073,State Senate,SD20,Rep,Rose Leary,0
-Kings,55076,State Senate,SD20,Rep,Rose Leary,3
-Kings,55078,State Senate,SD20,Rep,Rose Leary,11
-Kings,55079,State Senate,SD20,Rep,Rose Leary,9
-Kings,55080,State Senate,SD20,Rep,Rose Leary,0
-Kings,55081,State Senate,SD20,Rep,Rose Leary,9
-Kings,55082,State Senate,SD20,Rep,Rose Leary,5
-Kings,55083,State Senate,SD20,Rep,Rose Leary,3
-Kings,55084,State Senate,SD20,Rep,Rose Leary,2
-Kings,55085,State Senate,SD20,Rep,Rose Leary,7
-Kings,55086,State Senate,SD20,Rep,Rose Leary,3
-Kings,55087,State Senate,SD20,Rep,Rose Leary,6
-Kings,55088,State Senate,SD20,Rep,Rose Leary,2
-Kings,55089,State Senate,SD20,Rep,Rose Leary,4
-Kings,55090,State Senate,SD20,Rep,Rose Leary,5
-Kings,55091,State Senate,SD20,Rep,Rose Leary,5
-Kings,55092,State Senate,SD20,Rep,Rose Leary,3
-Kings,55093,State Senate,SD20,Rep,Rose Leary,6
-Kings,55094,State Senate,SD20,Rep,Rose Leary,3
-Kings,55095,State Senate,SD20,Rep,Rose Leary,1
-Kings,55096,State Senate,SD20,Rep,Rose Leary,2
-Kings,55097,State Senate,SD20,Rep,Rose Leary,0
-Kings,55100,State Senate,SD20,Rep,Rose Leary,7
-Kings,56073,State Senate,SD20,Rep,Rose Leary,3
-Kings,56075,State Senate,SD20,Rep,Rose Leary,3
-Kings,56076,State Senate,SD20,Rep,Rose Leary,2
-Kings,56077,State Senate,SD20,Rep,Rose Leary,13
-Kings,56078,State Senate,SD20,Rep,Rose Leary,15
-Kings,57067,State Senate,SD20,Rep,Rose Leary,8
-Kings,57068,State Senate,SD20,Rep,Rose Leary,10
-Kings,57069,State Senate,SD20,Rep,Rose Leary,11
-Kings,57070,State Senate,SD20,Rep,Rose Leary,16
-Kings,57071,State Senate,SD20,Rep,Rose Leary,9
-Kings,57072,State Senate,SD20,Rep,Rose Leary,16
-Kings,57073,State Senate,SD20,Rep,Rose Leary,10
-Kings,57074,State Senate,SD20,Rep,Rose Leary,14
-Kings,57075,State Senate,SD20,Rep,Rose Leary,7
-Kings,57076,State Senate,SD20,Rep,Rose Leary,13
-Kings,57077,State Senate,SD20,Rep,Rose Leary,9
-Kings,57078,State Senate,SD20,Rep,Rose Leary,20
-Kings,57079,State Senate,SD20,Rep,Rose Leary,7
-Kings,57080,State Senate,SD20,Rep,Rose Leary,8
-Kings,57081,State Senate,SD20,Rep,Rose Leary,7
-Kings,57082,State Senate,SD20,Rep,Rose Leary,4
-Kings,57083,State Senate,SD20,Rep,Rose Leary,1
-Kings,57084,State Senate,SD20,Rep,Rose Leary,4
-Kings,57085,State Senate,SD20,Rep,Rose Leary,12
-Kings,57088,State Senate,SD20,Rep,Rose Leary,4
-Kings,57089,State Senate,SD20,Rep,Rose Leary,5
-Kings,57090,State Senate,SD20,Rep,Rose Leary,4
-Kings,57091,State Senate,SD20,Rep,Rose Leary,7
-Kings,57092,State Senate,SD20,Rep,Rose Leary,5
-Kings,57093,State Senate,SD20,Rep,Rose Leary,3
-Kings,58001,State Senate,SD20,Rep,Rose Leary,7
-Kings,58002,State Senate,SD20,Rep,Rose Leary,6
-Kings,58003,State Senate,SD20,Rep,Rose Leary,7
-Kings,58004,State Senate,SD20,Rep,Rose Leary,5
-Kings,58005,State Senate,SD20,Rep,Rose Leary,3
-Kings,58006,State Senate,SD20,Rep,Rose Leary,1
-Kings,58007,State Senate,SD20,Rep,Rose Leary,2
-Kings,58008,State Senate,SD20,Rep,Rose Leary,2
-Kings,58009,State Senate,SD20,Rep,Rose Leary,6
-Kings,58010,State Senate,SD20,Rep,Rose Leary,2
-Kings,58011,State Senate,SD20,Rep,Rose Leary,2
-Kings,58012,State Senate,SD20,Rep,Rose Leary,2
-Kings,58013,State Senate,SD20,Rep,Rose Leary,3
-Kings,58014,State Senate,SD20,Rep,Rose Leary,6
-Kings,58015,State Senate,SD20,Rep,Rose Leary,6
-Kings,58045,State Senate,SD20,Rep,Rose Leary,5
-Kings,58046,State Senate,SD20,Rep,Rose Leary,2
-Kings,58047,State Senate,SD20,Rep,Rose Leary,2
-Kings,58048,State Senate,SD20,Rep,Rose Leary,4
-Kings,58052,State Senate,SD20,Rep,Rose Leary,3
-Kings,58053,State Senate,SD20,Rep,Rose Leary,2
-Kings,58054,State Senate,SD20,Rep,Rose Leary,3
-Kings,42068,State Senate,SD20,Ind,writein,0
-Kings,43014,State Senate,SD20,Ind,writein,0
-Kings,43015,State Senate,SD20,Ind,writein,0
-Kings,43016,State Senate,SD20,Ind,writein,0
-Kings,43017,State Senate,SD20,Ind,writein,0
-Kings,43018,State Senate,SD20,Ind,writein,0
-Kings,43019,State Senate,SD20,Ind,writein,1
-Kings,43020,State Senate,SD20,Ind,writein,0
-Kings,43021,State Senate,SD20,Ind,writein,0
-Kings,43022,State Senate,SD20,Ind,writein,0
-Kings,43023,State Senate,SD20,Ind,writein,0
-Kings,43024,State Senate,SD20,Ind,writein,0
-Kings,43025,State Senate,SD20,Ind,writein,0
-Kings,43026,State Senate,SD20,Ind,writein,0
-Kings,43027,State Senate,SD20,Ind,writein,0
-Kings,43028,State Senate,SD20,Ind,writein,0
-Kings,43029,State Senate,SD20,Ind,writein,0
-Kings,43030,State Senate,SD20,Ind,writein,0
-Kings,43031,State Senate,SD20,Ind,writein,0
-Kings,43032,State Senate,SD20,Ind,writein,1
-Kings,43033,State Senate,SD20,Ind,writein,0
-Kings,43034,State Senate,SD20,Ind,writein,0
-Kings,43035,State Senate,SD20,Ind,writein,1
-Kings,43036,State Senate,SD20,Ind,writein,0
-Kings,43037,State Senate,SD20,Ind,writein,0
-Kings,43038,State Senate,SD20,Ind,writein,0
-Kings,43039,State Senate,SD20,Ind,writein,0
-Kings,43040,State Senate,SD20,Ind,writein,0
-Kings,43041,State Senate,SD20,Ind,writein,0
-Kings,43042,State Senate,SD20,Ind,writein,0
-Kings,43043,State Senate,SD20,Ind,writein,0
-Kings,43044,State Senate,SD20,Ind,writein,0
-Kings,43052,State Senate,SD20,Ind,writein,0
-Kings,43053,State Senate,SD20,Ind,writein,0
-Kings,43054,State Senate,SD20,Ind,writein,0
-Kings,43055,State Senate,SD20,Ind,writein,0
-Kings,43056,State Senate,SD20,Ind,writein,0
-Kings,43057,State Senate,SD20,Ind,writein,0
-Kings,43058,State Senate,SD20,Ind,writein,0
-Kings,43059,State Senate,SD20,Ind,writein,1
-Kings,43060,State Senate,SD20,Ind,writein,1
-Kings,43061,State Senate,SD20,Ind,writein,0
-Kings,43062,State Senate,SD20,Ind,writein,0
-Kings,43063,State Senate,SD20,Ind,writein,0
-Kings,43064,State Senate,SD20,Ind,writein,0
-Kings,43065,State Senate,SD20,Ind,writein,0
-Kings,43066,State Senate,SD20,Ind,writein,0
-Kings,43067,State Senate,SD20,Ind,writein,2
-Kings,43068,State Senate,SD20,Ind,writein,0
-Kings,43069,State Senate,SD20,Ind,writein,0
-Kings,43070,State Senate,SD20,Ind,writein,0
-Kings,43071,State Senate,SD20,Ind,writein,0
-Kings,49001,State Senate,SD20,Ind,writein,0
-Kings,49002,State Senate,SD20,Ind,writein,1
-Kings,49003,State Senate,SD20,Ind,writein,0
-Kings,49004,State Senate,SD20,Ind,writein,2
-Kings,49005,State Senate,SD20,Ind,writein,0
-Kings,49014,State Senate,SD20,Ind,writein,0
-Kings,51020,State Senate,SD20,Ind,writein,0
-Kings,51028,State Senate,SD20,Ind,writein,0
-Kings,51029,State Senate,SD20,Ind,writein,0
-Kings,51030,State Senate,SD20,Ind,writein,2
-Kings,51031,State Senate,SD20,Ind,writein,2
-Kings,51032,State Senate,SD20,Ind,writein,0
-Kings,51033,State Senate,SD20,Ind,writein,1
-Kings,51034,State Senate,SD20,Ind,writein,0
-Kings,51035,State Senate,SD20,Ind,writein,0
-Kings,51036,State Senate,SD20,Ind,writein,0
-Kings,51037,State Senate,SD20,Ind,writein,0
-Kings,51038,State Senate,SD20,Ind,writein,1
-Kings,51039,State Senate,SD20,Ind,writein,2
-Kings,51040,State Senate,SD20,Ind,writein,0
-Kings,51041,State Senate,SD20,Ind,writein,0
-Kings,51042,State Senate,SD20,Ind,writein,1
-Kings,51043,State Senate,SD20,Ind,writein,1
-Kings,51063,State Senate,SD20,Ind,writein,0
-Kings,51064,State Senate,SD20,Ind,writein,1
-Kings,51065,State Senate,SD20,Ind,writein,0
-Kings,51066,State Senate,SD20,Ind,writein,0
-Kings,51067,State Senate,SD20,Ind,writein,1
-Kings,52064,State Senate,SD20,Ind,writein,1
-Kings,52065,State Senate,SD20,Ind,writein,1
-Kings,52066,State Senate,SD20,Ind,writein,0
-Kings,52067,State Senate,SD20,Ind,writein,1
-Kings,52072,State Senate,SD20,Ind,writein,0
-Kings,52073,State Senate,SD20,Ind,writein,0
-Kings,52074,State Senate,SD20,Ind,writein,0
-Kings,52075,State Senate,SD20,Ind,writein,1
-Kings,52079,State Senate,SD20,Ind,writein,0
-Kings,52087,State Senate,SD20,Ind,writein,0
-Kings,52088,State Senate,SD20,Ind,writein,0
-Kings,52092,State Senate,SD20,Ind,writein,0
-Kings,52093,State Senate,SD20,Ind,writein,0
-Kings,52094,State Senate,SD20,Ind,writein,0
-Kings,55035,State Senate,SD20,Ind,writein,0
-Kings,55057,State Senate,SD20,Ind,writein,0
-Kings,55058,State Senate,SD20,Ind,writein,0
-Kings,55059,State Senate,SD20,Ind,writein,0
-Kings,55061,State Senate,SD20,Ind,writein,0
-Kings,55065,State Senate,SD20,Ind,writein,0
-Kings,55066,State Senate,SD20,Ind,writein,0
-Kings,55067,State Senate,SD20,Ind,writein,0
-Kings,55068,State Senate,SD20,Ind,writein,0
-Kings,55069,State Senate,SD20,Ind,writein,0
-Kings,55070,State Senate,SD20,Ind,writein,1
-Kings,55071,State Senate,SD20,Ind,writein,0
-Kings,55072,State Senate,SD20,Ind,writein,0
-Kings,55073,State Senate,SD20,Ind,writein,0
-Kings,55076,State Senate,SD20,Ind,writein,1
-Kings,55078,State Senate,SD20,Ind,writein,0
-Kings,55079,State Senate,SD20,Ind,writein,0
-Kings,55080,State Senate,SD20,Ind,writein,0
-Kings,55081,State Senate,SD20,Ind,writein,0
-Kings,55082,State Senate,SD20,Ind,writein,0
-Kings,55083,State Senate,SD20,Ind,writein,1
-Kings,55084,State Senate,SD20,Ind,writein,1
-Kings,55085,State Senate,SD20,Ind,writein,0
-Kings,55086,State Senate,SD20,Ind,writein,0
-Kings,55087,State Senate,SD20,Ind,writein,0
-Kings,55088,State Senate,SD20,Ind,writein,0
-Kings,55089,State Senate,SD20,Ind,writein,0
-Kings,55090,State Senate,SD20,Ind,writein,0
-Kings,55091,State Senate,SD20,Ind,writein,1
-Kings,55092,State Senate,SD20,Ind,writein,0
-Kings,55093,State Senate,SD20,Ind,writein,0
-Kings,55094,State Senate,SD20,Ind,writein,0
-Kings,55095,State Senate,SD20,Ind,writein,0
-Kings,55096,State Senate,SD20,Ind,writein,0
-Kings,55097,State Senate,SD20,Ind,writein,0
-Kings,55100,State Senate,SD20,Ind,writein,0
-Kings,56073,State Senate,SD20,Ind,writein,0
-Kings,56075,State Senate,SD20,Ind,writein,0
-Kings,56076,State Senate,SD20,Ind,writein,0
-Kings,56077,State Senate,SD20,Ind,writein,0
-Kings,56078,State Senate,SD20,Ind,writein,0
-Kings,57067,State Senate,SD20,Ind,writein,1
-Kings,57068,State Senate,SD20,Ind,writein,0
-Kings,57069,State Senate,SD20,Ind,writein,0
-Kings,57070,State Senate,SD20,Ind,writein,1
-Kings,57071,State Senate,SD20,Ind,writein,1
-Kings,57072,State Senate,SD20,Ind,writein,0
-Kings,57073,State Senate,SD20,Ind,writein,0
-Kings,57074,State Senate,SD20,Ind,writein,0
-Kings,57075,State Senate,SD20,Ind,writein,1
-Kings,57076,State Senate,SD20,Ind,writein,0
-Kings,57077,State Senate,SD20,Ind,writein,0
-Kings,57078,State Senate,SD20,Ind,writein,0
-Kings,57079,State Senate,SD20,Ind,writein,1
-Kings,57080,State Senate,SD20,Ind,writein,0
-Kings,57081,State Senate,SD20,Ind,writein,0
-Kings,57082,State Senate,SD20,Ind,writein,0
-Kings,57083,State Senate,SD20,Ind,writein,1
-Kings,57084,State Senate,SD20,Ind,writein,0
-Kings,57085,State Senate,SD20,Ind,writein,0
-Kings,57088,State Senate,SD20,Ind,writein,0
-Kings,57089,State Senate,SD20,Ind,writein,1
-Kings,57090,State Senate,SD20,Ind,writein,0
-Kings,57091,State Senate,SD20,Ind,writein,0
-Kings,57092,State Senate,SD20,Ind,writein,0
-Kings,57093,State Senate,SD20,Ind,writein,0
-Kings,58001,State Senate,SD20,Ind,writein,0
-Kings,58002,State Senate,SD20,Ind,writein,0
-Kings,58003,State Senate,SD20,Ind,writein,0
-Kings,58004,State Senate,SD20,Ind,writein,0
-Kings,58005,State Senate,SD20,Ind,writein,0
-Kings,58006,State Senate,SD20,Ind,writein,0
-Kings,58007,State Senate,SD20,Ind,writein,0
-Kings,58008,State Senate,SD20,Ind,writein,0
-Kings,58009,State Senate,SD20,Ind,writein,0
-Kings,58010,State Senate,SD20,Ind,writein,0
-Kings,58011,State Senate,SD20,Ind,writein,0
-Kings,58012,State Senate,SD20,Ind,writein,0
-Kings,58013,State Senate,SD20,Ind,writein,0
-Kings,58014,State Senate,SD20,Ind,writein,0
-Kings,58015,State Senate,SD20,Ind,writein,0
-Kings,58045,State Senate,SD20,Ind,writein,0
-Kings,58046,State Senate,SD20,Ind,writein,0
-Kings,58047,State Senate,SD20,Ind,writein,0
-Kings,58048,State Senate,SD20,Ind,writein,0
-Kings,58052,State Senate,SD20,Ind,writein,0
-Kings,58053,State Senate,SD20,Ind,writein,0
-Kings,58054,State Senate,SD20,Ind,writein,0
-Kings,41023,State Senate,SD21,Dem,Kevin Parker,71
-Kings,41030,State Senate,SD21,Dem,Kevin Parker,549
-Kings,41031,State Senate,SD21,Dem,Kevin Parker,674
-Kings,41032,State Senate,SD21,Dem,Kevin Parker,569
-Kings,41033,State Senate,SD21,Dem,Kevin Parker,475
-Kings,41034,State Senate,SD21,Dem,Kevin Parker,401
-Kings,41036,State Senate,SD21,Dem,Kevin Parker,107
-Kings,41037,State Senate,SD21,Dem,Kevin Parker,463
-Kings,41038,State Senate,SD21,Dem,Kevin Parker,665
-Kings,41039,State Senate,SD21,Dem,Kevin Parker,610
-Kings,41040,State Senate,SD21,Dem,Kevin Parker,111
-Kings,41041,State Senate,SD21,Dem,Kevin Parker,735
-Kings,41042,State Senate,SD21,Dem,Kevin Parker,55
-Kings,41043,State Senate,SD21,Dem,Kevin Parker,455
-Kings,41045,State Senate,SD21,Dem,Kevin Parker,670
-Kings,41046,State Senate,SD21,Dem,Kevin Parker,1
-Kings,41047,State Senate,SD21,Dem,Kevin Parker,673
-Kings,41048,State Senate,SD21,Dem,Kevin Parker,261
-Kings,41049,State Senate,SD21,Dem,Kevin Parker,514
-Kings,41053,State Senate,SD21,Dem,Kevin Parker,473
-Kings,41054,State Senate,SD21,Dem,Kevin Parker,527
-Kings,41055,State Senate,SD21,Dem,Kevin Parker,496
-Kings,42001,State Senate,SD21,Dem,Kevin Parker,28
-Kings,42002,State Senate,SD21,Dem,Kevin Parker,524
-Kings,42003,State Senate,SD21,Dem,Kevin Parker,541
-Kings,42004,State Senate,SD21,Dem,Kevin Parker,574
-Kings,42005,State Senate,SD21,Dem,Kevin Parker,424
-Kings,42006,State Senate,SD21,Dem,Kevin Parker,437
-Kings,42007,State Senate,SD21,Dem,Kevin Parker,610
-Kings,42008,State Senate,SD21,Dem,Kevin Parker,332
-Kings,42009,State Senate,SD21,Dem,Kevin Parker,584
-Kings,42010,State Senate,SD21,Dem,Kevin Parker,583
-Kings,42011,State Senate,SD21,Dem,Kevin Parker,574
-Kings,42012,State Senate,SD21,Dem,Kevin Parker,622
-Kings,42013,State Senate,SD21,Dem,Kevin Parker,490
-Kings,42014,State Senate,SD21,Dem,Kevin Parker,233
-Kings,42015,State Senate,SD21,Dem,Kevin Parker,607
-Kings,42016,State Senate,SD21,Dem,Kevin Parker,550
-Kings,42017,State Senate,SD21,Dem,Kevin Parker,511
-Kings,42018,State Senate,SD21,Dem,Kevin Parker,575
-Kings,42019,State Senate,SD21,Dem,Kevin Parker,354
-Kings,42020,State Senate,SD21,Dem,Kevin Parker,516
-Kings,42021,State Senate,SD21,Dem,Kevin Parker,586
-Kings,42022,State Senate,SD21,Dem,Kevin Parker,522
-Kings,42023,State Senate,SD21,Dem,Kevin Parker,564
-Kings,42024,State Senate,SD21,Dem,Kevin Parker,562
-Kings,42025,State Senate,SD21,Dem,Kevin Parker,516
-Kings,42026,State Senate,SD21,Dem,Kevin Parker,558
-Kings,42027,State Senate,SD21,Dem,Kevin Parker,534
-Kings,42028,State Senate,SD21,Dem,Kevin Parker,559
-Kings,42029,State Senate,SD21,Dem,Kevin Parker,571
-Kings,42030,State Senate,SD21,Dem,Kevin Parker,332
-Kings,42031,State Senate,SD21,Dem,Kevin Parker,530
-Kings,42032,State Senate,SD21,Dem,Kevin Parker,144
-Kings,42033,State Senate,SD21,Dem,Kevin Parker,35
-Kings,42039,State Senate,SD21,Dem,Kevin Parker,763
-Kings,42040,State Senate,SD21,Dem,Kevin Parker,527
-Kings,42041,State Senate,SD21,Dem,Kevin Parker,619
-Kings,42042,State Senate,SD21,Dem,Kevin Parker,551
-Kings,42043,State Senate,SD21,Dem,Kevin Parker,567
-Kings,42044,State Senate,SD21,Dem,Kevin Parker,609
-Kings,42045,State Senate,SD21,Dem,Kevin Parker,531
-Kings,42046,State Senate,SD21,Dem,Kevin Parker,614
-Kings,42047,State Senate,SD21,Dem,Kevin Parker,652
-Kings,42048,State Senate,SD21,Dem,Kevin Parker,613
-Kings,42049,State Senate,SD21,Dem,Kevin Parker,539
-Kings,42050,State Senate,SD21,Dem,Kevin Parker,606
-Kings,42051,State Senate,SD21,Dem,Kevin Parker,543
-Kings,42052,State Senate,SD21,Dem,Kevin Parker,553
-Kings,42053,State Senate,SD21,Dem,Kevin Parker,569
-Kings,42054,State Senate,SD21,Dem,Kevin Parker,565
-Kings,42055,State Senate,SD21,Dem,Kevin Parker,569
-Kings,42056,State Senate,SD21,Dem,Kevin Parker,568
-Kings,42057,State Senate,SD21,Dem,Kevin Parker,536
-Kings,42058,State Senate,SD21,Dem,Kevin Parker,27
-Kings,43001,State Senate,SD21,Dem,Kevin Parker,452
-Kings,43002,State Senate,SD21,Dem,Kevin Parker,542
-Kings,43003,State Senate,SD21,Dem,Kevin Parker,606
-Kings,43004,State Senate,SD21,Dem,Kevin Parker,528
-Kings,43005,State Senate,SD21,Dem,Kevin Parker,309
-Kings,43006,State Senate,SD21,Dem,Kevin Parker,622
-Kings,43007,State Senate,SD21,Dem,Kevin Parker,293
-Kings,43008,State Senate,SD21,Dem,Kevin Parker,584
-Kings,43009,State Senate,SD21,Dem,Kevin Parker,580
-Kings,43010,State Senate,SD21,Dem,Kevin Parker,226
-Kings,44011,State Senate,SD21,Dem,Kevin Parker,132
-Kings,44012,State Senate,SD21,Dem,Kevin Parker,79
-Kings,44014,State Senate,SD21,Dem,Kevin Parker,460
-Kings,44015,State Senate,SD21,Dem,Kevin Parker,417
-Kings,44016,State Senate,SD21,Dem,Kevin Parker,488
-Kings,44017,State Senate,SD21,Dem,Kevin Parker,444
-Kings,44018,State Senate,SD21,Dem,Kevin Parker,320
-Kings,44019,State Senate,SD21,Dem,Kevin Parker,351
-Kings,44020,State Senate,SD21,Dem,Kevin Parker,243
-Kings,44034,State Senate,SD21,Dem,Kevin Parker,297
-Kings,44036,State Senate,SD21,Dem,Kevin Parker,554
-Kings,44037,State Senate,SD21,Dem,Kevin Parker,207
-Kings,44040,State Senate,SD21,Dem,Kevin Parker,86
-Kings,44046,State Senate,SD21,Dem,Kevin Parker,197
-Kings,44047,State Senate,SD21,Dem,Kevin Parker,100
-Kings,44048,State Senate,SD21,Dem,Kevin Parker,265
-Kings,44049,State Senate,SD21,Dem,Kevin Parker,446
-Kings,44050,State Senate,SD21,Dem,Kevin Parker,422
-Kings,44051,State Senate,SD21,Dem,Kevin Parker,420
-Kings,44052,State Senate,SD21,Dem,Kevin Parker,436
-Kings,44053,State Senate,SD21,Dem,Kevin Parker,361
-Kings,44054,State Senate,SD21,Dem,Kevin Parker,483
-Kings,44055,State Senate,SD21,Dem,Kevin Parker,470
-Kings,44056,State Senate,SD21,Dem,Kevin Parker,325
-Kings,44057,State Senate,SD21,Dem,Kevin Parker,586
-Kings,44058,State Senate,SD21,Dem,Kevin Parker,468
-Kings,44059,State Senate,SD21,Dem,Kevin Parker,439
-Kings,44060,State Senate,SD21,Dem,Kevin Parker,338
-Kings,44061,State Senate,SD21,Dem,Kevin Parker,269
-Kings,44062,State Senate,SD21,Dem,Kevin Parker,276
-Kings,44063,State Senate,SD21,Dem,Kevin Parker,314
-Kings,44064,State Senate,SD21,Dem,Kevin Parker,150
-Kings,44065,State Senate,SD21,Dem,Kevin Parker,511
-Kings,44066,State Senate,SD21,Dem,Kevin Parker,223
-Kings,44067,State Senate,SD21,Dem,Kevin Parker,8
-Kings,44068,State Senate,SD21,Dem,Kevin Parker,0
-Kings,44069,State Senate,SD21,Dem,Kevin Parker,484
-Kings,44070,State Senate,SD21,Dem,Kevin Parker,597
-Kings,44071,State Senate,SD21,Dem,Kevin Parker,472
-Kings,44072,State Senate,SD21,Dem,Kevin Parker,423
-Kings,44073,State Senate,SD21,Dem,Kevin Parker,476
-Kings,44074,State Senate,SD21,Dem,Kevin Parker,494
-Kings,44075,State Senate,SD21,Dem,Kevin Parker,435
-Kings,44076,State Senate,SD21,Dem,Kevin Parker,417
-Kings,44077,State Senate,SD21,Dem,Kevin Parker,421
-Kings,44078,State Senate,SD21,Dem,Kevin Parker,513
-Kings,44079,State Senate,SD21,Dem,Kevin Parker,491
-Kings,44080,State Senate,SD21,Dem,Kevin Parker,333
-Kings,51010,State Senate,SD21,Dem,Kevin Parker,135
-Kings,51011,State Senate,SD21,Dem,Kevin Parker,498
-Kings,51012,State Senate,SD21,Dem,Kevin Parker,476
-Kings,51013,State Senate,SD21,Dem,Kevin Parker,328
-Kings,51019,State Senate,SD21,Dem,Kevin Parker,40
-Kings,51021,State Senate,SD21,Dem,Kevin Parker,81
-Kings,51022,State Senate,SD21,Dem,Kevin Parker,59
-Kings,52068,State Senate,SD21,Dem,Kevin Parker,626
-Kings,52069,State Senate,SD21,Dem,Kevin Parker,529
-Kings,52070,State Senate,SD21,Dem,Kevin Parker,612
-Kings,52071,State Senate,SD21,Dem,Kevin Parker,462
-Kings,52076,State Senate,SD21,Dem,Kevin Parker,131
-Kings,52077,State Senate,SD21,Dem,Kevin Parker,24
-Kings,52078,State Senate,SD21,Dem,Kevin Parker,273
-Kings,52080,State Senate,SD21,Dem,Kevin Parker,152
-Kings,52081,State Senate,SD21,Dem,Kevin Parker,504
-Kings,52082,State Senate,SD21,Dem,Kevin Parker,431
-Kings,52083,State Senate,SD21,Dem,Kevin Parker,515
-Kings,52084,State Senate,SD21,Dem,Kevin Parker,412
-Kings,52085,State Senate,SD21,Dem,Kevin Parker,364
-Kings,52086,State Senate,SD21,Dem,Kevin Parker,571
-Kings,52113,State Senate,SD21,Dem,Kevin Parker,351
-Kings,52114,State Senate,SD21,Dem,Kevin Parker,376
-Kings,52115,State Senate,SD21,Dem,Kevin Parker,468
-Kings,57086,State Senate,SD21,Dem,Kevin Parker,707
-Kings,57087,State Senate,SD21,Dem,Kevin Parker,150
-Kings,58016,State Senate,SD21,Dem,Kevin Parker,367
-Kings,58017,State Senate,SD21,Dem,Kevin Parker,404
-Kings,58018,State Senate,SD21,Dem,Kevin Parker,554
-Kings,58019,State Senate,SD21,Dem,Kevin Parker,669
-Kings,58020,State Senate,SD21,Dem,Kevin Parker,548
-Kings,58021,State Senate,SD21,Dem,Kevin Parker,529
-Kings,58022,State Senate,SD21,Dem,Kevin Parker,303
-Kings,58023,State Senate,SD21,Dem,Kevin Parker,499
-Kings,58024,State Senate,SD21,Dem,Kevin Parker,639
-Kings,58025,State Senate,SD21,Dem,Kevin Parker,570
-Kings,58026,State Senate,SD21,Dem,Kevin Parker,639
-Kings,58027,State Senate,SD21,Dem,Kevin Parker,461
-Kings,58028,State Senate,SD21,Dem,Kevin Parker,540
-Kings,58029,State Senate,SD21,Dem,Kevin Parker,454
-Kings,58030,State Senate,SD21,Dem,Kevin Parker,683
-Kings,58031,State Senate,SD21,Dem,Kevin Parker,580
-Kings,58032,State Senate,SD21,Dem,Kevin Parker,545
-Kings,58033,State Senate,SD21,Dem,Kevin Parker,662
-Kings,58034,State Senate,SD21,Dem,Kevin Parker,562
-Kings,58035,State Senate,SD21,Dem,Kevin Parker,430
-Kings,58036,State Senate,SD21,Dem,Kevin Parker,625
-Kings,58037,State Senate,SD21,Dem,Kevin Parker,681
-Kings,58038,State Senate,SD21,Dem,Kevin Parker,538
-Kings,58039,State Senate,SD21,Dem,Kevin Parker,557
-Kings,58040,State Senate,SD21,Dem,Kevin Parker,618
-Kings,58041,State Senate,SD21,Dem,Kevin Parker,551
-Kings,58042,State Senate,SD21,Dem,Kevin Parker,275
-Kings,58049,State Senate,SD21,Dem,Kevin Parker,417
-Kings,58050,State Senate,SD21,Dem,Kevin Parker,450
-Kings,58051,State Senate,SD21,Dem,Kevin Parker,630
-Kings,58055,State Senate,SD21,Dem,Kevin Parker,481
-Kings,58056,State Senate,SD21,Dem,Kevin Parker,279
-Kings,58061,State Senate,SD21,Dem,Kevin Parker,581
-Kings,58062,State Senate,SD21,Dem,Kevin Parker,521
-Kings,58063,State Senate,SD21,Dem,Kevin Parker,349
-Kings,58064,State Senate,SD21,Dem,Kevin Parker,324
-Kings,59001,State Senate,SD21,Dem,Kevin Parker,364
-Kings,59002,State Senate,SD21,Dem,Kevin Parker,311
-Kings,59003,State Senate,SD21,Dem,Kevin Parker,328
-Kings,59004,State Senate,SD21,Dem,Kevin Parker,366
-Kings,59017,State Senate,SD21,Dem,Kevin Parker,541
-Kings,59018,State Senate,SD21,Dem,Kevin Parker,233
-Kings,59019,State Senate,SD21,Dem,Kevin Parker,152
-Kings,59020,State Senate,SD21,Dem,Kevin Parker,610
-Kings,59021,State Senate,SD21,Dem,Kevin Parker,404
-Kings,59022,State Senate,SD21,Dem,Kevin Parker,333
-Kings,59023,State Senate,SD21,Dem,Kevin Parker,460
-Kings,59025,State Senate,SD21,Dem,Kevin Parker,84
-Kings,41023,State Senate,SD21,Con,Kevin Parker,0
-Kings,41030,State Senate,SD21,Con,Kevin Parker,6
-Kings,41031,State Senate,SD21,Con,Kevin Parker,10
-Kings,41032,State Senate,SD21,Con,Kevin Parker,12
-Kings,41033,State Senate,SD21,Con,Kevin Parker,10
-Kings,41034,State Senate,SD21,Con,Kevin Parker,5
-Kings,41036,State Senate,SD21,Con,Kevin Parker,0
-Kings,41037,State Senate,SD21,Con,Kevin Parker,2
-Kings,41038,State Senate,SD21,Con,Kevin Parker,6
-Kings,41039,State Senate,SD21,Con,Kevin Parker,5
-Kings,41040,State Senate,SD21,Con,Kevin Parker,3
-Kings,41041,State Senate,SD21,Con,Kevin Parker,10
-Kings,41042,State Senate,SD21,Con,Kevin Parker,1
-Kings,41043,State Senate,SD21,Con,Kevin Parker,7
-Kings,41045,State Senate,SD21,Con,Kevin Parker,7
-Kings,41046,State Senate,SD21,Con,Kevin Parker,0
-Kings,41047,State Senate,SD21,Con,Kevin Parker,7
-Kings,41048,State Senate,SD21,Con,Kevin Parker,2
-Kings,41049,State Senate,SD21,Con,Kevin Parker,3
-Kings,41053,State Senate,SD21,Con,Kevin Parker,11
-Kings,41054,State Senate,SD21,Con,Kevin Parker,7
-Kings,41055,State Senate,SD21,Con,Kevin Parker,10
-Kings,42001,State Senate,SD21,Con,Kevin Parker,3
-Kings,42002,State Senate,SD21,Con,Kevin Parker,17
-Kings,42003,State Senate,SD21,Con,Kevin Parker,36
-Kings,42004,State Senate,SD21,Con,Kevin Parker,21
-Kings,42005,State Senate,SD21,Con,Kevin Parker,31
-Kings,42006,State Senate,SD21,Con,Kevin Parker,42
-Kings,42007,State Senate,SD21,Con,Kevin Parker,26
-Kings,42008,State Senate,SD21,Con,Kevin Parker,3
-Kings,42009,State Senate,SD21,Con,Kevin Parker,7
-Kings,42010,State Senate,SD21,Con,Kevin Parker,2
-Kings,42011,State Senate,SD21,Con,Kevin Parker,4
-Kings,42012,State Senate,SD21,Con,Kevin Parker,7
-Kings,42013,State Senate,SD21,Con,Kevin Parker,4
-Kings,42014,State Senate,SD21,Con,Kevin Parker,8
-Kings,42015,State Senate,SD21,Con,Kevin Parker,13
-Kings,42016,State Senate,SD21,Con,Kevin Parker,9
-Kings,42017,State Senate,SD21,Con,Kevin Parker,10
-Kings,42018,State Senate,SD21,Con,Kevin Parker,38
-Kings,42019,State Senate,SD21,Con,Kevin Parker,8
-Kings,42020,State Senate,SD21,Con,Kevin Parker,7
-Kings,42021,State Senate,SD21,Con,Kevin Parker,14
-Kings,42022,State Senate,SD21,Con,Kevin Parker,9
-Kings,42023,State Senate,SD21,Con,Kevin Parker,45
-Kings,42024,State Senate,SD21,Con,Kevin Parker,15
-Kings,42025,State Senate,SD21,Con,Kevin Parker,54
-Kings,42026,State Senate,SD21,Con,Kevin Parker,11
-Kings,42027,State Senate,SD21,Con,Kevin Parker,9
-Kings,42028,State Senate,SD21,Con,Kevin Parker,13
-Kings,42029,State Senate,SD21,Con,Kevin Parker,7
-Kings,42030,State Senate,SD21,Con,Kevin Parker,21
-Kings,42031,State Senate,SD21,Con,Kevin Parker,21
-Kings,42032,State Senate,SD21,Con,Kevin Parker,0
-Kings,42033,State Senate,SD21,Con,Kevin Parker,4
-Kings,42039,State Senate,SD21,Con,Kevin Parker,8
-Kings,42040,State Senate,SD21,Con,Kevin Parker,3
-Kings,42041,State Senate,SD21,Con,Kevin Parker,6
-Kings,42042,State Senate,SD21,Con,Kevin Parker,2
-Kings,42043,State Senate,SD21,Con,Kevin Parker,12
-Kings,42044,State Senate,SD21,Con,Kevin Parker,4
-Kings,42045,State Senate,SD21,Con,Kevin Parker,3
-Kings,42046,State Senate,SD21,Con,Kevin Parker,1
-Kings,42047,State Senate,SD21,Con,Kevin Parker,6
-Kings,42048,State Senate,SD21,Con,Kevin Parker,16
-Kings,42049,State Senate,SD21,Con,Kevin Parker,20
-Kings,42050,State Senate,SD21,Con,Kevin Parker,4
-Kings,42051,State Senate,SD21,Con,Kevin Parker,9
-Kings,42052,State Senate,SD21,Con,Kevin Parker,13
-Kings,42053,State Senate,SD21,Con,Kevin Parker,13
-Kings,42054,State Senate,SD21,Con,Kevin Parker,14
-Kings,42055,State Senate,SD21,Con,Kevin Parker,14
-Kings,42056,State Senate,SD21,Con,Kevin Parker,6
-Kings,42057,State Senate,SD21,Con,Kevin Parker,9
-Kings,42058,State Senate,SD21,Con,Kevin Parker,1
-Kings,43001,State Senate,SD21,Con,Kevin Parker,32
-Kings,43002,State Senate,SD21,Con,Kevin Parker,43
-Kings,43003,State Senate,SD21,Con,Kevin Parker,18
-Kings,43004,State Senate,SD21,Con,Kevin Parker,23
-Kings,43005,State Senate,SD21,Con,Kevin Parker,21
-Kings,43006,State Senate,SD21,Con,Kevin Parker,30
-Kings,43007,State Senate,SD21,Con,Kevin Parker,13
-Kings,43008,State Senate,SD21,Con,Kevin Parker,24
-Kings,43009,State Senate,SD21,Con,Kevin Parker,18
-Kings,43010,State Senate,SD21,Con,Kevin Parker,1
-Kings,44011,State Senate,SD21,Con,Kevin Parker,14
-Kings,44012,State Senate,SD21,Con,Kevin Parker,10
-Kings,44014,State Senate,SD21,Con,Kevin Parker,39
-Kings,44015,State Senate,SD21,Con,Kevin Parker,48
-Kings,44016,State Senate,SD21,Con,Kevin Parker,37
-Kings,44017,State Senate,SD21,Con,Kevin Parker,57
-Kings,44018,State Senate,SD21,Con,Kevin Parker,42
-Kings,44019,State Senate,SD21,Con,Kevin Parker,17
-Kings,44020,State Senate,SD21,Con,Kevin Parker,12
-Kings,44034,State Senate,SD21,Con,Kevin Parker,20
-Kings,44036,State Senate,SD21,Con,Kevin Parker,49
-Kings,44037,State Senate,SD21,Con,Kevin Parker,17
-Kings,44040,State Senate,SD21,Con,Kevin Parker,3
-Kings,44046,State Senate,SD21,Con,Kevin Parker,21
-Kings,44047,State Senate,SD21,Con,Kevin Parker,7
-Kings,44048,State Senate,SD21,Con,Kevin Parker,28
-Kings,44049,State Senate,SD21,Con,Kevin Parker,65
-Kings,44050,State Senate,SD21,Con,Kevin Parker,59
-Kings,44051,State Senate,SD21,Con,Kevin Parker,57
-Kings,44052,State Senate,SD21,Con,Kevin Parker,70
-Kings,44053,State Senate,SD21,Con,Kevin Parker,74
-Kings,44054,State Senate,SD21,Con,Kevin Parker,110
-Kings,44055,State Senate,SD21,Con,Kevin Parker,118
-Kings,44056,State Senate,SD21,Con,Kevin Parker,69
-Kings,44057,State Senate,SD21,Con,Kevin Parker,91
-Kings,44058,State Senate,SD21,Con,Kevin Parker,95
-Kings,44059,State Senate,SD21,Con,Kevin Parker,73
-Kings,44060,State Senate,SD21,Con,Kevin Parker,62
-Kings,44061,State Senate,SD21,Con,Kevin Parker,51
-Kings,44062,State Senate,SD21,Con,Kevin Parker,50
-Kings,44063,State Senate,SD21,Con,Kevin Parker,55
-Kings,44064,State Senate,SD21,Con,Kevin Parker,27
-Kings,44065,State Senate,SD21,Con,Kevin Parker,88
-Kings,44066,State Senate,SD21,Con,Kevin Parker,34
-Kings,44067,State Senate,SD21,Con,Kevin Parker,2
-Kings,44068,State Senate,SD21,Con,Kevin Parker,1
-Kings,44069,State Senate,SD21,Con,Kevin Parker,108
-Kings,44070,State Senate,SD21,Con,Kevin Parker,100
-Kings,44071,State Senate,SD21,Con,Kevin Parker,87
-Kings,44072,State Senate,SD21,Con,Kevin Parker,89
-Kings,44073,State Senate,SD21,Con,Kevin Parker,80
-Kings,44074,State Senate,SD21,Con,Kevin Parker,83
-Kings,44075,State Senate,SD21,Con,Kevin Parker,83
-Kings,44076,State Senate,SD21,Con,Kevin Parker,58
-Kings,44077,State Senate,SD21,Con,Kevin Parker,71
-Kings,44078,State Senate,SD21,Con,Kevin Parker,112
-Kings,44079,State Senate,SD21,Con,Kevin Parker,59
-Kings,44080,State Senate,SD21,Con,Kevin Parker,70
-Kings,51010,State Senate,SD21,Con,Kevin Parker,7
-Kings,51011,State Senate,SD21,Con,Kevin Parker,71
-Kings,51012,State Senate,SD21,Con,Kevin Parker,66
-Kings,51013,State Senate,SD21,Con,Kevin Parker,35
-Kings,51019,State Senate,SD21,Con,Kevin Parker,2
-Kings,51021,State Senate,SD21,Con,Kevin Parker,11
-Kings,51022,State Senate,SD21,Con,Kevin Parker,15
-Kings,52068,State Senate,SD21,Con,Kevin Parker,95
-Kings,52069,State Senate,SD21,Con,Kevin Parker,75
-Kings,52070,State Senate,SD21,Con,Kevin Parker,115
-Kings,52071,State Senate,SD21,Con,Kevin Parker,69
-Kings,52076,State Senate,SD21,Con,Kevin Parker,36
-Kings,52077,State Senate,SD21,Con,Kevin Parker,5
-Kings,52078,State Senate,SD21,Con,Kevin Parker,47
-Kings,52080,State Senate,SD21,Con,Kevin Parker,25
-Kings,52081,State Senate,SD21,Con,Kevin Parker,115
-Kings,52082,State Senate,SD21,Con,Kevin Parker,82
-Kings,52083,State Senate,SD21,Con,Kevin Parker,82
-Kings,52084,State Senate,SD21,Con,Kevin Parker,86
-Kings,52085,State Senate,SD21,Con,Kevin Parker,72
-Kings,52086,State Senate,SD21,Con,Kevin Parker,92
-Kings,52113,State Senate,SD21,Con,Kevin Parker,52
-Kings,52114,State Senate,SD21,Con,Kevin Parker,52
-Kings,52115,State Senate,SD21,Con,Kevin Parker,74
-Kings,57086,State Senate,SD21,Con,Kevin Parker,40
-Kings,57087,State Senate,SD21,Con,Kevin Parker,10
-Kings,58016,State Senate,SD21,Con,Kevin Parker,4
-Kings,58017,State Senate,SD21,Con,Kevin Parker,6
-Kings,58018,State Senate,SD21,Con,Kevin Parker,5
-Kings,58019,State Senate,SD21,Con,Kevin Parker,8
-Kings,58020,State Senate,SD21,Con,Kevin Parker,6
-Kings,58021,State Senate,SD21,Con,Kevin Parker,8
-Kings,58022,State Senate,SD21,Con,Kevin Parker,9
-Kings,58023,State Senate,SD21,Con,Kevin Parker,9
-Kings,58024,State Senate,SD21,Con,Kevin Parker,16
-Kings,58025,State Senate,SD21,Con,Kevin Parker,6
-Kings,58026,State Senate,SD21,Con,Kevin Parker,5
-Kings,58027,State Senate,SD21,Con,Kevin Parker,6
-Kings,58028,State Senate,SD21,Con,Kevin Parker,5
-Kings,58029,State Senate,SD21,Con,Kevin Parker,5
-Kings,58030,State Senate,SD21,Con,Kevin Parker,10
-Kings,58031,State Senate,SD21,Con,Kevin Parker,3
-Kings,58032,State Senate,SD21,Con,Kevin Parker,6
-Kings,58033,State Senate,SD21,Con,Kevin Parker,4
-Kings,58034,State Senate,SD21,Con,Kevin Parker,1
-Kings,58035,State Senate,SD21,Con,Kevin Parker,6
-Kings,58036,State Senate,SD21,Con,Kevin Parker,6
-Kings,58037,State Senate,SD21,Con,Kevin Parker,8
-Kings,58038,State Senate,SD21,Con,Kevin Parker,6
-Kings,58039,State Senate,SD21,Con,Kevin Parker,3
-Kings,58040,State Senate,SD21,Con,Kevin Parker,3
-Kings,58041,State Senate,SD21,Con,Kevin Parker,10
-Kings,58042,State Senate,SD21,Con,Kevin Parker,3
-Kings,58049,State Senate,SD21,Con,Kevin Parker,7
-Kings,58050,State Senate,SD21,Con,Kevin Parker,11
-Kings,58051,State Senate,SD21,Con,Kevin Parker,9
-Kings,58055,State Senate,SD21,Con,Kevin Parker,1
-Kings,58056,State Senate,SD21,Con,Kevin Parker,3
-Kings,58061,State Senate,SD21,Con,Kevin Parker,6
-Kings,58062,State Senate,SD21,Con,Kevin Parker,7
-Kings,58063,State Senate,SD21,Con,Kevin Parker,1
-Kings,58064,State Senate,SD21,Con,Kevin Parker,6
-Kings,59001,State Senate,SD21,Con,Kevin Parker,9
-Kings,59002,State Senate,SD21,Con,Kevin Parker,3
-Kings,59003,State Senate,SD21,Con,Kevin Parker,8
-Kings,59004,State Senate,SD21,Con,Kevin Parker,3
-Kings,59017,State Senate,SD21,Con,Kevin Parker,1
-Kings,59018,State Senate,SD21,Con,Kevin Parker,0
-Kings,59019,State Senate,SD21,Con,Kevin Parker,1
-Kings,59020,State Senate,SD21,Con,Kevin Parker,6
-Kings,59021,State Senate,SD21,Con,Kevin Parker,5
-Kings,59022,State Senate,SD21,Con,Kevin Parker,3
-Kings,59023,State Senate,SD21,Con,Kevin Parker,3
-Kings,59025,State Senate,SD21,Con,Kevin Parker,2
-Kings,41023,State Senate,SD21,Rep,Mindy Meyer,5
-Kings,41030,State Senate,SD21,Rep,Mindy Meyer,23
-Kings,41031,State Senate,SD21,Rep,Mindy Meyer,13
-Kings,41032,State Senate,SD21,Rep,Mindy Meyer,9
-Kings,41033,State Senate,SD21,Rep,Mindy Meyer,8
-Kings,41034,State Senate,SD21,Rep,Mindy Meyer,10
-Kings,41036,State Senate,SD21,Rep,Mindy Meyer,1
-Kings,41037,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,41038,State Senate,SD21,Rep,Mindy Meyer,15
-Kings,41039,State Senate,SD21,Rep,Mindy Meyer,11
-Kings,41040,State Senate,SD21,Rep,Mindy Meyer,4
-Kings,41041,State Senate,SD21,Rep,Mindy Meyer,17
-Kings,41042,State Senate,SD21,Rep,Mindy Meyer,1
-Kings,41043,State Senate,SD21,Rep,Mindy Meyer,13
-Kings,41045,State Senate,SD21,Rep,Mindy Meyer,8
-Kings,41046,State Senate,SD21,Rep,Mindy Meyer,0
-Kings,41047,State Senate,SD21,Rep,Mindy Meyer,13
-Kings,41048,State Senate,SD21,Rep,Mindy Meyer,1
-Kings,41049,State Senate,SD21,Rep,Mindy Meyer,4
-Kings,41053,State Senate,SD21,Rep,Mindy Meyer,39
-Kings,41054,State Senate,SD21,Rep,Mindy Meyer,9
-Kings,41055,State Senate,SD21,Rep,Mindy Meyer,8
-Kings,42001,State Senate,SD21,Rep,Mindy Meyer,1
-Kings,42002,State Senate,SD21,Rep,Mindy Meyer,8
-Kings,42003,State Senate,SD21,Rep,Mindy Meyer,4
-Kings,42004,State Senate,SD21,Rep,Mindy Meyer,9
-Kings,42005,State Senate,SD21,Rep,Mindy Meyer,7
-Kings,42006,State Senate,SD21,Rep,Mindy Meyer,14
-Kings,42007,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,42008,State Senate,SD21,Rep,Mindy Meyer,1
-Kings,42009,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,42010,State Senate,SD21,Rep,Mindy Meyer,4
-Kings,42011,State Senate,SD21,Rep,Mindy Meyer,3
-Kings,42012,State Senate,SD21,Rep,Mindy Meyer,8
-Kings,42013,State Senate,SD21,Rep,Mindy Meyer,0
-Kings,42014,State Senate,SD21,Rep,Mindy Meyer,1
-Kings,42015,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,42016,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,42017,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,42018,State Senate,SD21,Rep,Mindy Meyer,20
-Kings,42019,State Senate,SD21,Rep,Mindy Meyer,0
-Kings,42020,State Senate,SD21,Rep,Mindy Meyer,4
-Kings,42021,State Senate,SD21,Rep,Mindy Meyer,8
-Kings,42022,State Senate,SD21,Rep,Mindy Meyer,1
-Kings,42023,State Senate,SD21,Rep,Mindy Meyer,12
-Kings,42024,State Senate,SD21,Rep,Mindy Meyer,19
-Kings,42025,State Senate,SD21,Rep,Mindy Meyer,8
-Kings,42026,State Senate,SD21,Rep,Mindy Meyer,1
-Kings,42027,State Senate,SD21,Rep,Mindy Meyer,7
-Kings,42028,State Senate,SD21,Rep,Mindy Meyer,4
-Kings,42029,State Senate,SD21,Rep,Mindy Meyer,6
-Kings,42030,State Senate,SD21,Rep,Mindy Meyer,5
-Kings,42031,State Senate,SD21,Rep,Mindy Meyer,8
-Kings,42032,State Senate,SD21,Rep,Mindy Meyer,0
-Kings,42033,State Senate,SD21,Rep,Mindy Meyer,1
-Kings,42039,State Senate,SD21,Rep,Mindy Meyer,3
-Kings,42040,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,42041,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,42042,State Senate,SD21,Rep,Mindy Meyer,1
-Kings,42043,State Senate,SD21,Rep,Mindy Meyer,3
-Kings,42044,State Senate,SD21,Rep,Mindy Meyer,3
-Kings,42045,State Senate,SD21,Rep,Mindy Meyer,3
-Kings,42046,State Senate,SD21,Rep,Mindy Meyer,3
-Kings,42047,State Senate,SD21,Rep,Mindy Meyer,9
-Kings,42048,State Senate,SD21,Rep,Mindy Meyer,11
-Kings,42049,State Senate,SD21,Rep,Mindy Meyer,11
-Kings,42050,State Senate,SD21,Rep,Mindy Meyer,5
-Kings,42051,State Senate,SD21,Rep,Mindy Meyer,51
-Kings,42052,State Senate,SD21,Rep,Mindy Meyer,21
-Kings,42053,State Senate,SD21,Rep,Mindy Meyer,8
-Kings,42054,State Senate,SD21,Rep,Mindy Meyer,7
-Kings,42055,State Senate,SD21,Rep,Mindy Meyer,18
-Kings,42056,State Senate,SD21,Rep,Mindy Meyer,3
-Kings,42057,State Senate,SD21,Rep,Mindy Meyer,13
-Kings,42058,State Senate,SD21,Rep,Mindy Meyer,0
-Kings,43001,State Senate,SD21,Rep,Mindy Meyer,3
-Kings,43002,State Senate,SD21,Rep,Mindy Meyer,10
-Kings,43003,State Senate,SD21,Rep,Mindy Meyer,6
-Kings,43004,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,43005,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,43006,State Senate,SD21,Rep,Mindy Meyer,4
-Kings,43007,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,43008,State Senate,SD21,Rep,Mindy Meyer,8
-Kings,43009,State Senate,SD21,Rep,Mindy Meyer,3
-Kings,43010,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,44011,State Senate,SD21,Rep,Mindy Meyer,13
-Kings,44012,State Senate,SD21,Rep,Mindy Meyer,1
-Kings,44014,State Senate,SD21,Rep,Mindy Meyer,40
-Kings,44015,State Senate,SD21,Rep,Mindy Meyer,41
-Kings,44016,State Senate,SD21,Rep,Mindy Meyer,38
-Kings,44017,State Senate,SD21,Rep,Mindy Meyer,33
-Kings,44018,State Senate,SD21,Rep,Mindy Meyer,39
-Kings,44019,State Senate,SD21,Rep,Mindy Meyer,59
-Kings,44020,State Senate,SD21,Rep,Mindy Meyer,46
-Kings,44034,State Senate,SD21,Rep,Mindy Meyer,5
-Kings,44036,State Senate,SD21,Rep,Mindy Meyer,12
-Kings,44037,State Senate,SD21,Rep,Mindy Meyer,9
-Kings,44040,State Senate,SD21,Rep,Mindy Meyer,4
-Kings,44046,State Senate,SD21,Rep,Mindy Meyer,6
-Kings,44047,State Senate,SD21,Rep,Mindy Meyer,5
-Kings,44048,State Senate,SD21,Rep,Mindy Meyer,28
-Kings,44049,State Senate,SD21,Rep,Mindy Meyer,44
-Kings,44050,State Senate,SD21,Rep,Mindy Meyer,19
-Kings,44051,State Senate,SD21,Rep,Mindy Meyer,47
-Kings,44052,State Senate,SD21,Rep,Mindy Meyer,56
-Kings,44053,State Senate,SD21,Rep,Mindy Meyer,61
-Kings,44054,State Senate,SD21,Rep,Mindy Meyer,30
-Kings,44055,State Senate,SD21,Rep,Mindy Meyer,58
-Kings,44056,State Senate,SD21,Rep,Mindy Meyer,38
-Kings,44057,State Senate,SD21,Rep,Mindy Meyer,69
-Kings,44058,State Senate,SD21,Rep,Mindy Meyer,68
-Kings,44059,State Senate,SD21,Rep,Mindy Meyer,46
-Kings,44060,State Senate,SD21,Rep,Mindy Meyer,33
-Kings,44061,State Senate,SD21,Rep,Mindy Meyer,9
-Kings,44062,State Senate,SD21,Rep,Mindy Meyer,20
-Kings,44063,State Senate,SD21,Rep,Mindy Meyer,13
-Kings,44064,State Senate,SD21,Rep,Mindy Meyer,10
-Kings,44065,State Senate,SD21,Rep,Mindy Meyer,29
-Kings,44066,State Senate,SD21,Rep,Mindy Meyer,11
-Kings,44067,State Senate,SD21,Rep,Mindy Meyer,1
-Kings,44068,State Senate,SD21,Rep,Mindy Meyer,0
-Kings,44069,State Senate,SD21,Rep,Mindy Meyer,36
-Kings,44070,State Senate,SD21,Rep,Mindy Meyer,43
-Kings,44071,State Senate,SD21,Rep,Mindy Meyer,33
-Kings,44072,State Senate,SD21,Rep,Mindy Meyer,18
-Kings,44073,State Senate,SD21,Rep,Mindy Meyer,32
-Kings,44074,State Senate,SD21,Rep,Mindy Meyer,27
-Kings,44075,State Senate,SD21,Rep,Mindy Meyer,29
-Kings,44076,State Senate,SD21,Rep,Mindy Meyer,22
-Kings,44077,State Senate,SD21,Rep,Mindy Meyer,28
-Kings,44078,State Senate,SD21,Rep,Mindy Meyer,26
-Kings,44079,State Senate,SD21,Rep,Mindy Meyer,35
-Kings,44080,State Senate,SD21,Rep,Mindy Meyer,19
-Kings,51010,State Senate,SD21,Rep,Mindy Meyer,3
-Kings,51011,State Senate,SD21,Rep,Mindy Meyer,25
-Kings,51012,State Senate,SD21,Rep,Mindy Meyer,19
-Kings,51013,State Senate,SD21,Rep,Mindy Meyer,20
-Kings,51019,State Senate,SD21,Rep,Mindy Meyer,6
-Kings,51021,State Senate,SD21,Rep,Mindy Meyer,3
-Kings,51022,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,52068,State Senate,SD21,Rep,Mindy Meyer,43
-Kings,52069,State Senate,SD21,Rep,Mindy Meyer,29
-Kings,52070,State Senate,SD21,Rep,Mindy Meyer,55
-Kings,52071,State Senate,SD21,Rep,Mindy Meyer,10
-Kings,52076,State Senate,SD21,Rep,Mindy Meyer,6
-Kings,52077,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,52078,State Senate,SD21,Rep,Mindy Meyer,24
-Kings,52080,State Senate,SD21,Rep,Mindy Meyer,7
-Kings,52081,State Senate,SD21,Rep,Mindy Meyer,33
-Kings,52082,State Senate,SD21,Rep,Mindy Meyer,24
-Kings,52083,State Senate,SD21,Rep,Mindy Meyer,22
-Kings,52084,State Senate,SD21,Rep,Mindy Meyer,27
-Kings,52085,State Senate,SD21,Rep,Mindy Meyer,20
-Kings,52086,State Senate,SD21,Rep,Mindy Meyer,31
-Kings,52113,State Senate,SD21,Rep,Mindy Meyer,22
-Kings,52114,State Senate,SD21,Rep,Mindy Meyer,35
-Kings,52115,State Senate,SD21,Rep,Mindy Meyer,37
-Kings,57086,State Senate,SD21,Rep,Mindy Meyer,4
-Kings,57087,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,58016,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,58017,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,58018,State Senate,SD21,Rep,Mindy Meyer,1
-Kings,58019,State Senate,SD21,Rep,Mindy Meyer,3
-Kings,58020,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,58021,State Senate,SD21,Rep,Mindy Meyer,5
-Kings,58022,State Senate,SD21,Rep,Mindy Meyer,1
-Kings,58023,State Senate,SD21,Rep,Mindy Meyer,1
-Kings,58024,State Senate,SD21,Rep,Mindy Meyer,4
-Kings,58025,State Senate,SD21,Rep,Mindy Meyer,7
-Kings,58026,State Senate,SD21,Rep,Mindy Meyer,7
-Kings,58027,State Senate,SD21,Rep,Mindy Meyer,10
-Kings,58028,State Senate,SD21,Rep,Mindy Meyer,10
-Kings,58029,State Senate,SD21,Rep,Mindy Meyer,5
-Kings,58030,State Senate,SD21,Rep,Mindy Meyer,6
-Kings,58031,State Senate,SD21,Rep,Mindy Meyer,8
-Kings,58032,State Senate,SD21,Rep,Mindy Meyer,5
-Kings,58033,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,58034,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,58035,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,58036,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,58037,State Senate,SD21,Rep,Mindy Meyer,1
-Kings,58038,State Senate,SD21,Rep,Mindy Meyer,9
-Kings,58039,State Senate,SD21,Rep,Mindy Meyer,5
-Kings,58040,State Senate,SD21,Rep,Mindy Meyer,6
-Kings,58041,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,58042,State Senate,SD21,Rep,Mindy Meyer,1
-Kings,58049,State Senate,SD21,Rep,Mindy Meyer,7
-Kings,58050,State Senate,SD21,Rep,Mindy Meyer,7
-Kings,58051,State Senate,SD21,Rep,Mindy Meyer,10
-Kings,58055,State Senate,SD21,Rep,Mindy Meyer,0
-Kings,58056,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,58061,State Senate,SD21,Rep,Mindy Meyer,4
-Kings,58062,State Senate,SD21,Rep,Mindy Meyer,5
-Kings,58063,State Senate,SD21,Rep,Mindy Meyer,3
-Kings,58064,State Senate,SD21,Rep,Mindy Meyer,9
-Kings,59001,State Senate,SD21,Rep,Mindy Meyer,6
-Kings,59002,State Senate,SD21,Rep,Mindy Meyer,3
-Kings,59003,State Senate,SD21,Rep,Mindy Meyer,5
-Kings,59004,State Senate,SD21,Rep,Mindy Meyer,7
-Kings,59017,State Senate,SD21,Rep,Mindy Meyer,6
-Kings,59018,State Senate,SD21,Rep,Mindy Meyer,2
-Kings,59019,State Senate,SD21,Rep,Mindy Meyer,0
-Kings,59020,State Senate,SD21,Rep,Mindy Meyer,7
-Kings,59021,State Senate,SD21,Rep,Mindy Meyer,4
-Kings,59022,State Senate,SD21,Rep,Mindy Meyer,19
-Kings,59023,State Senate,SD21,Rep,Mindy Meyer,21
-Kings,59025,State Senate,SD21,Rep,Mindy Meyer,4
-Kings,41023,State Senate,SD21,Ind,writein,0
-Kings,41030,State Senate,SD21,Ind,writein,1
-Kings,41031,State Senate,SD21,Ind,writein,1
-Kings,41032,State Senate,SD21,Ind,writein,1
-Kings,41033,State Senate,SD21,Ind,writein,0
-Kings,41034,State Senate,SD21,Ind,writein,1
-Kings,41036,State Senate,SD21,Ind,writein,0
-Kings,41037,State Senate,SD21,Ind,writein,0
-Kings,41038,State Senate,SD21,Ind,writein,0
-Kings,41039,State Senate,SD21,Ind,writein,0
-Kings,41040,State Senate,SD21,Ind,writein,0
-Kings,41041,State Senate,SD21,Ind,writein,0
-Kings,41042,State Senate,SD21,Ind,writein,0
-Kings,41043,State Senate,SD21,Ind,writein,0
-Kings,41045,State Senate,SD21,Ind,writein,1
-Kings,41046,State Senate,SD21,Ind,writein,0
-Kings,41047,State Senate,SD21,Ind,writein,1
-Kings,41048,State Senate,SD21,Ind,writein,1
-Kings,41049,State Senate,SD21,Ind,writein,1
-Kings,41053,State Senate,SD21,Ind,writein,1
-Kings,41054,State Senate,SD21,Ind,writein,0
-Kings,41055,State Senate,SD21,Ind,writein,0
-Kings,42001,State Senate,SD21,Ind,writein,0
-Kings,42002,State Senate,SD21,Ind,writein,0
-Kings,42003,State Senate,SD21,Ind,writein,4
-Kings,42004,State Senate,SD21,Ind,writein,0
-Kings,42005,State Senate,SD21,Ind,writein,0
-Kings,42006,State Senate,SD21,Ind,writein,0
-Kings,42007,State Senate,SD21,Ind,writein,0
-Kings,42008,State Senate,SD21,Ind,writein,1
-Kings,42009,State Senate,SD21,Ind,writein,0
-Kings,42010,State Senate,SD21,Ind,writein,0
-Kings,42011,State Senate,SD21,Ind,writein,1
-Kings,42012,State Senate,SD21,Ind,writein,0
-Kings,42013,State Senate,SD21,Ind,writein,0
-Kings,42014,State Senate,SD21,Ind,writein,0
-Kings,42015,State Senate,SD21,Ind,writein,0
-Kings,42016,State Senate,SD21,Ind,writein,0
-Kings,42017,State Senate,SD21,Ind,writein,1
-Kings,42018,State Senate,SD21,Ind,writein,0
-Kings,42019,State Senate,SD21,Ind,writein,0
-Kings,42020,State Senate,SD21,Ind,writein,1
-Kings,42021,State Senate,SD21,Ind,writein,0
-Kings,42022,State Senate,SD21,Ind,writein,0
-Kings,42023,State Senate,SD21,Ind,writein,0
-Kings,42024,State Senate,SD21,Ind,writein,1
-Kings,42025,State Senate,SD21,Ind,writein,0
-Kings,42026,State Senate,SD21,Ind,writein,0
-Kings,42027,State Senate,SD21,Ind,writein,0
-Kings,42028,State Senate,SD21,Ind,writein,0
-Kings,42029,State Senate,SD21,Ind,writein,0
-Kings,42030,State Senate,SD21,Ind,writein,0
-Kings,42031,State Senate,SD21,Ind,writein,0
-Kings,42032,State Senate,SD21,Ind,writein,0
-Kings,42033,State Senate,SD21,Ind,writein,1
-Kings,42039,State Senate,SD21,Ind,writein,0
-Kings,42040,State Senate,SD21,Ind,writein,0
-Kings,42041,State Senate,SD21,Ind,writein,0
-Kings,42042,State Senate,SD21,Ind,writein,0
-Kings,42043,State Senate,SD21,Ind,writein,0
-Kings,42044,State Senate,SD21,Ind,writein,0
-Kings,42045,State Senate,SD21,Ind,writein,0
-Kings,42046,State Senate,SD21,Ind,writein,0
-Kings,42047,State Senate,SD21,Ind,writein,0
-Kings,42048,State Senate,SD21,Ind,writein,0
-Kings,42049,State Senate,SD21,Ind,writein,0
-Kings,42050,State Senate,SD21,Ind,writein,0
-Kings,42051,State Senate,SD21,Ind,writein,0
-Kings,42052,State Senate,SD21,Ind,writein,4
-Kings,42053,State Senate,SD21,Ind,writein,0
-Kings,42054,State Senate,SD21,Ind,writein,0
-Kings,42055,State Senate,SD21,Ind,writein,0
-Kings,42056,State Senate,SD21,Ind,writein,0
-Kings,42057,State Senate,SD21,Ind,writein,0
-Kings,42058,State Senate,SD21,Ind,writein,0
-Kings,43001,State Senate,SD21,Ind,writein,0
-Kings,43002,State Senate,SD21,Ind,writein,0
-Kings,43003,State Senate,SD21,Ind,writein,0
-Kings,43004,State Senate,SD21,Ind,writein,0
-Kings,43005,State Senate,SD21,Ind,writein,0
-Kings,43006,State Senate,SD21,Ind,writein,0
-Kings,43007,State Senate,SD21,Ind,writein,0
-Kings,43008,State Senate,SD21,Ind,writein,0
-Kings,43009,State Senate,SD21,Ind,writein,0
-Kings,43010,State Senate,SD21,Ind,writein,0
-Kings,44011,State Senate,SD21,Ind,writein,0
-Kings,44012,State Senate,SD21,Ind,writein,0
-Kings,44014,State Senate,SD21,Ind,writein,0
-Kings,44015,State Senate,SD21,Ind,writein,0
-Kings,44016,State Senate,SD21,Ind,writein,0
-Kings,44017,State Senate,SD21,Ind,writein,1
-Kings,44018,State Senate,SD21,Ind,writein,0
-Kings,44019,State Senate,SD21,Ind,writein,2
-Kings,44020,State Senate,SD21,Ind,writein,0
-Kings,44034,State Senate,SD21,Ind,writein,0
-Kings,44036,State Senate,SD21,Ind,writein,2
-Kings,44037,State Senate,SD21,Ind,writein,0
-Kings,44040,State Senate,SD21,Ind,writein,0
-Kings,44046,State Senate,SD21,Ind,writein,1
-Kings,44047,State Senate,SD21,Ind,writein,0
-Kings,44048,State Senate,SD21,Ind,writein,0
-Kings,44049,State Senate,SD21,Ind,writein,1
-Kings,44050,State Senate,SD21,Ind,writein,1
-Kings,44051,State Senate,SD21,Ind,writein,0
-Kings,44052,State Senate,SD21,Ind,writein,0
-Kings,44053,State Senate,SD21,Ind,writein,1
-Kings,44054,State Senate,SD21,Ind,writein,0
-Kings,44055,State Senate,SD21,Ind,writein,0
-Kings,44056,State Senate,SD21,Ind,writein,1
-Kings,44057,State Senate,SD21,Ind,writein,0
-Kings,44058,State Senate,SD21,Ind,writein,2
-Kings,44059,State Senate,SD21,Ind,writein,0
-Kings,44060,State Senate,SD21,Ind,writein,0
-Kings,44061,State Senate,SD21,Ind,writein,0
-Kings,44062,State Senate,SD21,Ind,writein,0
-Kings,44063,State Senate,SD21,Ind,writein,0
-Kings,44064,State Senate,SD21,Ind,writein,0
-Kings,44065,State Senate,SD21,Ind,writein,1
-Kings,44066,State Senate,SD21,Ind,writein,0
-Kings,44067,State Senate,SD21,Ind,writein,0
-Kings,44068,State Senate,SD21,Ind,writein,0
-Kings,44069,State Senate,SD21,Ind,writein,1
-Kings,44070,State Senate,SD21,Ind,writein,1
-Kings,44071,State Senate,SD21,Ind,writein,0
-Kings,44072,State Senate,SD21,Ind,writein,0
-Kings,44073,State Senate,SD21,Ind,writein,3
-Kings,44074,State Senate,SD21,Ind,writein,0
-Kings,44075,State Senate,SD21,Ind,writein,0
-Kings,44076,State Senate,SD21,Ind,writein,0
-Kings,44077,State Senate,SD21,Ind,writein,4
-Kings,44078,State Senate,SD21,Ind,writein,0
-Kings,44079,State Senate,SD21,Ind,writein,0
-Kings,44080,State Senate,SD21,Ind,writein,0
-Kings,51010,State Senate,SD21,Ind,writein,0
-Kings,51011,State Senate,SD21,Ind,writein,0
-Kings,51012,State Senate,SD21,Ind,writein,0
-Kings,51013,State Senate,SD21,Ind,writein,1
-Kings,51019,State Senate,SD21,Ind,writein,0
-Kings,51021,State Senate,SD21,Ind,writein,0
-Kings,51022,State Senate,SD21,Ind,writein,0
-Kings,52068,State Senate,SD21,Ind,writein,0
-Kings,52069,State Senate,SD21,Ind,writein,0
-Kings,52070,State Senate,SD21,Ind,writein,1
-Kings,52071,State Senate,SD21,Ind,writein,3
-Kings,52076,State Senate,SD21,Ind,writein,0
-Kings,52077,State Senate,SD21,Ind,writein,0
-Kings,52078,State Senate,SD21,Ind,writein,0
-Kings,52080,State Senate,SD21,Ind,writein,0
-Kings,52081,State Senate,SD21,Ind,writein,1
-Kings,52082,State Senate,SD21,Ind,writein,0
-Kings,52083,State Senate,SD21,Ind,writein,2
-Kings,52084,State Senate,SD21,Ind,writein,0
-Kings,52085,State Senate,SD21,Ind,writein,0
-Kings,52086,State Senate,SD21,Ind,writein,0
-Kings,52113,State Senate,SD21,Ind,writein,0
-Kings,52114,State Senate,SD21,Ind,writein,0
-Kings,52115,State Senate,SD21,Ind,writein,1
-Kings,57086,State Senate,SD21,Ind,writein,0
-Kings,57087,State Senate,SD21,Ind,writein,0
-Kings,58016,State Senate,SD21,Ind,writein,0
-Kings,58017,State Senate,SD21,Ind,writein,0
-Kings,58018,State Senate,SD21,Ind,writein,1
-Kings,58019,State Senate,SD21,Ind,writein,0
-Kings,58020,State Senate,SD21,Ind,writein,0
-Kings,58021,State Senate,SD21,Ind,writein,1
-Kings,58022,State Senate,SD21,Ind,writein,1
-Kings,58023,State Senate,SD21,Ind,writein,0
-Kings,58024,State Senate,SD21,Ind,writein,0
-Kings,58025,State Senate,SD21,Ind,writein,0
-Kings,58026,State Senate,SD21,Ind,writein,0
-Kings,58027,State Senate,SD21,Ind,writein,0
-Kings,58028,State Senate,SD21,Ind,writein,0
-Kings,58029,State Senate,SD21,Ind,writein,0
-Kings,58030,State Senate,SD21,Ind,writein,0
-Kings,58031,State Senate,SD21,Ind,writein,0
-Kings,58032,State Senate,SD21,Ind,writein,0
-Kings,58033,State Senate,SD21,Ind,writein,0
-Kings,58034,State Senate,SD21,Ind,writein,0
-Kings,58035,State Senate,SD21,Ind,writein,0
-Kings,58036,State Senate,SD21,Ind,writein,0
-Kings,58037,State Senate,SD21,Ind,writein,0
-Kings,58038,State Senate,SD21,Ind,writein,2
-Kings,58039,State Senate,SD21,Ind,writein,0
-Kings,58040,State Senate,SD21,Ind,writein,0
-Kings,58041,State Senate,SD21,Ind,writein,0
-Kings,58042,State Senate,SD21,Ind,writein,0
-Kings,58049,State Senate,SD21,Ind,writein,0
-Kings,58050,State Senate,SD21,Ind,writein,1
-Kings,58051,State Senate,SD21,Ind,writein,0
-Kings,58055,State Senate,SD21,Ind,writein,0
-Kings,58056,State Senate,SD21,Ind,writein,0
-Kings,58061,State Senate,SD21,Ind,writein,0
-Kings,58062,State Senate,SD21,Ind,writein,0
-Kings,58063,State Senate,SD21,Ind,writein,0
-Kings,58064,State Senate,SD21,Ind,writein,0
-Kings,59001,State Senate,SD21,Ind,writein,0
-Kings,59002,State Senate,SD21,Ind,writein,0
-Kings,59003,State Senate,SD21,Ind,writein,0
-Kings,59004,State Senate,SD21,Ind,writein,0
-Kings,59017,State Senate,SD21,Ind,writein,0
-Kings,59018,State Senate,SD21,Ind,writein,0
-Kings,59019,State Senate,SD21,Ind,writein,0
-Kings,59020,State Senate,SD21,Ind,writein,0
-Kings,59021,State Senate,SD21,Ind,writein,0
-Kings,59022,State Senate,SD21,Ind,writein,0
-Kings,59023,State Senate,SD21,Ind,writein,0
-Kings,59025,State Senate,SD21,Ind,writein,0
-Kings,41016,State Senate,SD22,WF,Andrew Gounardes,8
-Kings,41017,State Senate,SD22,WF,Andrew Gounardes,9
-Kings,41018,State Senate,SD22,WF,Andrew Gounardes,9
-Kings,41056,State Senate,SD22,WF,Andrew Gounardes,3
-Kings,41081,State Senate,SD22,WF,Andrew Gounardes,7
-Kings,41082,State Senate,SD22,WF,Andrew Gounardes,13
-Kings,41083,State Senate,SD22,WF,Andrew Gounardes,6
-Kings,41086,State Senate,SD22,WF,Andrew Gounardes,0
-Kings,41090,State Senate,SD22,WF,Andrew Gounardes,1
-Kings,41093,State Senate,SD22,WF,Andrew Gounardes,9
-Kings,41094,State Senate,SD22,WF,Andrew Gounardes,10
-Kings,41095,State Senate,SD22,WF,Andrew Gounardes,7
-Kings,45006,State Senate,SD22,WF,Andrew Gounardes,3
-Kings,45008,State Senate,SD22,WF,Andrew Gounardes,4
-Kings,45009,State Senate,SD22,WF,Andrew Gounardes,6
-Kings,45015,State Senate,SD22,WF,Andrew Gounardes,0
-Kings,45016,State Senate,SD22,WF,Andrew Gounardes,5
-Kings,45017,State Senate,SD22,WF,Andrew Gounardes,5
-Kings,45019,State Senate,SD22,WF,Andrew Gounardes,9
-Kings,45020,State Senate,SD22,WF,Andrew Gounardes,2
-Kings,45021,State Senate,SD22,WF,Andrew Gounardes,2
-Kings,45022,State Senate,SD22,WF,Andrew Gounardes,4
-Kings,45031,State Senate,SD22,WF,Andrew Gounardes,3
-Kings,45032,State Senate,SD22,WF,Andrew Gounardes,2
-Kings,45033,State Senate,SD22,WF,Andrew Gounardes,5
-Kings,45034,State Senate,SD22,WF,Andrew Gounardes,6
-Kings,45035,State Senate,SD22,WF,Andrew Gounardes,7
-Kings,45036,State Senate,SD22,WF,Andrew Gounardes,3
-Kings,45037,State Senate,SD22,WF,Andrew Gounardes,5
-Kings,45041,State Senate,SD22,WF,Andrew Gounardes,3
-Kings,45049,State Senate,SD22,WF,Andrew Gounardes,3
-Kings,45051,State Senate,SD22,WF,Andrew Gounardes,8
-Kings,45052,State Senate,SD22,WF,Andrew Gounardes,1
-Kings,45068,State Senate,SD22,WF,Andrew Gounardes,7
-Kings,45069,State Senate,SD22,WF,Andrew Gounardes,2
-Kings,45070,State Senate,SD22,WF,Andrew Gounardes,6
-Kings,45072,State Senate,SD22,WF,Andrew Gounardes,2
-Kings,45080,State Senate,SD22,WF,Andrew Gounardes,5
-Kings,45081,State Senate,SD22,WF,Andrew Gounardes,4
-Kings,46048,State Senate,SD22,WF,Andrew Gounardes,21
-Kings,46049,State Senate,SD22,WF,Andrew Gounardes,25
-Kings,46050,State Senate,SD22,WF,Andrew Gounardes,20
-Kings,46051,State Senate,SD22,WF,Andrew Gounardes,21
-Kings,46052,State Senate,SD22,WF,Andrew Gounardes,10
-Kings,46053,State Senate,SD22,WF,Andrew Gounardes,17
-Kings,46054,State Senate,SD22,WF,Andrew Gounardes,34
-Kings,46055,State Senate,SD22,WF,Andrew Gounardes,12
-Kings,46056,State Senate,SD22,WF,Andrew Gounardes,30
-Kings,46057,State Senate,SD22,WF,Andrew Gounardes,24
-Kings,46058,State Senate,SD22,WF,Andrew Gounardes,29
-Kings,46059,State Senate,SD22,WF,Andrew Gounardes,19
-Kings,46060,State Senate,SD22,WF,Andrew Gounardes,19
-Kings,46061,State Senate,SD22,WF,Andrew Gounardes,29
-Kings,46062,State Senate,SD22,WF,Andrew Gounardes,17
-Kings,46063,State Senate,SD22,WF,Andrew Gounardes,30
-Kings,46064,State Senate,SD22,WF,Andrew Gounardes,23
-Kings,46065,State Senate,SD22,WF,Andrew Gounardes,18
-Kings,46066,State Senate,SD22,WF,Andrew Gounardes,14
-Kings,46067,State Senate,SD22,WF,Andrew Gounardes,8
-Kings,46068,State Senate,SD22,WF,Andrew Gounardes,17
-Kings,46069,State Senate,SD22,WF,Andrew Gounardes,12
-Kings,46070,State Senate,SD22,WF,Andrew Gounardes,9
-Kings,46071,State Senate,SD22,WF,Andrew Gounardes,13
-Kings,46072,State Senate,SD22,WF,Andrew Gounardes,17
-Kings,46073,State Senate,SD22,WF,Andrew Gounardes,8
-Kings,46074,State Senate,SD22,WF,Andrew Gounardes,3
-Kings,46075,State Senate,SD22,WF,Andrew Gounardes,12
-Kings,46081,State Senate,SD22,WF,Andrew Gounardes,9
-Kings,47001,State Senate,SD22,WF,Andrew Gounardes,10
-Kings,47002,State Senate,SD22,WF,Andrew Gounardes,11
-Kings,47003,State Senate,SD22,WF,Andrew Gounardes,19
-Kings,47005,State Senate,SD22,WF,Andrew Gounardes,12
-Kings,47006,State Senate,SD22,WF,Andrew Gounardes,12
-Kings,47007,State Senate,SD22,WF,Andrew Gounardes,8
-Kings,47008,State Senate,SD22,WF,Andrew Gounardes,2
-Kings,47009,State Senate,SD22,WF,Andrew Gounardes,5
-Kings,47019,State Senate,SD22,WF,Andrew Gounardes,2
-Kings,47020,State Senate,SD22,WF,Andrew Gounardes,6
-Kings,47021,State Senate,SD22,WF,Andrew Gounardes,8
-Kings,47022,State Senate,SD22,WF,Andrew Gounardes,9
-Kings,47034,State Senate,SD22,WF,Andrew Gounardes,11
-Kings,47038,State Senate,SD22,WF,Andrew Gounardes,3
-Kings,47039,State Senate,SD22,WF,Andrew Gounardes,1
-Kings,47043,State Senate,SD22,WF,Andrew Gounardes,4
-Kings,47044,State Senate,SD22,WF,Andrew Gounardes,13
-Kings,47045,State Senate,SD22,WF,Andrew Gounardes,5
-Kings,47046,State Senate,SD22,WF,Andrew Gounardes,15
-Kings,47047,State Senate,SD22,WF,Andrew Gounardes,10
-Kings,47048,State Senate,SD22,WF,Andrew Gounardes,3
-Kings,47049,State Senate,SD22,WF,Andrew Gounardes,10
-Kings,47050,State Senate,SD22,WF,Andrew Gounardes,6
-Kings,47051,State Senate,SD22,WF,Andrew Gounardes,2
-Kings,47052,State Senate,SD22,WF,Andrew Gounardes,3
-Kings,47055,State Senate,SD22,WF,Andrew Gounardes,1
-Kings,47056,State Senate,SD22,WF,Andrew Gounardes,9
-Kings,47065,State Senate,SD22,WF,Andrew Gounardes,2
-Kings,48034,State Senate,SD22,WF,Andrew Gounardes,3
-Kings,48035,State Senate,SD22,WF,Andrew Gounardes,2
-Kings,48037,State Senate,SD22,WF,Andrew Gounardes,1
-Kings,48046,State Senate,SD22,WF,Andrew Gounardes,4
-Kings,48047,State Senate,SD22,WF,Andrew Gounardes,7
-Kings,48048,State Senate,SD22,WF,Andrew Gounardes,1
-Kings,48050,State Senate,SD22,WF,Andrew Gounardes,2
-Kings,48051,State Senate,SD22,WF,Andrew Gounardes,5
-Kings,48052,State Senate,SD22,WF,Andrew Gounardes,5
-Kings,48059,State Senate,SD22,WF,Andrew Gounardes,2
-Kings,49016,State Senate,SD22,WF,Andrew Gounardes,1
-Kings,49017,State Senate,SD22,WF,Andrew Gounardes,2
-Kings,49018,State Senate,SD22,WF,Andrew Gounardes,0
-Kings,49019,State Senate,SD22,WF,Andrew Gounardes,10
-Kings,49020,State Senate,SD22,WF,Andrew Gounardes,16
-Kings,49021,State Senate,SD22,WF,Andrew Gounardes,7
-Kings,49022,State Senate,SD22,WF,Andrew Gounardes,4
-Kings,49023,State Senate,SD22,WF,Andrew Gounardes,8
-Kings,49024,State Senate,SD22,WF,Andrew Gounardes,10
-Kings,49025,State Senate,SD22,WF,Andrew Gounardes,14
-Kings,49026,State Senate,SD22,WF,Andrew Gounardes,9
-Kings,49027,State Senate,SD22,WF,Andrew Gounardes,11
-Kings,49028,State Senate,SD22,WF,Andrew Gounardes,2
-Kings,49029,State Senate,SD22,WF,Andrew Gounardes,0
-Kings,49035,State Senate,SD22,WF,Andrew Gounardes,9
-Kings,49037,State Senate,SD22,WF,Andrew Gounardes,12
-Kings,49038,State Senate,SD22,WF,Andrew Gounardes,10
-Kings,49039,State Senate,SD22,WF,Andrew Gounardes,16
-Kings,49040,State Senate,SD22,WF,Andrew Gounardes,8
-Kings,49041,State Senate,SD22,WF,Andrew Gounardes,15
-Kings,49045,State Senate,SD22,WF,Andrew Gounardes,3
-Kings,49047,State Senate,SD22,WF,Andrew Gounardes,17
-Kings,49048,State Senate,SD22,WF,Andrew Gounardes,12
-Kings,49049,State Senate,SD22,WF,Andrew Gounardes,5
-Kings,49050,State Senate,SD22,WF,Andrew Gounardes,11
-Kings,49051,State Senate,SD22,WF,Andrew Gounardes,9
-Kings,49052,State Senate,SD22,WF,Andrew Gounardes,8
-Kings,49053,State Senate,SD22,WF,Andrew Gounardes,12
-Kings,49054,State Senate,SD22,WF,Andrew Gounardes,17
-Kings,49056,State Senate,SD22,WF,Andrew Gounardes,2
-Kings,49057,State Senate,SD22,WF,Andrew Gounardes,1
-Kings,51059,State Senate,SD22,WF,Andrew Gounardes,27
-Kings,51061,State Senate,SD22,WF,Andrew Gounardes,21
-Kings,51062,State Senate,SD22,WF,Andrew Gounardes,29
-Kings,59033,State Senate,SD22,WF,Andrew Gounardes,7
-Kings,59034,State Senate,SD22,WF,Andrew Gounardes,5
-Kings,59035,State Senate,SD22,WF,Andrew Gounardes,13
-Kings,59036,State Senate,SD22,WF,Andrew Gounardes,18
-Kings,59037,State Senate,SD22,WF,Andrew Gounardes,4
-Kings,59038,State Senate,SD22,WF,Andrew Gounardes,11
-Kings,59039,State Senate,SD22,WF,Andrew Gounardes,10
-Kings,59040,State Senate,SD22,WF,Andrew Gounardes,7
-Kings,59041,State Senate,SD22,WF,Andrew Gounardes,2
-Kings,59042,State Senate,SD22,WF,Andrew Gounardes,8
-Kings,59043,State Senate,SD22,WF,Andrew Gounardes,9
-Kings,59044,State Senate,SD22,WF,Andrew Gounardes,9
-Kings,59045,State Senate,SD22,WF,Andrew Gounardes,7
-Kings,59046,State Senate,SD22,WF,Andrew Gounardes,2
-Kings,59048,State Senate,SD22,WF,Andrew Gounardes,0
-Kings,64075,State Senate,SD22,WF,Andrew Gounardes,17
-Kings,64076,State Senate,SD22,WF,Andrew Gounardes,21
-Kings,64077,State Senate,SD22,WF,Andrew Gounardes,30
-Kings,64078,State Senate,SD22,WF,Andrew Gounardes,27
-Kings,64079,State Senate,SD22,WF,Andrew Gounardes,19
-Kings,64080,State Senate,SD22,WF,Andrew Gounardes,23
-Kings,64083,State Senate,SD22,WF,Andrew Gounardes,39
-Kings,64084,State Senate,SD22,WF,Andrew Gounardes,31
-Kings,64085,State Senate,SD22,WF,Andrew Gounardes,22
-Kings,64086,State Senate,SD22,WF,Andrew Gounardes,24
-Kings,64087,State Senate,SD22,WF,Andrew Gounardes,14
-Kings,64088,State Senate,SD22,WF,Andrew Gounardes,27
-Kings,64089,State Senate,SD22,WF,Andrew Gounardes,6
-Kings,64090,State Senate,SD22,WF,Andrew Gounardes,15
-Kings,64091,State Senate,SD22,WF,Andrew Gounardes,5
-Kings,41016,State Senate,SD22,Dem,Andrew Gournardes,159
-Kings,41017,State Senate,SD22,Dem,Andrew Gournardes,183
-Kings,41018,State Senate,SD22,Dem,Andrew Gournardes,73
-Kings,41056,State Senate,SD22,Dem,Andrew Gournardes,66
-Kings,41081,State Senate,SD22,Dem,Andrew Gournardes,183
-Kings,41082,State Senate,SD22,Dem,Andrew Gournardes,135
-Kings,41083,State Senate,SD22,Dem,Andrew Gournardes,205
-Kings,41086,State Senate,SD22,Dem,Andrew Gournardes,22
-Kings,41090,State Senate,SD22,Dem,Andrew Gournardes,34
-Kings,41093,State Senate,SD22,Dem,Andrew Gournardes,142
-Kings,41094,State Senate,SD22,Dem,Andrew Gournardes,200
-Kings,41095,State Senate,SD22,Dem,Andrew Gournardes,98
-Kings,45006,State Senate,SD22,Dem,Andrew Gournardes,74
-Kings,45008,State Senate,SD22,Dem,Andrew Gournardes,114
-Kings,45009,State Senate,SD22,Dem,Andrew Gournardes,69
-Kings,45015,State Senate,SD22,Dem,Andrew Gournardes,6
-Kings,45016,State Senate,SD22,Dem,Andrew Gournardes,81
-Kings,45017,State Senate,SD22,Dem,Andrew Gournardes,39
-Kings,45019,State Senate,SD22,Dem,Andrew Gournardes,85
-Kings,45020,State Senate,SD22,Dem,Andrew Gournardes,33
-Kings,45021,State Senate,SD22,Dem,Andrew Gournardes,47
-Kings,45022,State Senate,SD22,Dem,Andrew Gournardes,67
-Kings,45031,State Senate,SD22,Dem,Andrew Gournardes,52
-Kings,45032,State Senate,SD22,Dem,Andrew Gournardes,49
-Kings,45033,State Senate,SD22,Dem,Andrew Gournardes,103
-Kings,45034,State Senate,SD22,Dem,Andrew Gournardes,155
-Kings,45035,State Senate,SD22,Dem,Andrew Gournardes,78
-Kings,45036,State Senate,SD22,Dem,Andrew Gournardes,69
-Kings,45037,State Senate,SD22,Dem,Andrew Gournardes,95
-Kings,45041,State Senate,SD22,Dem,Andrew Gournardes,41
-Kings,45049,State Senate,SD22,Dem,Andrew Gournardes,33
-Kings,45051,State Senate,SD22,Dem,Andrew Gournardes,100
-Kings,45052,State Senate,SD22,Dem,Andrew Gournardes,14
-Kings,45068,State Senate,SD22,Dem,Andrew Gournardes,61
-Kings,45069,State Senate,SD22,Dem,Andrew Gournardes,85
-Kings,45070,State Senate,SD22,Dem,Andrew Gournardes,78
-Kings,45072,State Senate,SD22,Dem,Andrew Gournardes,33
-Kings,45080,State Senate,SD22,Dem,Andrew Gournardes,72
-Kings,45081,State Senate,SD22,Dem,Andrew Gournardes,147
-Kings,46048,State Senate,SD22,Dem,Andrew Gournardes,296
-Kings,46049,State Senate,SD22,Dem,Andrew Gournardes,372
-Kings,46050,State Senate,SD22,Dem,Andrew Gournardes,283
-Kings,46051,State Senate,SD22,Dem,Andrew Gournardes,187
-Kings,46052,State Senate,SD22,Dem,Andrew Gournardes,211
-Kings,46053,State Senate,SD22,Dem,Andrew Gournardes,279
-Kings,46054,State Senate,SD22,Dem,Andrew Gournardes,339
-Kings,46055,State Senate,SD22,Dem,Andrew Gournardes,305
-Kings,46056,State Senate,SD22,Dem,Andrew Gournardes,315
-Kings,46057,State Senate,SD22,Dem,Andrew Gournardes,292
-Kings,46058,State Senate,SD22,Dem,Andrew Gournardes,286
-Kings,46059,State Senate,SD22,Dem,Andrew Gournardes,284
-Kings,46060,State Senate,SD22,Dem,Andrew Gournardes,273
-Kings,46061,State Senate,SD22,Dem,Andrew Gournardes,335
-Kings,46062,State Senate,SD22,Dem,Andrew Gournardes,347
-Kings,46063,State Senate,SD22,Dem,Andrew Gournardes,320
-Kings,46064,State Senate,SD22,Dem,Andrew Gournardes,308
-Kings,46065,State Senate,SD22,Dem,Andrew Gournardes,350
-Kings,46066,State Senate,SD22,Dem,Andrew Gournardes,267
-Kings,46067,State Senate,SD22,Dem,Andrew Gournardes,165
-Kings,46068,State Senate,SD22,Dem,Andrew Gournardes,161
-Kings,46069,State Senate,SD22,Dem,Andrew Gournardes,194
-Kings,46070,State Senate,SD22,Dem,Andrew Gournardes,137
-Kings,46071,State Senate,SD22,Dem,Andrew Gournardes,173
-Kings,46072,State Senate,SD22,Dem,Andrew Gournardes,261
-Kings,46073,State Senate,SD22,Dem,Andrew Gournardes,181
-Kings,46074,State Senate,SD22,Dem,Andrew Gournardes,89
-Kings,46075,State Senate,SD22,Dem,Andrew Gournardes,266
-Kings,46081,State Senate,SD22,Dem,Andrew Gournardes,179
-Kings,47001,State Senate,SD22,Dem,Andrew Gournardes,150
-Kings,47002,State Senate,SD22,Dem,Andrew Gournardes,185
-Kings,47003,State Senate,SD22,Dem,Andrew Gournardes,189
-Kings,47005,State Senate,SD22,Dem,Andrew Gournardes,144
-Kings,47006,State Senate,SD22,Dem,Andrew Gournardes,200
-Kings,47007,State Senate,SD22,Dem,Andrew Gournardes,141
-Kings,47008,State Senate,SD22,Dem,Andrew Gournardes,126
-Kings,47009,State Senate,SD22,Dem,Andrew Gournardes,191
-Kings,47019,State Senate,SD22,Dem,Andrew Gournardes,66
-Kings,47020,State Senate,SD22,Dem,Andrew Gournardes,143
-Kings,47021,State Senate,SD22,Dem,Andrew Gournardes,189
-Kings,47022,State Senate,SD22,Dem,Andrew Gournardes,163
-Kings,47034,State Senate,SD22,Dem,Andrew Gournardes,176
-Kings,47038,State Senate,SD22,Dem,Andrew Gournardes,51
-Kings,47039,State Senate,SD22,Dem,Andrew Gournardes,50
-Kings,47043,State Senate,SD22,Dem,Andrew Gournardes,119
-Kings,47044,State Senate,SD22,Dem,Andrew Gournardes,163
-Kings,47045,State Senate,SD22,Dem,Andrew Gournardes,121
-Kings,47046,State Senate,SD22,Dem,Andrew Gournardes,163
-Kings,47047,State Senate,SD22,Dem,Andrew Gournardes,176
-Kings,47048,State Senate,SD22,Dem,Andrew Gournardes,112
-Kings,47049,State Senate,SD22,Dem,Andrew Gournardes,169
-Kings,47050,State Senate,SD22,Dem,Andrew Gournardes,187
-Kings,47051,State Senate,SD22,Dem,Andrew Gournardes,149
-Kings,47052,State Senate,SD22,Dem,Andrew Gournardes,30
-Kings,47055,State Senate,SD22,Dem,Andrew Gournardes,118
-Kings,47056,State Senate,SD22,Dem,Andrew Gournardes,153
-Kings,47065,State Senate,SD22,Dem,Andrew Gournardes,65
-Kings,48034,State Senate,SD22,Dem,Andrew Gournardes,72
-Kings,48035,State Senate,SD22,Dem,Andrew Gournardes,22
-Kings,48037,State Senate,SD22,Dem,Andrew Gournardes,93
-Kings,48046,State Senate,SD22,Dem,Andrew Gournardes,63
-Kings,48047,State Senate,SD22,Dem,Andrew Gournardes,150
-Kings,48048,State Senate,SD22,Dem,Andrew Gournardes,52
-Kings,48050,State Senate,SD22,Dem,Andrew Gournardes,28
-Kings,48051,State Senate,SD22,Dem,Andrew Gournardes,54
-Kings,48052,State Senate,SD22,Dem,Andrew Gournardes,85
-Kings,48059,State Senate,SD22,Dem,Andrew Gournardes,53
-Kings,49016,State Senate,SD22,Dem,Andrew Gournardes,51
-Kings,49017,State Senate,SD22,Dem,Andrew Gournardes,27
-Kings,49018,State Senate,SD22,Dem,Andrew Gournardes,34
-Kings,49019,State Senate,SD22,Dem,Andrew Gournardes,197
-Kings,49020,State Senate,SD22,Dem,Andrew Gournardes,205
-Kings,49021,State Senate,SD22,Dem,Andrew Gournardes,206
-Kings,49022,State Senate,SD22,Dem,Andrew Gournardes,177
-Kings,49023,State Senate,SD22,Dem,Andrew Gournardes,177
-Kings,49024,State Senate,SD22,Dem,Andrew Gournardes,167
-Kings,49025,State Senate,SD22,Dem,Andrew Gournardes,210
-Kings,49026,State Senate,SD22,Dem,Andrew Gournardes,170
-Kings,49027,State Senate,SD22,Dem,Andrew Gournardes,212
-Kings,49028,State Senate,SD22,Dem,Andrew Gournardes,105
-Kings,49029,State Senate,SD22,Dem,Andrew Gournardes,20
-Kings,49035,State Senate,SD22,Dem,Andrew Gournardes,137
-Kings,49037,State Senate,SD22,Dem,Andrew Gournardes,202
-Kings,49038,State Senate,SD22,Dem,Andrew Gournardes,154
-Kings,49039,State Senate,SD22,Dem,Andrew Gournardes,222
-Kings,49040,State Senate,SD22,Dem,Andrew Gournardes,211
-Kings,49041,State Senate,SD22,Dem,Andrew Gournardes,182
-Kings,49045,State Senate,SD22,Dem,Andrew Gournardes,52
-Kings,49047,State Senate,SD22,Dem,Andrew Gournardes,202
-Kings,49048,State Senate,SD22,Dem,Andrew Gournardes,170
-Kings,49049,State Senate,SD22,Dem,Andrew Gournardes,149
-Kings,49050,State Senate,SD22,Dem,Andrew Gournardes,239
-Kings,49051,State Senate,SD22,Dem,Andrew Gournardes,168
-Kings,49052,State Senate,SD22,Dem,Andrew Gournardes,208
-Kings,49053,State Senate,SD22,Dem,Andrew Gournardes,184
-Kings,49054,State Senate,SD22,Dem,Andrew Gournardes,187
-Kings,49056,State Senate,SD22,Dem,Andrew Gournardes,11
-Kings,49057,State Senate,SD22,Dem,Andrew Gournardes,24
-Kings,51059,State Senate,SD22,Dem,Andrew Gournardes,321
-Kings,51061,State Senate,SD22,Dem,Andrew Gournardes,323
-Kings,51062,State Senate,SD22,Dem,Andrew Gournardes,279
-Kings,59033,State Senate,SD22,Dem,Andrew Gournardes,146
-Kings,59034,State Senate,SD22,Dem,Andrew Gournardes,119
-Kings,59035,State Senate,SD22,Dem,Andrew Gournardes,181
-Kings,59036,State Senate,SD22,Dem,Andrew Gournardes,162
-Kings,59037,State Senate,SD22,Dem,Andrew Gournardes,132
-Kings,59038,State Senate,SD22,Dem,Andrew Gournardes,177
-Kings,59039,State Senate,SD22,Dem,Andrew Gournardes,115
-Kings,59040,State Senate,SD22,Dem,Andrew Gournardes,150
-Kings,59041,State Senate,SD22,Dem,Andrew Gournardes,52
-Kings,59042,State Senate,SD22,Dem,Andrew Gournardes,83
-Kings,59043,State Senate,SD22,Dem,Andrew Gournardes,48
-Kings,59044,State Senate,SD22,Dem,Andrew Gournardes,104
-Kings,59045,State Senate,SD22,Dem,Andrew Gournardes,53
-Kings,59046,State Senate,SD22,Dem,Andrew Gournardes,4
-Kings,59048,State Senate,SD22,Dem,Andrew Gournardes,29
-Kings,64075,State Senate,SD22,Dem,Andrew Gournardes,342
-Kings,64076,State Senate,SD22,Dem,Andrew Gournardes,303
-Kings,64077,State Senate,SD22,Dem,Andrew Gournardes,300
-Kings,64078,State Senate,SD22,Dem,Andrew Gournardes,369
-Kings,64079,State Senate,SD22,Dem,Andrew Gournardes,285
-Kings,64080,State Senate,SD22,Dem,Andrew Gournardes,270
-Kings,64083,State Senate,SD22,Dem,Andrew Gournardes,324
-Kings,64084,State Senate,SD22,Dem,Andrew Gournardes,247
-Kings,64085,State Senate,SD22,Dem,Andrew Gournardes,260
-Kings,64086,State Senate,SD22,Dem,Andrew Gournardes,325
-Kings,64087,State Senate,SD22,Dem,Andrew Gournardes,232
-Kings,64088,State Senate,SD22,Dem,Andrew Gournardes,283
-Kings,64089,State Senate,SD22,Dem,Andrew Gournardes,148
-Kings,64090,State Senate,SD22,Dem,Andrew Gournardes,255
-Kings,64091,State Senate,SD22,Dem,Andrew Gournardes,76
-Kings,41016,State Senate,SD22,Rep,Martin Golden,213
-Kings,41017,State Senate,SD22,Rep,Martin Golden,339
-Kings,41018,State Senate,SD22,Rep,Martin Golden,198
-Kings,41056,State Senate,SD22,Rep,Martin Golden,142
-Kings,41081,State Senate,SD22,Rep,Martin Golden,190
-Kings,41082,State Senate,SD22,Rep,Martin Golden,252
-Kings,41083,State Senate,SD22,Rep,Martin Golden,223
-Kings,41086,State Senate,SD22,Rep,Martin Golden,40
-Kings,41090,State Senate,SD22,Rep,Martin Golden,13
-Kings,41093,State Senate,SD22,Rep,Martin Golden,364
-Kings,41094,State Senate,SD22,Rep,Martin Golden,241
-Kings,41095,State Senate,SD22,Rep,Martin Golden,240
-Kings,45006,State Senate,SD22,Rep,Martin Golden,332
-Kings,45008,State Senate,SD22,Rep,Martin Golden,181
-Kings,45009,State Senate,SD22,Rep,Martin Golden,294
-Kings,45015,State Senate,SD22,Rep,Martin Golden,124
-Kings,45016,State Senate,SD22,Rep,Martin Golden,334
-Kings,45017,State Senate,SD22,Rep,Martin Golden,233
-Kings,45019,State Senate,SD22,Rep,Martin Golden,252
-Kings,45020,State Senate,SD22,Rep,Martin Golden,305
-Kings,45021,State Senate,SD22,Rep,Martin Golden,299
-Kings,45022,State Senate,SD22,Rep,Martin Golden,215
-Kings,45031,State Senate,SD22,Rep,Martin Golden,189
-Kings,45032,State Senate,SD22,Rep,Martin Golden,180
-Kings,45033,State Senate,SD22,Rep,Martin Golden,153
-Kings,45034,State Senate,SD22,Rep,Martin Golden,179
-Kings,45035,State Senate,SD22,Rep,Martin Golden,149
-Kings,45036,State Senate,SD22,Rep,Martin Golden,168
-Kings,45037,State Senate,SD22,Rep,Martin Golden,270
-Kings,45041,State Senate,SD22,Rep,Martin Golden,77
-Kings,45049,State Senate,SD22,Rep,Martin Golden,49
-Kings,45051,State Senate,SD22,Rep,Martin Golden,93
-Kings,45052,State Senate,SD22,Rep,Martin Golden,29
-Kings,45068,State Senate,SD22,Rep,Martin Golden,174
-Kings,45069,State Senate,SD22,Rep,Martin Golden,187
-Kings,45070,State Senate,SD22,Rep,Martin Golden,193
-Kings,45072,State Senate,SD22,Rep,Martin Golden,91
-Kings,45080,State Senate,SD22,Rep,Martin Golden,158
-Kings,45081,State Senate,SD22,Rep,Martin Golden,169
-Kings,46048,State Senate,SD22,Rep,Martin Golden,184
-Kings,46049,State Senate,SD22,Rep,Martin Golden,222
-Kings,46050,State Senate,SD22,Rep,Martin Golden,301
-Kings,46051,State Senate,SD22,Rep,Martin Golden,345
-Kings,46052,State Senate,SD22,Rep,Martin Golden,329
-Kings,46053,State Senate,SD22,Rep,Martin Golden,236
-Kings,46054,State Senate,SD22,Rep,Martin Golden,216
-Kings,46055,State Senate,SD22,Rep,Martin Golden,168
-Kings,46056,State Senate,SD22,Rep,Martin Golden,190
-Kings,46057,State Senate,SD22,Rep,Martin Golden,288
-Kings,46058,State Senate,SD22,Rep,Martin Golden,160
-Kings,46059,State Senate,SD22,Rep,Martin Golden,174
-Kings,46060,State Senate,SD22,Rep,Martin Golden,293
-Kings,46061,State Senate,SD22,Rep,Martin Golden,295
-Kings,46062,State Senate,SD22,Rep,Martin Golden,285
-Kings,46063,State Senate,SD22,Rep,Martin Golden,193
-Kings,46064,State Senate,SD22,Rep,Martin Golden,292
-Kings,46065,State Senate,SD22,Rep,Martin Golden,267
-Kings,46066,State Senate,SD22,Rep,Martin Golden,223
-Kings,46067,State Senate,SD22,Rep,Martin Golden,337
-Kings,46068,State Senate,SD22,Rep,Martin Golden,302
-Kings,46069,State Senate,SD22,Rep,Martin Golden,363
-Kings,46070,State Senate,SD22,Rep,Martin Golden,384
-Kings,46071,State Senate,SD22,Rep,Martin Golden,355
-Kings,46072,State Senate,SD22,Rep,Martin Golden,267
-Kings,46073,State Senate,SD22,Rep,Martin Golden,228
-Kings,46074,State Senate,SD22,Rep,Martin Golden,115
-Kings,46075,State Senate,SD22,Rep,Martin Golden,247
-Kings,46081,State Senate,SD22,Rep,Martin Golden,295
-Kings,47001,State Senate,SD22,Rep,Martin Golden,227
-Kings,47002,State Senate,SD22,Rep,Martin Golden,167
-Kings,47003,State Senate,SD22,Rep,Martin Golden,147
-Kings,47005,State Senate,SD22,Rep,Martin Golden,172
-Kings,47006,State Senate,SD22,Rep,Martin Golden,117
-Kings,47007,State Senate,SD22,Rep,Martin Golden,118
-Kings,47008,State Senate,SD22,Rep,Martin Golden,155
-Kings,47009,State Senate,SD22,Rep,Martin Golden,238
-Kings,47019,State Senate,SD22,Rep,Martin Golden,107
-Kings,47020,State Senate,SD22,Rep,Martin Golden,163
-Kings,47021,State Senate,SD22,Rep,Martin Golden,169
-Kings,47022,State Senate,SD22,Rep,Martin Golden,177
-Kings,47034,State Senate,SD22,Rep,Martin Golden,174
-Kings,47038,State Senate,SD22,Rep,Martin Golden,56
-Kings,47039,State Senate,SD22,Rep,Martin Golden,68
-Kings,47043,State Senate,SD22,Rep,Martin Golden,153
-Kings,47044,State Senate,SD22,Rep,Martin Golden,186
-Kings,47045,State Senate,SD22,Rep,Martin Golden,125
-Kings,47046,State Senate,SD22,Rep,Martin Golden,186
-Kings,47047,State Senate,SD22,Rep,Martin Golden,178
-Kings,47048,State Senate,SD22,Rep,Martin Golden,188
-Kings,47049,State Senate,SD22,Rep,Martin Golden,264
-Kings,47050,State Senate,SD22,Rep,Martin Golden,164
-Kings,47051,State Senate,SD22,Rep,Martin Golden,130
-Kings,47052,State Senate,SD22,Rep,Martin Golden,24
-Kings,47055,State Senate,SD22,Rep,Martin Golden,113
-Kings,47056,State Senate,SD22,Rep,Martin Golden,155
-Kings,47065,State Senate,SD22,Rep,Martin Golden,109
-Kings,48034,State Senate,SD22,Rep,Martin Golden,97
-Kings,48035,State Senate,SD22,Rep,Martin Golden,14
-Kings,48037,State Senate,SD22,Rep,Martin Golden,106
-Kings,48046,State Senate,SD22,Rep,Martin Golden,154
-Kings,48047,State Senate,SD22,Rep,Martin Golden,242
-Kings,48048,State Senate,SD22,Rep,Martin Golden,296
-Kings,48050,State Senate,SD22,Rep,Martin Golden,247
-Kings,48051,State Senate,SD22,Rep,Martin Golden,189
-Kings,48052,State Senate,SD22,Rep,Martin Golden,243
-Kings,48059,State Senate,SD22,Rep,Martin Golden,333
-Kings,49016,State Senate,SD22,Rep,Martin Golden,25
-Kings,49017,State Senate,SD22,Rep,Martin Golden,38
-Kings,49018,State Senate,SD22,Rep,Martin Golden,21
-Kings,49019,State Senate,SD22,Rep,Martin Golden,211
-Kings,49020,State Senate,SD22,Rep,Martin Golden,203
-Kings,49021,State Senate,SD22,Rep,Martin Golden,162
-Kings,49022,State Senate,SD22,Rep,Martin Golden,192
-Kings,49023,State Senate,SD22,Rep,Martin Golden,150
-Kings,49024,State Senate,SD22,Rep,Martin Golden,142
-Kings,49025,State Senate,SD22,Rep,Martin Golden,167
-Kings,49026,State Senate,SD22,Rep,Martin Golden,135
-Kings,49027,State Senate,SD22,Rep,Martin Golden,216
-Kings,49028,State Senate,SD22,Rep,Martin Golden,172
-Kings,49029,State Senate,SD22,Rep,Martin Golden,43
-Kings,49035,State Senate,SD22,Rep,Martin Golden,129
-Kings,49037,State Senate,SD22,Rep,Martin Golden,185
-Kings,49038,State Senate,SD22,Rep,Martin Golden,169
-Kings,49039,State Senate,SD22,Rep,Martin Golden,223
-Kings,49040,State Senate,SD22,Rep,Martin Golden,175
-Kings,49041,State Senate,SD22,Rep,Martin Golden,172
-Kings,49045,State Senate,SD22,Rep,Martin Golden,62
-Kings,49047,State Senate,SD22,Rep,Martin Golden,110
-Kings,49048,State Senate,SD22,Rep,Martin Golden,243
-Kings,49049,State Senate,SD22,Rep,Martin Golden,174
-Kings,49050,State Senate,SD22,Rep,Martin Golden,205
-Kings,49051,State Senate,SD22,Rep,Martin Golden,174
-Kings,49052,State Senate,SD22,Rep,Martin Golden,237
-Kings,49053,State Senate,SD22,Rep,Martin Golden,281
-Kings,49054,State Senate,SD22,Rep,Martin Golden,354
-Kings,49056,State Senate,SD22,Rep,Martin Golden,10
-Kings,49057,State Senate,SD22,Rep,Martin Golden,20
-Kings,51059,State Senate,SD22,Rep,Martin Golden,167
-Kings,51061,State Senate,SD22,Rep,Martin Golden,199
-Kings,51062,State Senate,SD22,Rep,Martin Golden,200
-Kings,59033,State Senate,SD22,Rep,Martin Golden,261
-Kings,59034,State Senate,SD22,Rep,Martin Golden,205
-Kings,59035,State Senate,SD22,Rep,Martin Golden,343
-Kings,59036,State Senate,SD22,Rep,Martin Golden,270
-Kings,59037,State Senate,SD22,Rep,Martin Golden,274
-Kings,59038,State Senate,SD22,Rep,Martin Golden,386
-Kings,59039,State Senate,SD22,Rep,Martin Golden,219
-Kings,59040,State Senate,SD22,Rep,Martin Golden,266
-Kings,59041,State Senate,SD22,Rep,Martin Golden,61
-Kings,59042,State Senate,SD22,Rep,Martin Golden,234
-Kings,59043,State Senate,SD22,Rep,Martin Golden,121
-Kings,59044,State Senate,SD22,Rep,Martin Golden,192
-Kings,59045,State Senate,SD22,Rep,Martin Golden,137
-Kings,59046,State Senate,SD22,Rep,Martin Golden,6
-Kings,59048,State Senate,SD22,Rep,Martin Golden,8
-Kings,64075,State Senate,SD22,Rep,Martin Golden,235
-Kings,64076,State Senate,SD22,Rep,Martin Golden,255
-Kings,64077,State Senate,SD22,Rep,Martin Golden,259
-Kings,64078,State Senate,SD22,Rep,Martin Golden,252
-Kings,64079,State Senate,SD22,Rep,Martin Golden,173
-Kings,64080,State Senate,SD22,Rep,Martin Golden,146
-Kings,64083,State Senate,SD22,Rep,Martin Golden,187
-Kings,64084,State Senate,SD22,Rep,Martin Golden,216
-Kings,64085,State Senate,SD22,Rep,Martin Golden,217
-Kings,64086,State Senate,SD22,Rep,Martin Golden,173
-Kings,64087,State Senate,SD22,Rep,Martin Golden,167
-Kings,64088,State Senate,SD22,Rep,Martin Golden,210
-Kings,64089,State Senate,SD22,Rep,Martin Golden,339
-Kings,64090,State Senate,SD22,Rep,Martin Golden,265
-Kings,64091,State Senate,SD22,Rep,Martin Golden,174
-Kings,41016,State Senate,SD22,Con,Martin Golden,23
-Kings,41017,State Senate,SD22,Con,Martin Golden,52
-Kings,41018,State Senate,SD22,Con,Martin Golden,13
-Kings,41056,State Senate,SD22,Con,Martin Golden,18
-Kings,41081,State Senate,SD22,Con,Martin Golden,14
-Kings,41082,State Senate,SD22,Con,Martin Golden,23
-Kings,41083,State Senate,SD22,Con,Martin Golden,11
-Kings,41086,State Senate,SD22,Con,Martin Golden,2
-Kings,41090,State Senate,SD22,Con,Martin Golden,1
-Kings,41093,State Senate,SD22,Con,Martin Golden,37
-Kings,41094,State Senate,SD22,Con,Martin Golden,36
-Kings,41095,State Senate,SD22,Con,Martin Golden,27
-Kings,45006,State Senate,SD22,Con,Martin Golden,53
-Kings,45008,State Senate,SD22,Con,Martin Golden,28
-Kings,45009,State Senate,SD22,Con,Martin Golden,28
-Kings,45015,State Senate,SD22,Con,Martin Golden,10
-Kings,45016,State Senate,SD22,Con,Martin Golden,49
-Kings,45017,State Senate,SD22,Con,Martin Golden,12
-Kings,45019,State Senate,SD22,Con,Martin Golden,23
-Kings,45020,State Senate,SD22,Con,Martin Golden,12
-Kings,45021,State Senate,SD22,Con,Martin Golden,17
-Kings,45022,State Senate,SD22,Con,Martin Golden,22
-Kings,45031,State Senate,SD22,Con,Martin Golden,10
-Kings,45032,State Senate,SD22,Con,Martin Golden,16
-Kings,45033,State Senate,SD22,Con,Martin Golden,15
-Kings,45034,State Senate,SD22,Con,Martin Golden,20
-Kings,45035,State Senate,SD22,Con,Martin Golden,13
-Kings,45036,State Senate,SD22,Con,Martin Golden,13
-Kings,45037,State Senate,SD22,Con,Martin Golden,12
-Kings,45041,State Senate,SD22,Con,Martin Golden,10
-Kings,45049,State Senate,SD22,Con,Martin Golden,4
-Kings,45051,State Senate,SD22,Con,Martin Golden,11
-Kings,45052,State Senate,SD22,Con,Martin Golden,3
-Kings,45068,State Senate,SD22,Con,Martin Golden,16
-Kings,45069,State Senate,SD22,Con,Martin Golden,13
-Kings,45070,State Senate,SD22,Con,Martin Golden,10
-Kings,45072,State Senate,SD22,Con,Martin Golden,1
-Kings,45080,State Senate,SD22,Con,Martin Golden,6
-Kings,45081,State Senate,SD22,Con,Martin Golden,14
-Kings,46048,State Senate,SD22,Con,Martin Golden,23
-Kings,46049,State Senate,SD22,Con,Martin Golden,44
-Kings,46050,State Senate,SD22,Con,Martin Golden,49
-Kings,46051,State Senate,SD22,Con,Martin Golden,45
-Kings,46052,State Senate,SD22,Con,Martin Golden,42
-Kings,46053,State Senate,SD22,Con,Martin Golden,34
-Kings,46054,State Senate,SD22,Con,Martin Golden,37
-Kings,46055,State Senate,SD22,Con,Martin Golden,31
-Kings,46056,State Senate,SD22,Con,Martin Golden,31
-Kings,46057,State Senate,SD22,Con,Martin Golden,33
-Kings,46058,State Senate,SD22,Con,Martin Golden,27
-Kings,46059,State Senate,SD22,Con,Martin Golden,37
-Kings,46060,State Senate,SD22,Con,Martin Golden,44
-Kings,46061,State Senate,SD22,Con,Martin Golden,45
-Kings,46062,State Senate,SD22,Con,Martin Golden,36
-Kings,46063,State Senate,SD22,Con,Martin Golden,21
-Kings,46064,State Senate,SD22,Con,Martin Golden,46
-Kings,46065,State Senate,SD22,Con,Martin Golden,52
-Kings,46066,State Senate,SD22,Con,Martin Golden,28
-Kings,46067,State Senate,SD22,Con,Martin Golden,46
-Kings,46068,State Senate,SD22,Con,Martin Golden,51
-Kings,46069,State Senate,SD22,Con,Martin Golden,57
-Kings,46070,State Senate,SD22,Con,Martin Golden,50
-Kings,46071,State Senate,SD22,Con,Martin Golden,39
-Kings,46072,State Senate,SD22,Con,Martin Golden,36
-Kings,46073,State Senate,SD22,Con,Martin Golden,32
-Kings,46074,State Senate,SD22,Con,Martin Golden,14
-Kings,46075,State Senate,SD22,Con,Martin Golden,31
-Kings,46081,State Senate,SD22,Con,Martin Golden,33
-Kings,47001,State Senate,SD22,Con,Martin Golden,24
-Kings,47002,State Senate,SD22,Con,Martin Golden,20
-Kings,47003,State Senate,SD22,Con,Martin Golden,20
-Kings,47005,State Senate,SD22,Con,Martin Golden,19
-Kings,47006,State Senate,SD22,Con,Martin Golden,10
-Kings,47007,State Senate,SD22,Con,Martin Golden,17
-Kings,47008,State Senate,SD22,Con,Martin Golden,11
-Kings,47009,State Senate,SD22,Con,Martin Golden,25
-Kings,47019,State Senate,SD22,Con,Martin Golden,6
-Kings,47020,State Senate,SD22,Con,Martin Golden,23
-Kings,47021,State Senate,SD22,Con,Martin Golden,10
-Kings,47022,State Senate,SD22,Con,Martin Golden,20
-Kings,47034,State Senate,SD22,Con,Martin Golden,21
-Kings,47038,State Senate,SD22,Con,Martin Golden,3
-Kings,47039,State Senate,SD22,Con,Martin Golden,11
-Kings,47043,State Senate,SD22,Con,Martin Golden,11
-Kings,47044,State Senate,SD22,Con,Martin Golden,13
-Kings,47045,State Senate,SD22,Con,Martin Golden,8
-Kings,47046,State Senate,SD22,Con,Martin Golden,21
-Kings,47047,State Senate,SD22,Con,Martin Golden,17
-Kings,47048,State Senate,SD22,Con,Martin Golden,12
-Kings,47049,State Senate,SD22,Con,Martin Golden,28
-Kings,47050,State Senate,SD22,Con,Martin Golden,9
-Kings,47051,State Senate,SD22,Con,Martin Golden,13
-Kings,47052,State Senate,SD22,Con,Martin Golden,3
-Kings,47055,State Senate,SD22,Con,Martin Golden,20
-Kings,47056,State Senate,SD22,Con,Martin Golden,15
-Kings,47065,State Senate,SD22,Con,Martin Golden,10
-Kings,48034,State Senate,SD22,Con,Martin Golden,12
-Kings,48035,State Senate,SD22,Con,Martin Golden,2
-Kings,48037,State Senate,SD22,Con,Martin Golden,17
-Kings,48046,State Senate,SD22,Con,Martin Golden,19
-Kings,48047,State Senate,SD22,Con,Martin Golden,37
-Kings,48048,State Senate,SD22,Con,Martin Golden,35
-Kings,48050,State Senate,SD22,Con,Martin Golden,33
-Kings,48051,State Senate,SD22,Con,Martin Golden,19
-Kings,48052,State Senate,SD22,Con,Martin Golden,20
-Kings,48059,State Senate,SD22,Con,Martin Golden,43
-Kings,49016,State Senate,SD22,Con,Martin Golden,6
-Kings,49017,State Senate,SD22,Con,Martin Golden,2
-Kings,49018,State Senate,SD22,Con,Martin Golden,7
-Kings,49019,State Senate,SD22,Con,Martin Golden,22
-Kings,49020,State Senate,SD22,Con,Martin Golden,24
-Kings,49021,State Senate,SD22,Con,Martin Golden,22
-Kings,49022,State Senate,SD22,Con,Martin Golden,31
-Kings,49023,State Senate,SD22,Con,Martin Golden,14
-Kings,49024,State Senate,SD22,Con,Martin Golden,26
-Kings,49025,State Senate,SD22,Con,Martin Golden,16
-Kings,49026,State Senate,SD22,Con,Martin Golden,14
-Kings,49027,State Senate,SD22,Con,Martin Golden,21
-Kings,49028,State Senate,SD22,Con,Martin Golden,25
-Kings,49029,State Senate,SD22,Con,Martin Golden,8
-Kings,49035,State Senate,SD22,Con,Martin Golden,9
-Kings,49037,State Senate,SD22,Con,Martin Golden,32
-Kings,49038,State Senate,SD22,Con,Martin Golden,23
-Kings,49039,State Senate,SD22,Con,Martin Golden,22
-Kings,49040,State Senate,SD22,Con,Martin Golden,24
-Kings,49041,State Senate,SD22,Con,Martin Golden,14
-Kings,49045,State Senate,SD22,Con,Martin Golden,7
-Kings,49047,State Senate,SD22,Con,Martin Golden,21
-Kings,49048,State Senate,SD22,Con,Martin Golden,29
-Kings,49049,State Senate,SD22,Con,Martin Golden,22
-Kings,49050,State Senate,SD22,Con,Martin Golden,27
-Kings,49051,State Senate,SD22,Con,Martin Golden,27
-Kings,49052,State Senate,SD22,Con,Martin Golden,29
-Kings,49053,State Senate,SD22,Con,Martin Golden,44
-Kings,49054,State Senate,SD22,Con,Martin Golden,47
-Kings,49056,State Senate,SD22,Con,Martin Golden,2
-Kings,49057,State Senate,SD22,Con,Martin Golden,2
-Kings,51059,State Senate,SD22,Con,Martin Golden,34
-Kings,51061,State Senate,SD22,Con,Martin Golden,28
-Kings,51062,State Senate,SD22,Con,Martin Golden,27
-Kings,59033,State Senate,SD22,Con,Martin Golden,32
-Kings,59034,State Senate,SD22,Con,Martin Golden,34
-Kings,59035,State Senate,SD22,Con,Martin Golden,50
-Kings,59036,State Senate,SD22,Con,Martin Golden,42
-Kings,59037,State Senate,SD22,Con,Martin Golden,36
-Kings,59038,State Senate,SD22,Con,Martin Golden,52
-Kings,59039,State Senate,SD22,Con,Martin Golden,46
-Kings,59040,State Senate,SD22,Con,Martin Golden,40
-Kings,59041,State Senate,SD22,Con,Martin Golden,12
-Kings,59042,State Senate,SD22,Con,Martin Golden,49
-Kings,59043,State Senate,SD22,Con,Martin Golden,23
-Kings,59044,State Senate,SD22,Con,Martin Golden,32
-Kings,59045,State Senate,SD22,Con,Martin Golden,21
-Kings,59046,State Senate,SD22,Con,Martin Golden,1
-Kings,59048,State Senate,SD22,Con,Martin Golden,1
-Kings,64075,State Senate,SD22,Con,Martin Golden,53
-Kings,64076,State Senate,SD22,Con,Martin Golden,31
-Kings,64077,State Senate,SD22,Con,Martin Golden,40
-Kings,64078,State Senate,SD22,Con,Martin Golden,37
-Kings,64079,State Senate,SD22,Con,Martin Golden,28
-Kings,64080,State Senate,SD22,Con,Martin Golden,28
-Kings,64083,State Senate,SD22,Con,Martin Golden,36
-Kings,64084,State Senate,SD22,Con,Martin Golden,53
-Kings,64085,State Senate,SD22,Con,Martin Golden,43
-Kings,64086,State Senate,SD22,Con,Martin Golden,25
-Kings,64087,State Senate,SD22,Con,Martin Golden,32
-Kings,64088,State Senate,SD22,Con,Martin Golden,35
-Kings,64089,State Senate,SD22,Con,Martin Golden,52
-Kings,64090,State Senate,SD22,Con,Martin Golden,35
-Kings,64091,State Senate,SD22,Con,Martin Golden,26
-Kings,41016,State Senate,SD22,Ind,Martin Golden,11
-Kings,41017,State Senate,SD22,Ind,Martin Golden,14
-Kings,41018,State Senate,SD22,Ind,Martin Golden,8
-Kings,41056,State Senate,SD22,Ind,Martin Golden,6
-Kings,41081,State Senate,SD22,Ind,Martin Golden,7
-Kings,41082,State Senate,SD22,Ind,Martin Golden,11
-Kings,41083,State Senate,SD22,Ind,Martin Golden,6
-Kings,41086,State Senate,SD22,Ind,Martin Golden,3
-Kings,41090,State Senate,SD22,Ind,Martin Golden,1
-Kings,41093,State Senate,SD22,Ind,Martin Golden,19
-Kings,41094,State Senate,SD22,Ind,Martin Golden,15
-Kings,41095,State Senate,SD22,Ind,Martin Golden,13
-Kings,45006,State Senate,SD22,Ind,Martin Golden,4
-Kings,45008,State Senate,SD22,Ind,Martin Golden,11
-Kings,45009,State Senate,SD22,Ind,Martin Golden,2
-Kings,45015,State Senate,SD22,Ind,Martin Golden,0
-Kings,45016,State Senate,SD22,Ind,Martin Golden,9
-Kings,45017,State Senate,SD22,Ind,Martin Golden,8
-Kings,45019,State Senate,SD22,Ind,Martin Golden,6
-Kings,45020,State Senate,SD22,Ind,Martin Golden,3
-Kings,45021,State Senate,SD22,Ind,Martin Golden,10
-Kings,45022,State Senate,SD22,Ind,Martin Golden,6
-Kings,45031,State Senate,SD22,Ind,Martin Golden,5
-Kings,45032,State Senate,SD22,Ind,Martin Golden,7
-Kings,45033,State Senate,SD22,Ind,Martin Golden,5
-Kings,45034,State Senate,SD22,Ind,Martin Golden,9
-Kings,45035,State Senate,SD22,Ind,Martin Golden,5
-Kings,45036,State Senate,SD22,Ind,Martin Golden,8
-Kings,45037,State Senate,SD22,Ind,Martin Golden,5
-Kings,45041,State Senate,SD22,Ind,Martin Golden,1
-Kings,45049,State Senate,SD22,Ind,Martin Golden,3
-Kings,45051,State Senate,SD22,Ind,Martin Golden,10
-Kings,45052,State Senate,SD22,Ind,Martin Golden,0
-Kings,45068,State Senate,SD22,Ind,Martin Golden,8
-Kings,45069,State Senate,SD22,Ind,Martin Golden,4
-Kings,45070,State Senate,SD22,Ind,Martin Golden,7
-Kings,45072,State Senate,SD22,Ind,Martin Golden,4
-Kings,45080,State Senate,SD22,Ind,Martin Golden,5
-Kings,45081,State Senate,SD22,Ind,Martin Golden,11
-Kings,46048,State Senate,SD22,Ind,Martin Golden,13
-Kings,46049,State Senate,SD22,Ind,Martin Golden,15
-Kings,46050,State Senate,SD22,Ind,Martin Golden,12
-Kings,46051,State Senate,SD22,Ind,Martin Golden,8
-Kings,46052,State Senate,SD22,Ind,Martin Golden,75
-Kings,46053,State Senate,SD22,Ind,Martin Golden,14
-Kings,46054,State Senate,SD22,Ind,Martin Golden,13
-Kings,46055,State Senate,SD22,Ind,Martin Golden,7
-Kings,46056,State Senate,SD22,Ind,Martin Golden,14
-Kings,46057,State Senate,SD22,Ind,Martin Golden,13
-Kings,46058,State Senate,SD22,Ind,Martin Golden,11
-Kings,46059,State Senate,SD22,Ind,Martin Golden,10
-Kings,46060,State Senate,SD22,Ind,Martin Golden,16
-Kings,46061,State Senate,SD22,Ind,Martin Golden,13
-Kings,46062,State Senate,SD22,Ind,Martin Golden,15
-Kings,46063,State Senate,SD22,Ind,Martin Golden,11
-Kings,46064,State Senate,SD22,Ind,Martin Golden,20
-Kings,46065,State Senate,SD22,Ind,Martin Golden,11
-Kings,46066,State Senate,SD22,Ind,Martin Golden,21
-Kings,46067,State Senate,SD22,Ind,Martin Golden,13
-Kings,46068,State Senate,SD22,Ind,Martin Golden,12
-Kings,46069,State Senate,SD22,Ind,Martin Golden,12
-Kings,46070,State Senate,SD22,Ind,Martin Golden,9
-Kings,46071,State Senate,SD22,Ind,Martin Golden,8
-Kings,46072,State Senate,SD22,Ind,Martin Golden,12
-Kings,46073,State Senate,SD22,Ind,Martin Golden,10
-Kings,46074,State Senate,SD22,Ind,Martin Golden,3
-Kings,46075,State Senate,SD22,Ind,Martin Golden,11
-Kings,46081,State Senate,SD22,Ind,Martin Golden,10
-Kings,47001,State Senate,SD22,Ind,Martin Golden,10
-Kings,47002,State Senate,SD22,Ind,Martin Golden,14
-Kings,47003,State Senate,SD22,Ind,Martin Golden,22
-Kings,47005,State Senate,SD22,Ind,Martin Golden,9
-Kings,47006,State Senate,SD22,Ind,Martin Golden,14
-Kings,47007,State Senate,SD22,Ind,Martin Golden,5
-Kings,47008,State Senate,SD22,Ind,Martin Golden,12
-Kings,47009,State Senate,SD22,Ind,Martin Golden,6
-Kings,47019,State Senate,SD22,Ind,Martin Golden,7
-Kings,47020,State Senate,SD22,Ind,Martin Golden,7
-Kings,47021,State Senate,SD22,Ind,Martin Golden,10
-Kings,47022,State Senate,SD22,Ind,Martin Golden,6
-Kings,47034,State Senate,SD22,Ind,Martin Golden,10
-Kings,47038,State Senate,SD22,Ind,Martin Golden,3
-Kings,47039,State Senate,SD22,Ind,Martin Golden,2
-Kings,47043,State Senate,SD22,Ind,Martin Golden,7
-Kings,47044,State Senate,SD22,Ind,Martin Golden,10
-Kings,47045,State Senate,SD22,Ind,Martin Golden,5
-Kings,47046,State Senate,SD22,Ind,Martin Golden,8
-Kings,47047,State Senate,SD22,Ind,Martin Golden,11
-Kings,47048,State Senate,SD22,Ind,Martin Golden,3
-Kings,47049,State Senate,SD22,Ind,Martin Golden,10
-Kings,47050,State Senate,SD22,Ind,Martin Golden,11
-Kings,47051,State Senate,SD22,Ind,Martin Golden,6
-Kings,47052,State Senate,SD22,Ind,Martin Golden,1
-Kings,47055,State Senate,SD22,Ind,Martin Golden,4
-Kings,47056,State Senate,SD22,Ind,Martin Golden,13
-Kings,47065,State Senate,SD22,Ind,Martin Golden,3
-Kings,48034,State Senate,SD22,Ind,Martin Golden,5
-Kings,48035,State Senate,SD22,Ind,Martin Golden,2
-Kings,48037,State Senate,SD22,Ind,Martin Golden,3
-Kings,48046,State Senate,SD22,Ind,Martin Golden,6
-Kings,48047,State Senate,SD22,Ind,Martin Golden,5
-Kings,48048,State Senate,SD22,Ind,Martin Golden,4
-Kings,48050,State Senate,SD22,Ind,Martin Golden,13
-Kings,48051,State Senate,SD22,Ind,Martin Golden,6
-Kings,48052,State Senate,SD22,Ind,Martin Golden,5
-Kings,48059,State Senate,SD22,Ind,Martin Golden,6
-Kings,49016,State Senate,SD22,Ind,Martin Golden,4
-Kings,49017,State Senate,SD22,Ind,Martin Golden,1
-Kings,49018,State Senate,SD22,Ind,Martin Golden,3
-Kings,49019,State Senate,SD22,Ind,Martin Golden,7
-Kings,49020,State Senate,SD22,Ind,Martin Golden,10
-Kings,49021,State Senate,SD22,Ind,Martin Golden,7
-Kings,49022,State Senate,SD22,Ind,Martin Golden,5
-Kings,49023,State Senate,SD22,Ind,Martin Golden,8
-Kings,49024,State Senate,SD22,Ind,Martin Golden,5
-Kings,49025,State Senate,SD22,Ind,Martin Golden,9
-Kings,49026,State Senate,SD22,Ind,Martin Golden,11
-Kings,49027,State Senate,SD22,Ind,Martin Golden,8
-Kings,49028,State Senate,SD22,Ind,Martin Golden,4
-Kings,49029,State Senate,SD22,Ind,Martin Golden,3
-Kings,49035,State Senate,SD22,Ind,Martin Golden,12
-Kings,49037,State Senate,SD22,Ind,Martin Golden,7
-Kings,49038,State Senate,SD22,Ind,Martin Golden,13
-Kings,49039,State Senate,SD22,Ind,Martin Golden,15
-Kings,49040,State Senate,SD22,Ind,Martin Golden,11
-Kings,49041,State Senate,SD22,Ind,Martin Golden,10
-Kings,49045,State Senate,SD22,Ind,Martin Golden,2
-Kings,49047,State Senate,SD22,Ind,Martin Golden,5
-Kings,49048,State Senate,SD22,Ind,Martin Golden,10
-Kings,49049,State Senate,SD22,Ind,Martin Golden,13
-Kings,49050,State Senate,SD22,Ind,Martin Golden,9
-Kings,49051,State Senate,SD22,Ind,Martin Golden,10
-Kings,49052,State Senate,SD22,Ind,Martin Golden,13
-Kings,49053,State Senate,SD22,Ind,Martin Golden,10
-Kings,49054,State Senate,SD22,Ind,Martin Golden,14
-Kings,49056,State Senate,SD22,Ind,Martin Golden,1
-Kings,49057,State Senate,SD22,Ind,Martin Golden,4
-Kings,51059,State Senate,SD22,Ind,Martin Golden,11
-Kings,51061,State Senate,SD22,Ind,Martin Golden,21
-Kings,51062,State Senate,SD22,Ind,Martin Golden,9
-Kings,59033,State Senate,SD22,Ind,Martin Golden,19
-Kings,59034,State Senate,SD22,Ind,Martin Golden,7
-Kings,59035,State Senate,SD22,Ind,Martin Golden,17
-Kings,59036,State Senate,SD22,Ind,Martin Golden,19
-Kings,59037,State Senate,SD22,Ind,Martin Golden,15
-Kings,59038,State Senate,SD22,Ind,Martin Golden,14
-Kings,59039,State Senate,SD22,Ind,Martin Golden,11
-Kings,59040,State Senate,SD22,Ind,Martin Golden,11
-Kings,59041,State Senate,SD22,Ind,Martin Golden,6
-Kings,59042,State Senate,SD22,Ind,Martin Golden,16
-Kings,59043,State Senate,SD22,Ind,Martin Golden,14
-Kings,59044,State Senate,SD22,Ind,Martin Golden,8
-Kings,59045,State Senate,SD22,Ind,Martin Golden,10
-Kings,59046,State Senate,SD22,Ind,Martin Golden,2
-Kings,59048,State Senate,SD22,Ind,Martin Golden,2
-Kings,64075,State Senate,SD22,Ind,Martin Golden,18
-Kings,64076,State Senate,SD22,Ind,Martin Golden,22
-Kings,64077,State Senate,SD22,Ind,Martin Golden,19
-Kings,64078,State Senate,SD22,Ind,Martin Golden,19
-Kings,64079,State Senate,SD22,Ind,Martin Golden,8
-Kings,64080,State Senate,SD22,Ind,Martin Golden,18
-Kings,64083,State Senate,SD22,Ind,Martin Golden,17
-Kings,64084,State Senate,SD22,Ind,Martin Golden,12
-Kings,64085,State Senate,SD22,Ind,Martin Golden,16
-Kings,64086,State Senate,SD22,Ind,Martin Golden,9
-Kings,64087,State Senate,SD22,Ind,Martin Golden,4
-Kings,64088,State Senate,SD22,Ind,Martin Golden,15
-Kings,64089,State Senate,SD22,Ind,Martin Golden,13
-Kings,64090,State Senate,SD22,Ind,Martin Golden,11
-Kings,64091,State Senate,SD22,Ind,Martin Golden,14
-Kings,41016,State Senate,SD22,Ind,writein,1
-Kings,41017,State Senate,SD22,Ind,writein,3
-Kings,41018,State Senate,SD22,Ind,writein,0
-Kings,41056,State Senate,SD22,Ind,writein,0
-Kings,41081,State Senate,SD22,Ind,writein,0
-Kings,41082,State Senate,SD22,Ind,writein,1
-Kings,41083,State Senate,SD22,Ind,writein,0
-Kings,41086,State Senate,SD22,Ind,writein,0
-Kings,41090,State Senate,SD22,Ind,writein,0
-Kings,41093,State Senate,SD22,Ind,writein,0
-Kings,41094,State Senate,SD22,Ind,writein,0
-Kings,41095,State Senate,SD22,Ind,writein,1
-Kings,45006,State Senate,SD22,Ind,writein,1
-Kings,45008,State Senate,SD22,Ind,writein,0
-Kings,45009,State Senate,SD22,Ind,writein,1
-Kings,45015,State Senate,SD22,Ind,writein,0
-Kings,45016,State Senate,SD22,Ind,writein,0
-Kings,45017,State Senate,SD22,Ind,writein,0
-Kings,45019,State Senate,SD22,Ind,writein,2
-Kings,45020,State Senate,SD22,Ind,writein,0
-Kings,45021,State Senate,SD22,Ind,writein,0
-Kings,45022,State Senate,SD22,Ind,writein,0
-Kings,45031,State Senate,SD22,Ind,writein,0
-Kings,45032,State Senate,SD22,Ind,writein,0
-Kings,45033,State Senate,SD22,Ind,writein,0
-Kings,45034,State Senate,SD22,Ind,writein,0
-Kings,45035,State Senate,SD22,Ind,writein,0
-Kings,45036,State Senate,SD22,Ind,writein,0
-Kings,45037,State Senate,SD22,Ind,writein,2
-Kings,45041,State Senate,SD22,Ind,writein,0
-Kings,45049,State Senate,SD22,Ind,writein,0
-Kings,45051,State Senate,SD22,Ind,writein,0
-Kings,45052,State Senate,SD22,Ind,writein,0
-Kings,45068,State Senate,SD22,Ind,writein,0
-Kings,45069,State Senate,SD22,Ind,writein,2
-Kings,45070,State Senate,SD22,Ind,writein,0
-Kings,45072,State Senate,SD22,Ind,writein,0
-Kings,45080,State Senate,SD22,Ind,writein,1
-Kings,45081,State Senate,SD22,Ind,writein,2
-Kings,46048,State Senate,SD22,Ind,writein,2
-Kings,46049,State Senate,SD22,Ind,writein,0
-Kings,46050,State Senate,SD22,Ind,writein,0
-Kings,46051,State Senate,SD22,Ind,writein,0
-Kings,46052,State Senate,SD22,Ind,writein,0
-Kings,46053,State Senate,SD22,Ind,writein,0
-Kings,46054,State Senate,SD22,Ind,writein,0
-Kings,46055,State Senate,SD22,Ind,writein,0
-Kings,46056,State Senate,SD22,Ind,writein,0
-Kings,46057,State Senate,SD22,Ind,writein,0
-Kings,46058,State Senate,SD22,Ind,writein,1
-Kings,46059,State Senate,SD22,Ind,writein,1
-Kings,46060,State Senate,SD22,Ind,writein,0
-Kings,46061,State Senate,SD22,Ind,writein,1
-Kings,46062,State Senate,SD22,Ind,writein,1
-Kings,46063,State Senate,SD22,Ind,writein,0
-Kings,46064,State Senate,SD22,Ind,writein,0
-Kings,46065,State Senate,SD22,Ind,writein,0
-Kings,46066,State Senate,SD22,Ind,writein,0
-Kings,46067,State Senate,SD22,Ind,writein,0
-Kings,46068,State Senate,SD22,Ind,writein,0
-Kings,46069,State Senate,SD22,Ind,writein,0
-Kings,46070,State Senate,SD22,Ind,writein,1
-Kings,46071,State Senate,SD22,Ind,writein,0
-Kings,46072,State Senate,SD22,Ind,writein,0
-Kings,46073,State Senate,SD22,Ind,writein,3
-Kings,46074,State Senate,SD22,Ind,writein,0
-Kings,46075,State Senate,SD22,Ind,writein,0
-Kings,46081,State Senate,SD22,Ind,writein,0
-Kings,47001,State Senate,SD22,Ind,writein,0
-Kings,47002,State Senate,SD22,Ind,writein,0
-Kings,47003,State Senate,SD22,Ind,writein,1
-Kings,47005,State Senate,SD22,Ind,writein,0
-Kings,47006,State Senate,SD22,Ind,writein,0
-Kings,47007,State Senate,SD22,Ind,writein,0
-Kings,47008,State Senate,SD22,Ind,writein,0
-Kings,47009,State Senate,SD22,Ind,writein,0
-Kings,47019,State Senate,SD22,Ind,writein,2
-Kings,47020,State Senate,SD22,Ind,writein,0
-Kings,47021,State Senate,SD22,Ind,writein,0
-Kings,47022,State Senate,SD22,Ind,writein,0
-Kings,47034,State Senate,SD22,Ind,writein,1
-Kings,47038,State Senate,SD22,Ind,writein,0
-Kings,47039,State Senate,SD22,Ind,writein,0
-Kings,47043,State Senate,SD22,Ind,writein,0
-Kings,47044,State Senate,SD22,Ind,writein,0
-Kings,47045,State Senate,SD22,Ind,writein,1
-Kings,47046,State Senate,SD22,Ind,writein,0
-Kings,47047,State Senate,SD22,Ind,writein,1
-Kings,47048,State Senate,SD22,Ind,writein,1
-Kings,47049,State Senate,SD22,Ind,writein,0
-Kings,47050,State Senate,SD22,Ind,writein,0
-Kings,47051,State Senate,SD22,Ind,writein,0
-Kings,47052,State Senate,SD22,Ind,writein,0
-Kings,47055,State Senate,SD22,Ind,writein,0
-Kings,47056,State Senate,SD22,Ind,writein,0
-Kings,47065,State Senate,SD22,Ind,writein,0
-Kings,48034,State Senate,SD22,Ind,writein,1
-Kings,48035,State Senate,SD22,Ind,writein,0
-Kings,48037,State Senate,SD22,Ind,writein,1
-Kings,48046,State Senate,SD22,Ind,writein,0
-Kings,48047,State Senate,SD22,Ind,writein,0
-Kings,48048,State Senate,SD22,Ind,writein,1
-Kings,48050,State Senate,SD22,Ind,writein,0
-Kings,48051,State Senate,SD22,Ind,writein,1
-Kings,48052,State Senate,SD22,Ind,writein,2
-Kings,48059,State Senate,SD22,Ind,writein,0
-Kings,49016,State Senate,SD22,Ind,writein,0
-Kings,49017,State Senate,SD22,Ind,writein,0
-Kings,49018,State Senate,SD22,Ind,writein,0
-Kings,49019,State Senate,SD22,Ind,writein,0
-Kings,49020,State Senate,SD22,Ind,writein,0
-Kings,49021,State Senate,SD22,Ind,writein,0
-Kings,49022,State Senate,SD22,Ind,writein,0
-Kings,49023,State Senate,SD22,Ind,writein,0
-Kings,49024,State Senate,SD22,Ind,writein,0
-Kings,49025,State Senate,SD22,Ind,writein,0
-Kings,49026,State Senate,SD22,Ind,writein,0
-Kings,49027,State Senate,SD22,Ind,writein,0
-Kings,49028,State Senate,SD22,Ind,writein,0
-Kings,49029,State Senate,SD22,Ind,writein,2
-Kings,49035,State Senate,SD22,Ind,writein,0
-Kings,49037,State Senate,SD22,Ind,writein,0
-Kings,49038,State Senate,SD22,Ind,writein,0
-Kings,49039,State Senate,SD22,Ind,writein,0
-Kings,49040,State Senate,SD22,Ind,writein,0
-Kings,49041,State Senate,SD22,Ind,writein,0
-Kings,49045,State Senate,SD22,Ind,writein,0
-Kings,49047,State Senate,SD22,Ind,writein,0
-Kings,49048,State Senate,SD22,Ind,writein,0
-Kings,49049,State Senate,SD22,Ind,writein,0
-Kings,49050,State Senate,SD22,Ind,writein,0
-Kings,49051,State Senate,SD22,Ind,writein,0
-Kings,49052,State Senate,SD22,Ind,writein,0
-Kings,49053,State Senate,SD22,Ind,writein,0
-Kings,49054,State Senate,SD22,Ind,writein,0
-Kings,49056,State Senate,SD22,Ind,writein,0
-Kings,49057,State Senate,SD22,Ind,writein,0
-Kings,51059,State Senate,SD22,Ind,writein,0
-Kings,51061,State Senate,SD22,Ind,writein,0
-Kings,51062,State Senate,SD22,Ind,writein,1
-Kings,59033,State Senate,SD22,Ind,writein,1
-Kings,59034,State Senate,SD22,Ind,writein,1
-Kings,59035,State Senate,SD22,Ind,writein,0
-Kings,59036,State Senate,SD22,Ind,writein,0
-Kings,59037,State Senate,SD22,Ind,writein,0
-Kings,59038,State Senate,SD22,Ind,writein,0
-Kings,59039,State Senate,SD22,Ind,writein,0
-Kings,59040,State Senate,SD22,Ind,writein,0
-Kings,59041,State Senate,SD22,Ind,writein,0
-Kings,59042,State Senate,SD22,Ind,writein,0
-Kings,59043,State Senate,SD22,Ind,writein,0
-Kings,59044,State Senate,SD22,Ind,writein,0
-Kings,59045,State Senate,SD22,Ind,writein,0
-Kings,59046,State Senate,SD22,Ind,writein,0
-Kings,59048,State Senate,SD22,Ind,writein,0
-Kings,64075,State Senate,SD22,Ind,writein,0
-Kings,64076,State Senate,SD22,Ind,writein,2
-Kings,64077,State Senate,SD22,Ind,writein,0
-Kings,64078,State Senate,SD22,Ind,writein,0
-Kings,64079,State Senate,SD22,Ind,writein,0
-Kings,64080,State Senate,SD22,Ind,writein,0
-Kings,64083,State Senate,SD22,Ind,writein,0
-Kings,64084,State Senate,SD22,Ind,writein,0
-Kings,64085,State Senate,SD22,Ind,writein,0
-Kings,64086,State Senate,SD22,Ind,writein,0
-Kings,64087,State Senate,SD22,Ind,writein,3
-Kings,64088,State Senate,SD22,Ind,writein,0
-Kings,64089,State Senate,SD22,Ind,writein,1
-Kings,64090,State Senate,SD22,Ind,writein,0
-Kings,64091,State Senate,SD22,Ind,writein,0
-Kings,41085,State Senate,SD23,Dem,Diane Savino,171
-Kings,41087,State Senate,SD23,Dem,Diane Savino,134
-Kings,41088,State Senate,SD23,Dem,Diane Savino,92
-Kings,41089,State Senate,SD23,Dem,Diane Savino,126
-Kings,41092,State Senate,SD23,Dem,Diane Savino,82
-Kings,45040,State Senate,SD23,Dem,Diane Savino,180
-Kings,45042,State Senate,SD23,Dem,Diane Savino,157
-Kings,45043,State Senate,SD23,Dem,Diane Savino,210
-Kings,45044,State Senate,SD23,Dem,Diane Savino,70
-Kings,45045,State Senate,SD23,Dem,Diane Savino,354
-Kings,45046,State Senate,SD23,Dem,Diane Savino,457
-Kings,45047,State Senate,SD23,Dem,Diane Savino,29
-Kings,45048,State Senate,SD23,Dem,Diane Savino,264
-Kings,45050,State Senate,SD23,Dem,Diane Savino,190
-Kings,45053,State Senate,SD23,Dem,Diane Savino,90
-Kings,45054,State Senate,SD23,Dem,Diane Savino,77
-Kings,45057,State Senate,SD23,Dem,Diane Savino,14
-Kings,45058,State Senate,SD23,Dem,Diane Savino,64
-Kings,45059,State Senate,SD23,Dem,Diane Savino,139
-Kings,45060,State Senate,SD23,Dem,Diane Savino,129
-Kings,45061,State Senate,SD23,Dem,Diane Savino,77
-Kings,45062,State Senate,SD23,Dem,Diane Savino,186
-Kings,45063,State Senate,SD23,Dem,Diane Savino,97
-Kings,45064,State Senate,SD23,Dem,Diane Savino,121
-Kings,45065,State Senate,SD23,Dem,Diane Savino,83
-Kings,45066,State Senate,SD23,Dem,Diane Savino,120
-Kings,45074,State Senate,SD23,Dem,Diane Savino,80
-Kings,45075,State Senate,SD23,Dem,Diane Savino,138
-Kings,45076,State Senate,SD23,Dem,Diane Savino,19
-Kings,45077,State Senate,SD23,Dem,Diane Savino,110
-Kings,45078,State Senate,SD23,Dem,Diane Savino,92
-Kings,46001,State Senate,SD23,Dem,Diane Savino,64
-Kings,46002,State Senate,SD23,Dem,Diane Savino,149
-Kings,46003,State Senate,SD23,Dem,Diane Savino,40
-Kings,46004,State Senate,SD23,Dem,Diane Savino,353
-Kings,46005,State Senate,SD23,Dem,Diane Savino,386
-Kings,46006,State Senate,SD23,Dem,Diane Savino,291
-Kings,46007,State Senate,SD23,Dem,Diane Savino,251
-Kings,46008,State Senate,SD23,Dem,Diane Savino,185
-Kings,46009,State Senate,SD23,Dem,Diane Savino,435
-Kings,46010,State Senate,SD23,Dem,Diane Savino,202
-Kings,46011,State Senate,SD23,Dem,Diane Savino,298
-Kings,46012,State Senate,SD23,Dem,Diane Savino,316
-Kings,46013,State Senate,SD23,Dem,Diane Savino,328
-Kings,46014,State Senate,SD23,Dem,Diane Savino,296
-Kings,46015,State Senate,SD23,Dem,Diane Savino,433
-Kings,46016,State Senate,SD23,Dem,Diane Savino,188
-Kings,46017,State Senate,SD23,Dem,Diane Savino,95
-Kings,46018,State Senate,SD23,Dem,Diane Savino,97
-Kings,46019,State Senate,SD23,Dem,Diane Savino,192
-Kings,46020,State Senate,SD23,Dem,Diane Savino,245
-Kings,46021,State Senate,SD23,Dem,Diane Savino,141
-Kings,46022,State Senate,SD23,Dem,Diane Savino,190
-Kings,46023,State Senate,SD23,Dem,Diane Savino,128
-Kings,46024,State Senate,SD23,Dem,Diane Savino,159
-Kings,46025,State Senate,SD23,Dem,Diane Savino,185
-Kings,46026,State Senate,SD23,Dem,Diane Savino,67
-Kings,46027,State Senate,SD23,Dem,Diane Savino,76
-Kings,46028,State Senate,SD23,Dem,Diane Savino,84
-Kings,46029,State Senate,SD23,Dem,Diane Savino,85
-Kings,46030,State Senate,SD23,Dem,Diane Savino,101
-Kings,46037,State Senate,SD23,Dem,Diane Savino,10
-Kings,46038,State Senate,SD23,Dem,Diane Savino,196
-Kings,46039,State Senate,SD23,Dem,Diane Savino,244
-Kings,46040,State Senate,SD23,Dem,Diane Savino,57
-Kings,46043,State Senate,SD23,Dem,Diane Savino,142
-Kings,46044,State Senate,SD23,Dem,Diane Savino,178
-Kings,46045,State Senate,SD23,Dem,Diane Savino,130
-Kings,46046,State Senate,SD23,Dem,Diane Savino,91
-Kings,46077,State Senate,SD23,Dem,Diane Savino,14
-Kings,47004,State Senate,SD23,Dem,Diane Savino,23
-Kings,47010,State Senate,SD23,Dem,Diane Savino,38
-Kings,47011,State Senate,SD23,Dem,Diane Savino,180
-Kings,47012,State Senate,SD23,Dem,Diane Savino,177
-Kings,47013,State Senate,SD23,Dem,Diane Savino,170
-Kings,47014,State Senate,SD23,Dem,Diane Savino,224
-Kings,47015,State Senate,SD23,Dem,Diane Savino,297
-Kings,47016,State Senate,SD23,Dem,Diane Savino,188
-Kings,47017,State Senate,SD23,Dem,Diane Savino,155
-Kings,47018,State Senate,SD23,Dem,Diane Savino,187
-Kings,47035,State Senate,SD23,Dem,Diane Savino,5
-Kings,47036,State Senate,SD23,Dem,Diane Savino,165
-Kings,47037,State Senate,SD23,Dem,Diane Savino,144
-Kings,47040,State Senate,SD23,Dem,Diane Savino,92
-Kings,47041,State Senate,SD23,Dem,Diane Savino,224
-Kings,47042,State Senate,SD23,Dem,Diane Savino,80
-Kings,47053,State Senate,SD23,Dem,Diane Savino,292
-Kings,47054,State Senate,SD23,Dem,Diane Savino,285
-Kings,47057,State Senate,SD23,Dem,Diane Savino,234
-Kings,47058,State Senate,SD23,Dem,Diane Savino,197
-Kings,47059,State Senate,SD23,Dem,Diane Savino,176
-Kings,47060,State Senate,SD23,Dem,Diane Savino,92
-Kings,47061,State Senate,SD23,Dem,Diane Savino,162
-Kings,47062,State Senate,SD23,Dem,Diane Savino,180
-Kings,47063,State Senate,SD23,Dem,Diane Savino,234
-Kings,47064,State Senate,SD23,Dem,Diane Savino,190
-Kings,49034,State Senate,SD23,Dem,Diane Savino,72
-Kings,49036,State Senate,SD23,Dem,Diane Savino,75
-Kings,49044,State Senate,SD23,Dem,Diane Savino,63
-Kings,49055,State Senate,SD23,Dem,Diane Savino,95
-Kings,51025,State Senate,SD23,Dem,Diane Savino,12
-Kings,51026,State Senate,SD23,Dem,Diane Savino,349
-Kings,51027,State Senate,SD23,Dem,Diane Savino,112
-Kings,51056,State Senate,SD23,Dem,Diane Savino,6
-Kings,51057,State Senate,SD23,Dem,Diane Savino,40
-Kings,51058,State Senate,SD23,Dem,Diane Savino,81
-Kings,51060,State Senate,SD23,Dem,Diane Savino,345
-Kings,64081,State Senate,SD23,Dem,Diane Savino,137
-Kings,64082,State Senate,SD23,Dem,Diane Savino,66
-Kings,41085,State Senate,SD23,WF,Diane Savino,4
-Kings,41087,State Senate,SD23,WF,Diane Savino,5
-Kings,41088,State Senate,SD23,WF,Diane Savino,4
-Kings,41089,State Senate,SD23,WF,Diane Savino,10
-Kings,41092,State Senate,SD23,WF,Diane Savino,2
-Kings,45040,State Senate,SD23,WF,Diane Savino,7
-Kings,45042,State Senate,SD23,WF,Diane Savino,8
-Kings,45043,State Senate,SD23,WF,Diane Savino,10
-Kings,45044,State Senate,SD23,WF,Diane Savino,8
-Kings,45045,State Senate,SD23,WF,Diane Savino,5
-Kings,45046,State Senate,SD23,WF,Diane Savino,6
-Kings,45047,State Senate,SD23,WF,Diane Savino,2
-Kings,45048,State Senate,SD23,WF,Diane Savino,13
-Kings,45050,State Senate,SD23,WF,Diane Savino,15
-Kings,45053,State Senate,SD23,WF,Diane Savino,7
-Kings,45054,State Senate,SD23,WF,Diane Savino,6
-Kings,45057,State Senate,SD23,WF,Diane Savino,1
-Kings,45058,State Senate,SD23,WF,Diane Savino,4
-Kings,45059,State Senate,SD23,WF,Diane Savino,4
-Kings,45060,State Senate,SD23,WF,Diane Savino,6
-Kings,45061,State Senate,SD23,WF,Diane Savino,1
-Kings,45062,State Senate,SD23,WF,Diane Savino,4
-Kings,45063,State Senate,SD23,WF,Diane Savino,3
-Kings,45064,State Senate,SD23,WF,Diane Savino,11
-Kings,45065,State Senate,SD23,WF,Diane Savino,6
-Kings,45066,State Senate,SD23,WF,Diane Savino,10
-Kings,45074,State Senate,SD23,WF,Diane Savino,8
-Kings,45075,State Senate,SD23,WF,Diane Savino,8
-Kings,45076,State Senate,SD23,WF,Diane Savino,1
-Kings,45077,State Senate,SD23,WF,Diane Savino,8
-Kings,45078,State Senate,SD23,WF,Diane Savino,6
-Kings,46001,State Senate,SD23,WF,Diane Savino,4
-Kings,46002,State Senate,SD23,WF,Diane Savino,10
-Kings,46003,State Senate,SD23,WF,Diane Savino,0
-Kings,46004,State Senate,SD23,WF,Diane Savino,5
-Kings,46005,State Senate,SD23,WF,Diane Savino,5
-Kings,46006,State Senate,SD23,WF,Diane Savino,4
-Kings,46007,State Senate,SD23,WF,Diane Savino,3
-Kings,46008,State Senate,SD23,WF,Diane Savino,0
-Kings,46009,State Senate,SD23,WF,Diane Savino,9
-Kings,46010,State Senate,SD23,WF,Diane Savino,1
-Kings,46011,State Senate,SD23,WF,Diane Savino,12
-Kings,46012,State Senate,SD23,WF,Diane Savino,0
-Kings,46013,State Senate,SD23,WF,Diane Savino,8
-Kings,46014,State Senate,SD23,WF,Diane Savino,4
-Kings,46015,State Senate,SD23,WF,Diane Savino,5
-Kings,46016,State Senate,SD23,WF,Diane Savino,9
-Kings,46017,State Senate,SD23,WF,Diane Savino,7
-Kings,46018,State Senate,SD23,WF,Diane Savino,4
-Kings,46019,State Senate,SD23,WF,Diane Savino,10
-Kings,46020,State Senate,SD23,WF,Diane Savino,7
-Kings,46021,State Senate,SD23,WF,Diane Savino,5
-Kings,46022,State Senate,SD23,WF,Diane Savino,6
-Kings,46023,State Senate,SD23,WF,Diane Savino,9
-Kings,46024,State Senate,SD23,WF,Diane Savino,11
-Kings,46025,State Senate,SD23,WF,Diane Savino,6
-Kings,46026,State Senate,SD23,WF,Diane Savino,2
-Kings,46027,State Senate,SD23,WF,Diane Savino,8
-Kings,46028,State Senate,SD23,WF,Diane Savino,5
-Kings,46029,State Senate,SD23,WF,Diane Savino,6
-Kings,46030,State Senate,SD23,WF,Diane Savino,4
-Kings,46037,State Senate,SD23,WF,Diane Savino,0
-Kings,46038,State Senate,SD23,WF,Diane Savino,8
-Kings,46039,State Senate,SD23,WF,Diane Savino,12
-Kings,46040,State Senate,SD23,WF,Diane Savino,9
-Kings,46043,State Senate,SD23,WF,Diane Savino,9
-Kings,46044,State Senate,SD23,WF,Diane Savino,10
-Kings,46045,State Senate,SD23,WF,Diane Savino,15
-Kings,46046,State Senate,SD23,WF,Diane Savino,4
-Kings,46077,State Senate,SD23,WF,Diane Savino,1
-Kings,47004,State Senate,SD23,WF,Diane Savino,1
-Kings,47010,State Senate,SD23,WF,Diane Savino,2
-Kings,47011,State Senate,SD23,WF,Diane Savino,15
-Kings,47012,State Senate,SD23,WF,Diane Savino,11
-Kings,47013,State Senate,SD23,WF,Diane Savino,8
-Kings,47014,State Senate,SD23,WF,Diane Savino,8
-Kings,47015,State Senate,SD23,WF,Diane Savino,15
-Kings,47016,State Senate,SD23,WF,Diane Savino,17
-Kings,47017,State Senate,SD23,WF,Diane Savino,10
-Kings,47018,State Senate,SD23,WF,Diane Savino,11
-Kings,47035,State Senate,SD23,WF,Diane Savino,0
-Kings,47036,State Senate,SD23,WF,Diane Savino,10
-Kings,47037,State Senate,SD23,WF,Diane Savino,3
-Kings,47040,State Senate,SD23,WF,Diane Savino,3
-Kings,47041,State Senate,SD23,WF,Diane Savino,10
-Kings,47042,State Senate,SD23,WF,Diane Savino,6
-Kings,47053,State Senate,SD23,WF,Diane Savino,0
-Kings,47054,State Senate,SD23,WF,Diane Savino,2
-Kings,47057,State Senate,SD23,WF,Diane Savino,21
-Kings,47058,State Senate,SD23,WF,Diane Savino,15
-Kings,47059,State Senate,SD23,WF,Diane Savino,4
-Kings,47060,State Senate,SD23,WF,Diane Savino,2
-Kings,47061,State Senate,SD23,WF,Diane Savino,8
-Kings,47062,State Senate,SD23,WF,Diane Savino,16
-Kings,47063,State Senate,SD23,WF,Diane Savino,21
-Kings,47064,State Senate,SD23,WF,Diane Savino,12
-Kings,49034,State Senate,SD23,WF,Diane Savino,4
-Kings,49036,State Senate,SD23,WF,Diane Savino,5
-Kings,49044,State Senate,SD23,WF,Diane Savino,3
-Kings,49055,State Senate,SD23,WF,Diane Savino,2
-Kings,51025,State Senate,SD23,WF,Diane Savino,2
-Kings,51026,State Senate,SD23,WF,Diane Savino,25
-Kings,51027,State Senate,SD23,WF,Diane Savino,5
-Kings,51056,State Senate,SD23,WF,Diane Savino,1
-Kings,51057,State Senate,SD23,WF,Diane Savino,1
-Kings,51058,State Senate,SD23,WF,Diane Savino,5
-Kings,51060,State Senate,SD23,WF,Diane Savino,20
-Kings,64081,State Senate,SD23,WF,Diane Savino,9
-Kings,64082,State Senate,SD23,WF,Diane Savino,2
-Kings,41085,State Senate,SD23,Ind,Diane Savino,3
-Kings,41087,State Senate,SD23,Ind,Diane Savino,2
-Kings,41088,State Senate,SD23,Ind,Diane Savino,6
-Kings,41089,State Senate,SD23,Ind,Diane Savino,2
-Kings,41092,State Senate,SD23,Ind,Diane Savino,1
-Kings,45040,State Senate,SD23,Ind,Diane Savino,5
-Kings,45042,State Senate,SD23,Ind,Diane Savino,7
-Kings,45043,State Senate,SD23,Ind,Diane Savino,5
-Kings,45044,State Senate,SD23,Ind,Diane Savino,1
-Kings,45045,State Senate,SD23,Ind,Diane Savino,3
-Kings,45046,State Senate,SD23,Ind,Diane Savino,2
-Kings,45047,State Senate,SD23,Ind,Diane Savino,0
-Kings,45048,State Senate,SD23,Ind,Diane Savino,9
-Kings,45050,State Senate,SD23,Ind,Diane Savino,7
-Kings,45053,State Senate,SD23,Ind,Diane Savino,8
-Kings,45054,State Senate,SD23,Ind,Diane Savino,4
-Kings,45057,State Senate,SD23,Ind,Diane Savino,0
-Kings,45058,State Senate,SD23,Ind,Diane Savino,2
-Kings,45059,State Senate,SD23,Ind,Diane Savino,5
-Kings,45060,State Senate,SD23,Ind,Diane Savino,1
-Kings,45061,State Senate,SD23,Ind,Diane Savino,0
-Kings,45062,State Senate,SD23,Ind,Diane Savino,5
-Kings,45063,State Senate,SD23,Ind,Diane Savino,0
-Kings,45064,State Senate,SD23,Ind,Diane Savino,7
-Kings,45065,State Senate,SD23,Ind,Diane Savino,11
-Kings,45066,State Senate,SD23,Ind,Diane Savino,16
-Kings,45074,State Senate,SD23,Ind,Diane Savino,10
-Kings,45075,State Senate,SD23,Ind,Diane Savino,5
-Kings,45076,State Senate,SD23,Ind,Diane Savino,0
-Kings,45077,State Senate,SD23,Ind,Diane Savino,12
-Kings,45078,State Senate,SD23,Ind,Diane Savino,8
-Kings,46001,State Senate,SD23,Ind,Diane Savino,4
-Kings,46002,State Senate,SD23,Ind,Diane Savino,0
-Kings,46003,State Senate,SD23,Ind,Diane Savino,0
-Kings,46004,State Senate,SD23,Ind,Diane Savino,2
-Kings,46005,State Senate,SD23,Ind,Diane Savino,1
-Kings,46006,State Senate,SD23,Ind,Diane Savino,0
-Kings,46007,State Senate,SD23,Ind,Diane Savino,0
-Kings,46008,State Senate,SD23,Ind,Diane Savino,0
-Kings,46009,State Senate,SD23,Ind,Diane Savino,1
-Kings,46010,State Senate,SD23,Ind,Diane Savino,1
-Kings,46011,State Senate,SD23,Ind,Diane Savino,2
-Kings,46012,State Senate,SD23,Ind,Diane Savino,0
-Kings,46013,State Senate,SD23,Ind,Diane Savino,1
-Kings,46014,State Senate,SD23,Ind,Diane Savino,0
-Kings,46015,State Senate,SD23,Ind,Diane Savino,0
-Kings,46016,State Senate,SD23,Ind,Diane Savino,8
-Kings,46017,State Senate,SD23,Ind,Diane Savino,5
-Kings,46018,State Senate,SD23,Ind,Diane Savino,5
-Kings,46019,State Senate,SD23,Ind,Diane Savino,2
-Kings,46020,State Senate,SD23,Ind,Diane Savino,6
-Kings,46021,State Senate,SD23,Ind,Diane Savino,11
-Kings,46022,State Senate,SD23,Ind,Diane Savino,2
-Kings,46023,State Senate,SD23,Ind,Diane Savino,2
-Kings,46024,State Senate,SD23,Ind,Diane Savino,1
-Kings,46025,State Senate,SD23,Ind,Diane Savino,3
-Kings,46026,State Senate,SD23,Ind,Diane Savino,0
-Kings,46027,State Senate,SD23,Ind,Diane Savino,4
-Kings,46028,State Senate,SD23,Ind,Diane Savino,1
-Kings,46029,State Senate,SD23,Ind,Diane Savino,3
-Kings,46030,State Senate,SD23,Ind,Diane Savino,3
-Kings,46037,State Senate,SD23,Ind,Diane Savino,1
-Kings,46038,State Senate,SD23,Ind,Diane Savino,3
-Kings,46039,State Senate,SD23,Ind,Diane Savino,5
-Kings,46040,State Senate,SD23,Ind,Diane Savino,0
-Kings,46043,State Senate,SD23,Ind,Diane Savino,6
-Kings,46044,State Senate,SD23,Ind,Diane Savino,5
-Kings,46045,State Senate,SD23,Ind,Diane Savino,5
-Kings,46046,State Senate,SD23,Ind,Diane Savino,2
-Kings,46077,State Senate,SD23,Ind,Diane Savino,0
-Kings,47004,State Senate,SD23,Ind,Diane Savino,3
-Kings,47010,State Senate,SD23,Ind,Diane Savino,4
-Kings,47011,State Senate,SD23,Ind,Diane Savino,7
-Kings,47012,State Senate,SD23,Ind,Diane Savino,9
-Kings,47013,State Senate,SD23,Ind,Diane Savino,5
-Kings,47014,State Senate,SD23,Ind,Diane Savino,4
-Kings,47015,State Senate,SD23,Ind,Diane Savino,2
-Kings,47016,State Senate,SD23,Ind,Diane Savino,5
-Kings,47017,State Senate,SD23,Ind,Diane Savino,1
-Kings,47018,State Senate,SD23,Ind,Diane Savino,3
-Kings,47035,State Senate,SD23,Ind,Diane Savino,0
-Kings,47036,State Senate,SD23,Ind,Diane Savino,11
-Kings,47037,State Senate,SD23,Ind,Diane Savino,0
-Kings,47040,State Senate,SD23,Ind,Diane Savino,0
-Kings,47041,State Senate,SD23,Ind,Diane Savino,9
-Kings,47042,State Senate,SD23,Ind,Diane Savino,2
-Kings,47053,State Senate,SD23,Ind,Diane Savino,0
-Kings,47054,State Senate,SD23,Ind,Diane Savino,0
-Kings,47057,State Senate,SD23,Ind,Diane Savino,4
-Kings,47058,State Senate,SD23,Ind,Diane Savino,2
-Kings,47059,State Senate,SD23,Ind,Diane Savino,4
-Kings,47060,State Senate,SD23,Ind,Diane Savino,0
-Kings,47061,State Senate,SD23,Ind,Diane Savino,2
-Kings,47062,State Senate,SD23,Ind,Diane Savino,6
-Kings,47063,State Senate,SD23,Ind,Diane Savino,5
-Kings,47064,State Senate,SD23,Ind,Diane Savino,3
-Kings,49034,State Senate,SD23,Ind,Diane Savino,0
-Kings,49036,State Senate,SD23,Ind,Diane Savino,2
-Kings,49044,State Senate,SD23,Ind,Diane Savino,1
-Kings,49055,State Senate,SD23,Ind,Diane Savino,1
-Kings,51025,State Senate,SD23,Ind,Diane Savino,0
-Kings,51026,State Senate,SD23,Ind,Diane Savino,8
-Kings,51027,State Senate,SD23,Ind,Diane Savino,1
-Kings,51056,State Senate,SD23,Ind,Diane Savino,1
-Kings,51057,State Senate,SD23,Ind,Diane Savino,0
-Kings,51058,State Senate,SD23,Ind,Diane Savino,1
-Kings,51060,State Senate,SD23,Ind,Diane Savino,5
-Kings,64081,State Senate,SD23,Ind,Diane Savino,2
-Kings,64082,State Senate,SD23,Ind,Diane Savino,1
-Kings,41085,State Senate,SD23,Rep,Lisa Grey,74
-Kings,41087,State Senate,SD23,Rep,Lisa Grey,100
-Kings,41088,State Senate,SD23,Rep,Lisa Grey,174
-Kings,41089,State Senate,SD23,Rep,Lisa Grey,62
-Kings,41092,State Senate,SD23,Rep,Lisa Grey,61
-Kings,45040,State Senate,SD23,Rep,Lisa Grey,174
-Kings,45042,State Senate,SD23,Rep,Lisa Grey,124
-Kings,45043,State Senate,SD23,Rep,Lisa Grey,149
-Kings,45044,State Senate,SD23,Rep,Lisa Grey,52
-Kings,45045,State Senate,SD23,Rep,Lisa Grey,24
-Kings,45046,State Senate,SD23,Rep,Lisa Grey,30
-Kings,45047,State Senate,SD23,Rep,Lisa Grey,6
-Kings,45048,State Senate,SD23,Rep,Lisa Grey,199
-Kings,45050,State Senate,SD23,Rep,Lisa Grey,112
-Kings,45053,State Senate,SD23,Rep,Lisa Grey,96
-Kings,45054,State Senate,SD23,Rep,Lisa Grey,66
-Kings,45057,State Senate,SD23,Rep,Lisa Grey,10
-Kings,45058,State Senate,SD23,Rep,Lisa Grey,58
-Kings,45059,State Senate,SD23,Rep,Lisa Grey,85
-Kings,45060,State Senate,SD23,Rep,Lisa Grey,43
-Kings,45061,State Senate,SD23,Rep,Lisa Grey,10
-Kings,45062,State Senate,SD23,Rep,Lisa Grey,48
-Kings,45063,State Senate,SD23,Rep,Lisa Grey,16
-Kings,45064,State Senate,SD23,Rep,Lisa Grey,138
-Kings,45065,State Senate,SD23,Rep,Lisa Grey,67
-Kings,45066,State Senate,SD23,Rep,Lisa Grey,121
-Kings,45074,State Senate,SD23,Rep,Lisa Grey,288
-Kings,45075,State Senate,SD23,Rep,Lisa Grey,209
-Kings,45076,State Senate,SD23,Rep,Lisa Grey,26
-Kings,45077,State Senate,SD23,Rep,Lisa Grey,88
-Kings,45078,State Senate,SD23,Rep,Lisa Grey,75
-Kings,46001,State Senate,SD23,Rep,Lisa Grey,43
-Kings,46002,State Senate,SD23,Rep,Lisa Grey,34
-Kings,46003,State Senate,SD23,Rep,Lisa Grey,24
-Kings,46004,State Senate,SD23,Rep,Lisa Grey,10
-Kings,46005,State Senate,SD23,Rep,Lisa Grey,16
-Kings,46006,State Senate,SD23,Rep,Lisa Grey,8
-Kings,46007,State Senate,SD23,Rep,Lisa Grey,43
-Kings,46008,State Senate,SD23,Rep,Lisa Grey,9
-Kings,46009,State Senate,SD23,Rep,Lisa Grey,29
-Kings,46010,State Senate,SD23,Rep,Lisa Grey,6
-Kings,46011,State Senate,SD23,Rep,Lisa Grey,44
-Kings,46012,State Senate,SD23,Rep,Lisa Grey,12
-Kings,46013,State Senate,SD23,Rep,Lisa Grey,9
-Kings,46014,State Senate,SD23,Rep,Lisa Grey,14
-Kings,46015,State Senate,SD23,Rep,Lisa Grey,16
-Kings,46016,State Senate,SD23,Rep,Lisa Grey,76
-Kings,46017,State Senate,SD23,Rep,Lisa Grey,127
-Kings,46018,State Senate,SD23,Rep,Lisa Grey,98
-Kings,46019,State Senate,SD23,Rep,Lisa Grey,168
-Kings,46020,State Senate,SD23,Rep,Lisa Grey,165
-Kings,46021,State Senate,SD23,Rep,Lisa Grey,183
-Kings,46022,State Senate,SD23,Rep,Lisa Grey,147
-Kings,46023,State Senate,SD23,Rep,Lisa Grey,128
-Kings,46024,State Senate,SD23,Rep,Lisa Grey,130
-Kings,46025,State Senate,SD23,Rep,Lisa Grey,153
-Kings,46026,State Senate,SD23,Rep,Lisa Grey,58
-Kings,46027,State Senate,SD23,Rep,Lisa Grey,80
-Kings,46028,State Senate,SD23,Rep,Lisa Grey,92
-Kings,46029,State Senate,SD23,Rep,Lisa Grey,100
-Kings,46030,State Senate,SD23,Rep,Lisa Grey,90
-Kings,46037,State Senate,SD23,Rep,Lisa Grey,10
-Kings,46038,State Senate,SD23,Rep,Lisa Grey,213
-Kings,46039,State Senate,SD23,Rep,Lisa Grey,127
-Kings,46040,State Senate,SD23,Rep,Lisa Grey,28
-Kings,46043,State Senate,SD23,Rep,Lisa Grey,118
-Kings,46044,State Senate,SD23,Rep,Lisa Grey,172
-Kings,46045,State Senate,SD23,Rep,Lisa Grey,75
-Kings,46046,State Senate,SD23,Rep,Lisa Grey,120
-Kings,46077,State Senate,SD23,Rep,Lisa Grey,20
-Kings,47004,State Senate,SD23,Rep,Lisa Grey,6
-Kings,47010,State Senate,SD23,Rep,Lisa Grey,25
-Kings,47011,State Senate,SD23,Rep,Lisa Grey,90
-Kings,47012,State Senate,SD23,Rep,Lisa Grey,102
-Kings,47013,State Senate,SD23,Rep,Lisa Grey,69
-Kings,47014,State Senate,SD23,Rep,Lisa Grey,103
-Kings,47015,State Senate,SD23,Rep,Lisa Grey,93
-Kings,47016,State Senate,SD23,Rep,Lisa Grey,98
-Kings,47017,State Senate,SD23,Rep,Lisa Grey,64
-Kings,47018,State Senate,SD23,Rep,Lisa Grey,132
-Kings,47035,State Senate,SD23,Rep,Lisa Grey,3
-Kings,47036,State Senate,SD23,Rep,Lisa Grey,80
-Kings,47037,State Senate,SD23,Rep,Lisa Grey,59
-Kings,47040,State Senate,SD23,Rep,Lisa Grey,43
-Kings,47041,State Senate,SD23,Rep,Lisa Grey,67
-Kings,47042,State Senate,SD23,Rep,Lisa Grey,28
-Kings,47053,State Senate,SD23,Rep,Lisa Grey,10
-Kings,47054,State Senate,SD23,Rep,Lisa Grey,7
-Kings,47057,State Senate,SD23,Rep,Lisa Grey,121
-Kings,47058,State Senate,SD23,Rep,Lisa Grey,78
-Kings,47059,State Senate,SD23,Rep,Lisa Grey,123
-Kings,47060,State Senate,SD23,Rep,Lisa Grey,34
-Kings,47061,State Senate,SD23,Rep,Lisa Grey,61
-Kings,47062,State Senate,SD23,Rep,Lisa Grey,87
-Kings,47063,State Senate,SD23,Rep,Lisa Grey,105
-Kings,47064,State Senate,SD23,Rep,Lisa Grey,99
-Kings,49034,State Senate,SD23,Rep,Lisa Grey,15
-Kings,49036,State Senate,SD23,Rep,Lisa Grey,20
-Kings,49044,State Senate,SD23,Rep,Lisa Grey,38
-Kings,49055,State Senate,SD23,Rep,Lisa Grey,22
-Kings,51025,State Senate,SD23,Rep,Lisa Grey,0
-Kings,51026,State Senate,SD23,Rep,Lisa Grey,130
-Kings,51027,State Senate,SD23,Rep,Lisa Grey,32
-Kings,51056,State Senate,SD23,Rep,Lisa Grey,0
-Kings,51057,State Senate,SD23,Rep,Lisa Grey,7
-Kings,51058,State Senate,SD23,Rep,Lisa Grey,9
-Kings,51060,State Senate,SD23,Rep,Lisa Grey,78
-Kings,64081,State Senate,SD23,Rep,Lisa Grey,50
-Kings,64082,State Senate,SD23,Rep,Lisa Grey,26
-Kings,41085,State Senate,SD23,Con,Lisa Grey,11
-Kings,41087,State Senate,SD23,Con,Lisa Grey,6
-Kings,41088,State Senate,SD23,Con,Lisa Grey,13
-Kings,41089,State Senate,SD23,Con,Lisa Grey,7
-Kings,41092,State Senate,SD23,Con,Lisa Grey,3
-Kings,45040,State Senate,SD23,Con,Lisa Grey,15
-Kings,45042,State Senate,SD23,Con,Lisa Grey,20
-Kings,45043,State Senate,SD23,Con,Lisa Grey,10
-Kings,45044,State Senate,SD23,Con,Lisa Grey,4
-Kings,45045,State Senate,SD23,Con,Lisa Grey,3
-Kings,45046,State Senate,SD23,Con,Lisa Grey,4
-Kings,45047,State Senate,SD23,Con,Lisa Grey,2
-Kings,45048,State Senate,SD23,Con,Lisa Grey,19
-Kings,45050,State Senate,SD23,Con,Lisa Grey,4
-Kings,45053,State Senate,SD23,Con,Lisa Grey,6
-Kings,45054,State Senate,SD23,Con,Lisa Grey,0
-Kings,45057,State Senate,SD23,Con,Lisa Grey,2
-Kings,45058,State Senate,SD23,Con,Lisa Grey,8
-Kings,45059,State Senate,SD23,Con,Lisa Grey,6
-Kings,45060,State Senate,SD23,Con,Lisa Grey,8
-Kings,45061,State Senate,SD23,Con,Lisa Grey,0
-Kings,45062,State Senate,SD23,Con,Lisa Grey,7
-Kings,45063,State Senate,SD23,Con,Lisa Grey,5
-Kings,45064,State Senate,SD23,Con,Lisa Grey,6
-Kings,45065,State Senate,SD23,Con,Lisa Grey,6
-Kings,45066,State Senate,SD23,Con,Lisa Grey,6
-Kings,45074,State Senate,SD23,Con,Lisa Grey,12
-Kings,45075,State Senate,SD23,Con,Lisa Grey,7
-Kings,45076,State Senate,SD23,Con,Lisa Grey,2
-Kings,45077,State Senate,SD23,Con,Lisa Grey,9
-Kings,45078,State Senate,SD23,Con,Lisa Grey,4
-Kings,46001,State Senate,SD23,Con,Lisa Grey,6
-Kings,46002,State Senate,SD23,Con,Lisa Grey,5
-Kings,46003,State Senate,SD23,Con,Lisa Grey,2
-Kings,46004,State Senate,SD23,Con,Lisa Grey,1
-Kings,46005,State Senate,SD23,Con,Lisa Grey,1
-Kings,46006,State Senate,SD23,Con,Lisa Grey,0
-Kings,46007,State Senate,SD23,Con,Lisa Grey,6
-Kings,46008,State Senate,SD23,Con,Lisa Grey,0
-Kings,46009,State Senate,SD23,Con,Lisa Grey,4
-Kings,46010,State Senate,SD23,Con,Lisa Grey,2
-Kings,46011,State Senate,SD23,Con,Lisa Grey,3
-Kings,46012,State Senate,SD23,Con,Lisa Grey,2
-Kings,46013,State Senate,SD23,Con,Lisa Grey,1
-Kings,46014,State Senate,SD23,Con,Lisa Grey,0
-Kings,46015,State Senate,SD23,Con,Lisa Grey,2
-Kings,46016,State Senate,SD23,Con,Lisa Grey,5
-Kings,46017,State Senate,SD23,Con,Lisa Grey,6
-Kings,46018,State Senate,SD23,Con,Lisa Grey,5
-Kings,46019,State Senate,SD23,Con,Lisa Grey,9
-Kings,46020,State Senate,SD23,Con,Lisa Grey,11
-Kings,46021,State Senate,SD23,Con,Lisa Grey,5
-Kings,46022,State Senate,SD23,Con,Lisa Grey,8
-Kings,46023,State Senate,SD23,Con,Lisa Grey,6
-Kings,46024,State Senate,SD23,Con,Lisa Grey,3
-Kings,46025,State Senate,SD23,Con,Lisa Grey,13
-Kings,46026,State Senate,SD23,Con,Lisa Grey,1
-Kings,46027,State Senate,SD23,Con,Lisa Grey,4
-Kings,46028,State Senate,SD23,Con,Lisa Grey,6
-Kings,46029,State Senate,SD23,Con,Lisa Grey,3
-Kings,46030,State Senate,SD23,Con,Lisa Grey,4
-Kings,46037,State Senate,SD23,Con,Lisa Grey,1
-Kings,46038,State Senate,SD23,Con,Lisa Grey,11
-Kings,46039,State Senate,SD23,Con,Lisa Grey,7
-Kings,46040,State Senate,SD23,Con,Lisa Grey,4
-Kings,46043,State Senate,SD23,Con,Lisa Grey,14
-Kings,46044,State Senate,SD23,Con,Lisa Grey,10
-Kings,46045,State Senate,SD23,Con,Lisa Grey,2
-Kings,46046,State Senate,SD23,Con,Lisa Grey,1
-Kings,46077,State Senate,SD23,Con,Lisa Grey,0
-Kings,47004,State Senate,SD23,Con,Lisa Grey,1
-Kings,47010,State Senate,SD23,Con,Lisa Grey,2
-Kings,47011,State Senate,SD23,Con,Lisa Grey,16
-Kings,47012,State Senate,SD23,Con,Lisa Grey,12
-Kings,47013,State Senate,SD23,Con,Lisa Grey,12
-Kings,47014,State Senate,SD23,Con,Lisa Grey,14
-Kings,47015,State Senate,SD23,Con,Lisa Grey,9
-Kings,47016,State Senate,SD23,Con,Lisa Grey,6
-Kings,47017,State Senate,SD23,Con,Lisa Grey,6
-Kings,47018,State Senate,SD23,Con,Lisa Grey,22
-Kings,47035,State Senate,SD23,Con,Lisa Grey,0
-Kings,47036,State Senate,SD23,Con,Lisa Grey,6
-Kings,47037,State Senate,SD23,Con,Lisa Grey,3
-Kings,47040,State Senate,SD23,Con,Lisa Grey,3
-Kings,47041,State Senate,SD23,Con,Lisa Grey,10
-Kings,47042,State Senate,SD23,Con,Lisa Grey,3
-Kings,47053,State Senate,SD23,Con,Lisa Grey,3
-Kings,47054,State Senate,SD23,Con,Lisa Grey,0
-Kings,47057,State Senate,SD23,Con,Lisa Grey,13
-Kings,47058,State Senate,SD23,Con,Lisa Grey,11
-Kings,47059,State Senate,SD23,Con,Lisa Grey,4
-Kings,47060,State Senate,SD23,Con,Lisa Grey,2
-Kings,47061,State Senate,SD23,Con,Lisa Grey,4
-Kings,47062,State Senate,SD23,Con,Lisa Grey,8
-Kings,47063,State Senate,SD23,Con,Lisa Grey,10
-Kings,47064,State Senate,SD23,Con,Lisa Grey,13
-Kings,49034,State Senate,SD23,Con,Lisa Grey,0
-Kings,49036,State Senate,SD23,Con,Lisa Grey,0
-Kings,49044,State Senate,SD23,Con,Lisa Grey,1
-Kings,49055,State Senate,SD23,Con,Lisa Grey,9
-Kings,51025,State Senate,SD23,Con,Lisa Grey,0
-Kings,51026,State Senate,SD23,Con,Lisa Grey,25
-Kings,51027,State Senate,SD23,Con,Lisa Grey,4
-Kings,51056,State Senate,SD23,Con,Lisa Grey,1
-Kings,51057,State Senate,SD23,Con,Lisa Grey,0
-Kings,51058,State Senate,SD23,Con,Lisa Grey,1
-Kings,51060,State Senate,SD23,Con,Lisa Grey,13
-Kings,64081,State Senate,SD23,Con,Lisa Grey,10
-Kings,64082,State Senate,SD23,Con,Lisa Grey,1
-Kings,41085,State Senate,SD23,Ind,writein,0
-Kings,41087,State Senate,SD23,Ind,writein,0
-Kings,41088,State Senate,SD23,Ind,writein,0
-Kings,41089,State Senate,SD23,Ind,writein,0
-Kings,41092,State Senate,SD23,Ind,writein,0
-Kings,45040,State Senate,SD23,Ind,writein,1
-Kings,45042,State Senate,SD23,Ind,writein,0
-Kings,45043,State Senate,SD23,Ind,writein,0
-Kings,45044,State Senate,SD23,Ind,writein,0
-Kings,45045,State Senate,SD23,Ind,writein,0
-Kings,45046,State Senate,SD23,Ind,writein,0
-Kings,45047,State Senate,SD23,Ind,writein,0
-Kings,45048,State Senate,SD23,Ind,writein,0
-Kings,45050,State Senate,SD23,Ind,writein,0
-Kings,45053,State Senate,SD23,Ind,writein,0
-Kings,45054,State Senate,SD23,Ind,writein,0
-Kings,45057,State Senate,SD23,Ind,writein,0
-Kings,45058,State Senate,SD23,Ind,writein,0
-Kings,45059,State Senate,SD23,Ind,writein,0
-Kings,45060,State Senate,SD23,Ind,writein,1
-Kings,45061,State Senate,SD23,Ind,writein,0
-Kings,45062,State Senate,SD23,Ind,writein,0
-Kings,45063,State Senate,SD23,Ind,writein,0
-Kings,45064,State Senate,SD23,Ind,writein,0
-Kings,45065,State Senate,SD23,Ind,writein,0
-Kings,45066,State Senate,SD23,Ind,writein,0
-Kings,45074,State Senate,SD23,Ind,writein,0
-Kings,45075,State Senate,SD23,Ind,writein,0
-Kings,45076,State Senate,SD23,Ind,writein,0
-Kings,45077,State Senate,SD23,Ind,writein,0
-Kings,45078,State Senate,SD23,Ind,writein,0
-Kings,46001,State Senate,SD23,Ind,writein,0
-Kings,46002,State Senate,SD23,Ind,writein,1
-Kings,46003,State Senate,SD23,Ind,writein,1
-Kings,46004,State Senate,SD23,Ind,writein,0
-Kings,46005,State Senate,SD23,Ind,writein,0
-Kings,46006,State Senate,SD23,Ind,writein,0
-Kings,46007,State Senate,SD23,Ind,writein,0
-Kings,46008,State Senate,SD23,Ind,writein,0
-Kings,46009,State Senate,SD23,Ind,writein,0
-Kings,46010,State Senate,SD23,Ind,writein,0
-Kings,46011,State Senate,SD23,Ind,writein,1
-Kings,46012,State Senate,SD23,Ind,writein,0
-Kings,46013,State Senate,SD23,Ind,writein,0
-Kings,46014,State Senate,SD23,Ind,writein,0
-Kings,46015,State Senate,SD23,Ind,writein,0
-Kings,46016,State Senate,SD23,Ind,writein,0
-Kings,46017,State Senate,SD23,Ind,writein,0
-Kings,46018,State Senate,SD23,Ind,writein,0
-Kings,46019,State Senate,SD23,Ind,writein,0
-Kings,46020,State Senate,SD23,Ind,writein,0
-Kings,46021,State Senate,SD23,Ind,writein,0
-Kings,46022,State Senate,SD23,Ind,writein,1
-Kings,46023,State Senate,SD23,Ind,writein,0
-Kings,46024,State Senate,SD23,Ind,writein,0
-Kings,46025,State Senate,SD23,Ind,writein,0
-Kings,46026,State Senate,SD23,Ind,writein,0
-Kings,46027,State Senate,SD23,Ind,writein,0
-Kings,46028,State Senate,SD23,Ind,writein,0
-Kings,46029,State Senate,SD23,Ind,writein,0
-Kings,46030,State Senate,SD23,Ind,writein,0
-Kings,46037,State Senate,SD23,Ind,writein,0
-Kings,46038,State Senate,SD23,Ind,writein,2
-Kings,46039,State Senate,SD23,Ind,writein,0
-Kings,46040,State Senate,SD23,Ind,writein,0
-Kings,46043,State Senate,SD23,Ind,writein,0
-Kings,46044,State Senate,SD23,Ind,writein,0
-Kings,46045,State Senate,SD23,Ind,writein,0
-Kings,46046,State Senate,SD23,Ind,writein,0
-Kings,46077,State Senate,SD23,Ind,writein,0
-Kings,47004,State Senate,SD23,Ind,writein,0
-Kings,47010,State Senate,SD23,Ind,writein,1
-Kings,47011,State Senate,SD23,Ind,writein,0
-Kings,47012,State Senate,SD23,Ind,writein,3
-Kings,47013,State Senate,SD23,Ind,writein,0
-Kings,47014,State Senate,SD23,Ind,writein,0
-Kings,47015,State Senate,SD23,Ind,writein,0
-Kings,47016,State Senate,SD23,Ind,writein,0
-Kings,47017,State Senate,SD23,Ind,writein,0
-Kings,47018,State Senate,SD23,Ind,writein,0
-Kings,47035,State Senate,SD23,Ind,writein,0
-Kings,47036,State Senate,SD23,Ind,writein,0
-Kings,47037,State Senate,SD23,Ind,writein,1
-Kings,47040,State Senate,SD23,Ind,writein,0
-Kings,47041,State Senate,SD23,Ind,writein,0
-Kings,47042,State Senate,SD23,Ind,writein,0
-Kings,47053,State Senate,SD23,Ind,writein,0
-Kings,47054,State Senate,SD23,Ind,writein,1
-Kings,47057,State Senate,SD23,Ind,writein,0
-Kings,47058,State Senate,SD23,Ind,writein,0
-Kings,47059,State Senate,SD23,Ind,writein,0
-Kings,47060,State Senate,SD23,Ind,writein,0
-Kings,47061,State Senate,SD23,Ind,writein,0
-Kings,47062,State Senate,SD23,Ind,writein,1
-Kings,47063,State Senate,SD23,Ind,writein,0
-Kings,47064,State Senate,SD23,Ind,writein,2
-Kings,49034,State Senate,SD23,Ind,writein,0
-Kings,49036,State Senate,SD23,Ind,writein,0
-Kings,49044,State Senate,SD23,Ind,writein,0
-Kings,49055,State Senate,SD23,Ind,writein,0
-Kings,51025,State Senate,SD23,Ind,writein,0
-Kings,51026,State Senate,SD23,Ind,writein,0
-Kings,51027,State Senate,SD23,Ind,writein,1
-Kings,51056,State Senate,SD23,Ind,writein,0
-Kings,51057,State Senate,SD23,Ind,writein,0
-Kings,51058,State Senate,SD23,Ind,writein,0
-Kings,51060,State Senate,SD23,Ind,writein,1
-Kings,64081,State Senate,SD23,Ind,writein,0
-Kings,64082,State Senate,SD23,Ind,writein,0
-Kings,43045,State Senate,SD25,Rep,John Jasilli,11
-Kings,43046,State Senate,SD25,Rep,John Jasilli,4
-Kings,43047,State Senate,SD25,Rep,John Jasilli,5
-Kings,43048,State Senate,SD25,Rep,John Jasilli,9
-Kings,43049,State Senate,SD25,Rep,John Jasilli,4
-Kings,43050,State Senate,SD25,Rep,John Jasilli,4
-Kings,43051,State Senate,SD25,Rep,John Jasilli,11
-Kings,50083,State Senate,SD25,Rep,John Jasilli,52
-Kings,50085,State Senate,SD25,Rep,John Jasilli,5
-Kings,50086,State Senate,SD25,Rep,John Jasilli,0
-Kings,50089,State Senate,SD25,Rep,John Jasilli,13
-Kings,50090,State Senate,SD25,Rep,John Jasilli,4
-Kings,50091,State Senate,SD25,Rep,John Jasilli,20
-Kings,50092,State Senate,SD25,Rep,John Jasilli,12
-Kings,50093,State Senate,SD25,Rep,John Jasilli,2
-Kings,50095,State Senate,SD25,Rep,John Jasilli,1
-Kings,50097,State Senate,SD25,Rep,John Jasilli,1
-Kings,51008,State Senate,SD25,Rep,John Jasilli,12
-Kings,51044,State Senate,SD25,Rep,John Jasilli,6
-Kings,51045,State Senate,SD25,Rep,John Jasilli,0
-Kings,51046,State Senate,SD25,Rep,John Jasilli,2
-Kings,51048,State Senate,SD25,Rep,John Jasilli,1
-Kings,51049,State Senate,SD25,Rep,John Jasilli,2
-Kings,51050,State Senate,SD25,Rep,John Jasilli,5
-Kings,51051,State Senate,SD25,Rep,John Jasilli,34
-Kings,51052,State Senate,SD25,Rep,John Jasilli,17
-Kings,51053,State Senate,SD25,Rep,John Jasilli,20
-Kings,51055,State Senate,SD25,Rep,John Jasilli,26
-Kings,51069,State Senate,SD25,Rep,John Jasilli,4
-Kings,51070,State Senate,SD25,Rep,John Jasilli,10
-Kings,51071,State Senate,SD25,Rep,John Jasilli,6
-Kings,51072,State Senate,SD25,Rep,John Jasilli,4
-Kings,51073,State Senate,SD25,Rep,John Jasilli,7
-Kings,51074,State Senate,SD25,Rep,John Jasilli,4
-Kings,51075,State Senate,SD25,Rep,John Jasilli,6
-Kings,51076,State Senate,SD25,Rep,John Jasilli,6
-Kings,51078,State Senate,SD25,Rep,John Jasilli,6
-Kings,52022,State Senate,SD25,Rep,John Jasilli,17
-Kings,52023,State Senate,SD25,Rep,John Jasilli,73
-Kings,52024,State Senate,SD25,Rep,John Jasilli,48
-Kings,52025,State Senate,SD25,Rep,John Jasilli,56
-Kings,52026,State Senate,SD25,Rep,John Jasilli,1
-Kings,52027,State Senate,SD25,Rep,John Jasilli,5
-Kings,52028,State Senate,SD25,Rep,John Jasilli,38
-Kings,52029,State Senate,SD25,Rep,John Jasilli,59
-Kings,52030,State Senate,SD25,Rep,John Jasilli,51
-Kings,52031,State Senate,SD25,Rep,John Jasilli,24
-Kings,52032,State Senate,SD25,Rep,John Jasilli,32
-Kings,52033,State Senate,SD25,Rep,John Jasilli,21
-Kings,52048,State Senate,SD25,Rep,John Jasilli,29
-Kings,52049,State Senate,SD25,Rep,John Jasilli,34
-Kings,52050,State Senate,SD25,Rep,John Jasilli,15
-Kings,52051,State Senate,SD25,Rep,John Jasilli,5
-Kings,52052,State Senate,SD25,Rep,John Jasilli,8
-Kings,52053,State Senate,SD25,Rep,John Jasilli,15
-Kings,52054,State Senate,SD25,Rep,John Jasilli,7
-Kings,52055,State Senate,SD25,Rep,John Jasilli,22
-Kings,52056,State Senate,SD25,Rep,John Jasilli,16
-Kings,52057,State Senate,SD25,Rep,John Jasilli,26
-Kings,52058,State Senate,SD25,Rep,John Jasilli,33
-Kings,52059,State Senate,SD25,Rep,John Jasilli,24
-Kings,52060,State Senate,SD25,Rep,John Jasilli,18
-Kings,52061,State Senate,SD25,Rep,John Jasilli,24
-Kings,52062,State Senate,SD25,Rep,John Jasilli,25
-Kings,52063,State Senate,SD25,Rep,John Jasilli,2
-Kings,52089,State Senate,SD25,Rep,John Jasilli,42
-Kings,52090,State Senate,SD25,Rep,John Jasilli,29
-Kings,52091,State Senate,SD25,Rep,John Jasilli,29
-Kings,52095,State Senate,SD25,Rep,John Jasilli,2
-Kings,52096,State Senate,SD25,Rep,John Jasilli,39
-Kings,52097,State Senate,SD25,Rep,John Jasilli,32
-Kings,52098,State Senate,SD25,Rep,John Jasilli,75
-Kings,52099,State Senate,SD25,Rep,John Jasilli,53
-Kings,52100,State Senate,SD25,Rep,John Jasilli,48
-Kings,52102,State Senate,SD25,Rep,John Jasilli,0
-Kings,52108,State Senate,SD25,Rep,John Jasilli,0
-Kings,52109,State Senate,SD25,Rep,John Jasilli,0
-Kings,52112,State Senate,SD25,Rep,John Jasilli,27
-Kings,54015,State Senate,SD25,Rep,John Jasilli,3
-Kings,54026,State Senate,SD25,Rep,John Jasilli,0
-Kings,55002,State Senate,SD25,Rep,John Jasilli,3
-Kings,55004,State Senate,SD25,Rep,John Jasilli,3
-Kings,55008,State Senate,SD25,Rep,John Jasilli,0
-Kings,55009,State Senate,SD25,Rep,John Jasilli,3
-Kings,55010,State Senate,SD25,Rep,John Jasilli,2
-Kings,55011,State Senate,SD25,Rep,John Jasilli,5
-Kings,55012,State Senate,SD25,Rep,John Jasilli,3
-Kings,55017,State Senate,SD25,Rep,John Jasilli,1
-Kings,55018,State Senate,SD25,Rep,John Jasilli,5
-Kings,55019,State Senate,SD25,Rep,John Jasilli,2
-Kings,55020,State Senate,SD25,Rep,John Jasilli,6
-Kings,55021,State Senate,SD25,Rep,John Jasilli,3
-Kings,55022,State Senate,SD25,Rep,John Jasilli,1
-Kings,55023,State Senate,SD25,Rep,John Jasilli,4
-Kings,55024,State Senate,SD25,Rep,John Jasilli,4
-Kings,55025,State Senate,SD25,Rep,John Jasilli,3
-Kings,55028,State Senate,SD25,Rep,John Jasilli,3
-Kings,55029,State Senate,SD25,Rep,John Jasilli,0
-Kings,55030,State Senate,SD25,Rep,John Jasilli,2
-Kings,55031,State Senate,SD25,Rep,John Jasilli,3
-Kings,55032,State Senate,SD25,Rep,John Jasilli,2
-Kings,55033,State Senate,SD25,Rep,John Jasilli,5
-Kings,55034,State Senate,SD25,Rep,John Jasilli,3
-Kings,55101,State Senate,SD25,Rep,John Jasilli,4
-Kings,55102,State Senate,SD25,Rep,John Jasilli,3
-Kings,55103,State Senate,SD25,Rep,John Jasilli,2
-Kings,55104,State Senate,SD25,Rep,John Jasilli,5
-Kings,56012,State Senate,SD25,Rep,John Jasilli,4
-Kings,56013,State Senate,SD25,Rep,John Jasilli,6
-Kings,56014,State Senate,SD25,Rep,John Jasilli,10
-Kings,56015,State Senate,SD25,Rep,John Jasilli,5
-Kings,56016,State Senate,SD25,Rep,John Jasilli,10
-Kings,56018,State Senate,SD25,Rep,John Jasilli,4
-Kings,56019,State Senate,SD25,Rep,John Jasilli,2
-Kings,56021,State Senate,SD25,Rep,John Jasilli,0
-Kings,56022,State Senate,SD25,Rep,John Jasilli,1
-Kings,56023,State Senate,SD25,Rep,John Jasilli,0
-Kings,56024,State Senate,SD25,Rep,John Jasilli,8
-Kings,56025,State Senate,SD25,Rep,John Jasilli,5
-Kings,56026,State Senate,SD25,Rep,John Jasilli,8
-Kings,56027,State Senate,SD25,Rep,John Jasilli,2
-Kings,56028,State Senate,SD25,Rep,John Jasilli,4
-Kings,56029,State Senate,SD25,Rep,John Jasilli,6
-Kings,56030,State Senate,SD25,Rep,John Jasilli,0
-Kings,56031,State Senate,SD25,Rep,John Jasilli,9
-Kings,56032,State Senate,SD25,Rep,John Jasilli,7
-Kings,56033,State Senate,SD25,Rep,John Jasilli,4
-Kings,56034,State Senate,SD25,Rep,John Jasilli,4
-Kings,56035,State Senate,SD25,Rep,John Jasilli,6
-Kings,56036,State Senate,SD25,Rep,John Jasilli,3
-Kings,56037,State Senate,SD25,Rep,John Jasilli,6
-Kings,56038,State Senate,SD25,Rep,John Jasilli,4
-Kings,56039,State Senate,SD25,Rep,John Jasilli,4
-Kings,56040,State Senate,SD25,Rep,John Jasilli,9
-Kings,56041,State Senate,SD25,Rep,John Jasilli,6
-Kings,56042,State Senate,SD25,Rep,John Jasilli,3
-Kings,56043,State Senate,SD25,Rep,John Jasilli,3
-Kings,56044,State Senate,SD25,Rep,John Jasilli,0
-Kings,56045,State Senate,SD25,Rep,John Jasilli,1
-Kings,56046,State Senate,SD25,Rep,John Jasilli,7
-Kings,56047,State Senate,SD25,Rep,John Jasilli,8
-Kings,56048,State Senate,SD25,Rep,John Jasilli,5
-Kings,56049,State Senate,SD25,Rep,John Jasilli,4
-Kings,56050,State Senate,SD25,Rep,John Jasilli,7
-Kings,56051,State Senate,SD25,Rep,John Jasilli,9
-Kings,56052,State Senate,SD25,Rep,John Jasilli,2
-Kings,56053,State Senate,SD25,Rep,John Jasilli,6
-Kings,56054,State Senate,SD25,Rep,John Jasilli,8
-Kings,56055,State Senate,SD25,Rep,John Jasilli,15
-Kings,56056,State Senate,SD25,Rep,John Jasilli,2
-Kings,56057,State Senate,SD25,Rep,John Jasilli,7
-Kings,56058,State Senate,SD25,Rep,John Jasilli,5
-Kings,56059,State Senate,SD25,Rep,John Jasilli,4
-Kings,56060,State Senate,SD25,Rep,John Jasilli,1
-Kings,56061,State Senate,SD25,Rep,John Jasilli,0
-Kings,56062,State Senate,SD25,Rep,John Jasilli,1
-Kings,56063,State Senate,SD25,Rep,John Jasilli,0
-Kings,56064,State Senate,SD25,Rep,John Jasilli,6
-Kings,56065,State Senate,SD25,Rep,John Jasilli,2
-Kings,56066,State Senate,SD25,Rep,John Jasilli,0
-Kings,56068,State Senate,SD25,Rep,John Jasilli,7
-Kings,56069,State Senate,SD25,Rep,John Jasilli,4
-Kings,56070,State Senate,SD25,Rep,John Jasilli,9
-Kings,56071,State Senate,SD25,Rep,John Jasilli,9
-Kings,56072,State Senate,SD25,Rep,John Jasilli,4
-Kings,56074,State Senate,SD25,Rep,John Jasilli,1
-Kings,57001,State Senate,SD25,Rep,John Jasilli,6
-Kings,57002,State Senate,SD25,Rep,John Jasilli,3
-Kings,57003,State Senate,SD25,Rep,John Jasilli,4
-Kings,57004,State Senate,SD25,Rep,John Jasilli,25
-Kings,57006,State Senate,SD25,Rep,John Jasilli,2
-Kings,57007,State Senate,SD25,Rep,John Jasilli,6
-Kings,57008,State Senate,SD25,Rep,John Jasilli,5
-Kings,57009,State Senate,SD25,Rep,John Jasilli,42
-Kings,57010,State Senate,SD25,Rep,John Jasilli,26
-Kings,57011,State Senate,SD25,Rep,John Jasilli,16
-Kings,57012,State Senate,SD25,Rep,John Jasilli,0
-Kings,57013,State Senate,SD25,Rep,John Jasilli,2
-Kings,57014,State Senate,SD25,Rep,John Jasilli,4
-Kings,57015,State Senate,SD25,Rep,John Jasilli,12
-Kings,57016,State Senate,SD25,Rep,John Jasilli,17
-Kings,57017,State Senate,SD25,Rep,John Jasilli,22
-Kings,57018,State Senate,SD25,Rep,John Jasilli,12
-Kings,57019,State Senate,SD25,Rep,John Jasilli,14
-Kings,57020,State Senate,SD25,Rep,John Jasilli,1
-Kings,57021,State Senate,SD25,Rep,John Jasilli,18
-Kings,57022,State Senate,SD25,Rep,John Jasilli,16
-Kings,57023,State Senate,SD25,Rep,John Jasilli,22
-Kings,57024,State Senate,SD25,Rep,John Jasilli,19
-Kings,57025,State Senate,SD25,Rep,John Jasilli,30
-Kings,57026,State Senate,SD25,Rep,John Jasilli,18
-Kings,57027,State Senate,SD25,Rep,John Jasilli,25
-Kings,57028,State Senate,SD25,Rep,John Jasilli,17
-Kings,57029,State Senate,SD25,Rep,John Jasilli,13
-Kings,57030,State Senate,SD25,Rep,John Jasilli,2
-Kings,57031,State Senate,SD25,Rep,John Jasilli,9
-Kings,57032,State Senate,SD25,Rep,John Jasilli,6
-Kings,57033,State Senate,SD25,Rep,John Jasilli,8
-Kings,57034,State Senate,SD25,Rep,John Jasilli,9
-Kings,57035,State Senate,SD25,Rep,John Jasilli,6
-Kings,57036,State Senate,SD25,Rep,John Jasilli,10
-Kings,57037,State Senate,SD25,Rep,John Jasilli,9
-Kings,57038,State Senate,SD25,Rep,John Jasilli,12
-Kings,57039,State Senate,SD25,Rep,John Jasilli,7
-Kings,57040,State Senate,SD25,Rep,John Jasilli,13
-Kings,57041,State Senate,SD25,Rep,John Jasilli,14
-Kings,57042,State Senate,SD25,Rep,John Jasilli,12
-Kings,57043,State Senate,SD25,Rep,John Jasilli,23
-Kings,57044,State Senate,SD25,Rep,John Jasilli,9
-Kings,57045,State Senate,SD25,Rep,John Jasilli,8
-Kings,57046,State Senate,SD25,Rep,John Jasilli,3
-Kings,57047,State Senate,SD25,Rep,John Jasilli,12
-Kings,57048,State Senate,SD25,Rep,John Jasilli,9
-Kings,57049,State Senate,SD25,Rep,John Jasilli,2
-Kings,57050,State Senate,SD25,Rep,John Jasilli,6
-Kings,57051,State Senate,SD25,Rep,John Jasilli,13
-Kings,57052,State Senate,SD25,Rep,John Jasilli,7
-Kings,57053,State Senate,SD25,Rep,John Jasilli,8
-Kings,57054,State Senate,SD25,Rep,John Jasilli,5
-Kings,57055,State Senate,SD25,Rep,John Jasilli,9
-Kings,57056,State Senate,SD25,Rep,John Jasilli,3
-Kings,57057,State Senate,SD25,Rep,John Jasilli,11
-Kings,57058,State Senate,SD25,Rep,John Jasilli,7
-Kings,57059,State Senate,SD25,Rep,John Jasilli,8
-Kings,57060,State Senate,SD25,Rep,John Jasilli,18
-Kings,57061,State Senate,SD25,Rep,John Jasilli,28
-Kings,57062,State Senate,SD25,Rep,John Jasilli,5
-Kings,57063,State Senate,SD25,Rep,John Jasilli,13
-Kings,57064,State Senate,SD25,Rep,John Jasilli,12
-Kings,57065,State Senate,SD25,Rep,John Jasilli,11
-Kings,57066,State Senate,SD25,Rep,John Jasilli,6
-Kings,43045,State Senate,SD25,Con,John Jasilli,0
-Kings,43046,State Senate,SD25,Con,John Jasilli,0
-Kings,43047,State Senate,SD25,Con,John Jasilli,0
-Kings,43048,State Senate,SD25,Con,John Jasilli,3
-Kings,43049,State Senate,SD25,Con,John Jasilli,0
-Kings,43050,State Senate,SD25,Con,John Jasilli,2
-Kings,43051,State Senate,SD25,Con,John Jasilli,1
-Kings,50083,State Senate,SD25,Con,John Jasilli,7
-Kings,50085,State Senate,SD25,Con,John Jasilli,0
-Kings,50086,State Senate,SD25,Con,John Jasilli,0
-Kings,50089,State Senate,SD25,Con,John Jasilli,3
-Kings,50090,State Senate,SD25,Con,John Jasilli,2
-Kings,50091,State Senate,SD25,Con,John Jasilli,5
-Kings,50092,State Senate,SD25,Con,John Jasilli,1
-Kings,50093,State Senate,SD25,Con,John Jasilli,0
-Kings,50095,State Senate,SD25,Con,John Jasilli,0
-Kings,50097,State Senate,SD25,Con,John Jasilli,0
-Kings,51008,State Senate,SD25,Con,John Jasilli,0
-Kings,51044,State Senate,SD25,Con,John Jasilli,4
-Kings,51045,State Senate,SD25,Con,John Jasilli,0
-Kings,51046,State Senate,SD25,Con,John Jasilli,0
-Kings,51048,State Senate,SD25,Con,John Jasilli,0
-Kings,51049,State Senate,SD25,Con,John Jasilli,0
-Kings,51050,State Senate,SD25,Con,John Jasilli,3
-Kings,51051,State Senate,SD25,Con,John Jasilli,8
-Kings,51052,State Senate,SD25,Con,John Jasilli,6
-Kings,51053,State Senate,SD25,Con,John Jasilli,3
-Kings,51055,State Senate,SD25,Con,John Jasilli,0
-Kings,51069,State Senate,SD25,Con,John Jasilli,0
-Kings,51070,State Senate,SD25,Con,John Jasilli,0
-Kings,51071,State Senate,SD25,Con,John Jasilli,3
-Kings,51072,State Senate,SD25,Con,John Jasilli,0
-Kings,51073,State Senate,SD25,Con,John Jasilli,3
-Kings,51074,State Senate,SD25,Con,John Jasilli,1
-Kings,51075,State Senate,SD25,Con,John Jasilli,0
-Kings,51076,State Senate,SD25,Con,John Jasilli,2
-Kings,51078,State Senate,SD25,Con,John Jasilli,0
-Kings,52022,State Senate,SD25,Con,John Jasilli,0
-Kings,52023,State Senate,SD25,Con,John Jasilli,12
-Kings,52024,State Senate,SD25,Con,John Jasilli,2
-Kings,52025,State Senate,SD25,Con,John Jasilli,4
-Kings,52026,State Senate,SD25,Con,John Jasilli,0
-Kings,52027,State Senate,SD25,Con,John Jasilli,0
-Kings,52028,State Senate,SD25,Con,John Jasilli,5
-Kings,52029,State Senate,SD25,Con,John Jasilli,9
-Kings,52030,State Senate,SD25,Con,John Jasilli,5
-Kings,52031,State Senate,SD25,Con,John Jasilli,9
-Kings,52032,State Senate,SD25,Con,John Jasilli,9
-Kings,52033,State Senate,SD25,Con,John Jasilli,2
-Kings,52048,State Senate,SD25,Con,John Jasilli,6
-Kings,52049,State Senate,SD25,Con,John Jasilli,11
-Kings,52050,State Senate,SD25,Con,John Jasilli,2
-Kings,52051,State Senate,SD25,Con,John Jasilli,1
-Kings,52052,State Senate,SD25,Con,John Jasilli,1
-Kings,52053,State Senate,SD25,Con,John Jasilli,6
-Kings,52054,State Senate,SD25,Con,John Jasilli,0
-Kings,52055,State Senate,SD25,Con,John Jasilli,4
-Kings,52056,State Senate,SD25,Con,John Jasilli,5
-Kings,52057,State Senate,SD25,Con,John Jasilli,5
-Kings,52058,State Senate,SD25,Con,John Jasilli,6
-Kings,52059,State Senate,SD25,Con,John Jasilli,1
-Kings,52060,State Senate,SD25,Con,John Jasilli,4
-Kings,52061,State Senate,SD25,Con,John Jasilli,3
-Kings,52062,State Senate,SD25,Con,John Jasilli,4
-Kings,52063,State Senate,SD25,Con,John Jasilli,0
-Kings,52089,State Senate,SD25,Con,John Jasilli,7
-Kings,52090,State Senate,SD25,Con,John Jasilli,4
-Kings,52091,State Senate,SD25,Con,John Jasilli,4
-Kings,52095,State Senate,SD25,Con,John Jasilli,0
-Kings,52096,State Senate,SD25,Con,John Jasilli,4
-Kings,52097,State Senate,SD25,Con,John Jasilli,5
-Kings,52098,State Senate,SD25,Con,John Jasilli,19
-Kings,52099,State Senate,SD25,Con,John Jasilli,9
-Kings,52100,State Senate,SD25,Con,John Jasilli,3
-Kings,52102,State Senate,SD25,Con,John Jasilli,0
-Kings,52108,State Senate,SD25,Con,John Jasilli,0
-Kings,52109,State Senate,SD25,Con,John Jasilli,0
-Kings,52112,State Senate,SD25,Con,John Jasilli,7
-Kings,54015,State Senate,SD25,Con,John Jasilli,1
-Kings,54026,State Senate,SD25,Con,John Jasilli,0
-Kings,55002,State Senate,SD25,Con,John Jasilli,0
-Kings,55004,State Senate,SD25,Con,John Jasilli,1
-Kings,55008,State Senate,SD25,Con,John Jasilli,1
-Kings,55009,State Senate,SD25,Con,John Jasilli,0
-Kings,55010,State Senate,SD25,Con,John Jasilli,2
-Kings,55011,State Senate,SD25,Con,John Jasilli,2
-Kings,55012,State Senate,SD25,Con,John Jasilli,0
-Kings,55017,State Senate,SD25,Con,John Jasilli,2
-Kings,55018,State Senate,SD25,Con,John Jasilli,2
-Kings,55019,State Senate,SD25,Con,John Jasilli,0
-Kings,55020,State Senate,SD25,Con,John Jasilli,0
-Kings,55021,State Senate,SD25,Con,John Jasilli,1
-Kings,55022,State Senate,SD25,Con,John Jasilli,2
-Kings,55023,State Senate,SD25,Con,John Jasilli,1
-Kings,55024,State Senate,SD25,Con,John Jasilli,1
-Kings,55025,State Senate,SD25,Con,John Jasilli,0
-Kings,55028,State Senate,SD25,Con,John Jasilli,2
-Kings,55029,State Senate,SD25,Con,John Jasilli,1
-Kings,55030,State Senate,SD25,Con,John Jasilli,1
-Kings,55031,State Senate,SD25,Con,John Jasilli,1
-Kings,55032,State Senate,SD25,Con,John Jasilli,0
-Kings,55033,State Senate,SD25,Con,John Jasilli,3
-Kings,55034,State Senate,SD25,Con,John Jasilli,0
-Kings,55101,State Senate,SD25,Con,John Jasilli,1
-Kings,55102,State Senate,SD25,Con,John Jasilli,2
-Kings,55103,State Senate,SD25,Con,John Jasilli,2
-Kings,55104,State Senate,SD25,Con,John Jasilli,0
-Kings,56012,State Senate,SD25,Con,John Jasilli,3
-Kings,56013,State Senate,SD25,Con,John Jasilli,1
-Kings,56014,State Senate,SD25,Con,John Jasilli,1
-Kings,56015,State Senate,SD25,Con,John Jasilli,4
-Kings,56016,State Senate,SD25,Con,John Jasilli,4
-Kings,56018,State Senate,SD25,Con,John Jasilli,1
-Kings,56019,State Senate,SD25,Con,John Jasilli,0
-Kings,56021,State Senate,SD25,Con,John Jasilli,1
-Kings,56022,State Senate,SD25,Con,John Jasilli,3
-Kings,56023,State Senate,SD25,Con,John Jasilli,0
-Kings,56024,State Senate,SD25,Con,John Jasilli,2
-Kings,56025,State Senate,SD25,Con,John Jasilli,2
-Kings,56026,State Senate,SD25,Con,John Jasilli,0
-Kings,56027,State Senate,SD25,Con,John Jasilli,3
-Kings,56028,State Senate,SD25,Con,John Jasilli,1
-Kings,56029,State Senate,SD25,Con,John Jasilli,2
-Kings,56030,State Senate,SD25,Con,John Jasilli,2
-Kings,56031,State Senate,SD25,Con,John Jasilli,2
-Kings,56032,State Senate,SD25,Con,John Jasilli,2
-Kings,56033,State Senate,SD25,Con,John Jasilli,2
-Kings,56034,State Senate,SD25,Con,John Jasilli,0
-Kings,56035,State Senate,SD25,Con,John Jasilli,4
-Kings,56036,State Senate,SD25,Con,John Jasilli,1
-Kings,56037,State Senate,SD25,Con,John Jasilli,1
-Kings,56038,State Senate,SD25,Con,John Jasilli,0
-Kings,56039,State Senate,SD25,Con,John Jasilli,1
-Kings,56040,State Senate,SD25,Con,John Jasilli,4
-Kings,56041,State Senate,SD25,Con,John Jasilli,1
-Kings,56042,State Senate,SD25,Con,John Jasilli,1
-Kings,56043,State Senate,SD25,Con,John Jasilli,1
-Kings,56044,State Senate,SD25,Con,John Jasilli,2
-Kings,56045,State Senate,SD25,Con,John Jasilli,1
-Kings,56046,State Senate,SD25,Con,John Jasilli,3
-Kings,56047,State Senate,SD25,Con,John Jasilli,1
-Kings,56048,State Senate,SD25,Con,John Jasilli,2
-Kings,56049,State Senate,SD25,Con,John Jasilli,2
-Kings,56050,State Senate,SD25,Con,John Jasilli,3
-Kings,56051,State Senate,SD25,Con,John Jasilli,0
-Kings,56052,State Senate,SD25,Con,John Jasilli,3
-Kings,56053,State Senate,SD25,Con,John Jasilli,3
-Kings,56054,State Senate,SD25,Con,John Jasilli,1
-Kings,56055,State Senate,SD25,Con,John Jasilli,3
-Kings,56056,State Senate,SD25,Con,John Jasilli,0
-Kings,56057,State Senate,SD25,Con,John Jasilli,2
-Kings,56058,State Senate,SD25,Con,John Jasilli,0
-Kings,56059,State Senate,SD25,Con,John Jasilli,0
-Kings,56060,State Senate,SD25,Con,John Jasilli,0
-Kings,56061,State Senate,SD25,Con,John Jasilli,0
-Kings,56062,State Senate,SD25,Con,John Jasilli,1
-Kings,56063,State Senate,SD25,Con,John Jasilli,0
-Kings,56064,State Senate,SD25,Con,John Jasilli,2
-Kings,56065,State Senate,SD25,Con,John Jasilli,0
-Kings,56066,State Senate,SD25,Con,John Jasilli,1
-Kings,56068,State Senate,SD25,Con,John Jasilli,0
-Kings,56069,State Senate,SD25,Con,John Jasilli,2
-Kings,56070,State Senate,SD25,Con,John Jasilli,0
-Kings,56071,State Senate,SD25,Con,John Jasilli,2
-Kings,56072,State Senate,SD25,Con,John Jasilli,1
-Kings,56074,State Senate,SD25,Con,John Jasilli,0
-Kings,57001,State Senate,SD25,Con,John Jasilli,2
-Kings,57002,State Senate,SD25,Con,John Jasilli,1
-Kings,57003,State Senate,SD25,Con,John Jasilli,3
-Kings,57004,State Senate,SD25,Con,John Jasilli,1
-Kings,57006,State Senate,SD25,Con,John Jasilli,1
-Kings,57007,State Senate,SD25,Con,John Jasilli,0
-Kings,57008,State Senate,SD25,Con,John Jasilli,0
-Kings,57009,State Senate,SD25,Con,John Jasilli,2
-Kings,57010,State Senate,SD25,Con,John Jasilli,2
-Kings,57011,State Senate,SD25,Con,John Jasilli,2
-Kings,57012,State Senate,SD25,Con,John Jasilli,1
-Kings,57013,State Senate,SD25,Con,John Jasilli,1
-Kings,57014,State Senate,SD25,Con,John Jasilli,1
-Kings,57015,State Senate,SD25,Con,John Jasilli,3
-Kings,57016,State Senate,SD25,Con,John Jasilli,4
-Kings,57017,State Senate,SD25,Con,John Jasilli,3
-Kings,57018,State Senate,SD25,Con,John Jasilli,2
-Kings,57019,State Senate,SD25,Con,John Jasilli,1
-Kings,57020,State Senate,SD25,Con,John Jasilli,0
-Kings,57021,State Senate,SD25,Con,John Jasilli,6
-Kings,57022,State Senate,SD25,Con,John Jasilli,0
-Kings,57023,State Senate,SD25,Con,John Jasilli,3
-Kings,57024,State Senate,SD25,Con,John Jasilli,5
-Kings,57025,State Senate,SD25,Con,John Jasilli,6
-Kings,57026,State Senate,SD25,Con,John Jasilli,3
-Kings,57027,State Senate,SD25,Con,John Jasilli,2
-Kings,57028,State Senate,SD25,Con,John Jasilli,0
-Kings,57029,State Senate,SD25,Con,John Jasilli,4
-Kings,57030,State Senate,SD25,Con,John Jasilli,2
-Kings,57031,State Senate,SD25,Con,John Jasilli,4
-Kings,57032,State Senate,SD25,Con,John Jasilli,0
-Kings,57033,State Senate,SD25,Con,John Jasilli,3
-Kings,57034,State Senate,SD25,Con,John Jasilli,1
-Kings,57035,State Senate,SD25,Con,John Jasilli,3
-Kings,57036,State Senate,SD25,Con,John Jasilli,2
-Kings,57037,State Senate,SD25,Con,John Jasilli,0
-Kings,57038,State Senate,SD25,Con,John Jasilli,3
-Kings,57039,State Senate,SD25,Con,John Jasilli,2
-Kings,57040,State Senate,SD25,Con,John Jasilli,1
-Kings,57041,State Senate,SD25,Con,John Jasilli,1
-Kings,57042,State Senate,SD25,Con,John Jasilli,1
-Kings,57043,State Senate,SD25,Con,John Jasilli,2
-Kings,57044,State Senate,SD25,Con,John Jasilli,4
-Kings,57045,State Senate,SD25,Con,John Jasilli,0
-Kings,57046,State Senate,SD25,Con,John Jasilli,0
-Kings,57047,State Senate,SD25,Con,John Jasilli,0
-Kings,57048,State Senate,SD25,Con,John Jasilli,1
-Kings,57049,State Senate,SD25,Con,John Jasilli,1
-Kings,57050,State Senate,SD25,Con,John Jasilli,1
-Kings,57051,State Senate,SD25,Con,John Jasilli,1
-Kings,57052,State Senate,SD25,Con,John Jasilli,1
-Kings,57053,State Senate,SD25,Con,John Jasilli,1
-Kings,57054,State Senate,SD25,Con,John Jasilli,4
-Kings,57055,State Senate,SD25,Con,John Jasilli,1
-Kings,57056,State Senate,SD25,Con,John Jasilli,1
-Kings,57057,State Senate,SD25,Con,John Jasilli,0
-Kings,57058,State Senate,SD25,Con,John Jasilli,1
-Kings,57059,State Senate,SD25,Con,John Jasilli,2
-Kings,57060,State Senate,SD25,Con,John Jasilli,5
-Kings,57061,State Senate,SD25,Con,John Jasilli,0
-Kings,57062,State Senate,SD25,Con,John Jasilli,0
-Kings,57063,State Senate,SD25,Con,John Jasilli,0
-Kings,57064,State Senate,SD25,Con,John Jasilli,0
-Kings,57065,State Senate,SD25,Con,John Jasilli,2
-Kings,57066,State Senate,SD25,Con,John Jasilli,1
-Kings,43045,State Senate,SD25,Dem,Velmanette Montgomery,623
-Kings,43046,State Senate,SD25,Dem,Velmanette Montgomery,612
-Kings,43047,State Senate,SD25,Dem,Velmanette Montgomery,407
-Kings,43048,State Senate,SD25,Dem,Velmanette Montgomery,537
-Kings,43049,State Senate,SD25,Dem,Velmanette Montgomery,593
-Kings,43050,State Senate,SD25,Dem,Velmanette Montgomery,599
-Kings,43051,State Senate,SD25,Dem,Velmanette Montgomery,588
-Kings,50083,State Senate,SD25,Dem,Velmanette Montgomery,275
-Kings,50085,State Senate,SD25,Dem,Velmanette Montgomery,131
-Kings,50086,State Senate,SD25,Dem,Velmanette Montgomery,56
-Kings,50089,State Senate,SD25,Dem,Velmanette Montgomery,453
-Kings,50090,State Senate,SD25,Dem,Velmanette Montgomery,257
-Kings,50091,State Senate,SD25,Dem,Velmanette Montgomery,587
-Kings,50092,State Senate,SD25,Dem,Velmanette Montgomery,333
-Kings,50093,State Senate,SD25,Dem,Velmanette Montgomery,80
-Kings,50095,State Senate,SD25,Dem,Velmanette Montgomery,111
-Kings,50097,State Senate,SD25,Dem,Velmanette Montgomery,195
-Kings,51008,State Senate,SD25,Dem,Velmanette Montgomery,146
-Kings,51044,State Senate,SD25,Dem,Velmanette Montgomery,100
-Kings,51045,State Senate,SD25,Dem,Velmanette Montgomery,22
-Kings,51046,State Senate,SD25,Dem,Velmanette Montgomery,34
-Kings,51048,State Senate,SD25,Dem,Velmanette Montgomery,2
-Kings,51049,State Senate,SD25,Dem,Velmanette Montgomery,32
-Kings,51050,State Senate,SD25,Dem,Velmanette Montgomery,113
-Kings,51051,State Senate,SD25,Dem,Velmanette Montgomery,257
-Kings,51052,State Senate,SD25,Dem,Velmanette Montgomery,312
-Kings,51053,State Senate,SD25,Dem,Velmanette Montgomery,180
-Kings,51055,State Senate,SD25,Dem,Velmanette Montgomery,297
-Kings,51069,State Senate,SD25,Dem,Velmanette Montgomery,277
-Kings,51070,State Senate,SD25,Dem,Velmanette Montgomery,459
-Kings,51071,State Senate,SD25,Dem,Velmanette Montgomery,412
-Kings,51072,State Senate,SD25,Dem,Velmanette Montgomery,162
-Kings,51073,State Senate,SD25,Dem,Velmanette Montgomery,314
-Kings,51074,State Senate,SD25,Dem,Velmanette Montgomery,345
-Kings,51075,State Senate,SD25,Dem,Velmanette Montgomery,131
-Kings,51076,State Senate,SD25,Dem,Velmanette Montgomery,240
-Kings,51078,State Senate,SD25,Dem,Velmanette Montgomery,70
-Kings,52022,State Senate,SD25,Dem,Velmanette Montgomery,220
-Kings,52023,State Senate,SD25,Dem,Velmanette Montgomery,665
-Kings,52024,State Senate,SD25,Dem,Velmanette Montgomery,249
-Kings,52025,State Senate,SD25,Dem,Velmanette Montgomery,358
-Kings,52026,State Senate,SD25,Dem,Velmanette Montgomery,12
-Kings,52027,State Senate,SD25,Dem,Velmanette Montgomery,76
-Kings,52028,State Senate,SD25,Dem,Velmanette Montgomery,400
-Kings,52029,State Senate,SD25,Dem,Velmanette Montgomery,628
-Kings,52030,State Senate,SD25,Dem,Velmanette Montgomery,663
-Kings,52031,State Senate,SD25,Dem,Velmanette Montgomery,502
-Kings,52032,State Senate,SD25,Dem,Velmanette Montgomery,532
-Kings,52033,State Senate,SD25,Dem,Velmanette Montgomery,570
-Kings,52048,State Senate,SD25,Dem,Velmanette Montgomery,483
-Kings,52049,State Senate,SD25,Dem,Velmanette Montgomery,560
-Kings,52050,State Senate,SD25,Dem,Velmanette Montgomery,173
-Kings,52051,State Senate,SD25,Dem,Velmanette Montgomery,500
-Kings,52052,State Senate,SD25,Dem,Velmanette Montgomery,489
-Kings,52053,State Senate,SD25,Dem,Velmanette Montgomery,466
-Kings,52054,State Senate,SD25,Dem,Velmanette Montgomery,363
-Kings,52055,State Senate,SD25,Dem,Velmanette Montgomery,556
-Kings,52056,State Senate,SD25,Dem,Velmanette Montgomery,308
-Kings,52057,State Senate,SD25,Dem,Velmanette Montgomery,331
-Kings,52058,State Senate,SD25,Dem,Velmanette Montgomery,497
-Kings,52059,State Senate,SD25,Dem,Velmanette Montgomery,337
-Kings,52060,State Senate,SD25,Dem,Velmanette Montgomery,539
-Kings,52061,State Senate,SD25,Dem,Velmanette Montgomery,538
-Kings,52062,State Senate,SD25,Dem,Velmanette Montgomery,548
-Kings,52063,State Senate,SD25,Dem,Velmanette Montgomery,31
-Kings,52089,State Senate,SD25,Dem,Velmanette Montgomery,587
-Kings,52090,State Senate,SD25,Dem,Velmanette Montgomery,451
-Kings,52091,State Senate,SD25,Dem,Velmanette Montgomery,222
-Kings,52095,State Senate,SD25,Dem,Velmanette Montgomery,76
-Kings,52096,State Senate,SD25,Dem,Velmanette Montgomery,452
-Kings,52097,State Senate,SD25,Dem,Velmanette Montgomery,321
-Kings,52098,State Senate,SD25,Dem,Velmanette Montgomery,481
-Kings,52099,State Senate,SD25,Dem,Velmanette Montgomery,528
-Kings,52100,State Senate,SD25,Dem,Velmanette Montgomery,289
-Kings,52102,State Senate,SD25,Dem,Velmanette Montgomery,6
-Kings,52108,State Senate,SD25,Dem,Velmanette Montgomery,10
-Kings,52109,State Senate,SD25,Dem,Velmanette Montgomery,8
-Kings,52112,State Senate,SD25,Dem,Velmanette Montgomery,262
-Kings,54015,State Senate,SD25,Dem,Velmanette Montgomery,171
-Kings,54026,State Senate,SD25,Dem,Velmanette Montgomery,56
-Kings,55002,State Senate,SD25,Dem,Velmanette Montgomery,217
-Kings,55004,State Senate,SD25,Dem,Velmanette Montgomery,591
-Kings,55008,State Senate,SD25,Dem,Velmanette Montgomery,50
-Kings,55009,State Senate,SD25,Dem,Velmanette Montgomery,468
-Kings,55010,State Senate,SD25,Dem,Velmanette Montgomery,478
-Kings,55011,State Senate,SD25,Dem,Velmanette Montgomery,476
-Kings,55012,State Senate,SD25,Dem,Velmanette Montgomery,445
-Kings,55017,State Senate,SD25,Dem,Velmanette Montgomery,241
-Kings,55018,State Senate,SD25,Dem,Velmanette Montgomery,569
-Kings,55019,State Senate,SD25,Dem,Velmanette Montgomery,590
-Kings,55020,State Senate,SD25,Dem,Velmanette Montgomery,397
-Kings,55021,State Senate,SD25,Dem,Velmanette Montgomery,503
-Kings,55022,State Senate,SD25,Dem,Velmanette Montgomery,464
-Kings,55023,State Senate,SD25,Dem,Velmanette Montgomery,500
-Kings,55024,State Senate,SD25,Dem,Velmanette Montgomery,337
-Kings,55025,State Senate,SD25,Dem,Velmanette Montgomery,407
-Kings,55028,State Senate,SD25,Dem,Velmanette Montgomery,177
-Kings,55029,State Senate,SD25,Dem,Velmanette Montgomery,152
-Kings,55030,State Senate,SD25,Dem,Velmanette Montgomery,240
-Kings,55031,State Senate,SD25,Dem,Velmanette Montgomery,679
-Kings,55032,State Senate,SD25,Dem,Velmanette Montgomery,189
-Kings,55033,State Senate,SD25,Dem,Velmanette Montgomery,520
-Kings,55034,State Senate,SD25,Dem,Velmanette Montgomery,592
-Kings,55101,State Senate,SD25,Dem,Velmanette Montgomery,290
-Kings,55102,State Senate,SD25,Dem,Velmanette Montgomery,482
-Kings,55103,State Senate,SD25,Dem,Velmanette Montgomery,471
-Kings,55104,State Senate,SD25,Dem,Velmanette Montgomery,496
-Kings,56012,State Senate,SD25,Dem,Velmanette Montgomery,488
-Kings,56013,State Senate,SD25,Dem,Velmanette Montgomery,540
-Kings,56014,State Senate,SD25,Dem,Velmanette Montgomery,475
-Kings,56015,State Senate,SD25,Dem,Velmanette Montgomery,553
-Kings,56016,State Senate,SD25,Dem,Velmanette Montgomery,656
-Kings,56018,State Senate,SD25,Dem,Velmanette Montgomery,511
-Kings,56019,State Senate,SD25,Dem,Velmanette Montgomery,517
-Kings,56021,State Senate,SD25,Dem,Velmanette Montgomery,567
-Kings,56022,State Senate,SD25,Dem,Velmanette Montgomery,527
-Kings,56023,State Senate,SD25,Dem,Velmanette Montgomery,605
-Kings,56024,State Senate,SD25,Dem,Velmanette Montgomery,483
-Kings,56025,State Senate,SD25,Dem,Velmanette Montgomery,533
-Kings,56026,State Senate,SD25,Dem,Velmanette Montgomery,497
-Kings,56027,State Senate,SD25,Dem,Velmanette Montgomery,435
-Kings,56028,State Senate,SD25,Dem,Velmanette Montgomery,478
-Kings,56029,State Senate,SD25,Dem,Velmanette Montgomery,557
-Kings,56030,State Senate,SD25,Dem,Velmanette Montgomery,497
-Kings,56031,State Senate,SD25,Dem,Velmanette Montgomery,521
-Kings,56032,State Senate,SD25,Dem,Velmanette Montgomery,573
-Kings,56033,State Senate,SD25,Dem,Velmanette Montgomery,532
-Kings,56034,State Senate,SD25,Dem,Velmanette Montgomery,459
-Kings,56035,State Senate,SD25,Dem,Velmanette Montgomery,488
-Kings,56036,State Senate,SD25,Dem,Velmanette Montgomery,495
-Kings,56037,State Senate,SD25,Dem,Velmanette Montgomery,516
-Kings,56038,State Senate,SD25,Dem,Velmanette Montgomery,508
-Kings,56039,State Senate,SD25,Dem,Velmanette Montgomery,584
-Kings,56040,State Senate,SD25,Dem,Velmanette Montgomery,523
-Kings,56041,State Senate,SD25,Dem,Velmanette Montgomery,644
-Kings,56042,State Senate,SD25,Dem,Velmanette Montgomery,515
-Kings,56043,State Senate,SD25,Dem,Velmanette Montgomery,585
-Kings,56044,State Senate,SD25,Dem,Velmanette Montgomery,510
-Kings,56045,State Senate,SD25,Dem,Velmanette Montgomery,551
-Kings,56046,State Senate,SD25,Dem,Velmanette Montgomery,563
-Kings,56047,State Senate,SD25,Dem,Velmanette Montgomery,561
-Kings,56048,State Senate,SD25,Dem,Velmanette Montgomery,432
-Kings,56049,State Senate,SD25,Dem,Velmanette Montgomery,588
-Kings,56050,State Senate,SD25,Dem,Velmanette Montgomery,534
-Kings,56051,State Senate,SD25,Dem,Velmanette Montgomery,587
-Kings,56052,State Senate,SD25,Dem,Velmanette Montgomery,555
-Kings,56053,State Senate,SD25,Dem,Velmanette Montgomery,492
-Kings,56054,State Senate,SD25,Dem,Velmanette Montgomery,554
-Kings,56055,State Senate,SD25,Dem,Velmanette Montgomery,717
-Kings,56056,State Senate,SD25,Dem,Velmanette Montgomery,177
-Kings,56057,State Senate,SD25,Dem,Velmanette Montgomery,631
-Kings,56058,State Senate,SD25,Dem,Velmanette Montgomery,519
-Kings,56059,State Senate,SD25,Dem,Velmanette Montgomery,446
-Kings,56060,State Senate,SD25,Dem,Velmanette Montgomery,280
-Kings,56061,State Senate,SD25,Dem,Velmanette Montgomery,61
-Kings,56062,State Senate,SD25,Dem,Velmanette Montgomery,621
-Kings,56063,State Senate,SD25,Dem,Velmanette Montgomery,458
-Kings,56064,State Senate,SD25,Dem,Velmanette Montgomery,695
-Kings,56065,State Senate,SD25,Dem,Velmanette Montgomery,268
-Kings,56066,State Senate,SD25,Dem,Velmanette Montgomery,199
-Kings,56068,State Senate,SD25,Dem,Velmanette Montgomery,580
-Kings,56069,State Senate,SD25,Dem,Velmanette Montgomery,574
-Kings,56070,State Senate,SD25,Dem,Velmanette Montgomery,462
-Kings,56071,State Senate,SD25,Dem,Velmanette Montgomery,617
-Kings,56072,State Senate,SD25,Dem,Velmanette Montgomery,796
-Kings,56074,State Senate,SD25,Dem,Velmanette Montgomery,300
-Kings,57001,State Senate,SD25,Dem,Velmanette Montgomery,274
-Kings,57002,State Senate,SD25,Dem,Velmanette Montgomery,469
-Kings,57003,State Senate,SD25,Dem,Velmanette Montgomery,424
-Kings,57004,State Senate,SD25,Dem,Velmanette Montgomery,184
-Kings,57006,State Senate,SD25,Dem,Velmanette Montgomery,464
-Kings,57007,State Senate,SD25,Dem,Velmanette Montgomery,479
-Kings,57008,State Senate,SD25,Dem,Velmanette Montgomery,407
-Kings,57009,State Senate,SD25,Dem,Velmanette Montgomery,472
-Kings,57010,State Senate,SD25,Dem,Velmanette Montgomery,411
-Kings,57011,State Senate,SD25,Dem,Velmanette Montgomery,451
-Kings,57012,State Senate,SD25,Dem,Velmanette Montgomery,458
-Kings,57013,State Senate,SD25,Dem,Velmanette Montgomery,150
-Kings,57014,State Senate,SD25,Dem,Velmanette Montgomery,94
-Kings,57015,State Senate,SD25,Dem,Velmanette Montgomery,466
-Kings,57016,State Senate,SD25,Dem,Velmanette Montgomery,566
-Kings,57017,State Senate,SD25,Dem,Velmanette Montgomery,656
-Kings,57018,State Senate,SD25,Dem,Velmanette Montgomery,652
-Kings,57019,State Senate,SD25,Dem,Velmanette Montgomery,70
-Kings,57020,State Senate,SD25,Dem,Velmanette Montgomery,15
-Kings,57021,State Senate,SD25,Dem,Velmanette Montgomery,611
-Kings,57022,State Senate,SD25,Dem,Velmanette Montgomery,474
-Kings,57023,State Senate,SD25,Dem,Velmanette Montgomery,471
-Kings,57024,State Senate,SD25,Dem,Velmanette Montgomery,553
-Kings,57025,State Senate,SD25,Dem,Velmanette Montgomery,689
-Kings,57026,State Senate,SD25,Dem,Velmanette Montgomery,559
-Kings,57027,State Senate,SD25,Dem,Velmanette Montgomery,673
-Kings,57028,State Senate,SD25,Dem,Velmanette Montgomery,486
-Kings,57029,State Senate,SD25,Dem,Velmanette Montgomery,471
-Kings,57030,State Senate,SD25,Dem,Velmanette Montgomery,446
-Kings,57031,State Senate,SD25,Dem,Velmanette Montgomery,661
-Kings,57032,State Senate,SD25,Dem,Velmanette Montgomery,362
-Kings,57033,State Senate,SD25,Dem,Velmanette Montgomery,566
-Kings,57034,State Senate,SD25,Dem,Velmanette Montgomery,630
-Kings,57035,State Senate,SD25,Dem,Velmanette Montgomery,615
-Kings,57036,State Senate,SD25,Dem,Velmanette Montgomery,546
-Kings,57037,State Senate,SD25,Dem,Velmanette Montgomery,506
-Kings,57038,State Senate,SD25,Dem,Velmanette Montgomery,615
-Kings,57039,State Senate,SD25,Dem,Velmanette Montgomery,677
-Kings,57040,State Senate,SD25,Dem,Velmanette Montgomery,501
-Kings,57041,State Senate,SD25,Dem,Velmanette Montgomery,566
-Kings,57042,State Senate,SD25,Dem,Velmanette Montgomery,505
-Kings,57043,State Senate,SD25,Dem,Velmanette Montgomery,526
-Kings,57044,State Senate,SD25,Dem,Velmanette Montgomery,587
-Kings,57045,State Senate,SD25,Dem,Velmanette Montgomery,491
-Kings,57046,State Senate,SD25,Dem,Velmanette Montgomery,358
-Kings,57047,State Senate,SD25,Dem,Velmanette Montgomery,570
-Kings,57048,State Senate,SD25,Dem,Velmanette Montgomery,538
-Kings,57049,State Senate,SD25,Dem,Velmanette Montgomery,310
-Kings,57050,State Senate,SD25,Dem,Velmanette Montgomery,613
-Kings,57051,State Senate,SD25,Dem,Velmanette Montgomery,529
-Kings,57052,State Senate,SD25,Dem,Velmanette Montgomery,537
-Kings,57053,State Senate,SD25,Dem,Velmanette Montgomery,607
-Kings,57054,State Senate,SD25,Dem,Velmanette Montgomery,469
-Kings,57055,State Senate,SD25,Dem,Velmanette Montgomery,444
-Kings,57056,State Senate,SD25,Dem,Velmanette Montgomery,608
-Kings,57057,State Senate,SD25,Dem,Velmanette Montgomery,539
-Kings,57058,State Senate,SD25,Dem,Velmanette Montgomery,365
-Kings,57059,State Senate,SD25,Dem,Velmanette Montgomery,351
-Kings,57060,State Senate,SD25,Dem,Velmanette Montgomery,358
-Kings,57061,State Senate,SD25,Dem,Velmanette Montgomery,365
-Kings,57062,State Senate,SD25,Dem,Velmanette Montgomery,53
-Kings,57063,State Senate,SD25,Dem,Velmanette Montgomery,556
-Kings,57064,State Senate,SD25,Dem,Velmanette Montgomery,425
-Kings,57065,State Senate,SD25,Dem,Velmanette Montgomery,663
-Kings,57066,State Senate,SD25,Dem,Velmanette Montgomery,475
-Kings,43045,State Senate,SD25,WF,Velmanette Montgomery,41
-Kings,43046,State Senate,SD25,WF,Velmanette Montgomery,28
-Kings,43047,State Senate,SD25,WF,Velmanette Montgomery,19
-Kings,43048,State Senate,SD25,WF,Velmanette Montgomery,21
-Kings,43049,State Senate,SD25,WF,Velmanette Montgomery,12
-Kings,43050,State Senate,SD25,WF,Velmanette Montgomery,34
-Kings,43051,State Senate,SD25,WF,Velmanette Montgomery,12
-Kings,50083,State Senate,SD25,WF,Velmanette Montgomery,31
-Kings,50085,State Senate,SD25,WF,Velmanette Montgomery,23
-Kings,50086,State Senate,SD25,WF,Velmanette Montgomery,5
-Kings,50089,State Senate,SD25,WF,Velmanette Montgomery,76
-Kings,50090,State Senate,SD25,WF,Velmanette Montgomery,28
-Kings,50091,State Senate,SD25,WF,Velmanette Montgomery,75
-Kings,50092,State Senate,SD25,WF,Velmanette Montgomery,50
-Kings,50093,State Senate,SD25,WF,Velmanette Montgomery,6
-Kings,50095,State Senate,SD25,WF,Velmanette Montgomery,10
-Kings,50097,State Senate,SD25,WF,Velmanette Montgomery,2
-Kings,51008,State Senate,SD25,WF,Velmanette Montgomery,15
-Kings,51044,State Senate,SD25,WF,Velmanette Montgomery,15
-Kings,51045,State Senate,SD25,WF,Velmanette Montgomery,3
-Kings,51046,State Senate,SD25,WF,Velmanette Montgomery,2
-Kings,51048,State Senate,SD25,WF,Velmanette Montgomery,1
-Kings,51049,State Senate,SD25,WF,Velmanette Montgomery,1
-Kings,51050,State Senate,SD25,WF,Velmanette Montgomery,5
-Kings,51051,State Senate,SD25,WF,Velmanette Montgomery,15
-Kings,51052,State Senate,SD25,WF,Velmanette Montgomery,19
-Kings,51053,State Senate,SD25,WF,Velmanette Montgomery,14
-Kings,51055,State Senate,SD25,WF,Velmanette Montgomery,31
-Kings,51069,State Senate,SD25,WF,Velmanette Montgomery,12
-Kings,51070,State Senate,SD25,WF,Velmanette Montgomery,7
-Kings,51071,State Senate,SD25,WF,Velmanette Montgomery,11
-Kings,51072,State Senate,SD25,WF,Velmanette Montgomery,31
-Kings,51073,State Senate,SD25,WF,Velmanette Montgomery,16
-Kings,51074,State Senate,SD25,WF,Velmanette Montgomery,5
-Kings,51075,State Senate,SD25,WF,Velmanette Montgomery,13
-Kings,51076,State Senate,SD25,WF,Velmanette Montgomery,48
-Kings,51078,State Senate,SD25,WF,Velmanette Montgomery,15
-Kings,52022,State Senate,SD25,WF,Velmanette Montgomery,24
-Kings,52023,State Senate,SD25,WF,Velmanette Montgomery,76
-Kings,52024,State Senate,SD25,WF,Velmanette Montgomery,24
-Kings,52025,State Senate,SD25,WF,Velmanette Montgomery,23
-Kings,52026,State Senate,SD25,WF,Velmanette Montgomery,2
-Kings,52027,State Senate,SD25,WF,Velmanette Montgomery,6
-Kings,52028,State Senate,SD25,WF,Velmanette Montgomery,43
-Kings,52029,State Senate,SD25,WF,Velmanette Montgomery,71
-Kings,52030,State Senate,SD25,WF,Velmanette Montgomery,74
-Kings,52031,State Senate,SD25,WF,Velmanette Montgomery,58
-Kings,52032,State Senate,SD25,WF,Velmanette Montgomery,74
-Kings,52033,State Senate,SD25,WF,Velmanette Montgomery,68
-Kings,52048,State Senate,SD25,WF,Velmanette Montgomery,83
-Kings,52049,State Senate,SD25,WF,Velmanette Montgomery,75
-Kings,52050,State Senate,SD25,WF,Velmanette Montgomery,18
-Kings,52051,State Senate,SD25,WF,Velmanette Montgomery,17
-Kings,52052,State Senate,SD25,WF,Velmanette Montgomery,11
-Kings,52053,State Senate,SD25,WF,Velmanette Montgomery,76
-Kings,52054,State Senate,SD25,WF,Velmanette Montgomery,18
-Kings,52055,State Senate,SD25,WF,Velmanette Montgomery,75
-Kings,52056,State Senate,SD25,WF,Velmanette Montgomery,22
-Kings,52057,State Senate,SD25,WF,Velmanette Montgomery,75
-Kings,52058,State Senate,SD25,WF,Velmanette Montgomery,74
-Kings,52059,State Senate,SD25,WF,Velmanette Montgomery,52
-Kings,52060,State Senate,SD25,WF,Velmanette Montgomery,80
-Kings,52061,State Senate,SD25,WF,Velmanette Montgomery,69
-Kings,52062,State Senate,SD25,WF,Velmanette Montgomery,82
-Kings,52063,State Senate,SD25,WF,Velmanette Montgomery,3
-Kings,52089,State Senate,SD25,WF,Velmanette Montgomery,128
-Kings,52090,State Senate,SD25,WF,Velmanette Montgomery,67
-Kings,52091,State Senate,SD25,WF,Velmanette Montgomery,35
-Kings,52095,State Senate,SD25,WF,Velmanette Montgomery,17
-Kings,52096,State Senate,SD25,WF,Velmanette Montgomery,71
-Kings,52097,State Senate,SD25,WF,Velmanette Montgomery,31
-Kings,52098,State Senate,SD25,WF,Velmanette Montgomery,62
-Kings,52099,State Senate,SD25,WF,Velmanette Montgomery,78
-Kings,52100,State Senate,SD25,WF,Velmanette Montgomery,46
-Kings,52102,State Senate,SD25,WF,Velmanette Montgomery,1
-Kings,52108,State Senate,SD25,WF,Velmanette Montgomery,5
-Kings,52109,State Senate,SD25,WF,Velmanette Montgomery,2
-Kings,52112,State Senate,SD25,WF,Velmanette Montgomery,28
-Kings,54015,State Senate,SD25,WF,Velmanette Montgomery,9
-Kings,54026,State Senate,SD25,WF,Velmanette Montgomery,1
-Kings,55002,State Senate,SD25,WF,Velmanette Montgomery,7
-Kings,55004,State Senate,SD25,WF,Velmanette Montgomery,17
-Kings,55008,State Senate,SD25,WF,Velmanette Montgomery,1
-Kings,55009,State Senate,SD25,WF,Velmanette Montgomery,6
-Kings,55010,State Senate,SD25,WF,Velmanette Montgomery,11
-Kings,55011,State Senate,SD25,WF,Velmanette Montgomery,15
-Kings,55012,State Senate,SD25,WF,Velmanette Montgomery,9
-Kings,55017,State Senate,SD25,WF,Velmanette Montgomery,7
-Kings,55018,State Senate,SD25,WF,Velmanette Montgomery,9
-Kings,55019,State Senate,SD25,WF,Velmanette Montgomery,20
-Kings,55020,State Senate,SD25,WF,Velmanette Montgomery,8
-Kings,55021,State Senate,SD25,WF,Velmanette Montgomery,7
-Kings,55022,State Senate,SD25,WF,Velmanette Montgomery,5
-Kings,55023,State Senate,SD25,WF,Velmanette Montgomery,3
-Kings,55024,State Senate,SD25,WF,Velmanette Montgomery,6
-Kings,55025,State Senate,SD25,WF,Velmanette Montgomery,6
-Kings,55028,State Senate,SD25,WF,Velmanette Montgomery,3
-Kings,55029,State Senate,SD25,WF,Velmanette Montgomery,2
-Kings,55030,State Senate,SD25,WF,Velmanette Montgomery,8
-Kings,55031,State Senate,SD25,WF,Velmanette Montgomery,10
-Kings,55032,State Senate,SD25,WF,Velmanette Montgomery,6
-Kings,55033,State Senate,SD25,WF,Velmanette Montgomery,14
-Kings,55034,State Senate,SD25,WF,Velmanette Montgomery,9
-Kings,55101,State Senate,SD25,WF,Velmanette Montgomery,2
-Kings,55102,State Senate,SD25,WF,Velmanette Montgomery,6
-Kings,55103,State Senate,SD25,WF,Velmanette Montgomery,7
-Kings,55104,State Senate,SD25,WF,Velmanette Montgomery,10
-Kings,56012,State Senate,SD25,WF,Velmanette Montgomery,23
-Kings,56013,State Senate,SD25,WF,Velmanette Montgomery,29
-Kings,56014,State Senate,SD25,WF,Velmanette Montgomery,19
-Kings,56015,State Senate,SD25,WF,Velmanette Montgomery,22
-Kings,56016,State Senate,SD25,WF,Velmanette Montgomery,35
-Kings,56018,State Senate,SD25,WF,Velmanette Montgomery,27
-Kings,56019,State Senate,SD25,WF,Velmanette Montgomery,18
-Kings,56021,State Senate,SD25,WF,Velmanette Montgomery,15
-Kings,56022,State Senate,SD25,WF,Velmanette Montgomery,10
-Kings,56023,State Senate,SD25,WF,Velmanette Montgomery,18
-Kings,56024,State Senate,SD25,WF,Velmanette Montgomery,8
-Kings,56025,State Senate,SD25,WF,Velmanette Montgomery,9
-Kings,56026,State Senate,SD25,WF,Velmanette Montgomery,29
-Kings,56027,State Senate,SD25,WF,Velmanette Montgomery,10
-Kings,56028,State Senate,SD25,WF,Velmanette Montgomery,18
-Kings,56029,State Senate,SD25,WF,Velmanette Montgomery,20
-Kings,56030,State Senate,SD25,WF,Velmanette Montgomery,6
-Kings,56031,State Senate,SD25,WF,Velmanette Montgomery,8
-Kings,56032,State Senate,SD25,WF,Velmanette Montgomery,16
-Kings,56033,State Senate,SD25,WF,Velmanette Montgomery,16
-Kings,56034,State Senate,SD25,WF,Velmanette Montgomery,16
-Kings,56035,State Senate,SD25,WF,Velmanette Montgomery,23
-Kings,56036,State Senate,SD25,WF,Velmanette Montgomery,18
-Kings,56037,State Senate,SD25,WF,Velmanette Montgomery,33
-Kings,56038,State Senate,SD25,WF,Velmanette Montgomery,34
-Kings,56039,State Senate,SD25,WF,Velmanette Montgomery,26
-Kings,56040,State Senate,SD25,WF,Velmanette Montgomery,27
-Kings,56041,State Senate,SD25,WF,Velmanette Montgomery,25
-Kings,56042,State Senate,SD25,WF,Velmanette Montgomery,23
-Kings,56043,State Senate,SD25,WF,Velmanette Montgomery,25
-Kings,56044,State Senate,SD25,WF,Velmanette Montgomery,16
-Kings,56045,State Senate,SD25,WF,Velmanette Montgomery,16
-Kings,56046,State Senate,SD25,WF,Velmanette Montgomery,21
-Kings,56047,State Senate,SD25,WF,Velmanette Montgomery,12
-Kings,56048,State Senate,SD25,WF,Velmanette Montgomery,18
-Kings,56049,State Senate,SD25,WF,Velmanette Montgomery,27
-Kings,56050,State Senate,SD25,WF,Velmanette Montgomery,33
-Kings,56051,State Senate,SD25,WF,Velmanette Montgomery,17
-Kings,56052,State Senate,SD25,WF,Velmanette Montgomery,29
-Kings,56053,State Senate,SD25,WF,Velmanette Montgomery,18
-Kings,56054,State Senate,SD25,WF,Velmanette Montgomery,15
-Kings,56055,State Senate,SD25,WF,Velmanette Montgomery,48
-Kings,56056,State Senate,SD25,WF,Velmanette Montgomery,11
-Kings,56057,State Senate,SD25,WF,Velmanette Montgomery,13
-Kings,56058,State Senate,SD25,WF,Velmanette Montgomery,18
-Kings,56059,State Senate,SD25,WF,Velmanette Montgomery,9
-Kings,56060,State Senate,SD25,WF,Velmanette Montgomery,6
-Kings,56061,State Senate,SD25,WF,Velmanette Montgomery,0
-Kings,56062,State Senate,SD25,WF,Velmanette Montgomery,17
-Kings,56063,State Senate,SD25,WF,Velmanette Montgomery,5
-Kings,56064,State Senate,SD25,WF,Velmanette Montgomery,9
-Kings,56065,State Senate,SD25,WF,Velmanette Montgomery,6
-Kings,56066,State Senate,SD25,WF,Velmanette Montgomery,1
-Kings,56068,State Senate,SD25,WF,Velmanette Montgomery,12
-Kings,56069,State Senate,SD25,WF,Velmanette Montgomery,17
-Kings,56070,State Senate,SD25,WF,Velmanette Montgomery,10
-Kings,56071,State Senate,SD25,WF,Velmanette Montgomery,6
-Kings,56072,State Senate,SD25,WF,Velmanette Montgomery,22
-Kings,56074,State Senate,SD25,WF,Velmanette Montgomery,5
-Kings,57001,State Senate,SD25,WF,Velmanette Montgomery,5
-Kings,57002,State Senate,SD25,WF,Velmanette Montgomery,10
-Kings,57003,State Senate,SD25,WF,Velmanette Montgomery,7
-Kings,57004,State Senate,SD25,WF,Velmanette Montgomery,16
-Kings,57006,State Senate,SD25,WF,Velmanette Montgomery,4
-Kings,57007,State Senate,SD25,WF,Velmanette Montgomery,6
-Kings,57008,State Senate,SD25,WF,Velmanette Montgomery,8
-Kings,57009,State Senate,SD25,WF,Velmanette Montgomery,25
-Kings,57010,State Senate,SD25,WF,Velmanette Montgomery,29
-Kings,57011,State Senate,SD25,WF,Velmanette Montgomery,19
-Kings,57012,State Senate,SD25,WF,Velmanette Montgomery,7
-Kings,57013,State Senate,SD25,WF,Velmanette Montgomery,1
-Kings,57014,State Senate,SD25,WF,Velmanette Montgomery,6
-Kings,57015,State Senate,SD25,WF,Velmanette Montgomery,78
-Kings,57016,State Senate,SD25,WF,Velmanette Montgomery,73
-Kings,57017,State Senate,SD25,WF,Velmanette Montgomery,71
-Kings,57018,State Senate,SD25,WF,Velmanette Montgomery,31
-Kings,57019,State Senate,SD25,WF,Velmanette Montgomery,12
-Kings,57020,State Senate,SD25,WF,Velmanette Montgomery,2
-Kings,57021,State Senate,SD25,WF,Velmanette Montgomery,45
-Kings,57022,State Senate,SD25,WF,Velmanette Montgomery,56
-Kings,57023,State Senate,SD25,WF,Velmanette Montgomery,29
-Kings,57024,State Senate,SD25,WF,Velmanette Montgomery,62
-Kings,57025,State Senate,SD25,WF,Velmanette Montgomery,89
-Kings,57026,State Senate,SD25,WF,Velmanette Montgomery,71
-Kings,57027,State Senate,SD25,WF,Velmanette Montgomery,83
-Kings,57028,State Senate,SD25,WF,Velmanette Montgomery,56
-Kings,57029,State Senate,SD25,WF,Velmanette Montgomery,78
-Kings,57030,State Senate,SD25,WF,Velmanette Montgomery,20
-Kings,57031,State Senate,SD25,WF,Velmanette Montgomery,21
-Kings,57032,State Senate,SD25,WF,Velmanette Montgomery,3
-Kings,57033,State Senate,SD25,WF,Velmanette Montgomery,4
-Kings,57034,State Senate,SD25,WF,Velmanette Montgomery,76
-Kings,57035,State Senate,SD25,WF,Velmanette Montgomery,44
-Kings,57036,State Senate,SD25,WF,Velmanette Montgomery,60
-Kings,57037,State Senate,SD25,WF,Velmanette Montgomery,51
-Kings,57038,State Senate,SD25,WF,Velmanette Montgomery,49
-Kings,57039,State Senate,SD25,WF,Velmanette Montgomery,82
-Kings,57040,State Senate,SD25,WF,Velmanette Montgomery,54
-Kings,57041,State Senate,SD25,WF,Velmanette Montgomery,59
-Kings,57042,State Senate,SD25,WF,Velmanette Montgomery,49
-Kings,57043,State Senate,SD25,WF,Velmanette Montgomery,73
-Kings,57044,State Senate,SD25,WF,Velmanette Montgomery,31
-Kings,57045,State Senate,SD25,WF,Velmanette Montgomery,28
-Kings,57046,State Senate,SD25,WF,Velmanette Montgomery,8
-Kings,57047,State Senate,SD25,WF,Velmanette Montgomery,76
-Kings,57048,State Senate,SD25,WF,Velmanette Montgomery,68
-Kings,57049,State Senate,SD25,WF,Velmanette Montgomery,30
-Kings,57050,State Senate,SD25,WF,Velmanette Montgomery,68
-Kings,57051,State Senate,SD25,WF,Velmanette Montgomery,44
-Kings,57052,State Senate,SD25,WF,Velmanette Montgomery,35
-Kings,57053,State Senate,SD25,WF,Velmanette Montgomery,36
-Kings,57054,State Senate,SD25,WF,Velmanette Montgomery,32
-Kings,57055,State Senate,SD25,WF,Velmanette Montgomery,36
-Kings,57056,State Senate,SD25,WF,Velmanette Montgomery,48
-Kings,57057,State Senate,SD25,WF,Velmanette Montgomery,39
-Kings,57058,State Senate,SD25,WF,Velmanette Montgomery,25
-Kings,57059,State Senate,SD25,WF,Velmanette Montgomery,22
-Kings,57060,State Senate,SD25,WF,Velmanette Montgomery,45
-Kings,57061,State Senate,SD25,WF,Velmanette Montgomery,40
-Kings,57062,State Senate,SD25,WF,Velmanette Montgomery,5
-Kings,57063,State Senate,SD25,WF,Velmanette Montgomery,83
-Kings,57064,State Senate,SD25,WF,Velmanette Montgomery,64
-Kings,57065,State Senate,SD25,WF,Velmanette Montgomery,90
-Kings,57066,State Senate,SD25,WF,Velmanette Montgomery,57
-Kings,43045,State Senate,SD25,Ind,writein,0
-Kings,43046,State Senate,SD25,Ind,writein,0
-Kings,43047,State Senate,SD25,Ind,writein,0
-Kings,43048,State Senate,SD25,Ind,writein,0
-Kings,43049,State Senate,SD25,Ind,writein,0
-Kings,43050,State Senate,SD25,Ind,writein,0
-Kings,43051,State Senate,SD25,Ind,writein,0
-Kings,50083,State Senate,SD25,Ind,writein,0
-Kings,50085,State Senate,SD25,Ind,writein,0
-Kings,50086,State Senate,SD25,Ind,writein,0
-Kings,50089,State Senate,SD25,Ind,writein,1
-Kings,50090,State Senate,SD25,Ind,writein,1
-Kings,50091,State Senate,SD25,Ind,writein,0
-Kings,50092,State Senate,SD25,Ind,writein,1
-Kings,50093,State Senate,SD25,Ind,writein,0
-Kings,50095,State Senate,SD25,Ind,writein,0
-Kings,50097,State Senate,SD25,Ind,writein,0
-Kings,51008,State Senate,SD25,Ind,writein,0
-Kings,51044,State Senate,SD25,Ind,writein,0
-Kings,51045,State Senate,SD25,Ind,writein,0
-Kings,51046,State Senate,SD25,Ind,writein,0
-Kings,51048,State Senate,SD25,Ind,writein,0
-Kings,51049,State Senate,SD25,Ind,writein,0
-Kings,51050,State Senate,SD25,Ind,writein,0
-Kings,51051,State Senate,SD25,Ind,writein,2
-Kings,51052,State Senate,SD25,Ind,writein,0
-Kings,51053,State Senate,SD25,Ind,writein,0
-Kings,51055,State Senate,SD25,Ind,writein,0
-Kings,51069,State Senate,SD25,Ind,writein,0
-Kings,51070,State Senate,SD25,Ind,writein,0
-Kings,51071,State Senate,SD25,Ind,writein,0
-Kings,51072,State Senate,SD25,Ind,writein,0
-Kings,51073,State Senate,SD25,Ind,writein,0
-Kings,51074,State Senate,SD25,Ind,writein,1
-Kings,51075,State Senate,SD25,Ind,writein,0
-Kings,51076,State Senate,SD25,Ind,writein,3
-Kings,51078,State Senate,SD25,Ind,writein,0
-Kings,52022,State Senate,SD25,Ind,writein,0
-Kings,52023,State Senate,SD25,Ind,writein,1
-Kings,52024,State Senate,SD25,Ind,writein,0
-Kings,52025,State Senate,SD25,Ind,writein,0
-Kings,52026,State Senate,SD25,Ind,writein,0
-Kings,52027,State Senate,SD25,Ind,writein,0
-Kings,52028,State Senate,SD25,Ind,writein,0
-Kings,52029,State Senate,SD25,Ind,writein,3
-Kings,52030,State Senate,SD25,Ind,writein,0
-Kings,52031,State Senate,SD25,Ind,writein,0
-Kings,52032,State Senate,SD25,Ind,writein,0
-Kings,52033,State Senate,SD25,Ind,writein,0
-Kings,52048,State Senate,SD25,Ind,writein,0
-Kings,52049,State Senate,SD25,Ind,writein,1
-Kings,52050,State Senate,SD25,Ind,writein,0
-Kings,52051,State Senate,SD25,Ind,writein,0
-Kings,52052,State Senate,SD25,Ind,writein,0
-Kings,52053,State Senate,SD25,Ind,writein,0
-Kings,52054,State Senate,SD25,Ind,writein,0
-Kings,52055,State Senate,SD25,Ind,writein,0
-Kings,52056,State Senate,SD25,Ind,writein,0
-Kings,52057,State Senate,SD25,Ind,writein,1
-Kings,52058,State Senate,SD25,Ind,writein,0
-Kings,52059,State Senate,SD25,Ind,writein,1
-Kings,52060,State Senate,SD25,Ind,writein,0
-Kings,52061,State Senate,SD25,Ind,writein,0
-Kings,52062,State Senate,SD25,Ind,writein,1
-Kings,52063,State Senate,SD25,Ind,writein,1
-Kings,52089,State Senate,SD25,Ind,writein,1
-Kings,52090,State Senate,SD25,Ind,writein,1
-Kings,52091,State Senate,SD25,Ind,writein,0
-Kings,52095,State Senate,SD25,Ind,writein,0
-Kings,52096,State Senate,SD25,Ind,writein,0
-Kings,52097,State Senate,SD25,Ind,writein,0
-Kings,52098,State Senate,SD25,Ind,writein,0
-Kings,52099,State Senate,SD25,Ind,writein,1
-Kings,52100,State Senate,SD25,Ind,writein,0
-Kings,52102,State Senate,SD25,Ind,writein,0
-Kings,52108,State Senate,SD25,Ind,writein,0
-Kings,52109,State Senate,SD25,Ind,writein,0
-Kings,52112,State Senate,SD25,Ind,writein,0
-Kings,54015,State Senate,SD25,Ind,writein,0
-Kings,54026,State Senate,SD25,Ind,writein,0
-Kings,55002,State Senate,SD25,Ind,writein,0
-Kings,55004,State Senate,SD25,Ind,writein,0
-Kings,55008,State Senate,SD25,Ind,writein,0
-Kings,55009,State Senate,SD25,Ind,writein,0
-Kings,55010,State Senate,SD25,Ind,writein,0
-Kings,55011,State Senate,SD25,Ind,writein,0
-Kings,55012,State Senate,SD25,Ind,writein,0
-Kings,55017,State Senate,SD25,Ind,writein,0
-Kings,55018,State Senate,SD25,Ind,writein,0
-Kings,55019,State Senate,SD25,Ind,writein,0
-Kings,55020,State Senate,SD25,Ind,writein,0
-Kings,55021,State Senate,SD25,Ind,writein,0
-Kings,55022,State Senate,SD25,Ind,writein,0
-Kings,55023,State Senate,SD25,Ind,writein,0
-Kings,55024,State Senate,SD25,Ind,writein,0
-Kings,55025,State Senate,SD25,Ind,writein,0
-Kings,55028,State Senate,SD25,Ind,writein,0
-Kings,55029,State Senate,SD25,Ind,writein,1
-Kings,55030,State Senate,SD25,Ind,writein,0
-Kings,55031,State Senate,SD25,Ind,writein,0
-Kings,55032,State Senate,SD25,Ind,writein,0
-Kings,55033,State Senate,SD25,Ind,writein,0
-Kings,55034,State Senate,SD25,Ind,writein,0
-Kings,55101,State Senate,SD25,Ind,writein,0
-Kings,55102,State Senate,SD25,Ind,writein,0
-Kings,55103,State Senate,SD25,Ind,writein,0
-Kings,55104,State Senate,SD25,Ind,writein,0
-Kings,56012,State Senate,SD25,Ind,writein,0
-Kings,56013,State Senate,SD25,Ind,writein,0
-Kings,56014,State Senate,SD25,Ind,writein,0
-Kings,56015,State Senate,SD25,Ind,writein,1
-Kings,56016,State Senate,SD25,Ind,writein,0
-Kings,56018,State Senate,SD25,Ind,writein,1
-Kings,56019,State Senate,SD25,Ind,writein,0
-Kings,56021,State Senate,SD25,Ind,writein,0
-Kings,56022,State Senate,SD25,Ind,writein,0
-Kings,56023,State Senate,SD25,Ind,writein,0
-Kings,56024,State Senate,SD25,Ind,writein,0
-Kings,56025,State Senate,SD25,Ind,writein,0
-Kings,56026,State Senate,SD25,Ind,writein,0
-Kings,56027,State Senate,SD25,Ind,writein,0
-Kings,56028,State Senate,SD25,Ind,writein,1
-Kings,56029,State Senate,SD25,Ind,writein,1
-Kings,56030,State Senate,SD25,Ind,writein,0
-Kings,56031,State Senate,SD25,Ind,writein,0
-Kings,56032,State Senate,SD25,Ind,writein,0
-Kings,56033,State Senate,SD25,Ind,writein,0
-Kings,56034,State Senate,SD25,Ind,writein,0
-Kings,56035,State Senate,SD25,Ind,writein,1
-Kings,56036,State Senate,SD25,Ind,writein,0
-Kings,56037,State Senate,SD25,Ind,writein,0
-Kings,56038,State Senate,SD25,Ind,writein,0
-Kings,56039,State Senate,SD25,Ind,writein,0
-Kings,56040,State Senate,SD25,Ind,writein,0
-Kings,56041,State Senate,SD25,Ind,writein,0
-Kings,56042,State Senate,SD25,Ind,writein,0
-Kings,56043,State Senate,SD25,Ind,writein,0
-Kings,56044,State Senate,SD25,Ind,writein,0
-Kings,56045,State Senate,SD25,Ind,writein,0
-Kings,56046,State Senate,SD25,Ind,writein,0
-Kings,56047,State Senate,SD25,Ind,writein,0
-Kings,56048,State Senate,SD25,Ind,writein,0
-Kings,56049,State Senate,SD25,Ind,writein,0
-Kings,56050,State Senate,SD25,Ind,writein,0
-Kings,56051,State Senate,SD25,Ind,writein,0
-Kings,56052,State Senate,SD25,Ind,writein,0
-Kings,56053,State Senate,SD25,Ind,writein,0
-Kings,56054,State Senate,SD25,Ind,writein,0
-Kings,56055,State Senate,SD25,Ind,writein,1
-Kings,56056,State Senate,SD25,Ind,writein,1
-Kings,56057,State Senate,SD25,Ind,writein,0
-Kings,56058,State Senate,SD25,Ind,writein,0
-Kings,56059,State Senate,SD25,Ind,writein,0
-Kings,56060,State Senate,SD25,Ind,writein,0
-Kings,56061,State Senate,SD25,Ind,writein,0
-Kings,56062,State Senate,SD25,Ind,writein,0
-Kings,56063,State Senate,SD25,Ind,writein,0
-Kings,56064,State Senate,SD25,Ind,writein,0
-Kings,56065,State Senate,SD25,Ind,writein,0
-Kings,56066,State Senate,SD25,Ind,writein,0
-Kings,56068,State Senate,SD25,Ind,writein,0
-Kings,56069,State Senate,SD25,Ind,writein,0
-Kings,56070,State Senate,SD25,Ind,writein,0
-Kings,56071,State Senate,SD25,Ind,writein,0
-Kings,56072,State Senate,SD25,Ind,writein,0
-Kings,56074,State Senate,SD25,Ind,writein,0
-Kings,57001,State Senate,SD25,Ind,writein,0
-Kings,57002,State Senate,SD25,Ind,writein,0
-Kings,57003,State Senate,SD25,Ind,writein,0
-Kings,57004,State Senate,SD25,Ind,writein,0
-Kings,57006,State Senate,SD25,Ind,writein,0
-Kings,57007,State Senate,SD25,Ind,writein,0
-Kings,57008,State Senate,SD25,Ind,writein,0
-Kings,57009,State Senate,SD25,Ind,writein,1
-Kings,57010,State Senate,SD25,Ind,writein,1
-Kings,57011,State Senate,SD25,Ind,writein,0
-Kings,57012,State Senate,SD25,Ind,writein,0
-Kings,57013,State Senate,SD25,Ind,writein,0
-Kings,57014,State Senate,SD25,Ind,writein,0
-Kings,57015,State Senate,SD25,Ind,writein,0
-Kings,57016,State Senate,SD25,Ind,writein,0
-Kings,57017,State Senate,SD25,Ind,writein,0
-Kings,57018,State Senate,SD25,Ind,writein,0
-Kings,57019,State Senate,SD25,Ind,writein,0
-Kings,57020,State Senate,SD25,Ind,writein,0
-Kings,57021,State Senate,SD25,Ind,writein,0
-Kings,57022,State Senate,SD25,Ind,writein,1
-Kings,57023,State Senate,SD25,Ind,writein,2
-Kings,57024,State Senate,SD25,Ind,writein,0
-Kings,57025,State Senate,SD25,Ind,writein,0
-Kings,57026,State Senate,SD25,Ind,writein,0
-Kings,57027,State Senate,SD25,Ind,writein,0
-Kings,57028,State Senate,SD25,Ind,writein,1
-Kings,57029,State Senate,SD25,Ind,writein,1
-Kings,57030,State Senate,SD25,Ind,writein,0
-Kings,57031,State Senate,SD25,Ind,writein,0
-Kings,57032,State Senate,SD25,Ind,writein,0
-Kings,57033,State Senate,SD25,Ind,writein,0
-Kings,57034,State Senate,SD25,Ind,writein,0
-Kings,57035,State Senate,SD25,Ind,writein,0
-Kings,57036,State Senate,SD25,Ind,writein,0
-Kings,57037,State Senate,SD25,Ind,writein,0
-Kings,57038,State Senate,SD25,Ind,writein,0
-Kings,57039,State Senate,SD25,Ind,writein,0
-Kings,57040,State Senate,SD25,Ind,writein,0
-Kings,57041,State Senate,SD25,Ind,writein,0
-Kings,57042,State Senate,SD25,Ind,writein,1
-Kings,57043,State Senate,SD25,Ind,writein,0
-Kings,57044,State Senate,SD25,Ind,writein,1
-Kings,57045,State Senate,SD25,Ind,writein,0
-Kings,57046,State Senate,SD25,Ind,writein,1
-Kings,57047,State Senate,SD25,Ind,writein,1
-Kings,57048,State Senate,SD25,Ind,writein,0
-Kings,57049,State Senate,SD25,Ind,writein,0
-Kings,57050,State Senate,SD25,Ind,writein,0
-Kings,57051,State Senate,SD25,Ind,writein,0
-Kings,57052,State Senate,SD25,Ind,writein,0
-Kings,57053,State Senate,SD25,Ind,writein,0
-Kings,57054,State Senate,SD25,Ind,writein,0
-Kings,57055,State Senate,SD25,Ind,writein,2
-Kings,57056,State Senate,SD25,Ind,writein,0
-Kings,57057,State Senate,SD25,Ind,writein,0
-Kings,57058,State Senate,SD25,Ind,writein,0
-Kings,57059,State Senate,SD25,Ind,writein,0
-Kings,57060,State Senate,SD25,Ind,writein,2
-Kings,57061,State Senate,SD25,Ind,writein,0
-Kings,57062,State Senate,SD25,Ind,writein,0
-Kings,57063,State Senate,SD25,Ind,writein,0
-Kings,57064,State Senate,SD25,Ind,writein,0
-Kings,57065,State Senate,SD25,Ind,writein,0
-Kings,57066,State Senate,SD25,Ind,writein,0
-Kings,50024,State Senate,SD26,Dem,Daniel Squadron,54
-Kings,50026,State Senate,SD26,Dem,Daniel Squadron,321
-Kings,50027,State Senate,SD26,Dem,Daniel Squadron,479
-Kings,50028,State Senate,SD26,Dem,Daniel Squadron,358
-Kings,50029,State Senate,SD26,Dem,Daniel Squadron,436
-Kings,50030,State Senate,SD26,Dem,Daniel Squadron,343
-Kings,50031,State Senate,SD26,Dem,Daniel Squadron,396
-Kings,50032,State Senate,SD26,Dem,Daniel Squadron,412
-Kings,50033,State Senate,SD26,Dem,Daniel Squadron,503
-Kings,50034,State Senate,SD26,Dem,Daniel Squadron,288
-Kings,50035,State Senate,SD26,Dem,Daniel Squadron,444
-Kings,50036,State Senate,SD26,Dem,Daniel Squadron,92
-Kings,50037,State Senate,SD26,Dem,Daniel Squadron,935
-Kings,50038,State Senate,SD26,Dem,Daniel Squadron,519
-Kings,50039,State Senate,SD26,Dem,Daniel Squadron,337
-Kings,50040,State Senate,SD26,Dem,Daniel Squadron,384
-Kings,50041,State Senate,SD26,Dem,Daniel Squadron,567
-Kings,50042,State Senate,SD26,Dem,Daniel Squadron,412
-Kings,50047,State Senate,SD26,Dem,Daniel Squadron,283
-Kings,50048,State Senate,SD26,Dem,Daniel Squadron,319
-Kings,50055,State Senate,SD26,Dem,Daniel Squadron,93
-Kings,50064,State Senate,SD26,Dem,Daniel Squadron,83
-Kings,50065,State Senate,SD26,Dem,Daniel Squadron,113
-Kings,50066,State Senate,SD26,Dem,Daniel Squadron,97
-Kings,50067,State Senate,SD26,Dem,Daniel Squadron,73
-Kings,50068,State Senate,SD26,Dem,Daniel Squadron,123
-Kings,50069,State Senate,SD26,Dem,Daniel Squadron,138
-Kings,50070,State Senate,SD26,Dem,Daniel Squadron,44
-Kings,50071,State Senate,SD26,Dem,Daniel Squadron,35
-Kings,50072,State Senate,SD26,Dem,Daniel Squadron,148
-Kings,50073,State Senate,SD26,Dem,Daniel Squadron,87
-Kings,50074,State Senate,SD26,Dem,Daniel Squadron,90
-Kings,50075,State Senate,SD26,Dem,Daniel Squadron,163
-Kings,50076,State Senate,SD26,Dem,Daniel Squadron,109
-Kings,50077,State Senate,SD26,Dem,Daniel Squadron,111
-Kings,50078,State Senate,SD26,Dem,Daniel Squadron,106
-Kings,50079,State Senate,SD26,Dem,Daniel Squadron,102
-Kings,50080,State Senate,SD26,Dem,Daniel Squadron,90
-Kings,50082,State Senate,SD26,Dem,Daniel Squadron,65
-Kings,50087,State Senate,SD26,Dem,Daniel Squadron,80
-Kings,50094,State Senate,SD26,Dem,Daniel Squadron,72
-Kings,50099,State Senate,SD26,Dem,Daniel Squadron,11
-Kings,51007,State Senate,SD26,Dem,Daniel Squadron,427
-Kings,52001,State Senate,SD26,Dem,Daniel Squadron,525
-Kings,52002,State Senate,SD26,Dem,Daniel Squadron,143
-Kings,52004,State Senate,SD26,Dem,Daniel Squadron,297
-Kings,52005,State Senate,SD26,Dem,Daniel Squadron,335
-Kings,52006,State Senate,SD26,Dem,Daniel Squadron,126
-Kings,52007,State Senate,SD26,Dem,Daniel Squadron,540
-Kings,52008,State Senate,SD26,Dem,Daniel Squadron,565
-Kings,52009,State Senate,SD26,Dem,Daniel Squadron,497
-Kings,52010,State Senate,SD26,Dem,Daniel Squadron,616
-Kings,52011,State Senate,SD26,Dem,Daniel Squadron,451
-Kings,52012,State Senate,SD26,Dem,Daniel Squadron,546
-Kings,52013,State Senate,SD26,Dem,Daniel Squadron,528
-Kings,52014,State Senate,SD26,Dem,Daniel Squadron,566
-Kings,52015,State Senate,SD26,Dem,Daniel Squadron,587
-Kings,52016,State Senate,SD26,Dem,Daniel Squadron,616
-Kings,52017,State Senate,SD26,Dem,Daniel Squadron,593
-Kings,52018,State Senate,SD26,Dem,Daniel Squadron,510
-Kings,52019,State Senate,SD26,Dem,Daniel Squadron,523
-Kings,52020,State Senate,SD26,Dem,Daniel Squadron,302
-Kings,52021,State Senate,SD26,Dem,Daniel Squadron,207
-Kings,52034,State Senate,SD26,Dem,Daniel Squadron,468
-Kings,52035,State Senate,SD26,Dem,Daniel Squadron,498
-Kings,52036,State Senate,SD26,Dem,Daniel Squadron,647
-Kings,52037,State Senate,SD26,Dem,Daniel Squadron,503
-Kings,52038,State Senate,SD26,Dem,Daniel Squadron,591
-Kings,52039,State Senate,SD26,Dem,Daniel Squadron,543
-Kings,52040,State Senate,SD26,Dem,Daniel Squadron,662
-Kings,52041,State Senate,SD26,Dem,Daniel Squadron,182
-Kings,52042,State Senate,SD26,Dem,Daniel Squadron,462
-Kings,52043,State Senate,SD26,Dem,Daniel Squadron,491
-Kings,52044,State Senate,SD26,Dem,Daniel Squadron,526
-Kings,52045,State Senate,SD26,Dem,Daniel Squadron,435
-Kings,52046,State Senate,SD26,Dem,Daniel Squadron,571
-Kings,52047,State Senate,SD26,Dem,Daniel Squadron,429
-Kings,52103,State Senate,SD26,Dem,Daniel Squadron,4
-Kings,52104,State Senate,SD26,Dem,Daniel Squadron,1
-Kings,52105,State Senate,SD26,Dem,Daniel Squadron,4
-Kings,52106,State Senate,SD26,Dem,Daniel Squadron,3
-Kings,52110,State Senate,SD26,Dem,Daniel Squadron,459
-Kings,53014,State Senate,SD26,Dem,Daniel Squadron,10
-Kings,53078,State Senate,SD26,Dem,Daniel Squadron,98
-Kings,50024,State Senate,SD26,WF,Daniel Squadron,7
-Kings,50026,State Senate,SD26,WF,Daniel Squadron,47
-Kings,50027,State Senate,SD26,WF,Daniel Squadron,94
-Kings,50028,State Senate,SD26,WF,Daniel Squadron,50
-Kings,50029,State Senate,SD26,WF,Daniel Squadron,71
-Kings,50030,State Senate,SD26,WF,Daniel Squadron,61
-Kings,50031,State Senate,SD26,WF,Daniel Squadron,64
-Kings,50032,State Senate,SD26,WF,Daniel Squadron,61
-Kings,50033,State Senate,SD26,WF,Daniel Squadron,71
-Kings,50034,State Senate,SD26,WF,Daniel Squadron,39
-Kings,50035,State Senate,SD26,WF,Daniel Squadron,76
-Kings,50036,State Senate,SD26,WF,Daniel Squadron,4
-Kings,50037,State Senate,SD26,WF,Daniel Squadron,54
-Kings,50038,State Senate,SD26,WF,Daniel Squadron,66
-Kings,50039,State Senate,SD26,WF,Daniel Squadron,34
-Kings,50040,State Senate,SD26,WF,Daniel Squadron,35
-Kings,50041,State Senate,SD26,WF,Daniel Squadron,62
-Kings,50042,State Senate,SD26,WF,Daniel Squadron,58
-Kings,50047,State Senate,SD26,WF,Daniel Squadron,27
-Kings,50048,State Senate,SD26,WF,Daniel Squadron,29
-Kings,50055,State Senate,SD26,WF,Daniel Squadron,11
-Kings,50064,State Senate,SD26,WF,Daniel Squadron,7
-Kings,50065,State Senate,SD26,WF,Daniel Squadron,3
-Kings,50066,State Senate,SD26,WF,Daniel Squadron,4
-Kings,50067,State Senate,SD26,WF,Daniel Squadron,5
-Kings,50068,State Senate,SD26,WF,Daniel Squadron,2
-Kings,50069,State Senate,SD26,WF,Daniel Squadron,10
-Kings,50070,State Senate,SD26,WF,Daniel Squadron,3
-Kings,50071,State Senate,SD26,WF,Daniel Squadron,1
-Kings,50072,State Senate,SD26,WF,Daniel Squadron,13
-Kings,50073,State Senate,SD26,WF,Daniel Squadron,1
-Kings,50074,State Senate,SD26,WF,Daniel Squadron,5
-Kings,50075,State Senate,SD26,WF,Daniel Squadron,7
-Kings,50076,State Senate,SD26,WF,Daniel Squadron,15
-Kings,50077,State Senate,SD26,WF,Daniel Squadron,6
-Kings,50078,State Senate,SD26,WF,Daniel Squadron,4
-Kings,50079,State Senate,SD26,WF,Daniel Squadron,6
-Kings,50080,State Senate,SD26,WF,Daniel Squadron,10
-Kings,50082,State Senate,SD26,WF,Daniel Squadron,2
-Kings,50087,State Senate,SD26,WF,Daniel Squadron,8
-Kings,50094,State Senate,SD26,WF,Daniel Squadron,0
-Kings,50099,State Senate,SD26,WF,Daniel Squadron,0
-Kings,51007,State Senate,SD26,WF,Daniel Squadron,57
-Kings,52001,State Senate,SD26,WF,Daniel Squadron,46
-Kings,52002,State Senate,SD26,WF,Daniel Squadron,10
-Kings,52004,State Senate,SD26,WF,Daniel Squadron,16
-Kings,52005,State Senate,SD26,WF,Daniel Squadron,17
-Kings,52006,State Senate,SD26,WF,Daniel Squadron,9
-Kings,52007,State Senate,SD26,WF,Daniel Squadron,64
-Kings,52008,State Senate,SD26,WF,Daniel Squadron,58
-Kings,52009,State Senate,SD26,WF,Daniel Squadron,47
-Kings,52010,State Senate,SD26,WF,Daniel Squadron,51
-Kings,52011,State Senate,SD26,WF,Daniel Squadron,32
-Kings,52012,State Senate,SD26,WF,Daniel Squadron,50
-Kings,52013,State Senate,SD26,WF,Daniel Squadron,31
-Kings,52014,State Senate,SD26,WF,Daniel Squadron,42
-Kings,52015,State Senate,SD26,WF,Daniel Squadron,50
-Kings,52016,State Senate,SD26,WF,Daniel Squadron,51
-Kings,52017,State Senate,SD26,WF,Daniel Squadron,53
-Kings,52018,State Senate,SD26,WF,Daniel Squadron,49
-Kings,52019,State Senate,SD26,WF,Daniel Squadron,51
-Kings,52020,State Senate,SD26,WF,Daniel Squadron,30
-Kings,52021,State Senate,SD26,WF,Daniel Squadron,13
-Kings,52034,State Senate,SD26,WF,Daniel Squadron,65
-Kings,52035,State Senate,SD26,WF,Daniel Squadron,68
-Kings,52036,State Senate,SD26,WF,Daniel Squadron,85
-Kings,52037,State Senate,SD26,WF,Daniel Squadron,65
-Kings,52038,State Senate,SD26,WF,Daniel Squadron,72
-Kings,52039,State Senate,SD26,WF,Daniel Squadron,68
-Kings,52040,State Senate,SD26,WF,Daniel Squadron,64
-Kings,52041,State Senate,SD26,WF,Daniel Squadron,42
-Kings,52042,State Senate,SD26,WF,Daniel Squadron,63
-Kings,52043,State Senate,SD26,WF,Daniel Squadron,53
-Kings,52044,State Senate,SD26,WF,Daniel Squadron,64
-Kings,52045,State Senate,SD26,WF,Daniel Squadron,57
-Kings,52046,State Senate,SD26,WF,Daniel Squadron,86
-Kings,52047,State Senate,SD26,WF,Daniel Squadron,45
-Kings,52103,State Senate,SD26,WF,Daniel Squadron,0
-Kings,52104,State Senate,SD26,WF,Daniel Squadron,0
-Kings,52105,State Senate,SD26,WF,Daniel Squadron,0
-Kings,52106,State Senate,SD26,WF,Daniel Squadron,1
-Kings,52110,State Senate,SD26,WF,Daniel Squadron,57
-Kings,53014,State Senate,SD26,WF,Daniel Squadron,1
-Kings,53078,State Senate,SD26,WF,Daniel Squadron,10
-Kings,50024,State Senate,SD26,Rep,Jacqueline Haro,1
-Kings,50026,State Senate,SD26,Rep,Jacqueline Haro,32
-Kings,50027,State Senate,SD26,Rep,Jacqueline Haro,80
-Kings,50028,State Senate,SD26,Rep,Jacqueline Haro,36
-Kings,50029,State Senate,SD26,Rep,Jacqueline Haro,71
-Kings,50030,State Senate,SD26,Rep,Jacqueline Haro,74
-Kings,50031,State Senate,SD26,Rep,Jacqueline Haro,63
-Kings,50032,State Senate,SD26,Rep,Jacqueline Haro,97
-Kings,50033,State Senate,SD26,Rep,Jacqueline Haro,95
-Kings,50034,State Senate,SD26,Rep,Jacqueline Haro,78
-Kings,50035,State Senate,SD26,Rep,Jacqueline Haro,64
-Kings,50036,State Senate,SD26,Rep,Jacqueline Haro,11
-Kings,50037,State Senate,SD26,Rep,Jacqueline Haro,123
-Kings,50038,State Senate,SD26,Rep,Jacqueline Haro,50
-Kings,50039,State Senate,SD26,Rep,Jacqueline Haro,35
-Kings,50040,State Senate,SD26,Rep,Jacqueline Haro,45
-Kings,50041,State Senate,SD26,Rep,Jacqueline Haro,78
-Kings,50042,State Senate,SD26,Rep,Jacqueline Haro,89
-Kings,50047,State Senate,SD26,Rep,Jacqueline Haro,13
-Kings,50048,State Senate,SD26,Rep,Jacqueline Haro,42
-Kings,50055,State Senate,SD26,Rep,Jacqueline Haro,8
-Kings,50064,State Senate,SD26,Rep,Jacqueline Haro,24
-Kings,50065,State Senate,SD26,Rep,Jacqueline Haro,26
-Kings,50066,State Senate,SD26,Rep,Jacqueline Haro,40
-Kings,50067,State Senate,SD26,Rep,Jacqueline Haro,20
-Kings,50068,State Senate,SD26,Rep,Jacqueline Haro,30
-Kings,50069,State Senate,SD26,Rep,Jacqueline Haro,28
-Kings,50070,State Senate,SD26,Rep,Jacqueline Haro,15
-Kings,50071,State Senate,SD26,Rep,Jacqueline Haro,13
-Kings,50072,State Senate,SD26,Rep,Jacqueline Haro,32
-Kings,50073,State Senate,SD26,Rep,Jacqueline Haro,48
-Kings,50074,State Senate,SD26,Rep,Jacqueline Haro,40
-Kings,50075,State Senate,SD26,Rep,Jacqueline Haro,47
-Kings,50076,State Senate,SD26,Rep,Jacqueline Haro,28
-Kings,50077,State Senate,SD26,Rep,Jacqueline Haro,56
-Kings,50078,State Senate,SD26,Rep,Jacqueline Haro,52
-Kings,50079,State Senate,SD26,Rep,Jacqueline Haro,52
-Kings,50080,State Senate,SD26,Rep,Jacqueline Haro,26
-Kings,50082,State Senate,SD26,Rep,Jacqueline Haro,25
-Kings,50087,State Senate,SD26,Rep,Jacqueline Haro,6
-Kings,50094,State Senate,SD26,Rep,Jacqueline Haro,4
-Kings,50099,State Senate,SD26,Rep,Jacqueline Haro,1
-Kings,51007,State Senate,SD26,Rep,Jacqueline Haro,35
-Kings,52001,State Senate,SD26,Rep,Jacqueline Haro,65
-Kings,52002,State Senate,SD26,Rep,Jacqueline Haro,12
-Kings,52004,State Senate,SD26,Rep,Jacqueline Haro,53
-Kings,52005,State Senate,SD26,Rep,Jacqueline Haro,41
-Kings,52006,State Senate,SD26,Rep,Jacqueline Haro,16
-Kings,52007,State Senate,SD26,Rep,Jacqueline Haro,83
-Kings,52008,State Senate,SD26,Rep,Jacqueline Haro,64
-Kings,52009,State Senate,SD26,Rep,Jacqueline Haro,67
-Kings,52010,State Senate,SD26,Rep,Jacqueline Haro,91
-Kings,52011,State Senate,SD26,Rep,Jacqueline Haro,73
-Kings,52012,State Senate,SD26,Rep,Jacqueline Haro,98
-Kings,52013,State Senate,SD26,Rep,Jacqueline Haro,52
-Kings,52014,State Senate,SD26,Rep,Jacqueline Haro,72
-Kings,52015,State Senate,SD26,Rep,Jacqueline Haro,85
-Kings,52016,State Senate,SD26,Rep,Jacqueline Haro,83
-Kings,52017,State Senate,SD26,Rep,Jacqueline Haro,69
-Kings,52018,State Senate,SD26,Rep,Jacqueline Haro,73
-Kings,52019,State Senate,SD26,Rep,Jacqueline Haro,58
-Kings,52020,State Senate,SD26,Rep,Jacqueline Haro,49
-Kings,52021,State Senate,SD26,Rep,Jacqueline Haro,39
-Kings,52034,State Senate,SD26,Rep,Jacqueline Haro,40
-Kings,52035,State Senate,SD26,Rep,Jacqueline Haro,57
-Kings,52036,State Senate,SD26,Rep,Jacqueline Haro,58
-Kings,52037,State Senate,SD26,Rep,Jacqueline Haro,54
-Kings,52038,State Senate,SD26,Rep,Jacqueline Haro,60
-Kings,52039,State Senate,SD26,Rep,Jacqueline Haro,51
-Kings,52040,State Senate,SD26,Rep,Jacqueline Haro,46
-Kings,52041,State Senate,SD26,Rep,Jacqueline Haro,13
-Kings,52042,State Senate,SD26,Rep,Jacqueline Haro,57
-Kings,52043,State Senate,SD26,Rep,Jacqueline Haro,46
-Kings,52044,State Senate,SD26,Rep,Jacqueline Haro,94
-Kings,52045,State Senate,SD26,Rep,Jacqueline Haro,76
-Kings,52046,State Senate,SD26,Rep,Jacqueline Haro,51
-Kings,52047,State Senate,SD26,Rep,Jacqueline Haro,36
-Kings,52103,State Senate,SD26,Rep,Jacqueline Haro,0
-Kings,52104,State Senate,SD26,Rep,Jacqueline Haro,0
-Kings,52105,State Senate,SD26,Rep,Jacqueline Haro,0
-Kings,52106,State Senate,SD26,Rep,Jacqueline Haro,0
-Kings,52110,State Senate,SD26,Rep,Jacqueline Haro,31
-Kings,53014,State Senate,SD26,Rep,Jacqueline Haro,5
-Kings,53078,State Senate,SD26,Rep,Jacqueline Haro,47
-Kings,50024,State Senate,SD26,Ind,writein,0
-Kings,50026,State Senate,SD26,Ind,writein,0
-Kings,50027,State Senate,SD26,Ind,writein,0
-Kings,50028,State Senate,SD26,Ind,writein,0
-Kings,50029,State Senate,SD26,Ind,writein,0
-Kings,50030,State Senate,SD26,Ind,writein,0
-Kings,50031,State Senate,SD26,Ind,writein,1
-Kings,50032,State Senate,SD26,Ind,writein,0
-Kings,50033,State Senate,SD26,Ind,writein,0
-Kings,50034,State Senate,SD26,Ind,writein,0
-Kings,50035,State Senate,SD26,Ind,writein,1
-Kings,50036,State Senate,SD26,Ind,writein,0
-Kings,50037,State Senate,SD26,Ind,writein,0
-Kings,50038,State Senate,SD26,Ind,writein,0
-Kings,50039,State Senate,SD26,Ind,writein,0
-Kings,50040,State Senate,SD26,Ind,writein,0
-Kings,50041,State Senate,SD26,Ind,writein,1
-Kings,50042,State Senate,SD26,Ind,writein,0
-Kings,50047,State Senate,SD26,Ind,writein,1
-Kings,50048,State Senate,SD26,Ind,writein,0
-Kings,50055,State Senate,SD26,Ind,writein,0
-Kings,50064,State Senate,SD26,Ind,writein,2
-Kings,50065,State Senate,SD26,Ind,writein,0
-Kings,50066,State Senate,SD26,Ind,writein,5
-Kings,50067,State Senate,SD26,Ind,writein,1
-Kings,50068,State Senate,SD26,Ind,writein,0
-Kings,50069,State Senate,SD26,Ind,writein,1
-Kings,50070,State Senate,SD26,Ind,writein,0
-Kings,50071,State Senate,SD26,Ind,writein,1
-Kings,50072,State Senate,SD26,Ind,writein,0
-Kings,50073,State Senate,SD26,Ind,writein,0
-Kings,50074,State Senate,SD26,Ind,writein,2
-Kings,50075,State Senate,SD26,Ind,writein,1
-Kings,50076,State Senate,SD26,Ind,writein,1
-Kings,50077,State Senate,SD26,Ind,writein,1
-Kings,50078,State Senate,SD26,Ind,writein,1
-Kings,50079,State Senate,SD26,Ind,writein,0
-Kings,50080,State Senate,SD26,Ind,writein,3
-Kings,50082,State Senate,SD26,Ind,writein,4
-Kings,50087,State Senate,SD26,Ind,writein,0
-Kings,50094,State Senate,SD26,Ind,writein,0
-Kings,50099,State Senate,SD26,Ind,writein,0
-Kings,51007,State Senate,SD26,Ind,writein,0
-Kings,52001,State Senate,SD26,Ind,writein,0
-Kings,52002,State Senate,SD26,Ind,writein,0
-Kings,52004,State Senate,SD26,Ind,writein,0
-Kings,52005,State Senate,SD26,Ind,writein,1
-Kings,52006,State Senate,SD26,Ind,writein,0
-Kings,52007,State Senate,SD26,Ind,writein,0
-Kings,52008,State Senate,SD26,Ind,writein,1
-Kings,52009,State Senate,SD26,Ind,writein,0
-Kings,52010,State Senate,SD26,Ind,writein,3
-Kings,52011,State Senate,SD26,Ind,writein,4
-Kings,52012,State Senate,SD26,Ind,writein,1
-Kings,52013,State Senate,SD26,Ind,writein,0
-Kings,52014,State Senate,SD26,Ind,writein,1
-Kings,52015,State Senate,SD26,Ind,writein,0
-Kings,52016,State Senate,SD26,Ind,writein,0
-Kings,52017,State Senate,SD26,Ind,writein,0
-Kings,52018,State Senate,SD26,Ind,writein,0
-Kings,52019,State Senate,SD26,Ind,writein,0
-Kings,52020,State Senate,SD26,Ind,writein,0
-Kings,52021,State Senate,SD26,Ind,writein,1
-Kings,52034,State Senate,SD26,Ind,writein,0
-Kings,52035,State Senate,SD26,Ind,writein,2
-Kings,52036,State Senate,SD26,Ind,writein,0
-Kings,52037,State Senate,SD26,Ind,writein,0
-Kings,52038,State Senate,SD26,Ind,writein,1
-Kings,52039,State Senate,SD26,Ind,writein,0
-Kings,52040,State Senate,SD26,Ind,writein,0
-Kings,52041,State Senate,SD26,Ind,writein,0
-Kings,52042,State Senate,SD26,Ind,writein,0
-Kings,52043,State Senate,SD26,Ind,writein,0
-Kings,52044,State Senate,SD26,Ind,writein,0
-Kings,52045,State Senate,SD26,Ind,writein,2
-Kings,52046,State Senate,SD26,Ind,writein,2
-Kings,52047,State Senate,SD26,Ind,writein,3
-Kings,52103,State Senate,SD26,Ind,writein,0
-Kings,52104,State Senate,SD26,Ind,writein,0
-Kings,52105,State Senate,SD26,Ind,writein,0
-Kings,52106,State Senate,SD26,Ind,writein,0
-Kings,52110,State Senate,SD26,Ind,writein,0
-Kings,53014,State Senate,SD26,Ind,writein,0
-Kings,53078,State Senate,SD26,Ind,writein,1
+Kings,41001,State Senate,17,SC,Abraham Tischler,4
+Kings,41002,State Senate,17,SC,Abraham Tischler,1
+Kings,41003,State Senate,17,SC,Abraham Tischler,0
+Kings,41004,State Senate,17,SC,Abraham Tischler,0
+Kings,41005,State Senate,17,SC,Abraham Tischler,6
+Kings,41006,State Senate,17,SC,Abraham Tischler,5
+Kings,41007,State Senate,17,SC,Abraham Tischler,6
+Kings,41008,State Senate,17,SC,Abraham Tischler,1
+Kings,41009,State Senate,17,SC,Abraham Tischler,2
+Kings,41010,State Senate,17,SC,Abraham Tischler,2
+Kings,41011,State Senate,17,SC,Abraham Tischler,2
+Kings,41012,State Senate,17,SC,Abraham Tischler,2
+Kings,41024,State Senate,17,SC,Abraham Tischler,0
+Kings,41050,State Senate,17,SC,Abraham Tischler,1
+Kings,41051,State Senate,17,SC,Abraham Tischler,0
+Kings,41052,State Senate,17,SC,Abraham Tischler,0
+Kings,41058,State Senate,17,SC,Abraham Tischler,1
+Kings,41059,State Senate,17,SC,Abraham Tischler,1
+Kings,42034,State Senate,17,SC,Abraham Tischler,6
+Kings,42035,State Senate,17,SC,Abraham Tischler,3
+Kings,42036,State Senate,17,SC,Abraham Tischler,9
+Kings,42037,State Senate,17,SC,Abraham Tischler,3
+Kings,42038,State Senate,17,SC,Abraham Tischler,4
+Kings,42061,State Senate,17,SC,Abraham Tischler,2
+Kings,42062,State Senate,17,SC,Abraham Tischler,3
+Kings,42063,State Senate,17,SC,Abraham Tischler,2
+Kings,42064,State Senate,17,SC,Abraham Tischler,1
+Kings,42065,State Senate,17,SC,Abraham Tischler,4
+Kings,42066,State Senate,17,SC,Abraham Tischler,1
+Kings,42067,State Senate,17,SC,Abraham Tischler,2
+Kings,44001,State Senate,17,SC,Abraham Tischler,5
+Kings,44002,State Senate,17,SC,Abraham Tischler,8
+Kings,44003,State Senate,17,SC,Abraham Tischler,3
+Kings,44004,State Senate,17,SC,Abraham Tischler,3
+Kings,44005,State Senate,17,SC,Abraham Tischler,2
+Kings,44006,State Senate,17,SC,Abraham Tischler,6
+Kings,44007,State Senate,17,SC,Abraham Tischler,9
+Kings,44008,State Senate,17,SC,Abraham Tischler,4
+Kings,44010,State Senate,17,SC,Abraham Tischler,0
+Kings,44013,State Senate,17,SC,Abraham Tischler,1
+Kings,44021,State Senate,17,SC,Abraham Tischler,0
+Kings,44023,State Senate,17,SC,Abraham Tischler,2
+Kings,44024,State Senate,17,SC,Abraham Tischler,3
+Kings,44025,State Senate,17,SC,Abraham Tischler,4
+Kings,44026,State Senate,17,SC,Abraham Tischler,7
+Kings,44027,State Senate,17,SC,Abraham Tischler,4
+Kings,44028,State Senate,17,SC,Abraham Tischler,2
+Kings,44029,State Senate,17,SC,Abraham Tischler,5
+Kings,44030,State Senate,17,SC,Abraham Tischler,6
+Kings,44031,State Senate,17,SC,Abraham Tischler,13
+Kings,44032,State Senate,17,SC,Abraham Tischler,1
+Kings,44033,State Senate,17,SC,Abraham Tischler,6
+Kings,44035,State Senate,17,SC,Abraham Tischler,8
+Kings,44038,State Senate,17,SC,Abraham Tischler,10
+Kings,44039,State Senate,17,SC,Abraham Tischler,2
+Kings,44041,State Senate,17,SC,Abraham Tischler,0
+Kings,44042,State Senate,17,SC,Abraham Tischler,7
+Kings,44043,State Senate,17,SC,Abraham Tischler,8
+Kings,44044,State Senate,17,SC,Abraham Tischler,13
+Kings,44045,State Senate,17,SC,Abraham Tischler,6
+Kings,45001,State Senate,17,SC,Abraham Tischler,4
+Kings,45002,State Senate,17,SC,Abraham Tischler,7
+Kings,45003,State Senate,17,SC,Abraham Tischler,1
+Kings,45004,State Senate,17,SC,Abraham Tischler,5
+Kings,45005,State Senate,17,SC,Abraham Tischler,4
+Kings,45007,State Senate,17,SC,Abraham Tischler,0
+Kings,45010,State Senate,17,SC,Abraham Tischler,0
+Kings,45011,State Senate,17,SC,Abraham Tischler,4
+Kings,45012,State Senate,17,SC,Abraham Tischler,2
+Kings,45013,State Senate,17,SC,Abraham Tischler,2
+Kings,45014,State Senate,17,SC,Abraham Tischler,3
+Kings,45018,State Senate,17,SC,Abraham Tischler,0
+Kings,45023,State Senate,17,SC,Abraham Tischler,1
+Kings,45024,State Senate,17,SC,Abraham Tischler,4
+Kings,45029,State Senate,17,SC,Abraham Tischler,1
+Kings,45030,State Senate,17,SC,Abraham Tischler,4
+Kings,45038,State Senate,17,SC,Abraham Tischler,1
+Kings,45039,State Senate,17,SC,Abraham Tischler,1
+Kings,47023,State Senate,17,SC,Abraham Tischler,2
+Kings,47024,State Senate,17,SC,Abraham Tischler,2
+Kings,47025,State Senate,17,SC,Abraham Tischler,7
+Kings,47026,State Senate,17,SC,Abraham Tischler,0
+Kings,47027,State Senate,17,SC,Abraham Tischler,2
+Kings,47028,State Senate,17,SC,Abraham Tischler,5
+Kings,47029,State Senate,17,SC,Abraham Tischler,3
+Kings,47030,State Senate,17,SC,Abraham Tischler,0
+Kings,47031,State Senate,17,SC,Abraham Tischler,2
+Kings,47032,State Senate,17,SC,Abraham Tischler,0
+Kings,47033,State Senate,17,SC,Abraham Tischler,2
+Kings,48001,State Senate,17,SC,Abraham Tischler,0
+Kings,48002,State Senate,17,SC,Abraham Tischler,1
+Kings,48003,State Senate,17,SC,Abraham Tischler,6
+Kings,48004,State Senate,17,SC,Abraham Tischler,4
+Kings,48005,State Senate,17,SC,Abraham Tischler,1
+Kings,48006,State Senate,17,SC,Abraham Tischler,2
+Kings,48007,State Senate,17,SC,Abraham Tischler,5
+Kings,48008,State Senate,17,SC,Abraham Tischler,2
+Kings,48009,State Senate,17,SC,Abraham Tischler,5
+Kings,48010,State Senate,17,SC,Abraham Tischler,3
+Kings,48011,State Senate,17,SC,Abraham Tischler,7
+Kings,48012,State Senate,17,SC,Abraham Tischler,5
+Kings,48013,State Senate,17,SC,Abraham Tischler,3
+Kings,48014,State Senate,17,SC,Abraham Tischler,4
+Kings,48015,State Senate,17,SC,Abraham Tischler,0
+Kings,48016,State Senate,17,SC,Abraham Tischler,4
+Kings,48017,State Senate,17,SC,Abraham Tischler,3
+Kings,48018,State Senate,17,SC,Abraham Tischler,4
+Kings,48019,State Senate,17,SC,Abraham Tischler,6
+Kings,48020,State Senate,17,SC,Abraham Tischler,2
+Kings,48021,State Senate,17,SC,Abraham Tischler,3
+Kings,48022,State Senate,17,SC,Abraham Tischler,1
+Kings,48023,State Senate,17,SC,Abraham Tischler,1
+Kings,48024,State Senate,17,SC,Abraham Tischler,2
+Kings,48025,State Senate,17,SC,Abraham Tischler,7
+Kings,48026,State Senate,17,SC,Abraham Tischler,1
+Kings,48027,State Senate,17,SC,Abraham Tischler,2
+Kings,48028,State Senate,17,SC,Abraham Tischler,2
+Kings,48029,State Senate,17,SC,Abraham Tischler,4
+Kings,48030,State Senate,17,SC,Abraham Tischler,0
+Kings,48031,State Senate,17,SC,Abraham Tischler,1
+Kings,48032,State Senate,17,SC,Abraham Tischler,5
+Kings,48033,State Senate,17,SC,Abraham Tischler,1
+Kings,48036,State Senate,17,SC,Abraham Tischler,1
+Kings,48038,State Senate,17,SC,Abraham Tischler,1
+Kings,48039,State Senate,17,SC,Abraham Tischler,1
+Kings,48040,State Senate,17,SC,Abraham Tischler,2
+Kings,48041,State Senate,17,SC,Abraham Tischler,1
+Kings,48042,State Senate,17,SC,Abraham Tischler,4
+Kings,48043,State Senate,17,SC,Abraham Tischler,7
+Kings,48044,State Senate,17,SC,Abraham Tischler,2
+Kings,48045,State Senate,17,SC,Abraham Tischler,1
+Kings,48049,State Senate,17,SC,Abraham Tischler,0
+Kings,48054,State Senate,17,SC,Abraham Tischler,4
+Kings,48055,State Senate,17,SC,Abraham Tischler,6
+Kings,48056,State Senate,17,SC,Abraham Tischler,2
+Kings,48057,State Senate,17,SC,Abraham Tischler,5
+Kings,48058,State Senate,17,SC,Abraham Tischler,5
+Kings,48060,State Senate,17,SC,Abraham Tischler,5
+Kings,48061,State Senate,17,SC,Abraham Tischler,4
+Kings,48062,State Senate,17,SC,Abraham Tischler,11
+Kings,48063,State Senate,17,SC,Abraham Tischler,2
+Kings,48064,State Senate,17,SC,Abraham Tischler,4
+Kings,48065,State Senate,17,SC,Abraham Tischler,4
+Kings,48066,State Senate,17,SC,Abraham Tischler,1
+Kings,48067,State Senate,17,SC,Abraham Tischler,2
+Kings,49006,State Senate,17,SC,Abraham Tischler,0
+Kings,49007,State Senate,17,SC,Abraham Tischler,1
+Kings,49008,State Senate,17,SC,Abraham Tischler,6
+Kings,49009,State Senate,17,SC,Abraham Tischler,4
+Kings,49010,State Senate,17,SC,Abraham Tischler,6
+Kings,49011,State Senate,17,SC,Abraham Tischler,0
+Kings,49012,State Senate,17,SC,Abraham Tischler,2
+Kings,49013,State Senate,17,SC,Abraham Tischler,1
+Kings,49030,State Senate,17,SC,Abraham Tischler,3
+Kings,49031,State Senate,17,SC,Abraham Tischler,2
+Kings,49032,State Senate,17,SC,Abraham Tischler,0
+Kings,49033,State Senate,17,SC,Abraham Tischler,1
+Kings,49042,State Senate,17,SC,Abraham Tischler,4
+Kings,49043,State Senate,17,SC,Abraham Tischler,4
+Kings,51001,State Senate,17,SC,Abraham Tischler,11
+Kings,51002,State Senate,17,SC,Abraham Tischler,6
+Kings,51003,State Senate,17,SC,Abraham Tischler,3
+Kings,51004,State Senate,17,SC,Abraham Tischler,1
+Kings,51005,State Senate,17,SC,Abraham Tischler,3
+Kings,51006,State Senate,17,SC,Abraham Tischler,1
+Kings,51014,State Senate,17,SC,Abraham Tischler,2
+Kings,51015,State Senate,17,SC,Abraham Tischler,4
+Kings,51016,State Senate,17,SC,Abraham Tischler,4
+Kings,51017,State Senate,17,SC,Abraham Tischler,1
+Kings,51018,State Senate,17,SC,Abraham Tischler,0
+Kings,41001,State Senate,17,Rep,David Storobin,203
+Kings,41002,State Senate,17,Rep,David Storobin,208
+Kings,41003,State Senate,17,Rep,David Storobin,116
+Kings,41004,State Senate,17,Rep,David Storobin,181
+Kings,41005,State Senate,17,Rep,David Storobin,246
+Kings,41006,State Senate,17,Rep,David Storobin,165
+Kings,41007,State Senate,17,Rep,David Storobin,192
+Kings,41008,State Senate,17,Rep,David Storobin,282
+Kings,41009,State Senate,17,Rep,David Storobin,212
+Kings,41010,State Senate,17,Rep,David Storobin,143
+Kings,41011,State Senate,17,Rep,David Storobin,55
+Kings,41012,State Senate,17,Rep,David Storobin,132
+Kings,41024,State Senate,17,Rep,David Storobin,20
+Kings,41050,State Senate,17,Rep,David Storobin,131
+Kings,41051,State Senate,17,Rep,David Storobin,14
+Kings,41052,State Senate,17,Rep,David Storobin,45
+Kings,41058,State Senate,17,Rep,David Storobin,251
+Kings,41059,State Senate,17,Rep,David Storobin,200
+Kings,42034,State Senate,17,Rep,David Storobin,30
+Kings,42035,State Senate,17,Rep,David Storobin,13
+Kings,42036,State Senate,17,Rep,David Storobin,110
+Kings,42037,State Senate,17,Rep,David Storobin,5
+Kings,42038,State Senate,17,Rep,David Storobin,139
+Kings,42061,State Senate,17,Rep,David Storobin,143
+Kings,42062,State Senate,17,Rep,David Storobin,133
+Kings,42063,State Senate,17,Rep,David Storobin,73
+Kings,42064,State Senate,17,Rep,David Storobin,122
+Kings,42065,State Senate,17,Rep,David Storobin,146
+Kings,42066,State Senate,17,Rep,David Storobin,183
+Kings,42067,State Senate,17,Rep,David Storobin,47
+Kings,44001,State Senate,17,Rep,David Storobin,162
+Kings,44002,State Senate,17,Rep,David Storobin,126
+Kings,44003,State Senate,17,Rep,David Storobin,129
+Kings,44004,State Senate,17,Rep,David Storobin,111
+Kings,44005,State Senate,17,Rep,David Storobin,88
+Kings,44006,State Senate,17,Rep,David Storobin,69
+Kings,44007,State Senate,17,Rep,David Storobin,84
+Kings,44008,State Senate,17,Rep,David Storobin,44
+Kings,44010,State Senate,17,Rep,David Storobin,0
+Kings,44013,State Senate,17,Rep,David Storobin,30
+Kings,44021,State Senate,17,Rep,David Storobin,29
+Kings,44023,State Senate,17,Rep,David Storobin,75
+Kings,44024,State Senate,17,Rep,David Storobin,136
+Kings,44025,State Senate,17,Rep,David Storobin,264
+Kings,44026,State Senate,17,Rep,David Storobin,215
+Kings,44027,State Senate,17,Rep,David Storobin,148
+Kings,44028,State Senate,17,Rep,David Storobin,119
+Kings,44029,State Senate,17,Rep,David Storobin,115
+Kings,44030,State Senate,17,Rep,David Storobin,143
+Kings,44031,State Senate,17,Rep,David Storobin,72
+Kings,44032,State Senate,17,Rep,David Storobin,5
+Kings,44033,State Senate,17,Rep,David Storobin,55
+Kings,44035,State Senate,17,Rep,David Storobin,41
+Kings,44038,State Senate,17,Rep,David Storobin,43
+Kings,44039,State Senate,17,Rep,David Storobin,30
+Kings,44041,State Senate,17,Rep,David Storobin,35
+Kings,44042,State Senate,17,Rep,David Storobin,137
+Kings,44043,State Senate,17,Rep,David Storobin,83
+Kings,44044,State Senate,17,Rep,David Storobin,90
+Kings,44045,State Senate,17,Rep,David Storobin,99
+Kings,45001,State Senate,17,Rep,David Storobin,193
+Kings,45002,State Senate,17,Rep,David Storobin,200
+Kings,45003,State Senate,17,Rep,David Storobin,196
+Kings,45004,State Senate,17,Rep,David Storobin,168
+Kings,45005,State Senate,17,Rep,David Storobin,155
+Kings,45007,State Senate,17,Rep,David Storobin,11
+Kings,45010,State Senate,17,Rep,David Storobin,66
+Kings,45011,State Senate,17,Rep,David Storobin,181
+Kings,45012,State Senate,17,Rep,David Storobin,226
+Kings,45013,State Senate,17,Rep,David Storobin,191
+Kings,45014,State Senate,17,Rep,David Storobin,216
+Kings,45018,State Senate,17,Rep,David Storobin,9
+Kings,45023,State Senate,17,Rep,David Storobin,190
+Kings,45024,State Senate,17,Rep,David Storobin,188
+Kings,45029,State Senate,17,Rep,David Storobin,87
+Kings,45030,State Senate,17,Rep,David Storobin,190
+Kings,45038,State Senate,17,Rep,David Storobin,63
+Kings,45039,State Senate,17,Rep,David Storobin,13
+Kings,47023,State Senate,17,Rep,David Storobin,176
+Kings,47024,State Senate,17,Rep,David Storobin,182
+Kings,47025,State Senate,17,Rep,David Storobin,123
+Kings,47026,State Senate,17,Rep,David Storobin,176
+Kings,47027,State Senate,17,Rep,David Storobin,117
+Kings,47028,State Senate,17,Rep,David Storobin,167
+Kings,47029,State Senate,17,Rep,David Storobin,207
+Kings,47030,State Senate,17,Rep,David Storobin,4
+Kings,47031,State Senate,17,Rep,David Storobin,110
+Kings,47032,State Senate,17,Rep,David Storobin,25
+Kings,47033,State Senate,17,Rep,David Storobin,40
+Kings,48001,State Senate,17,Rep,David Storobin,20
+Kings,48002,State Senate,17,Rep,David Storobin,37
+Kings,48003,State Senate,17,Rep,David Storobin,172
+Kings,48004,State Senate,17,Rep,David Storobin,171
+Kings,48005,State Senate,17,Rep,David Storobin,122
+Kings,48006,State Senate,17,Rep,David Storobin,161
+Kings,48007,State Senate,17,Rep,David Storobin,139
+Kings,48008,State Senate,17,Rep,David Storobin,3
+Kings,48009,State Senate,17,Rep,David Storobin,169
+Kings,48010,State Senate,17,Rep,David Storobin,173
+Kings,48011,State Senate,17,Rep,David Storobin,142
+Kings,48012,State Senate,17,Rep,David Storobin,165
+Kings,48013,State Senate,17,Rep,David Storobin,130
+Kings,48014,State Senate,17,Rep,David Storobin,188
+Kings,48015,State Senate,17,Rep,David Storobin,15
+Kings,48016,State Senate,17,Rep,David Storobin,174
+Kings,48017,State Senate,17,Rep,David Storobin,207
+Kings,48018,State Senate,17,Rep,David Storobin,205
+Kings,48019,State Senate,17,Rep,David Storobin,141
+Kings,48020,State Senate,17,Rep,David Storobin,195
+Kings,48021,State Senate,17,Rep,David Storobin,174
+Kings,48022,State Senate,17,Rep,David Storobin,216
+Kings,48023,State Senate,17,Rep,David Storobin,164
+Kings,48024,State Senate,17,Rep,David Storobin,158
+Kings,48025,State Senate,17,Rep,David Storobin,157
+Kings,48026,State Senate,17,Rep,David Storobin,139
+Kings,48027,State Senate,17,Rep,David Storobin,103
+Kings,48028,State Senate,17,Rep,David Storobin,199
+Kings,48029,State Senate,17,Rep,David Storobin,192
+Kings,48030,State Senate,17,Rep,David Storobin,139
+Kings,48031,State Senate,17,Rep,David Storobin,47
+Kings,48032,State Senate,17,Rep,David Storobin,205
+Kings,48033,State Senate,17,Rep,David Storobin,83
+Kings,48036,State Senate,17,Rep,David Storobin,150
+Kings,48038,State Senate,17,Rep,David Storobin,55
+Kings,48039,State Senate,17,Rep,David Storobin,96
+Kings,48040,State Senate,17,Rep,David Storobin,151
+Kings,48041,State Senate,17,Rep,David Storobin,47
+Kings,48042,State Senate,17,Rep,David Storobin,117
+Kings,48043,State Senate,17,Rep,David Storobin,180
+Kings,48044,State Senate,17,Rep,David Storobin,83
+Kings,48045,State Senate,17,Rep,David Storobin,64
+Kings,48049,State Senate,17,Rep,David Storobin,27
+Kings,48054,State Senate,17,Rep,David Storobin,132
+Kings,48055,State Senate,17,Rep,David Storobin,267
+Kings,48056,State Senate,17,Rep,David Storobin,153
+Kings,48057,State Senate,17,Rep,David Storobin,138
+Kings,48058,State Senate,17,Rep,David Storobin,159
+Kings,48060,State Senate,17,Rep,David Storobin,196
+Kings,48061,State Senate,17,Rep,David Storobin,152
+Kings,48062,State Senate,17,Rep,David Storobin,139
+Kings,48063,State Senate,17,Rep,David Storobin,97
+Kings,48064,State Senate,17,Rep,David Storobin,137
+Kings,48065,State Senate,17,Rep,David Storobin,63
+Kings,48066,State Senate,17,Rep,David Storobin,81
+Kings,48067,State Senate,17,Rep,David Storobin,59
+Kings,49006,State Senate,17,Rep,David Storobin,18
+Kings,49007,State Senate,17,Rep,David Storobin,21
+Kings,49008,State Senate,17,Rep,David Storobin,76
+Kings,49009,State Senate,17,Rep,David Storobin,39
+Kings,49010,State Senate,17,Rep,David Storobin,50
+Kings,49011,State Senate,17,Rep,David Storobin,20
+Kings,49012,State Senate,17,Rep,David Storobin,12
+Kings,49013,State Senate,17,Rep,David Storobin,12
+Kings,49030,State Senate,17,Rep,David Storobin,64
+Kings,49031,State Senate,17,Rep,David Storobin,59
+Kings,49032,State Senate,17,Rep,David Storobin,14
+Kings,49033,State Senate,17,Rep,David Storobin,32
+Kings,49042,State Senate,17,Rep,David Storobin,108
+Kings,49043,State Senate,17,Rep,David Storobin,121
+Kings,51001,State Senate,17,Rep,David Storobin,62
+Kings,51002,State Senate,17,Rep,David Storobin,48
+Kings,51003,State Senate,17,Rep,David Storobin,46
+Kings,51004,State Senate,17,Rep,David Storobin,66
+Kings,51005,State Senate,17,Rep,David Storobin,38
+Kings,51006,State Senate,17,Rep,David Storobin,40
+Kings,51014,State Senate,17,Rep,David Storobin,20
+Kings,51015,State Senate,17,Rep,David Storobin,149
+Kings,51016,State Senate,17,Rep,David Storobin,128
+Kings,51017,State Senate,17,Rep,David Storobin,46
+Kings,51018,State Senate,17,Rep,David Storobin,47
+Kings,41001,State Senate,17,Dem,Simcha Felder,246
+Kings,41002,State Senate,17,Dem,Simcha Felder,260
+Kings,41003,State Senate,17,Dem,Simcha Felder,91
+Kings,41004,State Senate,17,Dem,Simcha Felder,165
+Kings,41005,State Senate,17,Dem,Simcha Felder,233
+Kings,41006,State Senate,17,Dem,Simcha Felder,154
+Kings,41007,State Senate,17,Dem,Simcha Felder,228
+Kings,41008,State Senate,17,Dem,Simcha Felder,191
+Kings,41009,State Senate,17,Dem,Simcha Felder,188
+Kings,41010,State Senate,17,Dem,Simcha Felder,136
+Kings,41011,State Senate,17,Dem,Simcha Felder,94
+Kings,41012,State Senate,17,Dem,Simcha Felder,135
+Kings,41024,State Senate,17,Dem,Simcha Felder,51
+Kings,41050,State Senate,17,Dem,Simcha Felder,265
+Kings,41051,State Senate,17,Dem,Simcha Felder,100
+Kings,41052,State Senate,17,Dem,Simcha Felder,183
+Kings,41058,State Senate,17,Dem,Simcha Felder,290
+Kings,41059,State Senate,17,Dem,Simcha Felder,194
+Kings,42034,State Senate,17,Dem,Simcha Felder,225
+Kings,42035,State Senate,17,Dem,Simcha Felder,66
+Kings,42036,State Senate,17,Dem,Simcha Felder,391
+Kings,42037,State Senate,17,Dem,Simcha Felder,92
+Kings,42038,State Senate,17,Dem,Simcha Felder,200
+Kings,42061,State Senate,17,Dem,Simcha Felder,248
+Kings,42062,State Senate,17,Dem,Simcha Felder,216
+Kings,42063,State Senate,17,Dem,Simcha Felder,131
+Kings,42064,State Senate,17,Dem,Simcha Felder,294
+Kings,42065,State Senate,17,Dem,Simcha Felder,281
+Kings,42066,State Senate,17,Dem,Simcha Felder,256
+Kings,42067,State Senate,17,Dem,Simcha Felder,108
+Kings,44001,State Senate,17,Dem,Simcha Felder,270
+Kings,44002,State Senate,17,Dem,Simcha Felder,294
+Kings,44003,State Senate,17,Dem,Simcha Felder,234
+Kings,44004,State Senate,17,Dem,Simcha Felder,299
+Kings,44005,State Senate,17,Dem,Simcha Felder,310
+Kings,44006,State Senate,17,Dem,Simcha Felder,311
+Kings,44007,State Senate,17,Dem,Simcha Felder,412
+Kings,44008,State Senate,17,Dem,Simcha Felder,222
+Kings,44010,State Senate,17,Dem,Simcha Felder,0
+Kings,44013,State Senate,17,Dem,Simcha Felder,74
+Kings,44021,State Senate,17,Dem,Simcha Felder,52
+Kings,44023,State Senate,17,Dem,Simcha Felder,185
+Kings,44024,State Senate,17,Dem,Simcha Felder,406
+Kings,44025,State Senate,17,Dem,Simcha Felder,329
+Kings,44026,State Senate,17,Dem,Simcha Felder,290
+Kings,44027,State Senate,17,Dem,Simcha Felder,238
+Kings,44028,State Senate,17,Dem,Simcha Felder,342
+Kings,44029,State Senate,17,Dem,Simcha Felder,322
+Kings,44030,State Senate,17,Dem,Simcha Felder,271
+Kings,44031,State Senate,17,Dem,Simcha Felder,402
+Kings,44032,State Senate,17,Dem,Simcha Felder,65
+Kings,44033,State Senate,17,Dem,Simcha Felder,368
+Kings,44035,State Senate,17,Dem,Simcha Felder,371
+Kings,44038,State Senate,17,Dem,Simcha Felder,362
+Kings,44039,State Senate,17,Dem,Simcha Felder,268
+Kings,44041,State Senate,17,Dem,Simcha Felder,103
+Kings,44042,State Senate,17,Dem,Simcha Felder,305
+Kings,44043,State Senate,17,Dem,Simcha Felder,270
+Kings,44044,State Senate,17,Dem,Simcha Felder,363
+Kings,44045,State Senate,17,Dem,Simcha Felder,353
+Kings,45001,State Senate,17,Dem,Simcha Felder,301
+Kings,45002,State Senate,17,Dem,Simcha Felder,262
+Kings,45003,State Senate,17,Dem,Simcha Felder,190
+Kings,45004,State Senate,17,Dem,Simcha Felder,211
+Kings,45005,State Senate,17,Dem,Simcha Felder,128
+Kings,45007,State Senate,17,Dem,Simcha Felder,15
+Kings,45010,State Senate,17,Dem,Simcha Felder,91
+Kings,45011,State Senate,17,Dem,Simcha Felder,209
+Kings,45012,State Senate,17,Dem,Simcha Felder,193
+Kings,45013,State Senate,17,Dem,Simcha Felder,199
+Kings,45014,State Senate,17,Dem,Simcha Felder,196
+Kings,45018,State Senate,17,Dem,Simcha Felder,19
+Kings,45023,State Senate,17,Dem,Simcha Felder,226
+Kings,45024,State Senate,17,Dem,Simcha Felder,244
+Kings,45029,State Senate,17,Dem,Simcha Felder,93
+Kings,45030,State Senate,17,Dem,Simcha Felder,203
+Kings,45038,State Senate,17,Dem,Simcha Felder,91
+Kings,45039,State Senate,17,Dem,Simcha Felder,9
+Kings,47023,State Senate,17,Dem,Simcha Felder,168
+Kings,47024,State Senate,17,Dem,Simcha Felder,212
+Kings,47025,State Senate,17,Dem,Simcha Felder,236
+Kings,47026,State Senate,17,Dem,Simcha Felder,179
+Kings,47027,State Senate,17,Dem,Simcha Felder,210
+Kings,47028,State Senate,17,Dem,Simcha Felder,207
+Kings,47029,State Senate,17,Dem,Simcha Felder,188
+Kings,47030,State Senate,17,Dem,Simcha Felder,12
+Kings,47031,State Senate,17,Dem,Simcha Felder,198
+Kings,47032,State Senate,17,Dem,Simcha Felder,71
+Kings,47033,State Senate,17,Dem,Simcha Felder,76
+Kings,48001,State Senate,17,Dem,Simcha Felder,34
+Kings,48002,State Senate,17,Dem,Simcha Felder,55
+Kings,48003,State Senate,17,Dem,Simcha Felder,170
+Kings,48004,State Senate,17,Dem,Simcha Felder,242
+Kings,48005,State Senate,17,Dem,Simcha Felder,234
+Kings,48006,State Senate,17,Dem,Simcha Felder,128
+Kings,48007,State Senate,17,Dem,Simcha Felder,170
+Kings,48008,State Senate,17,Dem,Simcha Felder,16
+Kings,48009,State Senate,17,Dem,Simcha Felder,178
+Kings,48010,State Senate,17,Dem,Simcha Felder,216
+Kings,48011,State Senate,17,Dem,Simcha Felder,266
+Kings,48012,State Senate,17,Dem,Simcha Felder,233
+Kings,48013,State Senate,17,Dem,Simcha Felder,227
+Kings,48014,State Senate,17,Dem,Simcha Felder,173
+Kings,48015,State Senate,17,Dem,Simcha Felder,24
+Kings,48016,State Senate,17,Dem,Simcha Felder,184
+Kings,48017,State Senate,17,Dem,Simcha Felder,218
+Kings,48018,State Senate,17,Dem,Simcha Felder,213
+Kings,48019,State Senate,17,Dem,Simcha Felder,285
+Kings,48020,State Senate,17,Dem,Simcha Felder,260
+Kings,48021,State Senate,17,Dem,Simcha Felder,213
+Kings,48022,State Senate,17,Dem,Simcha Felder,279
+Kings,48023,State Senate,17,Dem,Simcha Felder,217
+Kings,48024,State Senate,17,Dem,Simcha Felder,218
+Kings,48025,State Senate,17,Dem,Simcha Felder,269
+Kings,48026,State Senate,17,Dem,Simcha Felder,227
+Kings,48027,State Senate,17,Dem,Simcha Felder,258
+Kings,48028,State Senate,17,Dem,Simcha Felder,242
+Kings,48029,State Senate,17,Dem,Simcha Felder,222
+Kings,48030,State Senate,17,Dem,Simcha Felder,235
+Kings,48031,State Senate,17,Dem,Simcha Felder,98
+Kings,48032,State Senate,17,Dem,Simcha Felder,195
+Kings,48033,State Senate,17,Dem,Simcha Felder,126
+Kings,48036,State Senate,17,Dem,Simcha Felder,190
+Kings,48038,State Senate,17,Dem,Simcha Felder,81
+Kings,48039,State Senate,17,Dem,Simcha Felder,99
+Kings,48040,State Senate,17,Dem,Simcha Felder,220
+Kings,48041,State Senate,17,Dem,Simcha Felder,95
+Kings,48042,State Senate,17,Dem,Simcha Felder,152
+Kings,48043,State Senate,17,Dem,Simcha Felder,258
+Kings,48044,State Senate,17,Dem,Simcha Felder,133
+Kings,48045,State Senate,17,Dem,Simcha Felder,89
+Kings,48049,State Senate,17,Dem,Simcha Felder,71
+Kings,48054,State Senate,17,Dem,Simcha Felder,101
+Kings,48055,State Senate,17,Dem,Simcha Felder,228
+Kings,48056,State Senate,17,Dem,Simcha Felder,273
+Kings,48057,State Senate,17,Dem,Simcha Felder,183
+Kings,48058,State Senate,17,Dem,Simcha Felder,266
+Kings,48060,State Senate,17,Dem,Simcha Felder,283
+Kings,48061,State Senate,17,Dem,Simcha Felder,236
+Kings,48062,State Senate,17,Dem,Simcha Felder,299
+Kings,48063,State Senate,17,Dem,Simcha Felder,301
+Kings,48064,State Senate,17,Dem,Simcha Felder,206
+Kings,48065,State Senate,17,Dem,Simcha Felder,130
+Kings,48066,State Senate,17,Dem,Simcha Felder,141
+Kings,48067,State Senate,17,Dem,Simcha Felder,59
+Kings,49006,State Senate,17,Dem,Simcha Felder,69
+Kings,49007,State Senate,17,Dem,Simcha Felder,47
+Kings,49008,State Senate,17,Dem,Simcha Felder,203
+Kings,49009,State Senate,17,Dem,Simcha Felder,171
+Kings,49010,State Senate,17,Dem,Simcha Felder,194
+Kings,49011,State Senate,17,Dem,Simcha Felder,61
+Kings,49012,State Senate,17,Dem,Simcha Felder,60
+Kings,49013,State Senate,17,Dem,Simcha Felder,51
+Kings,49030,State Senate,17,Dem,Simcha Felder,93
+Kings,49031,State Senate,17,Dem,Simcha Felder,44
+Kings,49032,State Senate,17,Dem,Simcha Felder,47
+Kings,49033,State Senate,17,Dem,Simcha Felder,38
+Kings,49042,State Senate,17,Dem,Simcha Felder,233
+Kings,49043,State Senate,17,Dem,Simcha Felder,174
+Kings,51001,State Senate,17,Dem,Simcha Felder,387
+Kings,51002,State Senate,17,Dem,Simcha Felder,263
+Kings,51003,State Senate,17,Dem,Simcha Felder,382
+Kings,51004,State Senate,17,Dem,Simcha Felder,342
+Kings,51005,State Senate,17,Dem,Simcha Felder,294
+Kings,51006,State Senate,17,Dem,Simcha Felder,231
+Kings,51014,State Senate,17,Dem,Simcha Felder,61
+Kings,51015,State Senate,17,Dem,Simcha Felder,272
+Kings,51016,State Senate,17,Dem,Simcha Felder,221
+Kings,51017,State Senate,17,Dem,Simcha Felder,115
+Kings,51018,State Senate,17,Dem,Simcha Felder,63
+Kings,41001,State Senate,17,Con,Simcha Felder,56
+Kings,41002,State Senate,17,Con,Simcha Felder,37
+Kings,41003,State Senate,17,Con,Simcha Felder,4
+Kings,41004,State Senate,17,Con,Simcha Felder,20
+Kings,41005,State Senate,17,Con,Simcha Felder,52
+Kings,41006,State Senate,17,Con,Simcha Felder,27
+Kings,41007,State Senate,17,Con,Simcha Felder,30
+Kings,41008,State Senate,17,Con,Simcha Felder,21
+Kings,41009,State Senate,17,Con,Simcha Felder,36
+Kings,41010,State Senate,17,Con,Simcha Felder,8
+Kings,41011,State Senate,17,Con,Simcha Felder,8
+Kings,41012,State Senate,17,Con,Simcha Felder,38
+Kings,41024,State Senate,17,Con,Simcha Felder,4
+Kings,41050,State Senate,17,Con,Simcha Felder,67
+Kings,41051,State Senate,17,Con,Simcha Felder,10
+Kings,41052,State Senate,17,Con,Simcha Felder,35
+Kings,41058,State Senate,17,Con,Simcha Felder,72
+Kings,41059,State Senate,17,Con,Simcha Felder,44
+Kings,42034,State Senate,17,Con,Simcha Felder,6
+Kings,42035,State Senate,17,Con,Simcha Felder,3
+Kings,42036,State Senate,17,Con,Simcha Felder,72
+Kings,42037,State Senate,17,Con,Simcha Felder,4
+Kings,42038,State Senate,17,Con,Simcha Felder,96
+Kings,42061,State Senate,17,Con,Simcha Felder,62
+Kings,42062,State Senate,17,Con,Simcha Felder,131
+Kings,42063,State Senate,17,Con,Simcha Felder,26
+Kings,42064,State Senate,17,Con,Simcha Felder,100
+Kings,42065,State Senate,17,Con,Simcha Felder,112
+Kings,42066,State Senate,17,Con,Simcha Felder,83
+Kings,42067,State Senate,17,Con,Simcha Felder,10
+Kings,44001,State Senate,17,Con,Simcha Felder,96
+Kings,44002,State Senate,17,Con,Simcha Felder,133
+Kings,44003,State Senate,17,Con,Simcha Felder,130
+Kings,44004,State Senate,17,Con,Simcha Felder,84
+Kings,44005,State Senate,17,Con,Simcha Felder,59
+Kings,44006,State Senate,17,Con,Simcha Felder,40
+Kings,44007,State Senate,17,Con,Simcha Felder,21
+Kings,44008,State Senate,17,Con,Simcha Felder,25
+Kings,44010,State Senate,17,Con,Simcha Felder,0
+Kings,44013,State Senate,17,Con,Simcha Felder,18
+Kings,44021,State Senate,17,Con,Simcha Felder,17
+Kings,44023,State Senate,17,Con,Simcha Felder,50
+Kings,44024,State Senate,17,Con,Simcha Felder,98
+Kings,44025,State Senate,17,Con,Simcha Felder,96
+Kings,44026,State Senate,17,Con,Simcha Felder,38
+Kings,44027,State Senate,17,Con,Simcha Felder,68
+Kings,44028,State Senate,17,Con,Simcha Felder,18
+Kings,44029,State Senate,17,Con,Simcha Felder,17
+Kings,44030,State Senate,17,Con,Simcha Felder,26
+Kings,44031,State Senate,17,Con,Simcha Felder,15
+Kings,44032,State Senate,17,Con,Simcha Felder,5
+Kings,44033,State Senate,17,Con,Simcha Felder,8
+Kings,44035,State Senate,17,Con,Simcha Felder,19
+Kings,44038,State Senate,17,Con,Simcha Felder,6
+Kings,44039,State Senate,17,Con,Simcha Felder,5
+Kings,44041,State Senate,17,Con,Simcha Felder,29
+Kings,44042,State Senate,17,Con,Simcha Felder,60
+Kings,44043,State Senate,17,Con,Simcha Felder,37
+Kings,44044,State Senate,17,Con,Simcha Felder,32
+Kings,44045,State Senate,17,Con,Simcha Felder,11
+Kings,45001,State Senate,17,Con,Simcha Felder,88
+Kings,45002,State Senate,17,Con,Simcha Felder,45
+Kings,45003,State Senate,17,Con,Simcha Felder,73
+Kings,45004,State Senate,17,Con,Simcha Felder,46
+Kings,45005,State Senate,17,Con,Simcha Felder,44
+Kings,45007,State Senate,17,Con,Simcha Felder,2
+Kings,45010,State Senate,17,Con,Simcha Felder,35
+Kings,45011,State Senate,17,Con,Simcha Felder,18
+Kings,45012,State Senate,17,Con,Simcha Felder,18
+Kings,45013,State Senate,17,Con,Simcha Felder,46
+Kings,45014,State Senate,17,Con,Simcha Felder,40
+Kings,45018,State Senate,17,Con,Simcha Felder,3
+Kings,45023,State Senate,17,Con,Simcha Felder,32
+Kings,45024,State Senate,17,Con,Simcha Felder,30
+Kings,45029,State Senate,17,Con,Simcha Felder,10
+Kings,45030,State Senate,17,Con,Simcha Felder,18
+Kings,45038,State Senate,17,Con,Simcha Felder,2
+Kings,45039,State Senate,17,Con,Simcha Felder,1
+Kings,47023,State Senate,17,Con,Simcha Felder,9
+Kings,47024,State Senate,17,Con,Simcha Felder,12
+Kings,47025,State Senate,17,Con,Simcha Felder,15
+Kings,47026,State Senate,17,Con,Simcha Felder,13
+Kings,47027,State Senate,17,Con,Simcha Felder,21
+Kings,47028,State Senate,17,Con,Simcha Felder,11
+Kings,47029,State Senate,17,Con,Simcha Felder,16
+Kings,47030,State Senate,17,Con,Simcha Felder,0
+Kings,47031,State Senate,17,Con,Simcha Felder,15
+Kings,47032,State Senate,17,Con,Simcha Felder,1
+Kings,47033,State Senate,17,Con,Simcha Felder,1
+Kings,48001,State Senate,17,Con,Simcha Felder,6
+Kings,48002,State Senate,17,Con,Simcha Felder,7
+Kings,48003,State Senate,17,Con,Simcha Felder,46
+Kings,48004,State Senate,17,Con,Simcha Felder,49
+Kings,48005,State Senate,17,Con,Simcha Felder,40
+Kings,48006,State Senate,17,Con,Simcha Felder,34
+Kings,48007,State Senate,17,Con,Simcha Felder,53
+Kings,48008,State Senate,17,Con,Simcha Felder,0
+Kings,48009,State Senate,17,Con,Simcha Felder,57
+Kings,48010,State Senate,17,Con,Simcha Felder,61
+Kings,48011,State Senate,17,Con,Simcha Felder,97
+Kings,48012,State Senate,17,Con,Simcha Felder,82
+Kings,48013,State Senate,17,Con,Simcha Felder,60
+Kings,48014,State Senate,17,Con,Simcha Felder,56
+Kings,48015,State Senate,17,Con,Simcha Felder,3
+Kings,48016,State Senate,17,Con,Simcha Felder,57
+Kings,48017,State Senate,17,Con,Simcha Felder,73
+Kings,48018,State Senate,17,Con,Simcha Felder,69
+Kings,48019,State Senate,17,Con,Simcha Felder,72
+Kings,48020,State Senate,17,Con,Simcha Felder,80
+Kings,48021,State Senate,17,Con,Simcha Felder,69
+Kings,48022,State Senate,17,Con,Simcha Felder,80
+Kings,48023,State Senate,17,Con,Simcha Felder,68
+Kings,48024,State Senate,17,Con,Simcha Felder,83
+Kings,48025,State Senate,17,Con,Simcha Felder,78
+Kings,48026,State Senate,17,Con,Simcha Felder,89
+Kings,48027,State Senate,17,Con,Simcha Felder,107
+Kings,48028,State Senate,17,Con,Simcha Felder,75
+Kings,48029,State Senate,17,Con,Simcha Felder,76
+Kings,48030,State Senate,17,Con,Simcha Felder,93
+Kings,48031,State Senate,17,Con,Simcha Felder,33
+Kings,48032,State Senate,17,Con,Simcha Felder,51
+Kings,48033,State Senate,17,Con,Simcha Felder,28
+Kings,48036,State Senate,17,Con,Simcha Felder,14
+Kings,48038,State Senate,17,Con,Simcha Felder,17
+Kings,48039,State Senate,17,Con,Simcha Felder,20
+Kings,48040,State Senate,17,Con,Simcha Felder,52
+Kings,48041,State Senate,17,Con,Simcha Felder,15
+Kings,48042,State Senate,17,Con,Simcha Felder,25
+Kings,48043,State Senate,17,Con,Simcha Felder,6
+Kings,48044,State Senate,17,Con,Simcha Felder,6
+Kings,48045,State Senate,17,Con,Simcha Felder,20
+Kings,48049,State Senate,17,Con,Simcha Felder,8
+Kings,48054,State Senate,17,Con,Simcha Felder,30
+Kings,48055,State Senate,17,Con,Simcha Felder,21
+Kings,48056,State Senate,17,Con,Simcha Felder,60
+Kings,48057,State Senate,17,Con,Simcha Felder,39
+Kings,48058,State Senate,17,Con,Simcha Felder,60
+Kings,48060,State Senate,17,Con,Simcha Felder,81
+Kings,48061,State Senate,17,Con,Simcha Felder,51
+Kings,48062,State Senate,17,Con,Simcha Felder,42
+Kings,48063,State Senate,17,Con,Simcha Felder,20
+Kings,48064,State Senate,17,Con,Simcha Felder,36
+Kings,48065,State Senate,17,Con,Simcha Felder,20
+Kings,48066,State Senate,17,Con,Simcha Felder,29
+Kings,48067,State Senate,17,Con,Simcha Felder,21
+Kings,49006,State Senate,17,Con,Simcha Felder,7
+Kings,49007,State Senate,17,Con,Simcha Felder,2
+Kings,49008,State Senate,17,Con,Simcha Felder,19
+Kings,49009,State Senate,17,Con,Simcha Felder,15
+Kings,49010,State Senate,17,Con,Simcha Felder,9
+Kings,49011,State Senate,17,Con,Simcha Felder,2
+Kings,49012,State Senate,17,Con,Simcha Felder,1
+Kings,49013,State Senate,17,Con,Simcha Felder,3
+Kings,49030,State Senate,17,Con,Simcha Felder,10
+Kings,49031,State Senate,17,Con,Simcha Felder,6
+Kings,49032,State Senate,17,Con,Simcha Felder,5
+Kings,49033,State Senate,17,Con,Simcha Felder,13
+Kings,49042,State Senate,17,Con,Simcha Felder,7
+Kings,49043,State Senate,17,Con,Simcha Felder,23
+Kings,51001,State Senate,17,Con,Simcha Felder,11
+Kings,51002,State Senate,17,Con,Simcha Felder,10
+Kings,51003,State Senate,17,Con,Simcha Felder,9
+Kings,51004,State Senate,17,Con,Simcha Felder,11
+Kings,51005,State Senate,17,Con,Simcha Felder,6
+Kings,51006,State Senate,17,Con,Simcha Felder,14
+Kings,51014,State Senate,17,Con,Simcha Felder,5
+Kings,51015,State Senate,17,Con,Simcha Felder,48
+Kings,51016,State Senate,17,Con,Simcha Felder,51
+Kings,51017,State Senate,17,Con,Simcha Felder,15
+Kings,51018,State Senate,17,Con,Simcha Felder,12
+Kings,41001,State Senate,17,WF,Simcha Felder,1
+Kings,41002,State Senate,17,WF,Simcha Felder,1
+Kings,41003,State Senate,17,WF,Simcha Felder,0
+Kings,41004,State Senate,17,WF,Simcha Felder,4
+Kings,41005,State Senate,17,WF,Simcha Felder,2
+Kings,41006,State Senate,17,WF,Simcha Felder,0
+Kings,41007,State Senate,17,WF,Simcha Felder,4
+Kings,41008,State Senate,17,WF,Simcha Felder,4
+Kings,41009,State Senate,17,WF,Simcha Felder,5
+Kings,41010,State Senate,17,WF,Simcha Felder,0
+Kings,41011,State Senate,17,WF,Simcha Felder,0
+Kings,41012,State Senate,17,WF,Simcha Felder,2
+Kings,41024,State Senate,17,WF,Simcha Felder,0
+Kings,41050,State Senate,17,WF,Simcha Felder,4
+Kings,41051,State Senate,17,WF,Simcha Felder,1
+Kings,41052,State Senate,17,WF,Simcha Felder,0
+Kings,41058,State Senate,17,WF,Simcha Felder,2
+Kings,41059,State Senate,17,WF,Simcha Felder,1
+Kings,42034,State Senate,17,WF,Simcha Felder,2
+Kings,42035,State Senate,17,WF,Simcha Felder,1
+Kings,42036,State Senate,17,WF,Simcha Felder,6
+Kings,42037,State Senate,17,WF,Simcha Felder,2
+Kings,42038,State Senate,17,WF,Simcha Felder,4
+Kings,42061,State Senate,17,WF,Simcha Felder,4
+Kings,42062,State Senate,17,WF,Simcha Felder,3
+Kings,42063,State Senate,17,WF,Simcha Felder,0
+Kings,42064,State Senate,17,WF,Simcha Felder,4
+Kings,42065,State Senate,17,WF,Simcha Felder,5
+Kings,42066,State Senate,17,WF,Simcha Felder,3
+Kings,42067,State Senate,17,WF,Simcha Felder,1
+Kings,44001,State Senate,17,WF,Simcha Felder,0
+Kings,44002,State Senate,17,WF,Simcha Felder,4
+Kings,44003,State Senate,17,WF,Simcha Felder,4
+Kings,44004,State Senate,17,WF,Simcha Felder,3
+Kings,44005,State Senate,17,WF,Simcha Felder,2
+Kings,44006,State Senate,17,WF,Simcha Felder,2
+Kings,44007,State Senate,17,WF,Simcha Felder,3
+Kings,44008,State Senate,17,WF,Simcha Felder,1
+Kings,44010,State Senate,17,WF,Simcha Felder,0
+Kings,44013,State Senate,17,WF,Simcha Felder,1
+Kings,44021,State Senate,17,WF,Simcha Felder,0
+Kings,44023,State Senate,17,WF,Simcha Felder,0
+Kings,44024,State Senate,17,WF,Simcha Felder,2
+Kings,44025,State Senate,17,WF,Simcha Felder,2
+Kings,44026,State Senate,17,WF,Simcha Felder,1
+Kings,44027,State Senate,17,WF,Simcha Felder,4
+Kings,44028,State Senate,17,WF,Simcha Felder,3
+Kings,44029,State Senate,17,WF,Simcha Felder,4
+Kings,44030,State Senate,17,WF,Simcha Felder,2
+Kings,44031,State Senate,17,WF,Simcha Felder,1
+Kings,44032,State Senate,17,WF,Simcha Felder,1
+Kings,44033,State Senate,17,WF,Simcha Felder,4
+Kings,44035,State Senate,17,WF,Simcha Felder,1
+Kings,44038,State Senate,17,WF,Simcha Felder,4
+Kings,44039,State Senate,17,WF,Simcha Felder,3
+Kings,44041,State Senate,17,WF,Simcha Felder,0
+Kings,44042,State Senate,17,WF,Simcha Felder,5
+Kings,44043,State Senate,17,WF,Simcha Felder,2
+Kings,44044,State Senate,17,WF,Simcha Felder,2
+Kings,44045,State Senate,17,WF,Simcha Felder,2
+Kings,45001,State Senate,17,WF,Simcha Felder,13
+Kings,45002,State Senate,17,WF,Simcha Felder,5
+Kings,45003,State Senate,17,WF,Simcha Felder,5
+Kings,45004,State Senate,17,WF,Simcha Felder,3
+Kings,45005,State Senate,17,WF,Simcha Felder,3
+Kings,45007,State Senate,17,WF,Simcha Felder,0
+Kings,45010,State Senate,17,WF,Simcha Felder,0
+Kings,45011,State Senate,17,WF,Simcha Felder,1
+Kings,45012,State Senate,17,WF,Simcha Felder,2
+Kings,45013,State Senate,17,WF,Simcha Felder,2
+Kings,45014,State Senate,17,WF,Simcha Felder,2
+Kings,45018,State Senate,17,WF,Simcha Felder,0
+Kings,45023,State Senate,17,WF,Simcha Felder,3
+Kings,45024,State Senate,17,WF,Simcha Felder,2
+Kings,45029,State Senate,17,WF,Simcha Felder,0
+Kings,45030,State Senate,17,WF,Simcha Felder,2
+Kings,45038,State Senate,17,WF,Simcha Felder,1
+Kings,45039,State Senate,17,WF,Simcha Felder,1
+Kings,47023,State Senate,17,WF,Simcha Felder,2
+Kings,47024,State Senate,17,WF,Simcha Felder,2
+Kings,47025,State Senate,17,WF,Simcha Felder,1
+Kings,47026,State Senate,17,WF,Simcha Felder,3
+Kings,47027,State Senate,17,WF,Simcha Felder,2
+Kings,47028,State Senate,17,WF,Simcha Felder,4
+Kings,47029,State Senate,17,WF,Simcha Felder,1
+Kings,47030,State Senate,17,WF,Simcha Felder,2
+Kings,47031,State Senate,17,WF,Simcha Felder,2
+Kings,47032,State Senate,17,WF,Simcha Felder,0
+Kings,47033,State Senate,17,WF,Simcha Felder,1
+Kings,48001,State Senate,17,WF,Simcha Felder,0
+Kings,48002,State Senate,17,WF,Simcha Felder,4
+Kings,48003,State Senate,17,WF,Simcha Felder,2
+Kings,48004,State Senate,17,WF,Simcha Felder,2
+Kings,48005,State Senate,17,WF,Simcha Felder,3
+Kings,48006,State Senate,17,WF,Simcha Felder,1
+Kings,48007,State Senate,17,WF,Simcha Felder,2
+Kings,48008,State Senate,17,WF,Simcha Felder,0
+Kings,48009,State Senate,17,WF,Simcha Felder,3
+Kings,48010,State Senate,17,WF,Simcha Felder,1
+Kings,48011,State Senate,17,WF,Simcha Felder,3
+Kings,48012,State Senate,17,WF,Simcha Felder,6
+Kings,48013,State Senate,17,WF,Simcha Felder,1
+Kings,48014,State Senate,17,WF,Simcha Felder,1
+Kings,48015,State Senate,17,WF,Simcha Felder,1
+Kings,48016,State Senate,17,WF,Simcha Felder,2
+Kings,48017,State Senate,17,WF,Simcha Felder,5
+Kings,48018,State Senate,17,WF,Simcha Felder,4
+Kings,48019,State Senate,17,WF,Simcha Felder,1
+Kings,48020,State Senate,17,WF,Simcha Felder,3
+Kings,48021,State Senate,17,WF,Simcha Felder,2
+Kings,48022,State Senate,17,WF,Simcha Felder,0
+Kings,48023,State Senate,17,WF,Simcha Felder,1
+Kings,48024,State Senate,17,WF,Simcha Felder,1
+Kings,48025,State Senate,17,WF,Simcha Felder,6
+Kings,48026,State Senate,17,WF,Simcha Felder,3
+Kings,48027,State Senate,17,WF,Simcha Felder,4
+Kings,48028,State Senate,17,WF,Simcha Felder,5
+Kings,48029,State Senate,17,WF,Simcha Felder,3
+Kings,48030,State Senate,17,WF,Simcha Felder,1
+Kings,48031,State Senate,17,WF,Simcha Felder,0
+Kings,48032,State Senate,17,WF,Simcha Felder,6
+Kings,48033,State Senate,17,WF,Simcha Felder,4
+Kings,48036,State Senate,17,WF,Simcha Felder,2
+Kings,48038,State Senate,17,WF,Simcha Felder,1
+Kings,48039,State Senate,17,WF,Simcha Felder,1
+Kings,48040,State Senate,17,WF,Simcha Felder,3
+Kings,48041,State Senate,17,WF,Simcha Felder,1
+Kings,48042,State Senate,17,WF,Simcha Felder,5
+Kings,48043,State Senate,17,WF,Simcha Felder,6
+Kings,48044,State Senate,17,WF,Simcha Felder,4
+Kings,48045,State Senate,17,WF,Simcha Felder,3
+Kings,48049,State Senate,17,WF,Simcha Felder,0
+Kings,48054,State Senate,17,WF,Simcha Felder,2
+Kings,48055,State Senate,17,WF,Simcha Felder,6
+Kings,48056,State Senate,17,WF,Simcha Felder,1
+Kings,48057,State Senate,17,WF,Simcha Felder,0
+Kings,48058,State Senate,17,WF,Simcha Felder,4
+Kings,48060,State Senate,17,WF,Simcha Felder,4
+Kings,48061,State Senate,17,WF,Simcha Felder,9
+Kings,48062,State Senate,17,WF,Simcha Felder,2
+Kings,48063,State Senate,17,WF,Simcha Felder,2
+Kings,48064,State Senate,17,WF,Simcha Felder,1
+Kings,48065,State Senate,17,WF,Simcha Felder,1
+Kings,48066,State Senate,17,WF,Simcha Felder,2
+Kings,48067,State Senate,17,WF,Simcha Felder,0
+Kings,49006,State Senate,17,WF,Simcha Felder,0
+Kings,49007,State Senate,17,WF,Simcha Felder,0
+Kings,49008,State Senate,17,WF,Simcha Felder,1
+Kings,49009,State Senate,17,WF,Simcha Felder,2
+Kings,49010,State Senate,17,WF,Simcha Felder,6
+Kings,49011,State Senate,17,WF,Simcha Felder,3
+Kings,49012,State Senate,17,WF,Simcha Felder,0
+Kings,49013,State Senate,17,WF,Simcha Felder,2
+Kings,49030,State Senate,17,WF,Simcha Felder,2
+Kings,49031,State Senate,17,WF,Simcha Felder,0
+Kings,49032,State Senate,17,WF,Simcha Felder,1
+Kings,49033,State Senate,17,WF,Simcha Felder,0
+Kings,49042,State Senate,17,WF,Simcha Felder,1
+Kings,49043,State Senate,17,WF,Simcha Felder,1
+Kings,51001,State Senate,17,WF,Simcha Felder,1
+Kings,51002,State Senate,17,WF,Simcha Felder,2
+Kings,51003,State Senate,17,WF,Simcha Felder,2
+Kings,51004,State Senate,17,WF,Simcha Felder,1
+Kings,51005,State Senate,17,WF,Simcha Felder,3
+Kings,51006,State Senate,17,WF,Simcha Felder,2
+Kings,51014,State Senate,17,WF,Simcha Felder,0
+Kings,51015,State Senate,17,WF,Simcha Felder,5
+Kings,51016,State Senate,17,WF,Simcha Felder,1
+Kings,51017,State Senate,17,WF,Simcha Felder,1
+Kings,51018,State Senate,17,WF,Simcha Felder,1
+Kings,41001,State Senate,17,Ind,writein,0
+Kings,41002,State Senate,17,Ind,writein,1
+Kings,41003,State Senate,17,Ind,writein,2
+Kings,41004,State Senate,17,Ind,writein,0
+Kings,41005,State Senate,17,Ind,writein,0
+Kings,41006,State Senate,17,Ind,writein,0
+Kings,41007,State Senate,17,Ind,writein,2
+Kings,41008,State Senate,17,Ind,writein,1
+Kings,41009,State Senate,17,Ind,writein,2
+Kings,41010,State Senate,17,Ind,writein,1
+Kings,41011,State Senate,17,Ind,writein,1
+Kings,41012,State Senate,17,Ind,writein,0
+Kings,41024,State Senate,17,Ind,writein,0
+Kings,41050,State Senate,17,Ind,writein,0
+Kings,41051,State Senate,17,Ind,writein,0
+Kings,41052,State Senate,17,Ind,writein,0
+Kings,41058,State Senate,17,Ind,writein,0
+Kings,41059,State Senate,17,Ind,writein,3
+Kings,42034,State Senate,17,Ind,writein,7
+Kings,42035,State Senate,17,Ind,writein,1
+Kings,42036,State Senate,17,Ind,writein,3
+Kings,42037,State Senate,17,Ind,writein,2
+Kings,42038,State Senate,17,Ind,writein,1
+Kings,42061,State Senate,17,Ind,writein,3
+Kings,42062,State Senate,17,Ind,writein,0
+Kings,42063,State Senate,17,Ind,writein,3
+Kings,42064,State Senate,17,Ind,writein,0
+Kings,42065,State Senate,17,Ind,writein,0
+Kings,42066,State Senate,17,Ind,writein,1
+Kings,42067,State Senate,17,Ind,writein,0
+Kings,44001,State Senate,17,Ind,writein,1
+Kings,44002,State Senate,17,Ind,writein,0
+Kings,44003,State Senate,17,Ind,writein,0
+Kings,44004,State Senate,17,Ind,writein,1
+Kings,44005,State Senate,17,Ind,writein,1
+Kings,44006,State Senate,17,Ind,writein,1
+Kings,44007,State Senate,17,Ind,writein,3
+Kings,44008,State Senate,17,Ind,writein,1
+Kings,44010,State Senate,17,Ind,writein,0
+Kings,44013,State Senate,17,Ind,writein,0
+Kings,44021,State Senate,17,Ind,writein,0
+Kings,44023,State Senate,17,Ind,writein,0
+Kings,44024,State Senate,17,Ind,writein,3
+Kings,44025,State Senate,17,Ind,writein,0
+Kings,44026,State Senate,17,Ind,writein,0
+Kings,44027,State Senate,17,Ind,writein,2
+Kings,44028,State Senate,17,Ind,writein,4
+Kings,44029,State Senate,17,Ind,writein,2
+Kings,44030,State Senate,17,Ind,writein,0
+Kings,44031,State Senate,17,Ind,writein,6
+Kings,44032,State Senate,17,Ind,writein,0
+Kings,44033,State Senate,17,Ind,writein,5
+Kings,44035,State Senate,17,Ind,writein,9
+Kings,44038,State Senate,17,Ind,writein,0
+Kings,44039,State Senate,17,Ind,writein,4
+Kings,44041,State Senate,17,Ind,writein,0
+Kings,44042,State Senate,17,Ind,writein,8
+Kings,44043,State Senate,17,Ind,writein,4
+Kings,44044,State Senate,17,Ind,writein,8
+Kings,44045,State Senate,17,Ind,writein,2
+Kings,45001,State Senate,17,Ind,writein,0
+Kings,45002,State Senate,17,Ind,writein,2
+Kings,45003,State Senate,17,Ind,writein,0
+Kings,45004,State Senate,17,Ind,writein,0
+Kings,45005,State Senate,17,Ind,writein,1
+Kings,45007,State Senate,17,Ind,writein,0
+Kings,45010,State Senate,17,Ind,writein,0
+Kings,45011,State Senate,17,Ind,writein,0
+Kings,45012,State Senate,17,Ind,writein,1
+Kings,45013,State Senate,17,Ind,writein,3
+Kings,45014,State Senate,17,Ind,writein,1
+Kings,45018,State Senate,17,Ind,writein,0
+Kings,45023,State Senate,17,Ind,writein,0
+Kings,45024,State Senate,17,Ind,writein,0
+Kings,45029,State Senate,17,Ind,writein,1
+Kings,45030,State Senate,17,Ind,writein,0
+Kings,45038,State Senate,17,Ind,writein,1
+Kings,45039,State Senate,17,Ind,writein,0
+Kings,47023,State Senate,17,Ind,writein,0
+Kings,47024,State Senate,17,Ind,writein,0
+Kings,47025,State Senate,17,Ind,writein,0
+Kings,47026,State Senate,17,Ind,writein,1
+Kings,47027,State Senate,17,Ind,writein,1
+Kings,47028,State Senate,17,Ind,writein,0
+Kings,47029,State Senate,17,Ind,writein,0
+Kings,47030,State Senate,17,Ind,writein,0
+Kings,47031,State Senate,17,Ind,writein,0
+Kings,47032,State Senate,17,Ind,writein,0
+Kings,47033,State Senate,17,Ind,writein,0
+Kings,48001,State Senate,17,Ind,writein,0
+Kings,48002,State Senate,17,Ind,writein,0
+Kings,48003,State Senate,17,Ind,writein,1
+Kings,48004,State Senate,17,Ind,writein,1
+Kings,48005,State Senate,17,Ind,writein,2
+Kings,48006,State Senate,17,Ind,writein,0
+Kings,48007,State Senate,17,Ind,writein,0
+Kings,48008,State Senate,17,Ind,writein,0
+Kings,48009,State Senate,17,Ind,writein,1
+Kings,48010,State Senate,17,Ind,writein,1
+Kings,48011,State Senate,17,Ind,writein,0
+Kings,48012,State Senate,17,Ind,writein,0
+Kings,48013,State Senate,17,Ind,writein,0
+Kings,48014,State Senate,17,Ind,writein,0
+Kings,48015,State Senate,17,Ind,writein,0
+Kings,48016,State Senate,17,Ind,writein,1
+Kings,48017,State Senate,17,Ind,writein,0
+Kings,48018,State Senate,17,Ind,writein,2
+Kings,48019,State Senate,17,Ind,writein,0
+Kings,48020,State Senate,17,Ind,writein,0
+Kings,48021,State Senate,17,Ind,writein,0
+Kings,48022,State Senate,17,Ind,writein,2
+Kings,48023,State Senate,17,Ind,writein,1
+Kings,48024,State Senate,17,Ind,writein,0
+Kings,48025,State Senate,17,Ind,writein,0
+Kings,48026,State Senate,17,Ind,writein,3
+Kings,48027,State Senate,17,Ind,writein,0
+Kings,48028,State Senate,17,Ind,writein,1
+Kings,48029,State Senate,17,Ind,writein,0
+Kings,48030,State Senate,17,Ind,writein,0
+Kings,48031,State Senate,17,Ind,writein,0
+Kings,48032,State Senate,17,Ind,writein,0
+Kings,48033,State Senate,17,Ind,writein,1
+Kings,48036,State Senate,17,Ind,writein,0
+Kings,48038,State Senate,17,Ind,writein,0
+Kings,48039,State Senate,17,Ind,writein,0
+Kings,48040,State Senate,17,Ind,writein,1
+Kings,48041,State Senate,17,Ind,writein,0
+Kings,48042,State Senate,17,Ind,writein,0
+Kings,48043,State Senate,17,Ind,writein,0
+Kings,48044,State Senate,17,Ind,writein,0
+Kings,48045,State Senate,17,Ind,writein,1
+Kings,48049,State Senate,17,Ind,writein,0
+Kings,48054,State Senate,17,Ind,writein,0
+Kings,48055,State Senate,17,Ind,writein,2
+Kings,48056,State Senate,17,Ind,writein,0
+Kings,48057,State Senate,17,Ind,writein,0
+Kings,48058,State Senate,17,Ind,writein,0
+Kings,48060,State Senate,17,Ind,writein,0
+Kings,48061,State Senate,17,Ind,writein,0
+Kings,48062,State Senate,17,Ind,writein,1
+Kings,48063,State Senate,17,Ind,writein,0
+Kings,48064,State Senate,17,Ind,writein,0
+Kings,48065,State Senate,17,Ind,writein,3
+Kings,48066,State Senate,17,Ind,writein,0
+Kings,48067,State Senate,17,Ind,writein,0
+Kings,49006,State Senate,17,Ind,writein,0
+Kings,49007,State Senate,17,Ind,writein,0
+Kings,49008,State Senate,17,Ind,writein,0
+Kings,49009,State Senate,17,Ind,writein,0
+Kings,49010,State Senate,17,Ind,writein,0
+Kings,49011,State Senate,17,Ind,writein,0
+Kings,49012,State Senate,17,Ind,writein,0
+Kings,49013,State Senate,17,Ind,writein,0
+Kings,49030,State Senate,17,Ind,writein,0
+Kings,49031,State Senate,17,Ind,writein,3
+Kings,49032,State Senate,17,Ind,writein,0
+Kings,49033,State Senate,17,Ind,writein,0
+Kings,49042,State Senate,17,Ind,writein,0
+Kings,49043,State Senate,17,Ind,writein,0
+Kings,51001,State Senate,17,Ind,writein,4
+Kings,51002,State Senate,17,Ind,writein,2
+Kings,51003,State Senate,17,Ind,writein,2
+Kings,51004,State Senate,17,Ind,writein,3
+Kings,51005,State Senate,17,Ind,writein,1
+Kings,51006,State Senate,17,Ind,writein,0
+Kings,51014,State Senate,17,Ind,writein,0
+Kings,51015,State Senate,17,Ind,writein,3
+Kings,51016,State Senate,17,Ind,writein,0
+Kings,51017,State Senate,17,Ind,writein,1
+Kings,51018,State Senate,17,Ind,writein,0
+Kings,50001,State Senate,18,Dem,Martin Dilan,47
+Kings,50003,State Senate,18,Dem,Martin Dilan,254
+Kings,50004,State Senate,18,Dem,Martin Dilan,79
+Kings,50005,State Senate,18,Dem,Martin Dilan,468
+Kings,50006,State Senate,18,Dem,Martin Dilan,425
+Kings,50007,State Senate,18,Dem,Martin Dilan,495
+Kings,50008,State Senate,18,Dem,Martin Dilan,389
+Kings,50009,State Senate,18,Dem,Martin Dilan,355
+Kings,50010,State Senate,18,Dem,Martin Dilan,95
+Kings,50012,State Senate,18,Dem,Martin Dilan,405
+Kings,50015,State Senate,18,Dem,Martin Dilan,188
+Kings,50016,State Senate,18,Dem,Martin Dilan,396
+Kings,50017,State Senate,18,Dem,Martin Dilan,423
+Kings,50018,State Senate,18,Dem,Martin Dilan,324
+Kings,50019,State Senate,18,Dem,Martin Dilan,560
+Kings,50020,State Senate,18,Dem,Martin Dilan,412
+Kings,50021,State Senate,18,Dem,Martin Dilan,405
+Kings,50022,State Senate,18,Dem,Martin Dilan,258
+Kings,50025,State Senate,18,Dem,Martin Dilan,92
+Kings,50043,State Senate,18,Dem,Martin Dilan,280
+Kings,50044,State Senate,18,Dem,Martin Dilan,584
+Kings,50045,State Senate,18,Dem,Martin Dilan,117
+Kings,50046,State Senate,18,Dem,Martin Dilan,363
+Kings,50049,State Senate,18,Dem,Martin Dilan,474
+Kings,50050,State Senate,18,Dem,Martin Dilan,336
+Kings,50051,State Senate,18,Dem,Martin Dilan,342
+Kings,50052,State Senate,18,Dem,Martin Dilan,467
+Kings,50053,State Senate,18,Dem,Martin Dilan,212
+Kings,50054,State Senate,18,Dem,Martin Dilan,216
+Kings,50056,State Senate,18,Dem,Martin Dilan,124
+Kings,50057,State Senate,18,Dem,Martin Dilan,192
+Kings,50058,State Senate,18,Dem,Martin Dilan,160
+Kings,50059,State Senate,18,Dem,Martin Dilan,293
+Kings,50060,State Senate,18,Dem,Martin Dilan,293
+Kings,50061,State Senate,18,Dem,Martin Dilan,209
+Kings,50062,State Senate,18,Dem,Martin Dilan,352
+Kings,50063,State Senate,18,Dem,Martin Dilan,158
+Kings,50081,State Senate,18,Dem,Martin Dilan,68
+Kings,53001,State Senate,18,Dem,Martin Dilan,453
+Kings,53002,State Senate,18,Dem,Martin Dilan,314
+Kings,53003,State Senate,18,Dem,Martin Dilan,399
+Kings,53004,State Senate,18,Dem,Martin Dilan,336
+Kings,53005,State Senate,18,Dem,Martin Dilan,375
+Kings,53006,State Senate,18,Dem,Martin Dilan,44
+Kings,53007,State Senate,18,Dem,Martin Dilan,347
+Kings,53008,State Senate,18,Dem,Martin Dilan,328
+Kings,53009,State Senate,18,Dem,Martin Dilan,354
+Kings,53010,State Senate,18,Dem,Martin Dilan,447
+Kings,53011,State Senate,18,Dem,Martin Dilan,394
+Kings,53012,State Senate,18,Dem,Martin Dilan,355
+Kings,53013,State Senate,18,Dem,Martin Dilan,181
+Kings,53015,State Senate,18,Dem,Martin Dilan,395
+Kings,53016,State Senate,18,Dem,Martin Dilan,401
+Kings,53017,State Senate,18,Dem,Martin Dilan,519
+Kings,53018,State Senate,18,Dem,Martin Dilan,329
+Kings,53019,State Senate,18,Dem,Martin Dilan,489
+Kings,53020,State Senate,18,Dem,Martin Dilan,430
+Kings,53021,State Senate,18,Dem,Martin Dilan,464
+Kings,53022,State Senate,18,Dem,Martin Dilan,412
+Kings,53023,State Senate,18,Dem,Martin Dilan,287
+Kings,53024,State Senate,18,Dem,Martin Dilan,492
+Kings,53025,State Senate,18,Dem,Martin Dilan,503
+Kings,53026,State Senate,18,Dem,Martin Dilan,267
+Kings,53027,State Senate,18,Dem,Martin Dilan,314
+Kings,53028,State Senate,18,Dem,Martin Dilan,387
+Kings,53029,State Senate,18,Dem,Martin Dilan,238
+Kings,53030,State Senate,18,Dem,Martin Dilan,506
+Kings,53031,State Senate,18,Dem,Martin Dilan,406
+Kings,53032,State Senate,18,Dem,Martin Dilan,400
+Kings,53033,State Senate,18,Dem,Martin Dilan,425
+Kings,53034,State Senate,18,Dem,Martin Dilan,319
+Kings,53035,State Senate,18,Dem,Martin Dilan,454
+Kings,53036,State Senate,18,Dem,Martin Dilan,470
+Kings,53037,State Senate,18,Dem,Martin Dilan,236
+Kings,53038,State Senate,18,Dem,Martin Dilan,144
+Kings,53039,State Senate,18,Dem,Martin Dilan,288
+Kings,53040,State Senate,18,Dem,Martin Dilan,246
+Kings,53041,State Senate,18,Dem,Martin Dilan,380
+Kings,53042,State Senate,18,Dem,Martin Dilan,354
+Kings,53043,State Senate,18,Dem,Martin Dilan,334
+Kings,53044,State Senate,18,Dem,Martin Dilan,400
+Kings,53045,State Senate,18,Dem,Martin Dilan,412
+Kings,53046,State Senate,18,Dem,Martin Dilan,400
+Kings,53047,State Senate,18,Dem,Martin Dilan,472
+Kings,53048,State Senate,18,Dem,Martin Dilan,386
+Kings,53050,State Senate,18,Dem,Martin Dilan,46
+Kings,53052,State Senate,18,Dem,Martin Dilan,27
+Kings,53053,State Senate,18,Dem,Martin Dilan,318
+Kings,53054,State Senate,18,Dem,Martin Dilan,311
+Kings,53055,State Senate,18,Dem,Martin Dilan,271
+Kings,53056,State Senate,18,Dem,Martin Dilan,575
+Kings,53057,State Senate,18,Dem,Martin Dilan,462
+Kings,53058,State Senate,18,Dem,Martin Dilan,285
+Kings,53059,State Senate,18,Dem,Martin Dilan,457
+Kings,53060,State Senate,18,Dem,Martin Dilan,564
+Kings,53061,State Senate,18,Dem,Martin Dilan,394
+Kings,53062,State Senate,18,Dem,Martin Dilan,127
+Kings,53063,State Senate,18,Dem,Martin Dilan,476
+Kings,53064,State Senate,18,Dem,Martin Dilan,339
+Kings,53065,State Senate,18,Dem,Martin Dilan,246
+Kings,53066,State Senate,18,Dem,Martin Dilan,376
+Kings,53067,State Senate,18,Dem,Martin Dilan,370
+Kings,53068,State Senate,18,Dem,Martin Dilan,350
+Kings,53069,State Senate,18,Dem,Martin Dilan,253
+Kings,53070,State Senate,18,Dem,Martin Dilan,465
+Kings,53071,State Senate,18,Dem,Martin Dilan,313
+Kings,53072,State Senate,18,Dem,Martin Dilan,367
+Kings,53073,State Senate,18,Dem,Martin Dilan,440
+Kings,53074,State Senate,18,Dem,Martin Dilan,285
+Kings,53075,State Senate,18,Dem,Martin Dilan,264
+Kings,53076,State Senate,18,Dem,Martin Dilan,278
+Kings,53077,State Senate,18,Dem,Martin Dilan,318
+Kings,53079,State Senate,18,Dem,Martin Dilan,181
+Kings,53080,State Senate,18,Dem,Martin Dilan,415
+Kings,53082,State Senate,18,Dem,Martin Dilan,163
+Kings,53083,State Senate,18,Dem,Martin Dilan,178
+Kings,54001,State Senate,18,Dem,Martin Dilan,125
+Kings,54007,State Senate,18,Dem,Martin Dilan,458
+Kings,54008,State Senate,18,Dem,Martin Dilan,469
+Kings,54009,State Senate,18,Dem,Martin Dilan,256
+Kings,54010,State Senate,18,Dem,Martin Dilan,507
+Kings,54011,State Senate,18,Dem,Martin Dilan,543
+Kings,54012,State Senate,18,Dem,Martin Dilan,251
+Kings,54013,State Senate,18,Dem,Martin Dilan,401
+Kings,54014,State Senate,18,Dem,Martin Dilan,43
+Kings,54016,State Senate,18,Dem,Martin Dilan,35
+Kings,54017,State Senate,18,Dem,Martin Dilan,75
+Kings,54018,State Senate,18,Dem,Martin Dilan,27
+Kings,54019,State Senate,18,Dem,Martin Dilan,523
+Kings,54020,State Senate,18,Dem,Martin Dilan,436
+Kings,54021,State Senate,18,Dem,Martin Dilan,312
+Kings,54022,State Senate,18,Dem,Martin Dilan,388
+Kings,54023,State Senate,18,Dem,Martin Dilan,332
+Kings,54024,State Senate,18,Dem,Martin Dilan,249
+Kings,54025,State Senate,18,Dem,Martin Dilan,206
+Kings,54027,State Senate,18,Dem,Martin Dilan,352
+Kings,54028,State Senate,18,Dem,Martin Dilan,353
+Kings,54029,State Senate,18,Dem,Martin Dilan,417
+Kings,54030,State Senate,18,Dem,Martin Dilan,406
+Kings,54031,State Senate,18,Dem,Martin Dilan,147
+Kings,54032,State Senate,18,Dem,Martin Dilan,391
+Kings,54033,State Senate,18,Dem,Martin Dilan,374
+Kings,54034,State Senate,18,Dem,Martin Dilan,468
+Kings,54035,State Senate,18,Dem,Martin Dilan,440
+Kings,54036,State Senate,18,Dem,Martin Dilan,462
+Kings,54037,State Senate,18,Dem,Martin Dilan,433
+Kings,54038,State Senate,18,Dem,Martin Dilan,367
+Kings,54039,State Senate,18,Dem,Martin Dilan,449
+Kings,54040,State Senate,18,Dem,Martin Dilan,94
+Kings,54041,State Senate,18,Dem,Martin Dilan,371
+Kings,54042,State Senate,18,Dem,Martin Dilan,422
+Kings,54043,State Senate,18,Dem,Martin Dilan,437
+Kings,54044,State Senate,18,Dem,Martin Dilan,377
+Kings,54045,State Senate,18,Dem,Martin Dilan,443
+Kings,54046,State Senate,18,Dem,Martin Dilan,470
+Kings,54047,State Senate,18,Dem,Martin Dilan,348
+Kings,54048,State Senate,18,Dem,Martin Dilan,376
+Kings,54049,State Senate,18,Dem,Martin Dilan,467
+Kings,54050,State Senate,18,Dem,Martin Dilan,450
+Kings,54051,State Senate,18,Dem,Martin Dilan,396
+Kings,54052,State Senate,18,Dem,Martin Dilan,261
+Kings,54053,State Senate,18,Dem,Martin Dilan,251
+Kings,54054,State Senate,18,Dem,Martin Dilan,363
+Kings,54055,State Senate,18,Dem,Martin Dilan,362
+Kings,54056,State Senate,18,Dem,Martin Dilan,411
+Kings,54057,State Senate,18,Dem,Martin Dilan,390
+Kings,54058,State Senate,18,Dem,Martin Dilan,453
+Kings,54059,State Senate,18,Dem,Martin Dilan,400
+Kings,54060,State Senate,18,Dem,Martin Dilan,501
+Kings,54061,State Senate,18,Dem,Martin Dilan,484
+Kings,54062,State Senate,18,Dem,Martin Dilan,437
+Kings,54063,State Senate,18,Dem,Martin Dilan,454
+Kings,54064,State Senate,18,Dem,Martin Dilan,504
+Kings,54065,State Senate,18,Dem,Martin Dilan,411
+Kings,54066,State Senate,18,Dem,Martin Dilan,160
+Kings,54067,State Senate,18,Dem,Martin Dilan,368
+Kings,54068,State Senate,18,Dem,Martin Dilan,485
+Kings,54069,State Senate,18,Dem,Martin Dilan,360
+Kings,54070,State Senate,18,Dem,Martin Dilan,241
+Kings,54073,State Senate,18,Dem,Martin Dilan,326
+Kings,54074,State Senate,18,Dem,Martin Dilan,52
+Kings,54078,State Senate,18,Dem,Martin Dilan,1
+Kings,55003,State Senate,18,Dem,Martin Dilan,83
+Kings,55006,State Senate,18,Dem,Martin Dilan,235
+Kings,55007,State Senate,18,Dem,Martin Dilan,444
+Kings,55014,State Senate,18,Dem,Martin Dilan,368
+Kings,55015,State Senate,18,Dem,Martin Dilan,26
+Kings,55016,State Senate,18,Dem,Martin Dilan,415
+Kings,55026,State Senate,18,Dem,Martin Dilan,97
+Kings,55041,State Senate,18,Dem,Martin Dilan,195
+Kings,55045,State Senate,18,Dem,Martin Dilan,332
+Kings,55046,State Senate,18,Dem,Martin Dilan,378
+Kings,55050,State Senate,18,Dem,Martin Dilan,103
+Kings,55051,State Senate,18,Dem,Martin Dilan,59
+Kings,56001,State Senate,18,Dem,Martin Dilan,469
+Kings,56002,State Senate,18,Dem,Martin Dilan,315
+Kings,56003,State Senate,18,Dem,Martin Dilan,303
+Kings,56004,State Senate,18,Dem,Martin Dilan,363
+Kings,56006,State Senate,18,Dem,Martin Dilan,344
+Kings,56007,State Senate,18,Dem,Martin Dilan,446
+Kings,56008,State Senate,18,Dem,Martin Dilan,486
+Kings,56009,State Senate,18,Dem,Martin Dilan,280
+Kings,56010,State Senate,18,Dem,Martin Dilan,534
+Kings,56011,State Senate,18,Dem,Martin Dilan,376
+Kings,56017,State Senate,18,Dem,Martin Dilan,347
+Kings,56020,State Senate,18,Dem,Martin Dilan,256
+Kings,60004,State Senate,18,Dem,Martin Dilan,77
+Kings,60006,State Senate,18,Dem,Martin Dilan,138
+Kings,60010,State Senate,18,Dem,Martin Dilan,190
+Kings,60011,State Senate,18,Dem,Martin Dilan,60
+Kings,60013,State Senate,18,Dem,Martin Dilan,56
+Kings,60016,State Senate,18,Dem,Martin Dilan,238
+Kings,60018,State Senate,18,Dem,Martin Dilan,362
+Kings,60019,State Senate,18,Dem,Martin Dilan,217
+Kings,60020,State Senate,18,Dem,Martin Dilan,79
+Kings,50001,State Senate,18,Rep,Michael Freeman-Saulsberry,1
+Kings,50003,State Senate,18,Rep,Michael Freeman-Saulsberry,17
+Kings,50004,State Senate,18,Rep,Michael Freeman-Saulsberry,3
+Kings,50005,State Senate,18,Rep,Michael Freeman-Saulsberry,36
+Kings,50006,State Senate,18,Rep,Michael Freeman-Saulsberry,34
+Kings,50007,State Senate,18,Rep,Michael Freeman-Saulsberry,51
+Kings,50008,State Senate,18,Rep,Michael Freeman-Saulsberry,34
+Kings,50009,State Senate,18,Rep,Michael Freeman-Saulsberry,49
+Kings,50010,State Senate,18,Rep,Michael Freeman-Saulsberry,8
+Kings,50012,State Senate,18,Rep,Michael Freeman-Saulsberry,58
+Kings,50015,State Senate,18,Rep,Michael Freeman-Saulsberry,20
+Kings,50016,State Senate,18,Rep,Michael Freeman-Saulsberry,11
+Kings,50017,State Senate,18,Rep,Michael Freeman-Saulsberry,19
+Kings,50018,State Senate,18,Rep,Michael Freeman-Saulsberry,53
+Kings,50019,State Senate,18,Rep,Michael Freeman-Saulsberry,62
+Kings,50020,State Senate,18,Rep,Michael Freeman-Saulsberry,34
+Kings,50021,State Senate,18,Rep,Michael Freeman-Saulsberry,58
+Kings,50022,State Senate,18,Rep,Michael Freeman-Saulsberry,34
+Kings,50025,State Senate,18,Rep,Michael Freeman-Saulsberry,5
+Kings,50043,State Senate,18,Rep,Michael Freeman-Saulsberry,25
+Kings,50044,State Senate,18,Rep,Michael Freeman-Saulsberry,49
+Kings,50045,State Senate,18,Rep,Michael Freeman-Saulsberry,9
+Kings,50046,State Senate,18,Rep,Michael Freeman-Saulsberry,19
+Kings,50049,State Senate,18,Rep,Michael Freeman-Saulsberry,23
+Kings,50050,State Senate,18,Rep,Michael Freeman-Saulsberry,26
+Kings,50051,State Senate,18,Rep,Michael Freeman-Saulsberry,18
+Kings,50052,State Senate,18,Rep,Michael Freeman-Saulsberry,19
+Kings,50053,State Senate,18,Rep,Michael Freeman-Saulsberry,6
+Kings,50054,State Senate,18,Rep,Michael Freeman-Saulsberry,8
+Kings,50056,State Senate,18,Rep,Michael Freeman-Saulsberry,6
+Kings,50057,State Senate,18,Rep,Michael Freeman-Saulsberry,18
+Kings,50058,State Senate,18,Rep,Michael Freeman-Saulsberry,26
+Kings,50059,State Senate,18,Rep,Michael Freeman-Saulsberry,40
+Kings,50060,State Senate,18,Rep,Michael Freeman-Saulsberry,32
+Kings,50061,State Senate,18,Rep,Michael Freeman-Saulsberry,25
+Kings,50062,State Senate,18,Rep,Michael Freeman-Saulsberry,36
+Kings,50063,State Senate,18,Rep,Michael Freeman-Saulsberry,27
+Kings,50081,State Senate,18,Rep,Michael Freeman-Saulsberry,6
+Kings,53001,State Senate,18,Rep,Michael Freeman-Saulsberry,16
+Kings,53002,State Senate,18,Rep,Michael Freeman-Saulsberry,9
+Kings,53003,State Senate,18,Rep,Michael Freeman-Saulsberry,9
+Kings,53004,State Senate,18,Rep,Michael Freeman-Saulsberry,14
+Kings,53005,State Senate,18,Rep,Michael Freeman-Saulsberry,13
+Kings,53006,State Senate,18,Rep,Michael Freeman-Saulsberry,4
+Kings,53007,State Senate,18,Rep,Michael Freeman-Saulsberry,14
+Kings,53008,State Senate,18,Rep,Michael Freeman-Saulsberry,11
+Kings,53009,State Senate,18,Rep,Michael Freeman-Saulsberry,10
+Kings,53010,State Senate,18,Rep,Michael Freeman-Saulsberry,20
+Kings,53011,State Senate,18,Rep,Michael Freeman-Saulsberry,12
+Kings,53012,State Senate,18,Rep,Michael Freeman-Saulsberry,14
+Kings,53013,State Senate,18,Rep,Michael Freeman-Saulsberry,4
+Kings,53015,State Senate,18,Rep,Michael Freeman-Saulsberry,36
+Kings,53016,State Senate,18,Rep,Michael Freeman-Saulsberry,14
+Kings,53017,State Senate,18,Rep,Michael Freeman-Saulsberry,21
+Kings,53018,State Senate,18,Rep,Michael Freeman-Saulsberry,21
+Kings,53019,State Senate,18,Rep,Michael Freeman-Saulsberry,57
+Kings,53020,State Senate,18,Rep,Michael Freeman-Saulsberry,50
+Kings,53021,State Senate,18,Rep,Michael Freeman-Saulsberry,15
+Kings,53022,State Senate,18,Rep,Michael Freeman-Saulsberry,16
+Kings,53023,State Senate,18,Rep,Michael Freeman-Saulsberry,7
+Kings,53024,State Senate,18,Rep,Michael Freeman-Saulsberry,29
+Kings,53025,State Senate,18,Rep,Michael Freeman-Saulsberry,26
+Kings,53026,State Senate,18,Rep,Michael Freeman-Saulsberry,6
+Kings,53027,State Senate,18,Rep,Michael Freeman-Saulsberry,16
+Kings,53028,State Senate,18,Rep,Michael Freeman-Saulsberry,15
+Kings,53029,State Senate,18,Rep,Michael Freeman-Saulsberry,8
+Kings,53030,State Senate,18,Rep,Michael Freeman-Saulsberry,15
+Kings,53031,State Senate,18,Rep,Michael Freeman-Saulsberry,12
+Kings,53032,State Senate,18,Rep,Michael Freeman-Saulsberry,8
+Kings,53033,State Senate,18,Rep,Michael Freeman-Saulsberry,33
+Kings,53034,State Senate,18,Rep,Michael Freeman-Saulsberry,26
+Kings,53035,State Senate,18,Rep,Michael Freeman-Saulsberry,31
+Kings,53036,State Senate,18,Rep,Michael Freeman-Saulsberry,44
+Kings,53037,State Senate,18,Rep,Michael Freeman-Saulsberry,19
+Kings,53038,State Senate,18,Rep,Michael Freeman-Saulsberry,6
+Kings,53039,State Senate,18,Rep,Michael Freeman-Saulsberry,8
+Kings,53040,State Senate,18,Rep,Michael Freeman-Saulsberry,4
+Kings,53041,State Senate,18,Rep,Michael Freeman-Saulsberry,12
+Kings,53042,State Senate,18,Rep,Michael Freeman-Saulsberry,7
+Kings,53043,State Senate,18,Rep,Michael Freeman-Saulsberry,2
+Kings,53044,State Senate,18,Rep,Michael Freeman-Saulsberry,16
+Kings,53045,State Senate,18,Rep,Michael Freeman-Saulsberry,20
+Kings,53046,State Senate,18,Rep,Michael Freeman-Saulsberry,11
+Kings,53047,State Senate,18,Rep,Michael Freeman-Saulsberry,8
+Kings,53048,State Senate,18,Rep,Michael Freeman-Saulsberry,10
+Kings,53050,State Senate,18,Rep,Michael Freeman-Saulsberry,3
+Kings,53052,State Senate,18,Rep,Michael Freeman-Saulsberry,2
+Kings,53053,State Senate,18,Rep,Michael Freeman-Saulsberry,18
+Kings,53054,State Senate,18,Rep,Michael Freeman-Saulsberry,16
+Kings,53055,State Senate,18,Rep,Michael Freeman-Saulsberry,17
+Kings,53056,State Senate,18,Rep,Michael Freeman-Saulsberry,20
+Kings,53057,State Senate,18,Rep,Michael Freeman-Saulsberry,15
+Kings,53058,State Senate,18,Rep,Michael Freeman-Saulsberry,9
+Kings,53059,State Senate,18,Rep,Michael Freeman-Saulsberry,20
+Kings,53060,State Senate,18,Rep,Michael Freeman-Saulsberry,32
+Kings,53061,State Senate,18,Rep,Michael Freeman-Saulsberry,9
+Kings,53062,State Senate,18,Rep,Michael Freeman-Saulsberry,2
+Kings,53063,State Senate,18,Rep,Michael Freeman-Saulsberry,24
+Kings,53064,State Senate,18,Rep,Michael Freeman-Saulsberry,23
+Kings,53065,State Senate,18,Rep,Michael Freeman-Saulsberry,48
+Kings,53066,State Senate,18,Rep,Michael Freeman-Saulsberry,27
+Kings,53067,State Senate,18,Rep,Michael Freeman-Saulsberry,37
+Kings,53068,State Senate,18,Rep,Michael Freeman-Saulsberry,29
+Kings,53069,State Senate,18,Rep,Michael Freeman-Saulsberry,15
+Kings,53070,State Senate,18,Rep,Michael Freeman-Saulsberry,22
+Kings,53071,State Senate,18,Rep,Michael Freeman-Saulsberry,11
+Kings,53072,State Senate,18,Rep,Michael Freeman-Saulsberry,22
+Kings,53073,State Senate,18,Rep,Michael Freeman-Saulsberry,11
+Kings,53074,State Senate,18,Rep,Michael Freeman-Saulsberry,8
+Kings,53075,State Senate,18,Rep,Michael Freeman-Saulsberry,7
+Kings,53076,State Senate,18,Rep,Michael Freeman-Saulsberry,19
+Kings,53077,State Senate,18,Rep,Michael Freeman-Saulsberry,6
+Kings,53079,State Senate,18,Rep,Michael Freeman-Saulsberry,7
+Kings,53080,State Senate,18,Rep,Michael Freeman-Saulsberry,16
+Kings,53082,State Senate,18,Rep,Michael Freeman-Saulsberry,4
+Kings,53083,State Senate,18,Rep,Michael Freeman-Saulsberry,4
+Kings,54001,State Senate,18,Rep,Michael Freeman-Saulsberry,3
+Kings,54007,State Senate,18,Rep,Michael Freeman-Saulsberry,5
+Kings,54008,State Senate,18,Rep,Michael Freeman-Saulsberry,4
+Kings,54009,State Senate,18,Rep,Michael Freeman-Saulsberry,8
+Kings,54010,State Senate,18,Rep,Michael Freeman-Saulsberry,11
+Kings,54011,State Senate,18,Rep,Michael Freeman-Saulsberry,5
+Kings,54012,State Senate,18,Rep,Michael Freeman-Saulsberry,5
+Kings,54013,State Senate,18,Rep,Michael Freeman-Saulsberry,12
+Kings,54014,State Senate,18,Rep,Michael Freeman-Saulsberry,0
+Kings,54016,State Senate,18,Rep,Michael Freeman-Saulsberry,1
+Kings,54017,State Senate,18,Rep,Michael Freeman-Saulsberry,1
+Kings,54018,State Senate,18,Rep,Michael Freeman-Saulsberry,0
+Kings,54019,State Senate,18,Rep,Michael Freeman-Saulsberry,15
+Kings,54020,State Senate,18,Rep,Michael Freeman-Saulsberry,17
+Kings,54021,State Senate,18,Rep,Michael Freeman-Saulsberry,6
+Kings,54022,State Senate,18,Rep,Michael Freeman-Saulsberry,17
+Kings,54023,State Senate,18,Rep,Michael Freeman-Saulsberry,14
+Kings,54024,State Senate,18,Rep,Michael Freeman-Saulsberry,12
+Kings,54025,State Senate,18,Rep,Michael Freeman-Saulsberry,11
+Kings,54027,State Senate,18,Rep,Michael Freeman-Saulsberry,7
+Kings,54028,State Senate,18,Rep,Michael Freeman-Saulsberry,12
+Kings,54029,State Senate,18,Rep,Michael Freeman-Saulsberry,10
+Kings,54030,State Senate,18,Rep,Michael Freeman-Saulsberry,6
+Kings,54031,State Senate,18,Rep,Michael Freeman-Saulsberry,3
+Kings,54032,State Senate,18,Rep,Michael Freeman-Saulsberry,12
+Kings,54033,State Senate,18,Rep,Michael Freeman-Saulsberry,6
+Kings,54034,State Senate,18,Rep,Michael Freeman-Saulsberry,6
+Kings,54035,State Senate,18,Rep,Michael Freeman-Saulsberry,8
+Kings,54036,State Senate,18,Rep,Michael Freeman-Saulsberry,9
+Kings,54037,State Senate,18,Rep,Michael Freeman-Saulsberry,16
+Kings,54038,State Senate,18,Rep,Michael Freeman-Saulsberry,12
+Kings,54039,State Senate,18,Rep,Michael Freeman-Saulsberry,19
+Kings,54040,State Senate,18,Rep,Michael Freeman-Saulsberry,4
+Kings,54041,State Senate,18,Rep,Michael Freeman-Saulsberry,6
+Kings,54042,State Senate,18,Rep,Michael Freeman-Saulsberry,19
+Kings,54043,State Senate,18,Rep,Michael Freeman-Saulsberry,20
+Kings,54044,State Senate,18,Rep,Michael Freeman-Saulsberry,18
+Kings,54045,State Senate,18,Rep,Michael Freeman-Saulsberry,18
+Kings,54046,State Senate,18,Rep,Michael Freeman-Saulsberry,24
+Kings,54047,State Senate,18,Rep,Michael Freeman-Saulsberry,15
+Kings,54048,State Senate,18,Rep,Michael Freeman-Saulsberry,16
+Kings,54049,State Senate,18,Rep,Michael Freeman-Saulsberry,17
+Kings,54050,State Senate,18,Rep,Michael Freeman-Saulsberry,22
+Kings,54051,State Senate,18,Rep,Michael Freeman-Saulsberry,18
+Kings,54052,State Senate,18,Rep,Michael Freeman-Saulsberry,24
+Kings,54053,State Senate,18,Rep,Michael Freeman-Saulsberry,10
+Kings,54054,State Senate,18,Rep,Michael Freeman-Saulsberry,25
+Kings,54055,State Senate,18,Rep,Michael Freeman-Saulsberry,25
+Kings,54056,State Senate,18,Rep,Michael Freeman-Saulsberry,15
+Kings,54057,State Senate,18,Rep,Michael Freeman-Saulsberry,30
+Kings,54058,State Senate,18,Rep,Michael Freeman-Saulsberry,27
+Kings,54059,State Senate,18,Rep,Michael Freeman-Saulsberry,17
+Kings,54060,State Senate,18,Rep,Michael Freeman-Saulsberry,10
+Kings,54061,State Senate,18,Rep,Michael Freeman-Saulsberry,5
+Kings,54062,State Senate,18,Rep,Michael Freeman-Saulsberry,12
+Kings,54063,State Senate,18,Rep,Michael Freeman-Saulsberry,14
+Kings,54064,State Senate,18,Rep,Michael Freeman-Saulsberry,14
+Kings,54065,State Senate,18,Rep,Michael Freeman-Saulsberry,23
+Kings,54066,State Senate,18,Rep,Michael Freeman-Saulsberry,5
+Kings,54067,State Senate,18,Rep,Michael Freeman-Saulsberry,17
+Kings,54068,State Senate,18,Rep,Michael Freeman-Saulsberry,11
+Kings,54069,State Senate,18,Rep,Michael Freeman-Saulsberry,7
+Kings,54070,State Senate,18,Rep,Michael Freeman-Saulsberry,6
+Kings,54073,State Senate,18,Rep,Michael Freeman-Saulsberry,7
+Kings,54074,State Senate,18,Rep,Michael Freeman-Saulsberry,1
+Kings,54078,State Senate,18,Rep,Michael Freeman-Saulsberry,0
+Kings,55003,State Senate,18,Rep,Michael Freeman-Saulsberry,4
+Kings,55006,State Senate,18,Rep,Michael Freeman-Saulsberry,5
+Kings,55007,State Senate,18,Rep,Michael Freeman-Saulsberry,14
+Kings,55014,State Senate,18,Rep,Michael Freeman-Saulsberry,14
+Kings,55015,State Senate,18,Rep,Michael Freeman-Saulsberry,0
+Kings,55016,State Senate,18,Rep,Michael Freeman-Saulsberry,7
+Kings,55026,State Senate,18,Rep,Michael Freeman-Saulsberry,5
+Kings,55041,State Senate,18,Rep,Michael Freeman-Saulsberry,4
+Kings,55045,State Senate,18,Rep,Michael Freeman-Saulsberry,10
+Kings,55046,State Senate,18,Rep,Michael Freeman-Saulsberry,7
+Kings,55050,State Senate,18,Rep,Michael Freeman-Saulsberry,0
+Kings,55051,State Senate,18,Rep,Michael Freeman-Saulsberry,0
+Kings,56001,State Senate,18,Rep,Michael Freeman-Saulsberry,9
+Kings,56002,State Senate,18,Rep,Michael Freeman-Saulsberry,3
+Kings,56003,State Senate,18,Rep,Michael Freeman-Saulsberry,4
+Kings,56004,State Senate,18,Rep,Michael Freeman-Saulsberry,3
+Kings,56006,State Senate,18,Rep,Michael Freeman-Saulsberry,3
+Kings,56007,State Senate,18,Rep,Michael Freeman-Saulsberry,7
+Kings,56008,State Senate,18,Rep,Michael Freeman-Saulsberry,7
+Kings,56009,State Senate,18,Rep,Michael Freeman-Saulsberry,3
+Kings,56010,State Senate,18,Rep,Michael Freeman-Saulsberry,6
+Kings,56011,State Senate,18,Rep,Michael Freeman-Saulsberry,6
+Kings,56017,State Senate,18,Rep,Michael Freeman-Saulsberry,4
+Kings,56020,State Senate,18,Rep,Michael Freeman-Saulsberry,2
+Kings,60004,State Senate,18,Rep,Michael Freeman-Saulsberry,0
+Kings,60006,State Senate,18,Rep,Michael Freeman-Saulsberry,0
+Kings,60010,State Senate,18,Rep,Michael Freeman-Saulsberry,1
+Kings,60011,State Senate,18,Rep,Michael Freeman-Saulsberry,0
+Kings,60013,State Senate,18,Rep,Michael Freeman-Saulsberry,0
+Kings,60016,State Senate,18,Rep,Michael Freeman-Saulsberry,2
+Kings,60018,State Senate,18,Rep,Michael Freeman-Saulsberry,7
+Kings,60019,State Senate,18,Rep,Michael Freeman-Saulsberry,2
+Kings,60020,State Senate,18,Rep,Michael Freeman-Saulsberry,3
+Kings,50001,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,50003,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,50004,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,50005,State Senate,18,Con,Michael Freeman-Saulsberry,6
+Kings,50006,State Senate,18,Con,Michael Freeman-Saulsberry,6
+Kings,50007,State Senate,18,Con,Michael Freeman-Saulsberry,7
+Kings,50008,State Senate,18,Con,Michael Freeman-Saulsberry,10
+Kings,50009,State Senate,18,Con,Michael Freeman-Saulsberry,5
+Kings,50010,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,50012,State Senate,18,Con,Michael Freeman-Saulsberry,15
+Kings,50015,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,50016,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,50017,State Senate,18,Con,Michael Freeman-Saulsberry,9
+Kings,50018,State Senate,18,Con,Michael Freeman-Saulsberry,6
+Kings,50019,State Senate,18,Con,Michael Freeman-Saulsberry,7
+Kings,50020,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,50021,State Senate,18,Con,Michael Freeman-Saulsberry,13
+Kings,50022,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,50025,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,50043,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,50044,State Senate,18,Con,Michael Freeman-Saulsberry,6
+Kings,50045,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,50046,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,50049,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,50050,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,50051,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,50052,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,50053,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,50054,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,50056,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,50057,State Senate,18,Con,Michael Freeman-Saulsberry,8
+Kings,50058,State Senate,18,Con,Michael Freeman-Saulsberry,11
+Kings,50059,State Senate,18,Con,Michael Freeman-Saulsberry,7
+Kings,50060,State Senate,18,Con,Michael Freeman-Saulsberry,7
+Kings,50061,State Senate,18,Con,Michael Freeman-Saulsberry,9
+Kings,50062,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,50063,State Senate,18,Con,Michael Freeman-Saulsberry,7
+Kings,50081,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,53001,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,53002,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,53003,State Senate,18,Con,Michael Freeman-Saulsberry,7
+Kings,53004,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,53005,State Senate,18,Con,Michael Freeman-Saulsberry,6
+Kings,53006,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,53007,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,53008,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,53009,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,53010,State Senate,18,Con,Michael Freeman-Saulsberry,10
+Kings,53011,State Senate,18,Con,Michael Freeman-Saulsberry,8
+Kings,53012,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,53013,State Senate,18,Con,Michael Freeman-Saulsberry,6
+Kings,53015,State Senate,18,Con,Michael Freeman-Saulsberry,10
+Kings,53016,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,53017,State Senate,18,Con,Michael Freeman-Saulsberry,10
+Kings,53018,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,53019,State Senate,18,Con,Michael Freeman-Saulsberry,11
+Kings,53020,State Senate,18,Con,Michael Freeman-Saulsberry,9
+Kings,53021,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,53022,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,53023,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,53024,State Senate,18,Con,Michael Freeman-Saulsberry,10
+Kings,53025,State Senate,18,Con,Michael Freeman-Saulsberry,5
+Kings,53026,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,53027,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,53028,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,53029,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,53030,State Senate,18,Con,Michael Freeman-Saulsberry,8
+Kings,53031,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,53032,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,53033,State Senate,18,Con,Michael Freeman-Saulsberry,5
+Kings,53034,State Senate,18,Con,Michael Freeman-Saulsberry,10
+Kings,53035,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,53036,State Senate,18,Con,Michael Freeman-Saulsberry,6
+Kings,53037,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,53038,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,53039,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,53040,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,53041,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,53042,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,53043,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,53044,State Senate,18,Con,Michael Freeman-Saulsberry,5
+Kings,53045,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,53046,State Senate,18,Con,Michael Freeman-Saulsberry,5
+Kings,53047,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,53048,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,53050,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,53052,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,53053,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,53054,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,53055,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,53056,State Senate,18,Con,Michael Freeman-Saulsberry,6
+Kings,53057,State Senate,18,Con,Michael Freeman-Saulsberry,5
+Kings,53058,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,53059,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,53060,State Senate,18,Con,Michael Freeman-Saulsberry,8
+Kings,53061,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,53062,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,53063,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,53064,State Senate,18,Con,Michael Freeman-Saulsberry,7
+Kings,53065,State Senate,18,Con,Michael Freeman-Saulsberry,5
+Kings,53066,State Senate,18,Con,Michael Freeman-Saulsberry,7
+Kings,53067,State Senate,18,Con,Michael Freeman-Saulsberry,6
+Kings,53068,State Senate,18,Con,Michael Freeman-Saulsberry,9
+Kings,53069,State Senate,18,Con,Michael Freeman-Saulsberry,7
+Kings,53070,State Senate,18,Con,Michael Freeman-Saulsberry,6
+Kings,53071,State Senate,18,Con,Michael Freeman-Saulsberry,6
+Kings,53072,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,53073,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,53074,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,53075,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,53076,State Senate,18,Con,Michael Freeman-Saulsberry,5
+Kings,53077,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,53079,State Senate,18,Con,Michael Freeman-Saulsberry,6
+Kings,53080,State Senate,18,Con,Michael Freeman-Saulsberry,5
+Kings,53082,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,53083,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,54001,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,54007,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,54008,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,54009,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,54010,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,54011,State Senate,18,Con,Michael Freeman-Saulsberry,7
+Kings,54012,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,54013,State Senate,18,Con,Michael Freeman-Saulsberry,9
+Kings,54014,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,54016,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,54017,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,54018,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,54019,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,54020,State Senate,18,Con,Michael Freeman-Saulsberry,5
+Kings,54021,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,54022,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,54023,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,54024,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,54025,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,54027,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,54028,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,54029,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,54030,State Senate,18,Con,Michael Freeman-Saulsberry,7
+Kings,54031,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,54032,State Senate,18,Con,Michael Freeman-Saulsberry,12
+Kings,54033,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,54034,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,54035,State Senate,18,Con,Michael Freeman-Saulsberry,5
+Kings,54036,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,54037,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,54038,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,54039,State Senate,18,Con,Michael Freeman-Saulsberry,8
+Kings,54040,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,54041,State Senate,18,Con,Michael Freeman-Saulsberry,3
+Kings,54042,State Senate,18,Con,Michael Freeman-Saulsberry,5
+Kings,54043,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,54044,State Senate,18,Con,Michael Freeman-Saulsberry,5
+Kings,54045,State Senate,18,Con,Michael Freeman-Saulsberry,9
+Kings,54046,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,54047,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,54048,State Senate,18,Con,Michael Freeman-Saulsberry,6
+Kings,54049,State Senate,18,Con,Michael Freeman-Saulsberry,7
+Kings,54050,State Senate,18,Con,Michael Freeman-Saulsberry,9
+Kings,54051,State Senate,18,Con,Michael Freeman-Saulsberry,6
+Kings,54052,State Senate,18,Con,Michael Freeman-Saulsberry,6
+Kings,54053,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,54054,State Senate,18,Con,Michael Freeman-Saulsberry,13
+Kings,54055,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,54056,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,54057,State Senate,18,Con,Michael Freeman-Saulsberry,6
+Kings,54058,State Senate,18,Con,Michael Freeman-Saulsberry,6
+Kings,54059,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,54060,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,54061,State Senate,18,Con,Michael Freeman-Saulsberry,7
+Kings,54062,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,54063,State Senate,18,Con,Michael Freeman-Saulsberry,13
+Kings,54064,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,54065,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,54066,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,54067,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,54068,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,54069,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,54070,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,54073,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,54074,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,54078,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,55003,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,55006,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,55007,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,55014,State Senate,18,Con,Michael Freeman-Saulsberry,5
+Kings,55015,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,55016,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,55026,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,55041,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,55045,State Senate,18,Con,Michael Freeman-Saulsberry,5
+Kings,55046,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,55050,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,55051,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,56001,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,56002,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,56003,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,56004,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,56006,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,56007,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,56008,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,56009,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,56010,State Senate,18,Con,Michael Freeman-Saulsberry,5
+Kings,56011,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,56017,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,56020,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,60004,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,60006,State Senate,18,Con,Michael Freeman-Saulsberry,2
+Kings,60010,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,60011,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,60013,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,60016,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,60018,State Senate,18,Con,Michael Freeman-Saulsberry,4
+Kings,60019,State Senate,18,Con,Michael Freeman-Saulsberry,1
+Kings,60020,State Senate,18,Con,Michael Freeman-Saulsberry,0
+Kings,50001,State Senate,18,Ind,writein,0
+Kings,50003,State Senate,18,Ind,writein,0
+Kings,50004,State Senate,18,Ind,writein,0
+Kings,50005,State Senate,18,Ind,writein,1
+Kings,50006,State Senate,18,Ind,writein,2
+Kings,50007,State Senate,18,Ind,writein,3
+Kings,50008,State Senate,18,Ind,writein,0
+Kings,50009,State Senate,18,Ind,writein,0
+Kings,50010,State Senate,18,Ind,writein,0
+Kings,50012,State Senate,18,Ind,writein,0
+Kings,50015,State Senate,18,Ind,writein,1
+Kings,50016,State Senate,18,Ind,writein,0
+Kings,50017,State Senate,18,Ind,writein,0
+Kings,50018,State Senate,18,Ind,writein,2
+Kings,50019,State Senate,18,Ind,writein,2
+Kings,50020,State Senate,18,Ind,writein,2
+Kings,50021,State Senate,18,Ind,writein,3
+Kings,50022,State Senate,18,Ind,writein,1
+Kings,50025,State Senate,18,Ind,writein,0
+Kings,50043,State Senate,18,Ind,writein,0
+Kings,50044,State Senate,18,Ind,writein,2
+Kings,50045,State Senate,18,Ind,writein,0
+Kings,50046,State Senate,18,Ind,writein,3
+Kings,50049,State Senate,18,Ind,writein,2
+Kings,50050,State Senate,18,Ind,writein,0
+Kings,50051,State Senate,18,Ind,writein,0
+Kings,50052,State Senate,18,Ind,writein,2
+Kings,50053,State Senate,18,Ind,writein,1
+Kings,50054,State Senate,18,Ind,writein,0
+Kings,50056,State Senate,18,Ind,writein,0
+Kings,50057,State Senate,18,Ind,writein,0
+Kings,50058,State Senate,18,Ind,writein,0
+Kings,50059,State Senate,18,Ind,writein,1
+Kings,50060,State Senate,18,Ind,writein,0
+Kings,50061,State Senate,18,Ind,writein,1
+Kings,50062,State Senate,18,Ind,writein,1
+Kings,50063,State Senate,18,Ind,writein,0
+Kings,50081,State Senate,18,Ind,writein,0
+Kings,53001,State Senate,18,Ind,writein,0
+Kings,53002,State Senate,18,Ind,writein,1
+Kings,53003,State Senate,18,Ind,writein,0
+Kings,53004,State Senate,18,Ind,writein,2
+Kings,53005,State Senate,18,Ind,writein,0
+Kings,53006,State Senate,18,Ind,writein,0
+Kings,53007,State Senate,18,Ind,writein,0
+Kings,53008,State Senate,18,Ind,writein,1
+Kings,53009,State Senate,18,Ind,writein,1
+Kings,53010,State Senate,18,Ind,writein,1
+Kings,53011,State Senate,18,Ind,writein,0
+Kings,53012,State Senate,18,Ind,writein,2
+Kings,53013,State Senate,18,Ind,writein,1
+Kings,53015,State Senate,18,Ind,writein,0
+Kings,53016,State Senate,18,Ind,writein,2
+Kings,53017,State Senate,18,Ind,writein,2
+Kings,53018,State Senate,18,Ind,writein,1
+Kings,53019,State Senate,18,Ind,writein,1
+Kings,53020,State Senate,18,Ind,writein,2
+Kings,53021,State Senate,18,Ind,writein,0
+Kings,53022,State Senate,18,Ind,writein,0
+Kings,53023,State Senate,18,Ind,writein,3
+Kings,53024,State Senate,18,Ind,writein,0
+Kings,53025,State Senate,18,Ind,writein,0
+Kings,53026,State Senate,18,Ind,writein,0
+Kings,53027,State Senate,18,Ind,writein,0
+Kings,53028,State Senate,18,Ind,writein,0
+Kings,53029,State Senate,18,Ind,writein,0
+Kings,53030,State Senate,18,Ind,writein,4
+Kings,53031,State Senate,18,Ind,writein,0
+Kings,53032,State Senate,18,Ind,writein,1
+Kings,53033,State Senate,18,Ind,writein,0
+Kings,53034,State Senate,18,Ind,writein,1
+Kings,53035,State Senate,18,Ind,writein,3
+Kings,53036,State Senate,18,Ind,writein,1
+Kings,53037,State Senate,18,Ind,writein,0
+Kings,53038,State Senate,18,Ind,writein,0
+Kings,53039,State Senate,18,Ind,writein,2
+Kings,53040,State Senate,18,Ind,writein,0
+Kings,53041,State Senate,18,Ind,writein,0
+Kings,53042,State Senate,18,Ind,writein,0
+Kings,53043,State Senate,18,Ind,writein,0
+Kings,53044,State Senate,18,Ind,writein,1
+Kings,53045,State Senate,18,Ind,writein,1
+Kings,53046,State Senate,18,Ind,writein,0
+Kings,53047,State Senate,18,Ind,writein,3
+Kings,53048,State Senate,18,Ind,writein,1
+Kings,53050,State Senate,18,Ind,writein,0
+Kings,53052,State Senate,18,Ind,writein,1
+Kings,53053,State Senate,18,Ind,writein,1
+Kings,53054,State Senate,18,Ind,writein,0
+Kings,53055,State Senate,18,Ind,writein,1
+Kings,53056,State Senate,18,Ind,writein,2
+Kings,53057,State Senate,18,Ind,writein,4
+Kings,53058,State Senate,18,Ind,writein,1
+Kings,53059,State Senate,18,Ind,writein,0
+Kings,53060,State Senate,18,Ind,writein,0
+Kings,53061,State Senate,18,Ind,writein,1
+Kings,53062,State Senate,18,Ind,writein,0
+Kings,53063,State Senate,18,Ind,writein,2
+Kings,53064,State Senate,18,Ind,writein,0
+Kings,53065,State Senate,18,Ind,writein,0
+Kings,53066,State Senate,18,Ind,writein,0
+Kings,53067,State Senate,18,Ind,writein,0
+Kings,53068,State Senate,18,Ind,writein,0
+Kings,53069,State Senate,18,Ind,writein,1
+Kings,53070,State Senate,18,Ind,writein,0
+Kings,53071,State Senate,18,Ind,writein,0
+Kings,53072,State Senate,18,Ind,writein,2
+Kings,53073,State Senate,18,Ind,writein,0
+Kings,53074,State Senate,18,Ind,writein,1
+Kings,53075,State Senate,18,Ind,writein,0
+Kings,53076,State Senate,18,Ind,writein,1
+Kings,53077,State Senate,18,Ind,writein,2
+Kings,53079,State Senate,18,Ind,writein,0
+Kings,53080,State Senate,18,Ind,writein,1
+Kings,53082,State Senate,18,Ind,writein,0
+Kings,53083,State Senate,18,Ind,writein,0
+Kings,54001,State Senate,18,Ind,writein,0
+Kings,54007,State Senate,18,Ind,writein,1
+Kings,54008,State Senate,18,Ind,writein,0
+Kings,54009,State Senate,18,Ind,writein,0
+Kings,54010,State Senate,18,Ind,writein,0
+Kings,54011,State Senate,18,Ind,writein,0
+Kings,54012,State Senate,18,Ind,writein,0
+Kings,54013,State Senate,18,Ind,writein,0
+Kings,54014,State Senate,18,Ind,writein,0
+Kings,54016,State Senate,18,Ind,writein,0
+Kings,54017,State Senate,18,Ind,writein,0
+Kings,54018,State Senate,18,Ind,writein,0
+Kings,54019,State Senate,18,Ind,writein,0
+Kings,54020,State Senate,18,Ind,writein,0
+Kings,54021,State Senate,18,Ind,writein,1
+Kings,54022,State Senate,18,Ind,writein,0
+Kings,54023,State Senate,18,Ind,writein,0
+Kings,54024,State Senate,18,Ind,writein,0
+Kings,54025,State Senate,18,Ind,writein,0
+Kings,54027,State Senate,18,Ind,writein,0
+Kings,54028,State Senate,18,Ind,writein,0
+Kings,54029,State Senate,18,Ind,writein,0
+Kings,54030,State Senate,18,Ind,writein,0
+Kings,54031,State Senate,18,Ind,writein,0
+Kings,54032,State Senate,18,Ind,writein,0
+Kings,54033,State Senate,18,Ind,writein,1
+Kings,54034,State Senate,18,Ind,writein,0
+Kings,54035,State Senate,18,Ind,writein,0
+Kings,54036,State Senate,18,Ind,writein,0
+Kings,54037,State Senate,18,Ind,writein,0
+Kings,54038,State Senate,18,Ind,writein,0
+Kings,54039,State Senate,18,Ind,writein,0
+Kings,54040,State Senate,18,Ind,writein,0
+Kings,54041,State Senate,18,Ind,writein,1
+Kings,54042,State Senate,18,Ind,writein,0
+Kings,54043,State Senate,18,Ind,writein,0
+Kings,54044,State Senate,18,Ind,writein,0
+Kings,54045,State Senate,18,Ind,writein,0
+Kings,54046,State Senate,18,Ind,writein,0
+Kings,54047,State Senate,18,Ind,writein,0
+Kings,54048,State Senate,18,Ind,writein,0
+Kings,54049,State Senate,18,Ind,writein,0
+Kings,54050,State Senate,18,Ind,writein,1
+Kings,54051,State Senate,18,Ind,writein,0
+Kings,54052,State Senate,18,Ind,writein,0
+Kings,54053,State Senate,18,Ind,writein,0
+Kings,54054,State Senate,18,Ind,writein,0
+Kings,54055,State Senate,18,Ind,writein,1
+Kings,54056,State Senate,18,Ind,writein,0
+Kings,54057,State Senate,18,Ind,writein,1
+Kings,54058,State Senate,18,Ind,writein,0
+Kings,54059,State Senate,18,Ind,writein,0
+Kings,54060,State Senate,18,Ind,writein,0
+Kings,54061,State Senate,18,Ind,writein,0
+Kings,54062,State Senate,18,Ind,writein,1
+Kings,54063,State Senate,18,Ind,writein,1
+Kings,54064,State Senate,18,Ind,writein,0
+Kings,54065,State Senate,18,Ind,writein,0
+Kings,54066,State Senate,18,Ind,writein,0
+Kings,54067,State Senate,18,Ind,writein,0
+Kings,54068,State Senate,18,Ind,writein,0
+Kings,54069,State Senate,18,Ind,writein,0
+Kings,54070,State Senate,18,Ind,writein,0
+Kings,54073,State Senate,18,Ind,writein,0
+Kings,54074,State Senate,18,Ind,writein,0
+Kings,54078,State Senate,18,Ind,writein,0
+Kings,55003,State Senate,18,Ind,writein,0
+Kings,55006,State Senate,18,Ind,writein,0
+Kings,55007,State Senate,18,Ind,writein,1
+Kings,55014,State Senate,18,Ind,writein,0
+Kings,55015,State Senate,18,Ind,writein,0
+Kings,55016,State Senate,18,Ind,writein,0
+Kings,55026,State Senate,18,Ind,writein,0
+Kings,55041,State Senate,18,Ind,writein,0
+Kings,55045,State Senate,18,Ind,writein,1
+Kings,55046,State Senate,18,Ind,writein,0
+Kings,55050,State Senate,18,Ind,writein,0
+Kings,55051,State Senate,18,Ind,writein,0
+Kings,56001,State Senate,18,Ind,writein,0
+Kings,56002,State Senate,18,Ind,writein,0
+Kings,56003,State Senate,18,Ind,writein,0
+Kings,56004,State Senate,18,Ind,writein,0
+Kings,56006,State Senate,18,Ind,writein,1
+Kings,56007,State Senate,18,Ind,writein,0
+Kings,56008,State Senate,18,Ind,writein,0
+Kings,56009,State Senate,18,Ind,writein,0
+Kings,56010,State Senate,18,Ind,writein,0
+Kings,56011,State Senate,18,Ind,writein,0
+Kings,56017,State Senate,18,Ind,writein,0
+Kings,56020,State Senate,18,Ind,writein,0
+Kings,60004,State Senate,18,Ind,writein,0
+Kings,60006,State Senate,18,Ind,writein,0
+Kings,60010,State Senate,18,Ind,writein,0
+Kings,60011,State Senate,18,Ind,writein,0
+Kings,60013,State Senate,18,Ind,writein,0
+Kings,60016,State Senate,18,Ind,writein,0
+Kings,60018,State Senate,18,Ind,writein,0
+Kings,60019,State Senate,18,Ind,writein,0
+Kings,60020,State Senate,18,Ind,writein,0
+Kings,41013,State Senate,19,Con,Elias Weir,2
+Kings,41015,State Senate,19,Con,Elias Weir,7
+Kings,41019,State Senate,19,Con,Elias Weir,10
+Kings,41020,State Senate,19,Con,Elias Weir,15
+Kings,41021,State Senate,19,Con,Elias Weir,19
+Kings,41022,State Senate,19,Con,Elias Weir,19
+Kings,41025,State Senate,19,Con,Elias Weir,3
+Kings,41026,State Senate,19,Con,Elias Weir,0
+Kings,41027,State Senate,19,Con,Elias Weir,5
+Kings,41028,State Senate,19,Con,Elias Weir,4
+Kings,41029,State Senate,19,Con,Elias Weir,0
+Kings,41057,State Senate,19,Con,Elias Weir,19
+Kings,41060,State Senate,19,Con,Elias Weir,21
+Kings,41061,State Senate,19,Con,Elias Weir,30
+Kings,41062,State Senate,19,Con,Elias Weir,19
+Kings,41063,State Senate,19,Con,Elias Weir,30
+Kings,41064,State Senate,19,Con,Elias Weir,31
+Kings,41065,State Senate,19,Con,Elias Weir,3
+Kings,41066,State Senate,19,Con,Elias Weir,5
+Kings,41067,State Senate,19,Con,Elias Weir,3
+Kings,41068,State Senate,19,Con,Elias Weir,5
+Kings,41069,State Senate,19,Con,Elias Weir,8
+Kings,41070,State Senate,19,Con,Elias Weir,41
+Kings,41071,State Senate,19,Con,Elias Weir,27
+Kings,41072,State Senate,19,Con,Elias Weir,13
+Kings,41073,State Senate,19,Con,Elias Weir,16
+Kings,41074,State Senate,19,Con,Elias Weir,17
+Kings,41075,State Senate,19,Con,Elias Weir,11
+Kings,41076,State Senate,19,Con,Elias Weir,19
+Kings,41077,State Senate,19,Con,Elias Weir,19
+Kings,41078,State Senate,19,Con,Elias Weir,26
+Kings,41079,State Senate,19,Con,Elias Weir,21
+Kings,41080,State Senate,19,Con,Elias Weir,6
+Kings,42069,State Senate,19,Con,Elias Weir,4
+Kings,42070,State Senate,19,Con,Elias Weir,4
+Kings,45025,State Senate,19,Con,Elias Weir,4
+Kings,45026,State Senate,19,Con,Elias Weir,3
+Kings,45027,State Senate,19,Con,Elias Weir,9
+Kings,45028,State Senate,19,Con,Elias Weir,6
+Kings,45082,State Senate,19,Con,Elias Weir,6
+Kings,54002,State Senate,19,Con,Elias Weir,0
+Kings,54003,State Senate,19,Con,Elias Weir,3
+Kings,54004,State Senate,19,Con,Elias Weir,2
+Kings,54005,State Senate,19,Con,Elias Weir,1
+Kings,54006,State Senate,19,Con,Elias Weir,0
+Kings,54071,State Senate,19,Con,Elias Weir,1
+Kings,54072,State Senate,19,Con,Elias Weir,0
+Kings,55027,State Senate,19,Con,Elias Weir,2
+Kings,55036,State Senate,19,Con,Elias Weir,0
+Kings,55037,State Senate,19,Con,Elias Weir,1
+Kings,55038,State Senate,19,Con,Elias Weir,1
+Kings,55039,State Senate,19,Con,Elias Weir,0
+Kings,55040,State Senate,19,Con,Elias Weir,0
+Kings,55044,State Senate,19,Con,Elias Weir,0
+Kings,55047,State Senate,19,Con,Elias Weir,0
+Kings,55048,State Senate,19,Con,Elias Weir,2
+Kings,55049,State Senate,19,Con,Elias Weir,2
+Kings,55052,State Senate,19,Con,Elias Weir,2
+Kings,55055,State Senate,19,Con,Elias Weir,2
+Kings,55056,State Senate,19,Con,Elias Weir,2
+Kings,55060,State Senate,19,Con,Elias Weir,0
+Kings,55062,State Senate,19,Con,Elias Weir,2
+Kings,55063,State Senate,19,Con,Elias Weir,0
+Kings,55064,State Senate,19,Con,Elias Weir,5
+Kings,55074,State Senate,19,Con,Elias Weir,0
+Kings,55075,State Senate,19,Con,Elias Weir,0
+Kings,55077,State Senate,19,Con,Elias Weir,0
+Kings,55099,State Senate,19,Con,Elias Weir,3
+Kings,55105,State Senate,19,Con,Elias Weir,0
+Kings,58057,State Senate,19,Con,Elias Weir,0
+Kings,58058,State Senate,19,Con,Elias Weir,0
+Kings,58059,State Senate,19,Con,Elias Weir,8
+Kings,58060,State Senate,19,Con,Elias Weir,3
+Kings,58066,State Senate,19,Con,Elias Weir,1
+Kings,58067,State Senate,19,Con,Elias Weir,0
+Kings,58068,State Senate,19,Con,Elias Weir,2
+Kings,58069,State Senate,19,Con,Elias Weir,1
+Kings,58070,State Senate,19,Con,Elias Weir,3
+Kings,58071,State Senate,19,Con,Elias Weir,5
+Kings,58072,State Senate,19,Con,Elias Weir,0
+Kings,58073,State Senate,19,Con,Elias Weir,0
+Kings,58074,State Senate,19,Con,Elias Weir,1
+Kings,58075,State Senate,19,Con,Elias Weir,2
+Kings,58076,State Senate,19,Con,Elias Weir,0
+Kings,58077,State Senate,19,Con,Elias Weir,2
+Kings,58078,State Senate,19,Con,Elias Weir,2
+Kings,58079,State Senate,19,Con,Elias Weir,0
+Kings,59005,State Senate,19,Con,Elias Weir,0
+Kings,59006,State Senate,19,Con,Elias Weir,2
+Kings,59007,State Senate,19,Con,Elias Weir,3
+Kings,59008,State Senate,19,Con,Elias Weir,2
+Kings,59010,State Senate,19,Con,Elias Weir,1
+Kings,59011,State Senate,19,Con,Elias Weir,10
+Kings,59012,State Senate,19,Con,Elias Weir,7
+Kings,59013,State Senate,19,Con,Elias Weir,4
+Kings,59014,State Senate,19,Con,Elias Weir,2
+Kings,59015,State Senate,19,Con,Elias Weir,2
+Kings,59024,State Senate,19,Con,Elias Weir,7
+Kings,59026,State Senate,19,Con,Elias Weir,9
+Kings,59027,State Senate,19,Con,Elias Weir,14
+Kings,59028,State Senate,19,Con,Elias Weir,13
+Kings,59029,State Senate,19,Con,Elias Weir,10
+Kings,59030,State Senate,19,Con,Elias Weir,19
+Kings,59031,State Senate,19,Con,Elias Weir,16
+Kings,59032,State Senate,19,Con,Elias Weir,6
+Kings,59050,State Senate,19,Con,Elias Weir,9
+Kings,59051,State Senate,19,Con,Elias Weir,42
+Kings,59052,State Senate,19,Con,Elias Weir,23
+Kings,59053,State Senate,19,Con,Elias Weir,34
+Kings,59054,State Senate,19,Con,Elias Weir,17
+Kings,59055,State Senate,19,Con,Elias Weir,26
+Kings,59056,State Senate,19,Con,Elias Weir,14
+Kings,59057,State Senate,19,Con,Elias Weir,20
+Kings,59058,State Senate,19,Con,Elias Weir,35
+Kings,59059,State Senate,19,Con,Elias Weir,21
+Kings,59060,State Senate,19,Con,Elias Weir,15
+Kings,59061,State Senate,19,Con,Elias Weir,30
+Kings,59062,State Senate,19,Con,Elias Weir,14
+Kings,59063,State Senate,19,Con,Elias Weir,0
+Kings,59064,State Senate,19,Con,Elias Weir,2
+Kings,59065,State Senate,19,Con,Elias Weir,2
+Kings,59066,State Senate,19,Con,Elias Weir,5
+Kings,59067,State Senate,19,Con,Elias Weir,2
+Kings,59068,State Senate,19,Con,Elias Weir,8
+Kings,59069,State Senate,19,Con,Elias Weir,6
+Kings,59070,State Senate,19,Con,Elias Weir,7
+Kings,59071,State Senate,19,Con,Elias Weir,4
+Kings,59072,State Senate,19,Con,Elias Weir,2
+Kings,59073,State Senate,19,Con,Elias Weir,0
+Kings,59074,State Senate,19,Con,Elias Weir,4
+Kings,59075,State Senate,19,Con,Elias Weir,2
+Kings,59076,State Senate,19,Con,Elias Weir,3
+Kings,59077,State Senate,19,Con,Elias Weir,6
+Kings,59078,State Senate,19,Con,Elias Weir,4
+Kings,59079,State Senate,19,Con,Elias Weir,1
+Kings,59080,State Senate,19,Con,Elias Weir,6
+Kings,59081,State Senate,19,Con,Elias Weir,2
+Kings,60001,State Senate,19,Con,Elias Weir,2
+Kings,60002,State Senate,19,Con,Elias Weir,2
+Kings,60003,State Senate,19,Con,Elias Weir,2
+Kings,60005,State Senate,19,Con,Elias Weir,0
+Kings,60007,State Senate,19,Con,Elias Weir,0
+Kings,60008,State Senate,19,Con,Elias Weir,2
+Kings,60009,State Senate,19,Con,Elias Weir,0
+Kings,60012,State Senate,19,Con,Elias Weir,1
+Kings,60014,State Senate,19,Con,Elias Weir,3
+Kings,60015,State Senate,19,Con,Elias Weir,4
+Kings,60017,State Senate,19,Con,Elias Weir,0
+Kings,60021,State Senate,19,Con,Elias Weir,1
+Kings,60022,State Senate,19,Con,Elias Weir,1
+Kings,60023,State Senate,19,Con,Elias Weir,1
+Kings,60024,State Senate,19,Con,Elias Weir,1
+Kings,60025,State Senate,19,Con,Elias Weir,2
+Kings,60026,State Senate,19,Con,Elias Weir,1
+Kings,60027,State Senate,19,Con,Elias Weir,1
+Kings,60028,State Senate,19,Con,Elias Weir,1
+Kings,60029,State Senate,19,Con,Elias Weir,1
+Kings,60030,State Senate,19,Con,Elias Weir,4
+Kings,60031,State Senate,19,Con,Elias Weir,0
+Kings,60032,State Senate,19,Con,Elias Weir,0
+Kings,60033,State Senate,19,Con,Elias Weir,2
+Kings,60034,State Senate,19,Con,Elias Weir,2
+Kings,60035,State Senate,19,Con,Elias Weir,4
+Kings,60036,State Senate,19,Con,Elias Weir,1
+Kings,60037,State Senate,19,Con,Elias Weir,1
+Kings,60038,State Senate,19,Con,Elias Weir,0
+Kings,60039,State Senate,19,Con,Elias Weir,3
+Kings,60040,State Senate,19,Con,Elias Weir,5
+Kings,60041,State Senate,19,Con,Elias Weir,0
+Kings,60042,State Senate,19,Con,Elias Weir,1
+Kings,60043,State Senate,19,Con,Elias Weir,0
+Kings,60044,State Senate,19,Con,Elias Weir,2
+Kings,60045,State Senate,19,Con,Elias Weir,1
+Kings,60046,State Senate,19,Con,Elias Weir,3
+Kings,60047,State Senate,19,Con,Elias Weir,0
+Kings,60048,State Senate,19,Con,Elias Weir,2
+Kings,60049,State Senate,19,Con,Elias Weir,0
+Kings,60050,State Senate,19,Con,Elias Weir,0
+Kings,60051,State Senate,19,Con,Elias Weir,2
+Kings,60052,State Senate,19,Con,Elias Weir,0
+Kings,60053,State Senate,19,Con,Elias Weir,1
+Kings,60054,State Senate,19,Con,Elias Weir,2
+Kings,60055,State Senate,19,Con,Elias Weir,1
+Kings,60056,State Senate,19,Con,Elias Weir,0
+Kings,60057,State Senate,19,Con,Elias Weir,1
+Kings,60058,State Senate,19,Con,Elias Weir,2
+Kings,60059,State Senate,19,Con,Elias Weir,1
+Kings,60060,State Senate,19,Con,Elias Weir,3
+Kings,60061,State Senate,19,Con,Elias Weir,1
+Kings,60062,State Senate,19,Con,Elias Weir,0
+Kings,60063,State Senate,19,Con,Elias Weir,1
+Kings,60064,State Senate,19,Con,Elias Weir,2
+Kings,60065,State Senate,19,Con,Elias Weir,2
+Kings,60066,State Senate,19,Con,Elias Weir,3
+Kings,60067,State Senate,19,Con,Elias Weir,1
+Kings,60068,State Senate,19,Con,Elias Weir,0
+Kings,60069,State Senate,19,Con,Elias Weir,0
+Kings,60070,State Senate,19,Con,Elias Weir,0
+Kings,60071,State Senate,19,Con,Elias Weir,1
+Kings,60072,State Senate,19,Con,Elias Weir,3
+Kings,60073,State Senate,19,Con,Elias Weir,0
+Kings,60074,State Senate,19,Con,Elias Weir,2
+Kings,60075,State Senate,19,Con,Elias Weir,3
+Kings,60076,State Senate,19,Con,Elias Weir,0
+Kings,60077,State Senate,19,Con,Elias Weir,3
+Kings,60078,State Senate,19,Con,Elias Weir,3
+Kings,60079,State Senate,19,Con,Elias Weir,0
+Kings,60080,State Senate,19,Con,Elias Weir,0
+Kings,60081,State Senate,19,Con,Elias Weir,2
+Kings,60082,State Senate,19,Con,Elias Weir,4
+Kings,60083,State Senate,19,Con,Elias Weir,2
+Kings,60084,State Senate,19,Con,Elias Weir,6
+Kings,60085,State Senate,19,Con,Elias Weir,1
+Kings,60086,State Senate,19,Con,Elias Weir,1
+Kings,60087,State Senate,19,Con,Elias Weir,7
+Kings,60088,State Senate,19,Con,Elias Weir,4
+Kings,60089,State Senate,19,Con,Elias Weir,6
+Kings,60090,State Senate,19,Con,Elias Weir,3
+Kings,60091,State Senate,19,Con,Elias Weir,2
+Kings,41013,State Senate,19,Rep,Jane Neal,9
+Kings,41015,State Senate,19,Rep,Jane Neal,52
+Kings,41019,State Senate,19,Rep,Jane Neal,21
+Kings,41020,State Senate,19,Rep,Jane Neal,72
+Kings,41021,State Senate,19,Rep,Jane Neal,109
+Kings,41022,State Senate,19,Rep,Jane Neal,71
+Kings,41025,State Senate,19,Rep,Jane Neal,12
+Kings,41026,State Senate,19,Rep,Jane Neal,2
+Kings,41027,State Senate,19,Rep,Jane Neal,27
+Kings,41028,State Senate,19,Rep,Jane Neal,8
+Kings,41029,State Senate,19,Rep,Jane Neal,1
+Kings,41057,State Senate,19,Rep,Jane Neal,124
+Kings,41060,State Senate,19,Rep,Jane Neal,158
+Kings,41061,State Senate,19,Rep,Jane Neal,106
+Kings,41062,State Senate,19,Rep,Jane Neal,97
+Kings,41063,State Senate,19,Rep,Jane Neal,87
+Kings,41064,State Senate,19,Rep,Jane Neal,142
+Kings,41065,State Senate,19,Rep,Jane Neal,21
+Kings,41066,State Senate,19,Rep,Jane Neal,21
+Kings,41067,State Senate,19,Rep,Jane Neal,14
+Kings,41068,State Senate,19,Rep,Jane Neal,25
+Kings,41069,State Senate,19,Rep,Jane Neal,22
+Kings,41070,State Senate,19,Rep,Jane Neal,185
+Kings,41071,State Senate,19,Rep,Jane Neal,177
+Kings,41072,State Senate,19,Rep,Jane Neal,163
+Kings,41073,State Senate,19,Rep,Jane Neal,133
+Kings,41074,State Senate,19,Rep,Jane Neal,106
+Kings,41075,State Senate,19,Rep,Jane Neal,55
+Kings,41076,State Senate,19,Rep,Jane Neal,116
+Kings,41077,State Senate,19,Rep,Jane Neal,166
+Kings,41078,State Senate,19,Rep,Jane Neal,181
+Kings,41079,State Senate,19,Rep,Jane Neal,151
+Kings,41080,State Senate,19,Rep,Jane Neal,24
+Kings,42069,State Senate,19,Rep,Jane Neal,35
+Kings,42070,State Senate,19,Rep,Jane Neal,24
+Kings,45025,State Senate,19,Rep,Jane Neal,16
+Kings,45026,State Senate,19,Rep,Jane Neal,66
+Kings,45027,State Senate,19,Rep,Jane Neal,107
+Kings,45028,State Senate,19,Rep,Jane Neal,55
+Kings,45082,State Senate,19,Rep,Jane Neal,41
+Kings,54002,State Senate,19,Rep,Jane Neal,3
+Kings,54003,State Senate,19,Rep,Jane Neal,18
+Kings,54004,State Senate,19,Rep,Jane Neal,17
+Kings,54005,State Senate,19,Rep,Jane Neal,1
+Kings,54006,State Senate,19,Rep,Jane Neal,4
+Kings,54071,State Senate,19,Rep,Jane Neal,3
+Kings,54072,State Senate,19,Rep,Jane Neal,2
+Kings,55027,State Senate,19,Rep,Jane Neal,5
+Kings,55036,State Senate,19,Rep,Jane Neal,0
+Kings,55037,State Senate,19,Rep,Jane Neal,8
+Kings,55038,State Senate,19,Rep,Jane Neal,1
+Kings,55039,State Senate,19,Rep,Jane Neal,0
+Kings,55040,State Senate,19,Rep,Jane Neal,6
+Kings,55044,State Senate,19,Rep,Jane Neal,1
+Kings,55047,State Senate,19,Rep,Jane Neal,3
+Kings,55048,State Senate,19,Rep,Jane Neal,4
+Kings,55049,State Senate,19,Rep,Jane Neal,5
+Kings,55052,State Senate,19,Rep,Jane Neal,4
+Kings,55055,State Senate,19,Rep,Jane Neal,5
+Kings,55056,State Senate,19,Rep,Jane Neal,0
+Kings,55060,State Senate,19,Rep,Jane Neal,2
+Kings,55062,State Senate,19,Rep,Jane Neal,6
+Kings,55063,State Senate,19,Rep,Jane Neal,0
+Kings,55064,State Senate,19,Rep,Jane Neal,3
+Kings,55074,State Senate,19,Rep,Jane Neal,1
+Kings,55075,State Senate,19,Rep,Jane Neal,4
+Kings,55077,State Senate,19,Rep,Jane Neal,1
+Kings,55099,State Senate,19,Rep,Jane Neal,5
+Kings,55105,State Senate,19,Rep,Jane Neal,0
+Kings,58057,State Senate,19,Rep,Jane Neal,4
+Kings,58058,State Senate,19,Rep,Jane Neal,0
+Kings,58059,State Senate,19,Rep,Jane Neal,21
+Kings,58060,State Senate,19,Rep,Jane Neal,12
+Kings,58066,State Senate,19,Rep,Jane Neal,7
+Kings,58067,State Senate,19,Rep,Jane Neal,6
+Kings,58068,State Senate,19,Rep,Jane Neal,0
+Kings,58069,State Senate,19,Rep,Jane Neal,3
+Kings,58070,State Senate,19,Rep,Jane Neal,20
+Kings,58071,State Senate,19,Rep,Jane Neal,19
+Kings,58072,State Senate,19,Rep,Jane Neal,15
+Kings,58073,State Senate,19,Rep,Jane Neal,2
+Kings,58074,State Senate,19,Rep,Jane Neal,12
+Kings,58075,State Senate,19,Rep,Jane Neal,9
+Kings,58076,State Senate,19,Rep,Jane Neal,7
+Kings,58077,State Senate,19,Rep,Jane Neal,12
+Kings,58078,State Senate,19,Rep,Jane Neal,11
+Kings,58079,State Senate,19,Rep,Jane Neal,12
+Kings,59005,State Senate,19,Rep,Jane Neal,13
+Kings,59006,State Senate,19,Rep,Jane Neal,7
+Kings,59007,State Senate,19,Rep,Jane Neal,8
+Kings,59008,State Senate,19,Rep,Jane Neal,20
+Kings,59010,State Senate,19,Rep,Jane Neal,7
+Kings,59011,State Senate,19,Rep,Jane Neal,28
+Kings,59012,State Senate,19,Rep,Jane Neal,15
+Kings,59013,State Senate,19,Rep,Jane Neal,17
+Kings,59014,State Senate,19,Rep,Jane Neal,7
+Kings,59015,State Senate,19,Rep,Jane Neal,10
+Kings,59024,State Senate,19,Rep,Jane Neal,56
+Kings,59026,State Senate,19,Rep,Jane Neal,65
+Kings,59027,State Senate,19,Rep,Jane Neal,45
+Kings,59028,State Senate,19,Rep,Jane Neal,50
+Kings,59029,State Senate,19,Rep,Jane Neal,57
+Kings,59030,State Senate,19,Rep,Jane Neal,77
+Kings,59031,State Senate,19,Rep,Jane Neal,101
+Kings,59032,State Senate,19,Rep,Jane Neal,41
+Kings,59050,State Senate,19,Rep,Jane Neal,94
+Kings,59051,State Senate,19,Rep,Jane Neal,185
+Kings,59052,State Senate,19,Rep,Jane Neal,301
+Kings,59053,State Senate,19,Rep,Jane Neal,270
+Kings,59054,State Senate,19,Rep,Jane Neal,118
+Kings,59055,State Senate,19,Rep,Jane Neal,271
+Kings,59056,State Senate,19,Rep,Jane Neal,99
+Kings,59057,State Senate,19,Rep,Jane Neal,141
+Kings,59058,State Senate,19,Rep,Jane Neal,164
+Kings,59059,State Senate,19,Rep,Jane Neal,210
+Kings,59060,State Senate,19,Rep,Jane Neal,188
+Kings,59061,State Senate,19,Rep,Jane Neal,184
+Kings,59062,State Senate,19,Rep,Jane Neal,133
+Kings,59063,State Senate,19,Rep,Jane Neal,4
+Kings,59064,State Senate,19,Rep,Jane Neal,9
+Kings,59065,State Senate,19,Rep,Jane Neal,11
+Kings,59066,State Senate,19,Rep,Jane Neal,11
+Kings,59067,State Senate,19,Rep,Jane Neal,30
+Kings,59068,State Senate,19,Rep,Jane Neal,17
+Kings,59069,State Senate,19,Rep,Jane Neal,23
+Kings,59070,State Senate,19,Rep,Jane Neal,15
+Kings,59071,State Senate,19,Rep,Jane Neal,8
+Kings,59072,State Senate,19,Rep,Jane Neal,3
+Kings,59073,State Senate,19,Rep,Jane Neal,13
+Kings,59074,State Senate,19,Rep,Jane Neal,27
+Kings,59075,State Senate,19,Rep,Jane Neal,21
+Kings,59076,State Senate,19,Rep,Jane Neal,9
+Kings,59077,State Senate,19,Rep,Jane Neal,11
+Kings,59078,State Senate,19,Rep,Jane Neal,15
+Kings,59079,State Senate,19,Rep,Jane Neal,8
+Kings,59080,State Senate,19,Rep,Jane Neal,13
+Kings,59081,State Senate,19,Rep,Jane Neal,10
+Kings,60001,State Senate,19,Rep,Jane Neal,3
+Kings,60002,State Senate,19,Rep,Jane Neal,12
+Kings,60003,State Senate,19,Rep,Jane Neal,8
+Kings,60005,State Senate,19,Rep,Jane Neal,0
+Kings,60007,State Senate,19,Rep,Jane Neal,4
+Kings,60008,State Senate,19,Rep,Jane Neal,6
+Kings,60009,State Senate,19,Rep,Jane Neal,5
+Kings,60012,State Senate,19,Rep,Jane Neal,2
+Kings,60014,State Senate,19,Rep,Jane Neal,6
+Kings,60015,State Senate,19,Rep,Jane Neal,5
+Kings,60017,State Senate,19,Rep,Jane Neal,2
+Kings,60021,State Senate,19,Rep,Jane Neal,13
+Kings,60022,State Senate,19,Rep,Jane Neal,14
+Kings,60023,State Senate,19,Rep,Jane Neal,3
+Kings,60024,State Senate,19,Rep,Jane Neal,4
+Kings,60025,State Senate,19,Rep,Jane Neal,4
+Kings,60026,State Senate,19,Rep,Jane Neal,1
+Kings,60027,State Senate,19,Rep,Jane Neal,2
+Kings,60028,State Senate,19,Rep,Jane Neal,7
+Kings,60029,State Senate,19,Rep,Jane Neal,5
+Kings,60030,State Senate,19,Rep,Jane Neal,7
+Kings,60031,State Senate,19,Rep,Jane Neal,3
+Kings,60032,State Senate,19,Rep,Jane Neal,12
+Kings,60033,State Senate,19,Rep,Jane Neal,2
+Kings,60034,State Senate,19,Rep,Jane Neal,5
+Kings,60035,State Senate,19,Rep,Jane Neal,3
+Kings,60036,State Senate,19,Rep,Jane Neal,4
+Kings,60037,State Senate,19,Rep,Jane Neal,9
+Kings,60038,State Senate,19,Rep,Jane Neal,5
+Kings,60039,State Senate,19,Rep,Jane Neal,3
+Kings,60040,State Senate,19,Rep,Jane Neal,2
+Kings,60041,State Senate,19,Rep,Jane Neal,2
+Kings,60042,State Senate,19,Rep,Jane Neal,2
+Kings,60043,State Senate,19,Rep,Jane Neal,0
+Kings,60044,State Senate,19,Rep,Jane Neal,8
+Kings,60045,State Senate,19,Rep,Jane Neal,7
+Kings,60046,State Senate,19,Rep,Jane Neal,3
+Kings,60047,State Senate,19,Rep,Jane Neal,4
+Kings,60048,State Senate,19,Rep,Jane Neal,1
+Kings,60049,State Senate,19,Rep,Jane Neal,4
+Kings,60050,State Senate,19,Rep,Jane Neal,4
+Kings,60051,State Senate,19,Rep,Jane Neal,4
+Kings,60052,State Senate,19,Rep,Jane Neal,3
+Kings,60053,State Senate,19,Rep,Jane Neal,2
+Kings,60054,State Senate,19,Rep,Jane Neal,7
+Kings,60055,State Senate,19,Rep,Jane Neal,4
+Kings,60056,State Senate,19,Rep,Jane Neal,3
+Kings,60057,State Senate,19,Rep,Jane Neal,3
+Kings,60058,State Senate,19,Rep,Jane Neal,4
+Kings,60059,State Senate,19,Rep,Jane Neal,4
+Kings,60060,State Senate,19,Rep,Jane Neal,4
+Kings,60061,State Senate,19,Rep,Jane Neal,5
+Kings,60062,State Senate,19,Rep,Jane Neal,1
+Kings,60063,State Senate,19,Rep,Jane Neal,1
+Kings,60064,State Senate,19,Rep,Jane Neal,5
+Kings,60065,State Senate,19,Rep,Jane Neal,8
+Kings,60066,State Senate,19,Rep,Jane Neal,1
+Kings,60067,State Senate,19,Rep,Jane Neal,3
+Kings,60068,State Senate,19,Rep,Jane Neal,1
+Kings,60069,State Senate,19,Rep,Jane Neal,0
+Kings,60070,State Senate,19,Rep,Jane Neal,0
+Kings,60071,State Senate,19,Rep,Jane Neal,2
+Kings,60072,State Senate,19,Rep,Jane Neal,4
+Kings,60073,State Senate,19,Rep,Jane Neal,0
+Kings,60074,State Senate,19,Rep,Jane Neal,65
+Kings,60075,State Senate,19,Rep,Jane Neal,10
+Kings,60076,State Senate,19,Rep,Jane Neal,25
+Kings,60077,State Senate,19,Rep,Jane Neal,23
+Kings,60078,State Senate,19,Rep,Jane Neal,39
+Kings,60079,State Senate,19,Rep,Jane Neal,4
+Kings,60080,State Senate,19,Rep,Jane Neal,4
+Kings,60081,State Senate,19,Rep,Jane Neal,2
+Kings,60082,State Senate,19,Rep,Jane Neal,8
+Kings,60083,State Senate,19,Rep,Jane Neal,11
+Kings,60084,State Senate,19,Rep,Jane Neal,2
+Kings,60085,State Senate,19,Rep,Jane Neal,7
+Kings,60086,State Senate,19,Rep,Jane Neal,1
+Kings,60087,State Senate,19,Rep,Jane Neal,19
+Kings,60088,State Senate,19,Rep,Jane Neal,46
+Kings,60089,State Senate,19,Rep,Jane Neal,55
+Kings,60090,State Senate,19,Rep,Jane Neal,93
+Kings,60091,State Senate,19,Rep,Jane Neal,22
+Kings,41013,State Senate,19,Dem,John Sampson,6
+Kings,41015,State Senate,19,Dem,John Sampson,87
+Kings,41019,State Senate,19,Dem,John Sampson,17
+Kings,41020,State Senate,19,Dem,John Sampson,206
+Kings,41021,State Senate,19,Dem,John Sampson,261
+Kings,41022,State Senate,19,Dem,John Sampson,255
+Kings,41025,State Senate,19,Dem,John Sampson,69
+Kings,41026,State Senate,19,Dem,John Sampson,52
+Kings,41027,State Senate,19,Dem,John Sampson,225
+Kings,41028,State Senate,19,Dem,John Sampson,280
+Kings,41029,State Senate,19,Dem,John Sampson,28
+Kings,41057,State Senate,19,Dem,John Sampson,167
+Kings,41060,State Senate,19,Dem,John Sampson,260
+Kings,41061,State Senate,19,Dem,John Sampson,200
+Kings,41062,State Senate,19,Dem,John Sampson,208
+Kings,41063,State Senate,19,Dem,John Sampson,200
+Kings,41064,State Senate,19,Dem,John Sampson,338
+Kings,41065,State Senate,19,Dem,John Sampson,117
+Kings,41066,State Senate,19,Dem,John Sampson,341
+Kings,41067,State Senate,19,Dem,John Sampson,365
+Kings,41068,State Senate,19,Dem,John Sampson,323
+Kings,41069,State Senate,19,Dem,John Sampson,370
+Kings,41070,State Senate,19,Dem,John Sampson,190
+Kings,41071,State Senate,19,Dem,John Sampson,212
+Kings,41072,State Senate,19,Dem,John Sampson,182
+Kings,41073,State Senate,19,Dem,John Sampson,302
+Kings,41074,State Senate,19,Dem,John Sampson,213
+Kings,41075,State Senate,19,Dem,John Sampson,150
+Kings,41076,State Senate,19,Dem,John Sampson,210
+Kings,41077,State Senate,19,Dem,John Sampson,270
+Kings,41078,State Senate,19,Dem,John Sampson,251
+Kings,41079,State Senate,19,Dem,John Sampson,163
+Kings,41080,State Senate,19,Dem,John Sampson,22
+Kings,42069,State Senate,19,Dem,John Sampson,41
+Kings,42070,State Senate,19,Dem,John Sampson,13
+Kings,45025,State Senate,19,Dem,John Sampson,56
+Kings,45026,State Senate,19,Dem,John Sampson,138
+Kings,45027,State Senate,19,Dem,John Sampson,145
+Kings,45028,State Senate,19,Dem,John Sampson,146
+Kings,45082,State Senate,19,Dem,John Sampson,139
+Kings,54002,State Senate,19,Dem,John Sampson,164
+Kings,54003,State Senate,19,Dem,John Sampson,242
+Kings,54004,State Senate,19,Dem,John Sampson,438
+Kings,54005,State Senate,19,Dem,John Sampson,112
+Kings,54006,State Senate,19,Dem,John Sampson,89
+Kings,54071,State Senate,19,Dem,John Sampson,211
+Kings,54072,State Senate,19,Dem,John Sampson,65
+Kings,55027,State Senate,19,Dem,John Sampson,221
+Kings,55036,State Senate,19,Dem,John Sampson,25
+Kings,55037,State Senate,19,Dem,John Sampson,313
+Kings,55038,State Senate,19,Dem,John Sampson,103
+Kings,55039,State Senate,19,Dem,John Sampson,15
+Kings,55040,State Senate,19,Dem,John Sampson,86
+Kings,55044,State Senate,19,Dem,John Sampson,15
+Kings,55047,State Senate,19,Dem,John Sampson,160
+Kings,55048,State Senate,19,Dem,John Sampson,420
+Kings,55049,State Senate,19,Dem,John Sampson,243
+Kings,55052,State Senate,19,Dem,John Sampson,184
+Kings,55055,State Senate,19,Dem,John Sampson,283
+Kings,55056,State Senate,19,Dem,John Sampson,56
+Kings,55060,State Senate,19,Dem,John Sampson,101
+Kings,55062,State Senate,19,Dem,John Sampson,246
+Kings,55063,State Senate,19,Dem,John Sampson,186
+Kings,55064,State Senate,19,Dem,John Sampson,393
+Kings,55074,State Senate,19,Dem,John Sampson,377
+Kings,55075,State Senate,19,Dem,John Sampson,356
+Kings,55077,State Senate,19,Dem,John Sampson,76
+Kings,55099,State Senate,19,Dem,John Sampson,603
+Kings,55105,State Senate,19,Dem,John Sampson,3
+Kings,58057,State Senate,19,Dem,John Sampson,369
+Kings,58058,State Senate,19,Dem,John Sampson,153
+Kings,58059,State Senate,19,Dem,John Sampson,617
+Kings,58060,State Senate,19,Dem,John Sampson,456
+Kings,58066,State Senate,19,Dem,John Sampson,437
+Kings,58067,State Senate,19,Dem,John Sampson,498
+Kings,58068,State Senate,19,Dem,John Sampson,417
+Kings,58069,State Senate,19,Dem,John Sampson,135
+Kings,58070,State Senate,19,Dem,John Sampson,545
+Kings,58071,State Senate,19,Dem,John Sampson,685
+Kings,58072,State Senate,19,Dem,John Sampson,596
+Kings,58073,State Senate,19,Dem,John Sampson,247
+Kings,58074,State Senate,19,Dem,John Sampson,664
+Kings,58075,State Senate,19,Dem,John Sampson,650
+Kings,58076,State Senate,19,Dem,John Sampson,555
+Kings,58077,State Senate,19,Dem,John Sampson,579
+Kings,58078,State Senate,19,Dem,John Sampson,506
+Kings,58079,State Senate,19,Dem,John Sampson,396
+Kings,59005,State Senate,19,Dem,John Sampson,682
+Kings,59006,State Senate,19,Dem,John Sampson,713
+Kings,59007,State Senate,19,Dem,John Sampson,527
+Kings,59008,State Senate,19,Dem,John Sampson,461
+Kings,59010,State Senate,19,Dem,John Sampson,352
+Kings,59011,State Senate,19,Dem,John Sampson,557
+Kings,59012,State Senate,19,Dem,John Sampson,622
+Kings,59013,State Senate,19,Dem,John Sampson,704
+Kings,59014,State Senate,19,Dem,John Sampson,671
+Kings,59015,State Senate,19,Dem,John Sampson,784
+Kings,59024,State Senate,19,Dem,John Sampson,556
+Kings,59026,State Senate,19,Dem,John Sampson,581
+Kings,59027,State Senate,19,Dem,John Sampson,532
+Kings,59028,State Senate,19,Dem,John Sampson,446
+Kings,59029,State Senate,19,Dem,John Sampson,440
+Kings,59030,State Senate,19,Dem,John Sampson,497
+Kings,59031,State Senate,19,Dem,John Sampson,568
+Kings,59032,State Senate,19,Dem,John Sampson,262
+Kings,59050,State Senate,19,Dem,John Sampson,432
+Kings,59051,State Senate,19,Dem,John Sampson,287
+Kings,59052,State Senate,19,Dem,John Sampson,172
+Kings,59053,State Senate,19,Dem,John Sampson,168
+Kings,59054,State Senate,19,Dem,John Sampson,129
+Kings,59055,State Senate,19,Dem,John Sampson,196
+Kings,59056,State Senate,19,Dem,John Sampson,478
+Kings,59057,State Senate,19,Dem,John Sampson,383
+Kings,59058,State Senate,19,Dem,John Sampson,345
+Kings,59059,State Senate,19,Dem,John Sampson,239
+Kings,59060,State Senate,19,Dem,John Sampson,146
+Kings,59061,State Senate,19,Dem,John Sampson,133
+Kings,59062,State Senate,19,Dem,John Sampson,106
+Kings,59063,State Senate,19,Dem,John Sampson,14
+Kings,59064,State Senate,19,Dem,John Sampson,628
+Kings,59065,State Senate,19,Dem,John Sampson,620
+Kings,59066,State Senate,19,Dem,John Sampson,754
+Kings,59067,State Senate,19,Dem,John Sampson,673
+Kings,59068,State Senate,19,Dem,John Sampson,619
+Kings,59069,State Senate,19,Dem,John Sampson,726
+Kings,59070,State Senate,19,Dem,John Sampson,547
+Kings,59071,State Senate,19,Dem,John Sampson,618
+Kings,59072,State Senate,19,Dem,John Sampson,546
+Kings,59073,State Senate,19,Dem,John Sampson,647
+Kings,59074,State Senate,19,Dem,John Sampson,639
+Kings,59075,State Senate,19,Dem,John Sampson,552
+Kings,59076,State Senate,19,Dem,John Sampson,529
+Kings,59077,State Senate,19,Dem,John Sampson,509
+Kings,59078,State Senate,19,Dem,John Sampson,331
+Kings,59079,State Senate,19,Dem,John Sampson,310
+Kings,59080,State Senate,19,Dem,John Sampson,525
+Kings,59081,State Senate,19,Dem,John Sampson,410
+Kings,60001,State Senate,19,Dem,John Sampson,548
+Kings,60002,State Senate,19,Dem,John Sampson,573
+Kings,60003,State Senate,19,Dem,John Sampson,504
+Kings,60005,State Senate,19,Dem,John Sampson,56
+Kings,60007,State Senate,19,Dem,John Sampson,567
+Kings,60008,State Senate,19,Dem,John Sampson,644
+Kings,60009,State Senate,19,Dem,John Sampson,168
+Kings,60012,State Senate,19,Dem,John Sampson,69
+Kings,60014,State Senate,19,Dem,John Sampson,521
+Kings,60015,State Senate,19,Dem,John Sampson,412
+Kings,60017,State Senate,19,Dem,John Sampson,25
+Kings,60021,State Senate,19,Dem,John Sampson,470
+Kings,60022,State Senate,19,Dem,John Sampson,432
+Kings,60023,State Senate,19,Dem,John Sampson,82
+Kings,60024,State Senate,19,Dem,John Sampson,278
+Kings,60025,State Senate,19,Dem,John Sampson,319
+Kings,60026,State Senate,19,Dem,John Sampson,317
+Kings,60027,State Senate,19,Dem,John Sampson,302
+Kings,60028,State Senate,19,Dem,John Sampson,480
+Kings,60029,State Senate,19,Dem,John Sampson,427
+Kings,60030,State Senate,19,Dem,John Sampson,284
+Kings,60031,State Senate,19,Dem,John Sampson,411
+Kings,60032,State Senate,19,Dem,John Sampson,453
+Kings,60033,State Senate,19,Dem,John Sampson,412
+Kings,60034,State Senate,19,Dem,John Sampson,555
+Kings,60035,State Senate,19,Dem,John Sampson,570
+Kings,60036,State Senate,19,Dem,John Sampson,569
+Kings,60037,State Senate,19,Dem,John Sampson,574
+Kings,60038,State Senate,19,Dem,John Sampson,310
+Kings,60039,State Senate,19,Dem,John Sampson,406
+Kings,60040,State Senate,19,Dem,John Sampson,507
+Kings,60041,State Senate,19,Dem,John Sampson,549
+Kings,60042,State Senate,19,Dem,John Sampson,466
+Kings,60043,State Senate,19,Dem,John Sampson,551
+Kings,60044,State Senate,19,Dem,John Sampson,235
+Kings,60045,State Senate,19,Dem,John Sampson,547
+Kings,60046,State Senate,19,Dem,John Sampson,594
+Kings,60047,State Senate,19,Dem,John Sampson,564
+Kings,60048,State Senate,19,Dem,John Sampson,185
+Kings,60049,State Senate,19,Dem,John Sampson,459
+Kings,60050,State Senate,19,Dem,John Sampson,197
+Kings,60051,State Senate,19,Dem,John Sampson,535
+Kings,60052,State Senate,19,Dem,John Sampson,358
+Kings,60053,State Senate,19,Dem,John Sampson,437
+Kings,60054,State Senate,19,Dem,John Sampson,605
+Kings,60055,State Senate,19,Dem,John Sampson,373
+Kings,60056,State Senate,19,Dem,John Sampson,330
+Kings,60057,State Senate,19,Dem,John Sampson,610
+Kings,60058,State Senate,19,Dem,John Sampson,401
+Kings,60059,State Senate,19,Dem,John Sampson,272
+Kings,60060,State Senate,19,Dem,John Sampson,418
+Kings,60061,State Senate,19,Dem,John Sampson,295
+Kings,60062,State Senate,19,Dem,John Sampson,46
+Kings,60063,State Senate,19,Dem,John Sampson,462
+Kings,60064,State Senate,19,Dem,John Sampson,523
+Kings,60065,State Senate,19,Dem,John Sampson,559
+Kings,60066,State Senate,19,Dem,John Sampson,286
+Kings,60067,State Senate,19,Dem,John Sampson,347
+Kings,60068,State Senate,19,Dem,John Sampson,363
+Kings,60069,State Senate,19,Dem,John Sampson,106
+Kings,60070,State Senate,19,Dem,John Sampson,207
+Kings,60071,State Senate,19,Dem,John Sampson,384
+Kings,60072,State Senate,19,Dem,John Sampson,466
+Kings,60073,State Senate,19,Dem,John Sampson,394
+Kings,60074,State Senate,19,Dem,John Sampson,459
+Kings,60075,State Senate,19,Dem,John Sampson,630
+Kings,60076,State Senate,19,Dem,John Sampson,360
+Kings,60077,State Senate,19,Dem,John Sampson,397
+Kings,60078,State Senate,19,Dem,John Sampson,506
+Kings,60079,State Senate,19,Dem,John Sampson,229
+Kings,60080,State Senate,19,Dem,John Sampson,509
+Kings,60081,State Senate,19,Dem,John Sampson,428
+Kings,60082,State Senate,19,Dem,John Sampson,570
+Kings,60083,State Senate,19,Dem,John Sampson,710
+Kings,60084,State Senate,19,Dem,John Sampson,160
+Kings,60085,State Senate,19,Dem,John Sampson,337
+Kings,60086,State Senate,19,Dem,John Sampson,142
+Kings,60087,State Senate,19,Dem,John Sampson,479
+Kings,60088,State Senate,19,Dem,John Sampson,484
+Kings,60089,State Senate,19,Dem,John Sampson,533
+Kings,60090,State Senate,19,Dem,John Sampson,334
+Kings,60091,State Senate,19,Dem,John Sampson,271
+Kings,41013,State Senate,19,WF,John Sampson,0
+Kings,41015,State Senate,19,WF,John Sampson,5
+Kings,41019,State Senate,19,WF,John Sampson,0
+Kings,41020,State Senate,19,WF,John Sampson,5
+Kings,41021,State Senate,19,WF,John Sampson,9
+Kings,41022,State Senate,19,WF,John Sampson,12
+Kings,41025,State Senate,19,WF,John Sampson,1
+Kings,41026,State Senate,19,WF,John Sampson,1
+Kings,41027,State Senate,19,WF,John Sampson,4
+Kings,41028,State Senate,19,WF,John Sampson,5
+Kings,41029,State Senate,19,WF,John Sampson,0
+Kings,41057,State Senate,19,WF,John Sampson,8
+Kings,41060,State Senate,19,WF,John Sampson,8
+Kings,41061,State Senate,19,WF,John Sampson,9
+Kings,41062,State Senate,19,WF,John Sampson,9
+Kings,41063,State Senate,19,WF,John Sampson,11
+Kings,41064,State Senate,19,WF,John Sampson,25
+Kings,41065,State Senate,19,WF,John Sampson,2
+Kings,41066,State Senate,19,WF,John Sampson,3
+Kings,41067,State Senate,19,WF,John Sampson,15
+Kings,41068,State Senate,19,WF,John Sampson,5
+Kings,41069,State Senate,19,WF,John Sampson,8
+Kings,41070,State Senate,19,WF,John Sampson,12
+Kings,41071,State Senate,19,WF,John Sampson,6
+Kings,41072,State Senate,19,WF,John Sampson,5
+Kings,41073,State Senate,19,WF,John Sampson,13
+Kings,41074,State Senate,19,WF,John Sampson,7
+Kings,41075,State Senate,19,WF,John Sampson,5
+Kings,41076,State Senate,19,WF,John Sampson,2
+Kings,41077,State Senate,19,WF,John Sampson,17
+Kings,41078,State Senate,19,WF,John Sampson,15
+Kings,41079,State Senate,19,WF,John Sampson,13
+Kings,41080,State Senate,19,WF,John Sampson,1
+Kings,42069,State Senate,19,WF,John Sampson,4
+Kings,42070,State Senate,19,WF,John Sampson,0
+Kings,45025,State Senate,19,WF,John Sampson,4
+Kings,45026,State Senate,19,WF,John Sampson,5
+Kings,45027,State Senate,19,WF,John Sampson,11
+Kings,45028,State Senate,19,WF,John Sampson,8
+Kings,45082,State Senate,19,WF,John Sampson,12
+Kings,54002,State Senate,19,WF,John Sampson,10
+Kings,54003,State Senate,19,WF,John Sampson,4
+Kings,54004,State Senate,19,WF,John Sampson,3
+Kings,54005,State Senate,19,WF,John Sampson,0
+Kings,54006,State Senate,19,WF,John Sampson,2
+Kings,54071,State Senate,19,WF,John Sampson,2
+Kings,54072,State Senate,19,WF,John Sampson,1
+Kings,55027,State Senate,19,WF,John Sampson,10
+Kings,55036,State Senate,19,WF,John Sampson,1
+Kings,55037,State Senate,19,WF,John Sampson,8
+Kings,55038,State Senate,19,WF,John Sampson,0
+Kings,55039,State Senate,19,WF,John Sampson,0
+Kings,55040,State Senate,19,WF,John Sampson,4
+Kings,55044,State Senate,19,WF,John Sampson,0
+Kings,55047,State Senate,19,WF,John Sampson,0
+Kings,55048,State Senate,19,WF,John Sampson,6
+Kings,55049,State Senate,19,WF,John Sampson,3
+Kings,55052,State Senate,19,WF,John Sampson,2
+Kings,55055,State Senate,19,WF,John Sampson,8
+Kings,55056,State Senate,19,WF,John Sampson,0
+Kings,55060,State Senate,19,WF,John Sampson,4
+Kings,55062,State Senate,19,WF,John Sampson,3
+Kings,55063,State Senate,19,WF,John Sampson,2
+Kings,55064,State Senate,19,WF,John Sampson,2
+Kings,55074,State Senate,19,WF,John Sampson,4
+Kings,55075,State Senate,19,WF,John Sampson,4
+Kings,55077,State Senate,19,WF,John Sampson,3
+Kings,55099,State Senate,19,WF,John Sampson,6
+Kings,55105,State Senate,19,WF,John Sampson,0
+Kings,58057,State Senate,19,WF,John Sampson,0
+Kings,58058,State Senate,19,WF,John Sampson,0
+Kings,58059,State Senate,19,WF,John Sampson,6
+Kings,58060,State Senate,19,WF,John Sampson,4
+Kings,58066,State Senate,19,WF,John Sampson,4
+Kings,58067,State Senate,19,WF,John Sampson,6
+Kings,58068,State Senate,19,WF,John Sampson,3
+Kings,58069,State Senate,19,WF,John Sampson,1
+Kings,58070,State Senate,19,WF,John Sampson,9
+Kings,58071,State Senate,19,WF,John Sampson,8
+Kings,58072,State Senate,19,WF,John Sampson,2
+Kings,58073,State Senate,19,WF,John Sampson,5
+Kings,58074,State Senate,19,WF,John Sampson,2
+Kings,58075,State Senate,19,WF,John Sampson,6
+Kings,58076,State Senate,19,WF,John Sampson,18
+Kings,58077,State Senate,19,WF,John Sampson,10
+Kings,58078,State Senate,19,WF,John Sampson,5
+Kings,58079,State Senate,19,WF,John Sampson,3
+Kings,59005,State Senate,19,WF,John Sampson,3
+Kings,59006,State Senate,19,WF,John Sampson,3
+Kings,59007,State Senate,19,WF,John Sampson,3
+Kings,59008,State Senate,19,WF,John Sampson,7
+Kings,59010,State Senate,19,WF,John Sampson,4
+Kings,59011,State Senate,19,WF,John Sampson,12
+Kings,59012,State Senate,19,WF,John Sampson,2
+Kings,59013,State Senate,19,WF,John Sampson,2
+Kings,59014,State Senate,19,WF,John Sampson,5
+Kings,59015,State Senate,19,WF,John Sampson,0
+Kings,59024,State Senate,19,WF,John Sampson,13
+Kings,59026,State Senate,19,WF,John Sampson,14
+Kings,59027,State Senate,19,WF,John Sampson,8
+Kings,59028,State Senate,19,WF,John Sampson,6
+Kings,59029,State Senate,19,WF,John Sampson,13
+Kings,59030,State Senate,19,WF,John Sampson,9
+Kings,59031,State Senate,19,WF,John Sampson,13
+Kings,59032,State Senate,19,WF,John Sampson,8
+Kings,59050,State Senate,19,WF,John Sampson,18
+Kings,59051,State Senate,19,WF,John Sampson,16
+Kings,59052,State Senate,19,WF,John Sampson,6
+Kings,59053,State Senate,19,WF,John Sampson,6
+Kings,59054,State Senate,19,WF,John Sampson,3
+Kings,59055,State Senate,19,WF,John Sampson,0
+Kings,59056,State Senate,19,WF,John Sampson,12
+Kings,59057,State Senate,19,WF,John Sampson,5
+Kings,59058,State Senate,19,WF,John Sampson,10
+Kings,59059,State Senate,19,WF,John Sampson,7
+Kings,59060,State Senate,19,WF,John Sampson,10
+Kings,59061,State Senate,19,WF,John Sampson,0
+Kings,59062,State Senate,19,WF,John Sampson,1
+Kings,59063,State Senate,19,WF,John Sampson,1
+Kings,59064,State Senate,19,WF,John Sampson,2
+Kings,59065,State Senate,19,WF,John Sampson,12
+Kings,59066,State Senate,19,WF,John Sampson,5
+Kings,59067,State Senate,19,WF,John Sampson,7
+Kings,59068,State Senate,19,WF,John Sampson,15
+Kings,59069,State Senate,19,WF,John Sampson,8
+Kings,59070,State Senate,19,WF,John Sampson,7
+Kings,59071,State Senate,19,WF,John Sampson,5
+Kings,59072,State Senate,19,WF,John Sampson,4
+Kings,59073,State Senate,19,WF,John Sampson,7
+Kings,59074,State Senate,19,WF,John Sampson,4
+Kings,59075,State Senate,19,WF,John Sampson,6
+Kings,59076,State Senate,19,WF,John Sampson,8
+Kings,59077,State Senate,19,WF,John Sampson,16
+Kings,59078,State Senate,19,WF,John Sampson,9
+Kings,59079,State Senate,19,WF,John Sampson,12
+Kings,59080,State Senate,19,WF,John Sampson,14
+Kings,59081,State Senate,19,WF,John Sampson,12
+Kings,60001,State Senate,19,WF,John Sampson,8
+Kings,60002,State Senate,19,WF,John Sampson,8
+Kings,60003,State Senate,19,WF,John Sampson,7
+Kings,60005,State Senate,19,WF,John Sampson,0
+Kings,60007,State Senate,19,WF,John Sampson,10
+Kings,60008,State Senate,19,WF,John Sampson,7
+Kings,60009,State Senate,19,WF,John Sampson,3
+Kings,60012,State Senate,19,WF,John Sampson,7
+Kings,60014,State Senate,19,WF,John Sampson,3
+Kings,60015,State Senate,19,WF,John Sampson,7
+Kings,60017,State Senate,19,WF,John Sampson,4
+Kings,60021,State Senate,19,WF,John Sampson,4
+Kings,60022,State Senate,19,WF,John Sampson,6
+Kings,60023,State Senate,19,WF,John Sampson,1
+Kings,60024,State Senate,19,WF,John Sampson,4
+Kings,60025,State Senate,19,WF,John Sampson,5
+Kings,60026,State Senate,19,WF,John Sampson,0
+Kings,60027,State Senate,19,WF,John Sampson,2
+Kings,60028,State Senate,19,WF,John Sampson,5
+Kings,60029,State Senate,19,WF,John Sampson,5
+Kings,60030,State Senate,19,WF,John Sampson,1
+Kings,60031,State Senate,19,WF,John Sampson,4
+Kings,60032,State Senate,19,WF,John Sampson,1
+Kings,60033,State Senate,19,WF,John Sampson,9
+Kings,60034,State Senate,19,WF,John Sampson,9
+Kings,60035,State Senate,19,WF,John Sampson,8
+Kings,60036,State Senate,19,WF,John Sampson,12
+Kings,60037,State Senate,19,WF,John Sampson,5
+Kings,60038,State Senate,19,WF,John Sampson,3
+Kings,60039,State Senate,19,WF,John Sampson,8
+Kings,60040,State Senate,19,WF,John Sampson,18
+Kings,60041,State Senate,19,WF,John Sampson,3
+Kings,60042,State Senate,19,WF,John Sampson,8
+Kings,60043,State Senate,19,WF,John Sampson,6
+Kings,60044,State Senate,19,WF,John Sampson,6
+Kings,60045,State Senate,19,WF,John Sampson,9
+Kings,60046,State Senate,19,WF,John Sampson,3
+Kings,60047,State Senate,19,WF,John Sampson,7
+Kings,60048,State Senate,19,WF,John Sampson,3
+Kings,60049,State Senate,19,WF,John Sampson,9
+Kings,60050,State Senate,19,WF,John Sampson,1
+Kings,60051,State Senate,19,WF,John Sampson,13
+Kings,60052,State Senate,19,WF,John Sampson,3
+Kings,60053,State Senate,19,WF,John Sampson,8
+Kings,60054,State Senate,19,WF,John Sampson,11
+Kings,60055,State Senate,19,WF,John Sampson,14
+Kings,60056,State Senate,19,WF,John Sampson,5
+Kings,60057,State Senate,19,WF,John Sampson,7
+Kings,60058,State Senate,19,WF,John Sampson,8
+Kings,60059,State Senate,19,WF,John Sampson,9
+Kings,60060,State Senate,19,WF,John Sampson,9
+Kings,60061,State Senate,19,WF,John Sampson,9
+Kings,60062,State Senate,19,WF,John Sampson,2
+Kings,60063,State Senate,19,WF,John Sampson,6
+Kings,60064,State Senate,19,WF,John Sampson,13
+Kings,60065,State Senate,19,WF,John Sampson,11
+Kings,60066,State Senate,19,WF,John Sampson,3
+Kings,60067,State Senate,19,WF,John Sampson,3
+Kings,60068,State Senate,19,WF,John Sampson,7
+Kings,60069,State Senate,19,WF,John Sampson,0
+Kings,60070,State Senate,19,WF,John Sampson,1
+Kings,60071,State Senate,19,WF,John Sampson,9
+Kings,60072,State Senate,19,WF,John Sampson,5
+Kings,60073,State Senate,19,WF,John Sampson,2
+Kings,60074,State Senate,19,WF,John Sampson,13
+Kings,60075,State Senate,19,WF,John Sampson,6
+Kings,60076,State Senate,19,WF,John Sampson,6
+Kings,60077,State Senate,19,WF,John Sampson,9
+Kings,60078,State Senate,19,WF,John Sampson,14
+Kings,60079,State Senate,19,WF,John Sampson,1
+Kings,60080,State Senate,19,WF,John Sampson,6
+Kings,60081,State Senate,19,WF,John Sampson,6
+Kings,60082,State Senate,19,WF,John Sampson,6
+Kings,60083,State Senate,19,WF,John Sampson,8
+Kings,60084,State Senate,19,WF,John Sampson,1
+Kings,60085,State Senate,19,WF,John Sampson,10
+Kings,60086,State Senate,19,WF,John Sampson,0
+Kings,60087,State Senate,19,WF,John Sampson,6
+Kings,60088,State Senate,19,WF,John Sampson,7
+Kings,60089,State Senate,19,WF,John Sampson,9
+Kings,60090,State Senate,19,WF,John Sampson,7
+Kings,60091,State Senate,19,WF,John Sampson,8
+Kings,41013,State Senate,19,Ind,writein,0
+Kings,41015,State Senate,19,Ind,writein,0
+Kings,41019,State Senate,19,Ind,writein,0
+Kings,41020,State Senate,19,Ind,writein,0
+Kings,41021,State Senate,19,Ind,writein,1
+Kings,41022,State Senate,19,Ind,writein,0
+Kings,41025,State Senate,19,Ind,writein,0
+Kings,41026,State Senate,19,Ind,writein,0
+Kings,41027,State Senate,19,Ind,writein,1
+Kings,41028,State Senate,19,Ind,writein,0
+Kings,41029,State Senate,19,Ind,writein,0
+Kings,41057,State Senate,19,Ind,writein,1
+Kings,41060,State Senate,19,Ind,writein,0
+Kings,41061,State Senate,19,Ind,writein,0
+Kings,41062,State Senate,19,Ind,writein,0
+Kings,41063,State Senate,19,Ind,writein,0
+Kings,41064,State Senate,19,Ind,writein,0
+Kings,41065,State Senate,19,Ind,writein,0
+Kings,41066,State Senate,19,Ind,writein,0
+Kings,41067,State Senate,19,Ind,writein,0
+Kings,41068,State Senate,19,Ind,writein,0
+Kings,41069,State Senate,19,Ind,writein,0
+Kings,41070,State Senate,19,Ind,writein,0
+Kings,41071,State Senate,19,Ind,writein,1
+Kings,41072,State Senate,19,Ind,writein,0
+Kings,41073,State Senate,19,Ind,writein,1
+Kings,41074,State Senate,19,Ind,writein,0
+Kings,41075,State Senate,19,Ind,writein,1
+Kings,41076,State Senate,19,Ind,writein,0
+Kings,41077,State Senate,19,Ind,writein,1
+Kings,41078,State Senate,19,Ind,writein,1
+Kings,41079,State Senate,19,Ind,writein,0
+Kings,41080,State Senate,19,Ind,writein,0
+Kings,42069,State Senate,19,Ind,writein,0
+Kings,42070,State Senate,19,Ind,writein,1
+Kings,45025,State Senate,19,Ind,writein,1
+Kings,45026,State Senate,19,Ind,writein,0
+Kings,45027,State Senate,19,Ind,writein,2
+Kings,45028,State Senate,19,Ind,writein,2
+Kings,45082,State Senate,19,Ind,writein,1
+Kings,54002,State Senate,19,Ind,writein,0
+Kings,54003,State Senate,19,Ind,writein,0
+Kings,54004,State Senate,19,Ind,writein,0
+Kings,54005,State Senate,19,Ind,writein,0
+Kings,54006,State Senate,19,Ind,writein,0
+Kings,54071,State Senate,19,Ind,writein,0
+Kings,54072,State Senate,19,Ind,writein,0
+Kings,55027,State Senate,19,Ind,writein,0
+Kings,55036,State Senate,19,Ind,writein,0
+Kings,55037,State Senate,19,Ind,writein,0
+Kings,55038,State Senate,19,Ind,writein,0
+Kings,55039,State Senate,19,Ind,writein,0
+Kings,55040,State Senate,19,Ind,writein,0
+Kings,55044,State Senate,19,Ind,writein,0
+Kings,55047,State Senate,19,Ind,writein,0
+Kings,55048,State Senate,19,Ind,writein,0
+Kings,55049,State Senate,19,Ind,writein,0
+Kings,55052,State Senate,19,Ind,writein,0
+Kings,55055,State Senate,19,Ind,writein,0
+Kings,55056,State Senate,19,Ind,writein,0
+Kings,55060,State Senate,19,Ind,writein,0
+Kings,55062,State Senate,19,Ind,writein,0
+Kings,55063,State Senate,19,Ind,writein,1
+Kings,55064,State Senate,19,Ind,writein,0
+Kings,55074,State Senate,19,Ind,writein,0
+Kings,55075,State Senate,19,Ind,writein,0
+Kings,55077,State Senate,19,Ind,writein,0
+Kings,55099,State Senate,19,Ind,writein,0
+Kings,55105,State Senate,19,Ind,writein,0
+Kings,58057,State Senate,19,Ind,writein,0
+Kings,58058,State Senate,19,Ind,writein,0
+Kings,58059,State Senate,19,Ind,writein,0
+Kings,58060,State Senate,19,Ind,writein,0
+Kings,58066,State Senate,19,Ind,writein,0
+Kings,58067,State Senate,19,Ind,writein,0
+Kings,58068,State Senate,19,Ind,writein,1
+Kings,58069,State Senate,19,Ind,writein,0
+Kings,58070,State Senate,19,Ind,writein,0
+Kings,58071,State Senate,19,Ind,writein,0
+Kings,58072,State Senate,19,Ind,writein,0
+Kings,58073,State Senate,19,Ind,writein,0
+Kings,58074,State Senate,19,Ind,writein,0
+Kings,58075,State Senate,19,Ind,writein,0
+Kings,58076,State Senate,19,Ind,writein,0
+Kings,58077,State Senate,19,Ind,writein,0
+Kings,58078,State Senate,19,Ind,writein,0
+Kings,58079,State Senate,19,Ind,writein,0
+Kings,59005,State Senate,19,Ind,writein,0
+Kings,59006,State Senate,19,Ind,writein,0
+Kings,59007,State Senate,19,Ind,writein,0
+Kings,59008,State Senate,19,Ind,writein,0
+Kings,59010,State Senate,19,Ind,writein,0
+Kings,59011,State Senate,19,Ind,writein,0
+Kings,59012,State Senate,19,Ind,writein,1
+Kings,59013,State Senate,19,Ind,writein,0
+Kings,59014,State Senate,19,Ind,writein,0
+Kings,59015,State Senate,19,Ind,writein,0
+Kings,59024,State Senate,19,Ind,writein,0
+Kings,59026,State Senate,19,Ind,writein,0
+Kings,59027,State Senate,19,Ind,writein,0
+Kings,59028,State Senate,19,Ind,writein,0
+Kings,59029,State Senate,19,Ind,writein,2
+Kings,59030,State Senate,19,Ind,writein,0
+Kings,59031,State Senate,19,Ind,writein,0
+Kings,59032,State Senate,19,Ind,writein,0
+Kings,59050,State Senate,19,Ind,writein,0
+Kings,59051,State Senate,19,Ind,writein,0
+Kings,59052,State Senate,19,Ind,writein,0
+Kings,59053,State Senate,19,Ind,writein,1
+Kings,59054,State Senate,19,Ind,writein,0
+Kings,59055,State Senate,19,Ind,writein,0
+Kings,59056,State Senate,19,Ind,writein,0
+Kings,59057,State Senate,19,Ind,writein,0
+Kings,59058,State Senate,19,Ind,writein,0
+Kings,59059,State Senate,19,Ind,writein,0
+Kings,59060,State Senate,19,Ind,writein,0
+Kings,59061,State Senate,19,Ind,writein,0
+Kings,59062,State Senate,19,Ind,writein,0
+Kings,59063,State Senate,19,Ind,writein,0
+Kings,59064,State Senate,19,Ind,writein,0
+Kings,59065,State Senate,19,Ind,writein,0
+Kings,59066,State Senate,19,Ind,writein,0
+Kings,59067,State Senate,19,Ind,writein,0
+Kings,59068,State Senate,19,Ind,writein,0
+Kings,59069,State Senate,19,Ind,writein,0
+Kings,59070,State Senate,19,Ind,writein,0
+Kings,59071,State Senate,19,Ind,writein,0
+Kings,59072,State Senate,19,Ind,writein,0
+Kings,59073,State Senate,19,Ind,writein,0
+Kings,59074,State Senate,19,Ind,writein,0
+Kings,59075,State Senate,19,Ind,writein,0
+Kings,59076,State Senate,19,Ind,writein,0
+Kings,59077,State Senate,19,Ind,writein,0
+Kings,59078,State Senate,19,Ind,writein,0
+Kings,59079,State Senate,19,Ind,writein,0
+Kings,59080,State Senate,19,Ind,writein,0
+Kings,59081,State Senate,19,Ind,writein,0
+Kings,60001,State Senate,19,Ind,writein,0
+Kings,60002,State Senate,19,Ind,writein,0
+Kings,60003,State Senate,19,Ind,writein,0
+Kings,60005,State Senate,19,Ind,writein,0
+Kings,60007,State Senate,19,Ind,writein,0
+Kings,60008,State Senate,19,Ind,writein,1
+Kings,60009,State Senate,19,Ind,writein,0
+Kings,60012,State Senate,19,Ind,writein,0
+Kings,60014,State Senate,19,Ind,writein,0
+Kings,60015,State Senate,19,Ind,writein,0
+Kings,60017,State Senate,19,Ind,writein,0
+Kings,60021,State Senate,19,Ind,writein,0
+Kings,60022,State Senate,19,Ind,writein,0
+Kings,60023,State Senate,19,Ind,writein,0
+Kings,60024,State Senate,19,Ind,writein,0
+Kings,60025,State Senate,19,Ind,writein,0
+Kings,60026,State Senate,19,Ind,writein,0
+Kings,60027,State Senate,19,Ind,writein,0
+Kings,60028,State Senate,19,Ind,writein,0
+Kings,60029,State Senate,19,Ind,writein,0
+Kings,60030,State Senate,19,Ind,writein,0
+Kings,60031,State Senate,19,Ind,writein,0
+Kings,60032,State Senate,19,Ind,writein,0
+Kings,60033,State Senate,19,Ind,writein,0
+Kings,60034,State Senate,19,Ind,writein,0
+Kings,60035,State Senate,19,Ind,writein,0
+Kings,60036,State Senate,19,Ind,writein,0
+Kings,60037,State Senate,19,Ind,writein,0
+Kings,60038,State Senate,19,Ind,writein,0
+Kings,60039,State Senate,19,Ind,writein,0
+Kings,60040,State Senate,19,Ind,writein,0
+Kings,60041,State Senate,19,Ind,writein,0
+Kings,60042,State Senate,19,Ind,writein,0
+Kings,60043,State Senate,19,Ind,writein,0
+Kings,60044,State Senate,19,Ind,writein,0
+Kings,60045,State Senate,19,Ind,writein,0
+Kings,60046,State Senate,19,Ind,writein,0
+Kings,60047,State Senate,19,Ind,writein,0
+Kings,60048,State Senate,19,Ind,writein,0
+Kings,60049,State Senate,19,Ind,writein,0
+Kings,60050,State Senate,19,Ind,writein,0
+Kings,60051,State Senate,19,Ind,writein,0
+Kings,60052,State Senate,19,Ind,writein,0
+Kings,60053,State Senate,19,Ind,writein,0
+Kings,60054,State Senate,19,Ind,writein,0
+Kings,60055,State Senate,19,Ind,writein,0
+Kings,60056,State Senate,19,Ind,writein,0
+Kings,60057,State Senate,19,Ind,writein,0
+Kings,60058,State Senate,19,Ind,writein,1
+Kings,60059,State Senate,19,Ind,writein,0
+Kings,60060,State Senate,19,Ind,writein,0
+Kings,60061,State Senate,19,Ind,writein,0
+Kings,60062,State Senate,19,Ind,writein,0
+Kings,60063,State Senate,19,Ind,writein,0
+Kings,60064,State Senate,19,Ind,writein,0
+Kings,60065,State Senate,19,Ind,writein,0
+Kings,60066,State Senate,19,Ind,writein,0
+Kings,60067,State Senate,19,Ind,writein,0
+Kings,60068,State Senate,19,Ind,writein,0
+Kings,60069,State Senate,19,Ind,writein,0
+Kings,60070,State Senate,19,Ind,writein,0
+Kings,60071,State Senate,19,Ind,writein,0
+Kings,60072,State Senate,19,Ind,writein,0
+Kings,60073,State Senate,19,Ind,writein,0
+Kings,60074,State Senate,19,Ind,writein,0
+Kings,60075,State Senate,19,Ind,writein,0
+Kings,60076,State Senate,19,Ind,writein,0
+Kings,60077,State Senate,19,Ind,writein,0
+Kings,60078,State Senate,19,Ind,writein,0
+Kings,60079,State Senate,19,Ind,writein,0
+Kings,60080,State Senate,19,Ind,writein,0
+Kings,60081,State Senate,19,Ind,writein,0
+Kings,60082,State Senate,19,Ind,writein,0
+Kings,60083,State Senate,19,Ind,writein,0
+Kings,60084,State Senate,19,Ind,writein,0
+Kings,60085,State Senate,19,Ind,writein,0
+Kings,60086,State Senate,19,Ind,writein,0
+Kings,60087,State Senate,19,Ind,writein,0
+Kings,60088,State Senate,19,Ind,writein,0
+Kings,60089,State Senate,19,Ind,writein,0
+Kings,60090,State Senate,19,Ind,writein,0
+Kings,60091,State Senate,19,Ind,writein,0
+Kings,42068,State Senate,20,Con,Brian Kelly,0
+Kings,43014,State Senate,20,Con,Brian Kelly,1
+Kings,43015,State Senate,20,Con,Brian Kelly,3
+Kings,43016,State Senate,20,Con,Brian Kelly,0
+Kings,43017,State Senate,20,Con,Brian Kelly,11
+Kings,43018,State Senate,20,Con,Brian Kelly,1
+Kings,43019,State Senate,20,Con,Brian Kelly,4
+Kings,43020,State Senate,20,Con,Brian Kelly,3
+Kings,43021,State Senate,20,Con,Brian Kelly,1
+Kings,43022,State Senate,20,Con,Brian Kelly,0
+Kings,43023,State Senate,20,Con,Brian Kelly,1
+Kings,43024,State Senate,20,Con,Brian Kelly,2
+Kings,43025,State Senate,20,Con,Brian Kelly,0
+Kings,43026,State Senate,20,Con,Brian Kelly,2
+Kings,43027,State Senate,20,Con,Brian Kelly,2
+Kings,43028,State Senate,20,Con,Brian Kelly,1
+Kings,43029,State Senate,20,Con,Brian Kelly,3
+Kings,43030,State Senate,20,Con,Brian Kelly,2
+Kings,43031,State Senate,20,Con,Brian Kelly,1
+Kings,43032,State Senate,20,Con,Brian Kelly,1
+Kings,43033,State Senate,20,Con,Brian Kelly,1
+Kings,43034,State Senate,20,Con,Brian Kelly,1
+Kings,43035,State Senate,20,Con,Brian Kelly,2
+Kings,43036,State Senate,20,Con,Brian Kelly,3
+Kings,43037,State Senate,20,Con,Brian Kelly,14
+Kings,43038,State Senate,20,Con,Brian Kelly,16
+Kings,43039,State Senate,20,Con,Brian Kelly,7
+Kings,43040,State Senate,20,Con,Brian Kelly,58
+Kings,43041,State Senate,20,Con,Brian Kelly,7
+Kings,43042,State Senate,20,Con,Brian Kelly,1
+Kings,43043,State Senate,20,Con,Brian Kelly,12
+Kings,43044,State Senate,20,Con,Brian Kelly,2
+Kings,43052,State Senate,20,Con,Brian Kelly,3
+Kings,43053,State Senate,20,Con,Brian Kelly,10
+Kings,43054,State Senate,20,Con,Brian Kelly,2
+Kings,43055,State Senate,20,Con,Brian Kelly,2
+Kings,43056,State Senate,20,Con,Brian Kelly,30
+Kings,43057,State Senate,20,Con,Brian Kelly,52
+Kings,43058,State Senate,20,Con,Brian Kelly,30
+Kings,43059,State Senate,20,Con,Brian Kelly,25
+Kings,43060,State Senate,20,Con,Brian Kelly,21
+Kings,43061,State Senate,20,Con,Brian Kelly,2
+Kings,43062,State Senate,20,Con,Brian Kelly,13
+Kings,43063,State Senate,20,Con,Brian Kelly,27
+Kings,43064,State Senate,20,Con,Brian Kelly,20
+Kings,43065,State Senate,20,Con,Brian Kelly,4
+Kings,43066,State Senate,20,Con,Brian Kelly,1
+Kings,43067,State Senate,20,Con,Brian Kelly,6
+Kings,43068,State Senate,20,Con,Brian Kelly,4
+Kings,43069,State Senate,20,Con,Brian Kelly,0
+Kings,43070,State Senate,20,Con,Brian Kelly,2
+Kings,43071,State Senate,20,Con,Brian Kelly,1
+Kings,49001,State Senate,20,Con,Brian Kelly,18
+Kings,49002,State Senate,20,Con,Brian Kelly,13
+Kings,49003,State Senate,20,Con,Brian Kelly,10
+Kings,49004,State Senate,20,Con,Brian Kelly,29
+Kings,49005,State Senate,20,Con,Brian Kelly,24
+Kings,49014,State Senate,20,Con,Brian Kelly,0
+Kings,51020,State Senate,20,Con,Brian Kelly,7
+Kings,51028,State Senate,20,Con,Brian Kelly,4
+Kings,51029,State Senate,20,Con,Brian Kelly,17
+Kings,51030,State Senate,20,Con,Brian Kelly,14
+Kings,51031,State Senate,20,Con,Brian Kelly,25
+Kings,51032,State Senate,20,Con,Brian Kelly,10
+Kings,51033,State Senate,20,Con,Brian Kelly,4
+Kings,51034,State Senate,20,Con,Brian Kelly,4
+Kings,51035,State Senate,20,Con,Brian Kelly,8
+Kings,51036,State Senate,20,Con,Brian Kelly,8
+Kings,51037,State Senate,20,Con,Brian Kelly,5
+Kings,51038,State Senate,20,Con,Brian Kelly,22
+Kings,51039,State Senate,20,Con,Brian Kelly,12
+Kings,51040,State Senate,20,Con,Brian Kelly,13
+Kings,51041,State Senate,20,Con,Brian Kelly,7
+Kings,51042,State Senate,20,Con,Brian Kelly,9
+Kings,51043,State Senate,20,Con,Brian Kelly,5
+Kings,51063,State Senate,20,Con,Brian Kelly,21
+Kings,51064,State Senate,20,Con,Brian Kelly,5
+Kings,51065,State Senate,20,Con,Brian Kelly,7
+Kings,51066,State Senate,20,Con,Brian Kelly,10
+Kings,51067,State Senate,20,Con,Brian Kelly,8
+Kings,52064,State Senate,20,Con,Brian Kelly,8
+Kings,52065,State Senate,20,Con,Brian Kelly,8
+Kings,52066,State Senate,20,Con,Brian Kelly,6
+Kings,52067,State Senate,20,Con,Brian Kelly,3
+Kings,52072,State Senate,20,Con,Brian Kelly,2
+Kings,52073,State Senate,20,Con,Brian Kelly,9
+Kings,52074,State Senate,20,Con,Brian Kelly,3
+Kings,52075,State Senate,20,Con,Brian Kelly,3
+Kings,52079,State Senate,20,Con,Brian Kelly,3
+Kings,52087,State Senate,20,Con,Brian Kelly,5
+Kings,52088,State Senate,20,Con,Brian Kelly,9
+Kings,52092,State Senate,20,Con,Brian Kelly,0
+Kings,52093,State Senate,20,Con,Brian Kelly,5
+Kings,52094,State Senate,20,Con,Brian Kelly,5
+Kings,55035,State Senate,20,Con,Brian Kelly,1
+Kings,55057,State Senate,20,Con,Brian Kelly,1
+Kings,55058,State Senate,20,Con,Brian Kelly,2
+Kings,55059,State Senate,20,Con,Brian Kelly,4
+Kings,55061,State Senate,20,Con,Brian Kelly,0
+Kings,55065,State Senate,20,Con,Brian Kelly,4
+Kings,55066,State Senate,20,Con,Brian Kelly,4
+Kings,55067,State Senate,20,Con,Brian Kelly,3
+Kings,55068,State Senate,20,Con,Brian Kelly,0
+Kings,55069,State Senate,20,Con,Brian Kelly,6
+Kings,55070,State Senate,20,Con,Brian Kelly,2
+Kings,55071,State Senate,20,Con,Brian Kelly,2
+Kings,55072,State Senate,20,Con,Brian Kelly,3
+Kings,55073,State Senate,20,Con,Brian Kelly,0
+Kings,55076,State Senate,20,Con,Brian Kelly,0
+Kings,55078,State Senate,20,Con,Brian Kelly,1
+Kings,55079,State Senate,20,Con,Brian Kelly,2
+Kings,55080,State Senate,20,Con,Brian Kelly,0
+Kings,55081,State Senate,20,Con,Brian Kelly,2
+Kings,55082,State Senate,20,Con,Brian Kelly,1
+Kings,55083,State Senate,20,Con,Brian Kelly,0
+Kings,55084,State Senate,20,Con,Brian Kelly,2
+Kings,55085,State Senate,20,Con,Brian Kelly,2
+Kings,55086,State Senate,20,Con,Brian Kelly,1
+Kings,55087,State Senate,20,Con,Brian Kelly,1
+Kings,55088,State Senate,20,Con,Brian Kelly,1
+Kings,55089,State Senate,20,Con,Brian Kelly,2
+Kings,55090,State Senate,20,Con,Brian Kelly,4
+Kings,55091,State Senate,20,Con,Brian Kelly,1
+Kings,55092,State Senate,20,Con,Brian Kelly,4
+Kings,55093,State Senate,20,Con,Brian Kelly,3
+Kings,55094,State Senate,20,Con,Brian Kelly,1
+Kings,55095,State Senate,20,Con,Brian Kelly,1
+Kings,55096,State Senate,20,Con,Brian Kelly,1
+Kings,55097,State Senate,20,Con,Brian Kelly,2
+Kings,55100,State Senate,20,Con,Brian Kelly,4
+Kings,56073,State Senate,20,Con,Brian Kelly,0
+Kings,56075,State Senate,20,Con,Brian Kelly,1
+Kings,56076,State Senate,20,Con,Brian Kelly,2
+Kings,56077,State Senate,20,Con,Brian Kelly,7
+Kings,56078,State Senate,20,Con,Brian Kelly,3
+Kings,57067,State Senate,20,Con,Brian Kelly,3
+Kings,57068,State Senate,20,Con,Brian Kelly,4
+Kings,57069,State Senate,20,Con,Brian Kelly,5
+Kings,57070,State Senate,20,Con,Brian Kelly,2
+Kings,57071,State Senate,20,Con,Brian Kelly,3
+Kings,57072,State Senate,20,Con,Brian Kelly,3
+Kings,57073,State Senate,20,Con,Brian Kelly,1
+Kings,57074,State Senate,20,Con,Brian Kelly,1
+Kings,57075,State Senate,20,Con,Brian Kelly,4
+Kings,57076,State Senate,20,Con,Brian Kelly,2
+Kings,57077,State Senate,20,Con,Brian Kelly,0
+Kings,57078,State Senate,20,Con,Brian Kelly,6
+Kings,57079,State Senate,20,Con,Brian Kelly,3
+Kings,57080,State Senate,20,Con,Brian Kelly,3
+Kings,57081,State Senate,20,Con,Brian Kelly,3
+Kings,57082,State Senate,20,Con,Brian Kelly,0
+Kings,57083,State Senate,20,Con,Brian Kelly,1
+Kings,57084,State Senate,20,Con,Brian Kelly,1
+Kings,57085,State Senate,20,Con,Brian Kelly,1
+Kings,57088,State Senate,20,Con,Brian Kelly,0
+Kings,57089,State Senate,20,Con,Brian Kelly,0
+Kings,57090,State Senate,20,Con,Brian Kelly,0
+Kings,57091,State Senate,20,Con,Brian Kelly,0
+Kings,57092,State Senate,20,Con,Brian Kelly,3
+Kings,57093,State Senate,20,Con,Brian Kelly,0
+Kings,58001,State Senate,20,Con,Brian Kelly,3
+Kings,58002,State Senate,20,Con,Brian Kelly,2
+Kings,58003,State Senate,20,Con,Brian Kelly,1
+Kings,58004,State Senate,20,Con,Brian Kelly,3
+Kings,58005,State Senate,20,Con,Brian Kelly,1
+Kings,58006,State Senate,20,Con,Brian Kelly,0
+Kings,58007,State Senate,20,Con,Brian Kelly,1
+Kings,58008,State Senate,20,Con,Brian Kelly,1
+Kings,58009,State Senate,20,Con,Brian Kelly,0
+Kings,58010,State Senate,20,Con,Brian Kelly,1
+Kings,58011,State Senate,20,Con,Brian Kelly,0
+Kings,58012,State Senate,20,Con,Brian Kelly,0
+Kings,58013,State Senate,20,Con,Brian Kelly,0
+Kings,58014,State Senate,20,Con,Brian Kelly,1
+Kings,58015,State Senate,20,Con,Brian Kelly,1
+Kings,58045,State Senate,20,Con,Brian Kelly,0
+Kings,58046,State Senate,20,Con,Brian Kelly,0
+Kings,58047,State Senate,20,Con,Brian Kelly,1
+Kings,58048,State Senate,20,Con,Brian Kelly,0
+Kings,58052,State Senate,20,Con,Brian Kelly,0
+Kings,58053,State Senate,20,Con,Brian Kelly,0
+Kings,58054,State Senate,20,Con,Brian Kelly,0
+Kings,42068,State Senate,20,Dem,Eric Adams,335
+Kings,43014,State Senate,20,Dem,Eric Adams,504
+Kings,43015,State Senate,20,Dem,Eric Adams,549
+Kings,43016,State Senate,20,Dem,Eric Adams,626
+Kings,43017,State Senate,20,Dem,Eric Adams,526
+Kings,43018,State Senate,20,Dem,Eric Adams,629
+Kings,43019,State Senate,20,Dem,Eric Adams,644
+Kings,43020,State Senate,20,Dem,Eric Adams,514
+Kings,43021,State Senate,20,Dem,Eric Adams,650
+Kings,43022,State Senate,20,Dem,Eric Adams,570
+Kings,43023,State Senate,20,Dem,Eric Adams,634
+Kings,43024,State Senate,20,Dem,Eric Adams,609
+Kings,43025,State Senate,20,Dem,Eric Adams,629
+Kings,43026,State Senate,20,Dem,Eric Adams,537
+Kings,43027,State Senate,20,Dem,Eric Adams,566
+Kings,43028,State Senate,20,Dem,Eric Adams,543
+Kings,43029,State Senate,20,Dem,Eric Adams,437
+Kings,43030,State Senate,20,Dem,Eric Adams,411
+Kings,43031,State Senate,20,Dem,Eric Adams,588
+Kings,43032,State Senate,20,Dem,Eric Adams,506
+Kings,43033,State Senate,20,Dem,Eric Adams,621
+Kings,43034,State Senate,20,Dem,Eric Adams,574
+Kings,43035,State Senate,20,Dem,Eric Adams,615
+Kings,43036,State Senate,20,Dem,Eric Adams,566
+Kings,43037,State Senate,20,Dem,Eric Adams,581
+Kings,43038,State Senate,20,Dem,Eric Adams,575
+Kings,43039,State Senate,20,Dem,Eric Adams,494
+Kings,43040,State Senate,20,Dem,Eric Adams,347
+Kings,43041,State Senate,20,Dem,Eric Adams,551
+Kings,43042,State Senate,20,Dem,Eric Adams,371
+Kings,43043,State Senate,20,Dem,Eric Adams,320
+Kings,43044,State Senate,20,Dem,Eric Adams,551
+Kings,43052,State Senate,20,Dem,Eric Adams,559
+Kings,43053,State Senate,20,Dem,Eric Adams,499
+Kings,43054,State Senate,20,Dem,Eric Adams,440
+Kings,43055,State Senate,20,Dem,Eric Adams,239
+Kings,43056,State Senate,20,Dem,Eric Adams,468
+Kings,43057,State Senate,20,Dem,Eric Adams,290
+Kings,43058,State Senate,20,Dem,Eric Adams,435
+Kings,43059,State Senate,20,Dem,Eric Adams,460
+Kings,43060,State Senate,20,Dem,Eric Adams,450
+Kings,43061,State Senate,20,Dem,Eric Adams,574
+Kings,43062,State Senate,20,Dem,Eric Adams,215
+Kings,43063,State Senate,20,Dem,Eric Adams,207
+Kings,43064,State Senate,20,Dem,Eric Adams,530
+Kings,43065,State Senate,20,Dem,Eric Adams,414
+Kings,43066,State Senate,20,Dem,Eric Adams,666
+Kings,43067,State Senate,20,Dem,Eric Adams,560
+Kings,43068,State Senate,20,Dem,Eric Adams,484
+Kings,43069,State Senate,20,Dem,Eric Adams,547
+Kings,43070,State Senate,20,Dem,Eric Adams,261
+Kings,43071,State Senate,20,Dem,Eric Adams,452
+Kings,49001,State Senate,20,Dem,Eric Adams,209
+Kings,49002,State Senate,20,Dem,Eric Adams,201
+Kings,49003,State Senate,20,Dem,Eric Adams,244
+Kings,49004,State Senate,20,Dem,Eric Adams,200
+Kings,49005,State Senate,20,Dem,Eric Adams,166
+Kings,49014,State Senate,20,Dem,Eric Adams,3
+Kings,51020,State Senate,20,Dem,Eric Adams,310
+Kings,51028,State Senate,20,Dem,Eric Adams,32
+Kings,51029,State Senate,20,Dem,Eric Adams,249
+Kings,51030,State Senate,20,Dem,Eric Adams,243
+Kings,51031,State Senate,20,Dem,Eric Adams,310
+Kings,51032,State Senate,20,Dem,Eric Adams,347
+Kings,51033,State Senate,20,Dem,Eric Adams,371
+Kings,51034,State Senate,20,Dem,Eric Adams,298
+Kings,51035,State Senate,20,Dem,Eric Adams,339
+Kings,51036,State Senate,20,Dem,Eric Adams,301
+Kings,51037,State Senate,20,Dem,Eric Adams,275
+Kings,51038,State Senate,20,Dem,Eric Adams,409
+Kings,51039,State Senate,20,Dem,Eric Adams,409
+Kings,51040,State Senate,20,Dem,Eric Adams,387
+Kings,51041,State Senate,20,Dem,Eric Adams,410
+Kings,51042,State Senate,20,Dem,Eric Adams,374
+Kings,51043,State Senate,20,Dem,Eric Adams,288
+Kings,51063,State Senate,20,Dem,Eric Adams,249
+Kings,51064,State Senate,20,Dem,Eric Adams,288
+Kings,51065,State Senate,20,Dem,Eric Adams,241
+Kings,51066,State Senate,20,Dem,Eric Adams,305
+Kings,51067,State Senate,20,Dem,Eric Adams,342
+Kings,52064,State Senate,20,Dem,Eric Adams,637
+Kings,52065,State Senate,20,Dem,Eric Adams,496
+Kings,52066,State Senate,20,Dem,Eric Adams,444
+Kings,52067,State Senate,20,Dem,Eric Adams,332
+Kings,52072,State Senate,20,Dem,Eric Adams,223
+Kings,52073,State Senate,20,Dem,Eric Adams,715
+Kings,52074,State Senate,20,Dem,Eric Adams,701
+Kings,52075,State Senate,20,Dem,Eric Adams,429
+Kings,52079,State Senate,20,Dem,Eric Adams,185
+Kings,52087,State Senate,20,Dem,Eric Adams,568
+Kings,52088,State Senate,20,Dem,Eric Adams,529
+Kings,52092,State Senate,20,Dem,Eric Adams,9
+Kings,52093,State Senate,20,Dem,Eric Adams,303
+Kings,52094,State Senate,20,Dem,Eric Adams,269
+Kings,55035,State Senate,20,Dem,Eric Adams,242
+Kings,55057,State Senate,20,Dem,Eric Adams,437
+Kings,55058,State Senate,20,Dem,Eric Adams,257
+Kings,55059,State Senate,20,Dem,Eric Adams,405
+Kings,55061,State Senate,20,Dem,Eric Adams,1
+Kings,55065,State Senate,20,Dem,Eric Adams,439
+Kings,55066,State Senate,20,Dem,Eric Adams,424
+Kings,55067,State Senate,20,Dem,Eric Adams,364
+Kings,55068,State Senate,20,Dem,Eric Adams,463
+Kings,55069,State Senate,20,Dem,Eric Adams,363
+Kings,55070,State Senate,20,Dem,Eric Adams,207
+Kings,55071,State Senate,20,Dem,Eric Adams,249
+Kings,55072,State Senate,20,Dem,Eric Adams,469
+Kings,55073,State Senate,20,Dem,Eric Adams,4
+Kings,55076,State Senate,20,Dem,Eric Adams,403
+Kings,55078,State Senate,20,Dem,Eric Adams,692
+Kings,55079,State Senate,20,Dem,Eric Adams,532
+Kings,55080,State Senate,20,Dem,Eric Adams,214
+Kings,55081,State Senate,20,Dem,Eric Adams,451
+Kings,55082,State Senate,20,Dem,Eric Adams,641
+Kings,55083,State Senate,20,Dem,Eric Adams,367
+Kings,55084,State Senate,20,Dem,Eric Adams,330
+Kings,55085,State Senate,20,Dem,Eric Adams,665
+Kings,55086,State Senate,20,Dem,Eric Adams,227
+Kings,55087,State Senate,20,Dem,Eric Adams,570
+Kings,55088,State Senate,20,Dem,Eric Adams,459
+Kings,55089,State Senate,20,Dem,Eric Adams,520
+Kings,55090,State Senate,20,Dem,Eric Adams,523
+Kings,55091,State Senate,20,Dem,Eric Adams,510
+Kings,55092,State Senate,20,Dem,Eric Adams,439
+Kings,55093,State Senate,20,Dem,Eric Adams,325
+Kings,55094,State Senate,20,Dem,Eric Adams,436
+Kings,55095,State Senate,20,Dem,Eric Adams,164
+Kings,55096,State Senate,20,Dem,Eric Adams,218
+Kings,55097,State Senate,20,Dem,Eric Adams,421
+Kings,55100,State Senate,20,Dem,Eric Adams,253
+Kings,56073,State Senate,20,Dem,Eric Adams,246
+Kings,56075,State Senate,20,Dem,Eric Adams,280
+Kings,56076,State Senate,20,Dem,Eric Adams,169
+Kings,56077,State Senate,20,Dem,Eric Adams,595
+Kings,56078,State Senate,20,Dem,Eric Adams,454
+Kings,57067,State Senate,20,Dem,Eric Adams,601
+Kings,57068,State Senate,20,Dem,Eric Adams,672
+Kings,57069,State Senate,20,Dem,Eric Adams,579
+Kings,57070,State Senate,20,Dem,Eric Adams,546
+Kings,57071,State Senate,20,Dem,Eric Adams,377
+Kings,57072,State Senate,20,Dem,Eric Adams,490
+Kings,57073,State Senate,20,Dem,Eric Adams,269
+Kings,57074,State Senate,20,Dem,Eric Adams,591
+Kings,57075,State Senate,20,Dem,Eric Adams,588
+Kings,57076,State Senate,20,Dem,Eric Adams,512
+Kings,57077,State Senate,20,Dem,Eric Adams,222
+Kings,57078,State Senate,20,Dem,Eric Adams,491
+Kings,57079,State Senate,20,Dem,Eric Adams,519
+Kings,57080,State Senate,20,Dem,Eric Adams,590
+Kings,57081,State Senate,20,Dem,Eric Adams,495
+Kings,57082,State Senate,20,Dem,Eric Adams,221
+Kings,57083,State Senate,20,Dem,Eric Adams,467
+Kings,57084,State Senate,20,Dem,Eric Adams,322
+Kings,57085,State Senate,20,Dem,Eric Adams,711
+Kings,57088,State Senate,20,Dem,Eric Adams,532
+Kings,57089,State Senate,20,Dem,Eric Adams,461
+Kings,57090,State Senate,20,Dem,Eric Adams,635
+Kings,57091,State Senate,20,Dem,Eric Adams,548
+Kings,57092,State Senate,20,Dem,Eric Adams,390
+Kings,57093,State Senate,20,Dem,Eric Adams,367
+Kings,58001,State Senate,20,Dem,Eric Adams,566
+Kings,58002,State Senate,20,Dem,Eric Adams,503
+Kings,58003,State Senate,20,Dem,Eric Adams,513
+Kings,58004,State Senate,20,Dem,Eric Adams,586
+Kings,58005,State Senate,20,Dem,Eric Adams,602
+Kings,58006,State Senate,20,Dem,Eric Adams,538
+Kings,58007,State Senate,20,Dem,Eric Adams,517
+Kings,58008,State Senate,20,Dem,Eric Adams,627
+Kings,58009,State Senate,20,Dem,Eric Adams,502
+Kings,58010,State Senate,20,Dem,Eric Adams,524
+Kings,58011,State Senate,20,Dem,Eric Adams,616
+Kings,58012,State Senate,20,Dem,Eric Adams,565
+Kings,58013,State Senate,20,Dem,Eric Adams,531
+Kings,58014,State Senate,20,Dem,Eric Adams,320
+Kings,58015,State Senate,20,Dem,Eric Adams,454
+Kings,58045,State Senate,20,Dem,Eric Adams,461
+Kings,58046,State Senate,20,Dem,Eric Adams,478
+Kings,58047,State Senate,20,Dem,Eric Adams,457
+Kings,58048,State Senate,20,Dem,Eric Adams,392
+Kings,58052,State Senate,20,Dem,Eric Adams,632
+Kings,58053,State Senate,20,Dem,Eric Adams,174
+Kings,58054,State Senate,20,Dem,Eric Adams,308
+Kings,42068,State Senate,20,WF,Eric Adams,2
+Kings,43014,State Senate,20,WF,Eric Adams,31
+Kings,43015,State Senate,20,WF,Eric Adams,29
+Kings,43016,State Senate,20,WF,Eric Adams,8
+Kings,43017,State Senate,20,WF,Eric Adams,9
+Kings,43018,State Senate,20,WF,Eric Adams,41
+Kings,43019,State Senate,20,WF,Eric Adams,41
+Kings,43020,State Senate,20,WF,Eric Adams,41
+Kings,43021,State Senate,20,WF,Eric Adams,11
+Kings,43022,State Senate,20,WF,Eric Adams,13
+Kings,43023,State Senate,20,WF,Eric Adams,15
+Kings,43024,State Senate,20,WF,Eric Adams,26
+Kings,43025,State Senate,20,WF,Eric Adams,25
+Kings,43026,State Senate,20,WF,Eric Adams,8
+Kings,43027,State Senate,20,WF,Eric Adams,7
+Kings,43028,State Senate,20,WF,Eric Adams,4
+Kings,43029,State Senate,20,WF,Eric Adams,3
+Kings,43030,State Senate,20,WF,Eric Adams,4
+Kings,43031,State Senate,20,WF,Eric Adams,14
+Kings,43032,State Senate,20,WF,Eric Adams,4
+Kings,43033,State Senate,20,WF,Eric Adams,7
+Kings,43034,State Senate,20,WF,Eric Adams,14
+Kings,43035,State Senate,20,WF,Eric Adams,25
+Kings,43036,State Senate,20,WF,Eric Adams,25
+Kings,43037,State Senate,20,WF,Eric Adams,14
+Kings,43038,State Senate,20,WF,Eric Adams,12
+Kings,43039,State Senate,20,WF,Eric Adams,22
+Kings,43040,State Senate,20,WF,Eric Adams,7
+Kings,43041,State Senate,20,WF,Eric Adams,49
+Kings,43042,State Senate,20,WF,Eric Adams,28
+Kings,43043,State Senate,20,WF,Eric Adams,10
+Kings,43044,State Senate,20,WF,Eric Adams,24
+Kings,43052,State Senate,20,WF,Eric Adams,11
+Kings,43053,State Senate,20,WF,Eric Adams,4
+Kings,43054,State Senate,20,WF,Eric Adams,4
+Kings,43055,State Senate,20,WF,Eric Adams,2
+Kings,43056,State Senate,20,WF,Eric Adams,8
+Kings,43057,State Senate,20,WF,Eric Adams,8
+Kings,43058,State Senate,20,WF,Eric Adams,9
+Kings,43059,State Senate,20,WF,Eric Adams,14
+Kings,43060,State Senate,20,WF,Eric Adams,7
+Kings,43061,State Senate,20,WF,Eric Adams,5
+Kings,43062,State Senate,20,WF,Eric Adams,7
+Kings,43063,State Senate,20,WF,Eric Adams,9
+Kings,43064,State Senate,20,WF,Eric Adams,9
+Kings,43065,State Senate,20,WF,Eric Adams,3
+Kings,43066,State Senate,20,WF,Eric Adams,8
+Kings,43067,State Senate,20,WF,Eric Adams,2
+Kings,43068,State Senate,20,WF,Eric Adams,3
+Kings,43069,State Senate,20,WF,Eric Adams,5
+Kings,43070,State Senate,20,WF,Eric Adams,3
+Kings,43071,State Senate,20,WF,Eric Adams,5
+Kings,49001,State Senate,20,WF,Eric Adams,10
+Kings,49002,State Senate,20,WF,Eric Adams,11
+Kings,49003,State Senate,20,WF,Eric Adams,11
+Kings,49004,State Senate,20,WF,Eric Adams,12
+Kings,49005,State Senate,20,WF,Eric Adams,13
+Kings,49014,State Senate,20,WF,Eric Adams,1
+Kings,51020,State Senate,20,WF,Eric Adams,54
+Kings,51028,State Senate,20,WF,Eric Adams,4
+Kings,51029,State Senate,20,WF,Eric Adams,10
+Kings,51030,State Senate,20,WF,Eric Adams,14
+Kings,51031,State Senate,20,WF,Eric Adams,12
+Kings,51032,State Senate,20,WF,Eric Adams,21
+Kings,51033,State Senate,20,WF,Eric Adams,14
+Kings,51034,State Senate,20,WF,Eric Adams,14
+Kings,51035,State Senate,20,WF,Eric Adams,17
+Kings,51036,State Senate,20,WF,Eric Adams,33
+Kings,51037,State Senate,20,WF,Eric Adams,36
+Kings,51038,State Senate,20,WF,Eric Adams,58
+Kings,51039,State Senate,20,WF,Eric Adams,41
+Kings,51040,State Senate,20,WF,Eric Adams,43
+Kings,51041,State Senate,20,WF,Eric Adams,51
+Kings,51042,State Senate,20,WF,Eric Adams,69
+Kings,51043,State Senate,20,WF,Eric Adams,32
+Kings,51063,State Senate,20,WF,Eric Adams,14
+Kings,51064,State Senate,20,WF,Eric Adams,7
+Kings,51065,State Senate,20,WF,Eric Adams,22
+Kings,51066,State Senate,20,WF,Eric Adams,11
+Kings,51067,State Senate,20,WF,Eric Adams,11
+Kings,52064,State Senate,20,WF,Eric Adams,100
+Kings,52065,State Senate,20,WF,Eric Adams,70
+Kings,52066,State Senate,20,WF,Eric Adams,91
+Kings,52067,State Senate,20,WF,Eric Adams,61
+Kings,52072,State Senate,20,WF,Eric Adams,49
+Kings,52073,State Senate,20,WF,Eric Adams,113
+Kings,52074,State Senate,20,WF,Eric Adams,128
+Kings,52075,State Senate,20,WF,Eric Adams,80
+Kings,52079,State Senate,20,WF,Eric Adams,39
+Kings,52087,State Senate,20,WF,Eric Adams,97
+Kings,52088,State Senate,20,WF,Eric Adams,55
+Kings,52092,State Senate,20,WF,Eric Adams,3
+Kings,52093,State Senate,20,WF,Eric Adams,50
+Kings,52094,State Senate,20,WF,Eric Adams,53
+Kings,55035,State Senate,20,WF,Eric Adams,3
+Kings,55057,State Senate,20,WF,Eric Adams,4
+Kings,55058,State Senate,20,WF,Eric Adams,4
+Kings,55059,State Senate,20,WF,Eric Adams,6
+Kings,55061,State Senate,20,WF,Eric Adams,0
+Kings,55065,State Senate,20,WF,Eric Adams,9
+Kings,55066,State Senate,20,WF,Eric Adams,8
+Kings,55067,State Senate,20,WF,Eric Adams,3
+Kings,55068,State Senate,20,WF,Eric Adams,6
+Kings,55069,State Senate,20,WF,Eric Adams,7
+Kings,55070,State Senate,20,WF,Eric Adams,5
+Kings,55071,State Senate,20,WF,Eric Adams,2
+Kings,55072,State Senate,20,WF,Eric Adams,5
+Kings,55073,State Senate,20,WF,Eric Adams,1
+Kings,55076,State Senate,20,WF,Eric Adams,8
+Kings,55078,State Senate,20,WF,Eric Adams,7
+Kings,55079,State Senate,20,WF,Eric Adams,21
+Kings,55080,State Senate,20,WF,Eric Adams,4
+Kings,55081,State Senate,20,WF,Eric Adams,8
+Kings,55082,State Senate,20,WF,Eric Adams,7
+Kings,55083,State Senate,20,WF,Eric Adams,5
+Kings,55084,State Senate,20,WF,Eric Adams,7
+Kings,55085,State Senate,20,WF,Eric Adams,10
+Kings,55086,State Senate,20,WF,Eric Adams,4
+Kings,55087,State Senate,20,WF,Eric Adams,5
+Kings,55088,State Senate,20,WF,Eric Adams,1
+Kings,55089,State Senate,20,WF,Eric Adams,7
+Kings,55090,State Senate,20,WF,Eric Adams,5
+Kings,55091,State Senate,20,WF,Eric Adams,12
+Kings,55092,State Senate,20,WF,Eric Adams,2
+Kings,55093,State Senate,20,WF,Eric Adams,1
+Kings,55094,State Senate,20,WF,Eric Adams,5
+Kings,55095,State Senate,20,WF,Eric Adams,4
+Kings,55096,State Senate,20,WF,Eric Adams,2
+Kings,55097,State Senate,20,WF,Eric Adams,4
+Kings,55100,State Senate,20,WF,Eric Adams,1
+Kings,56073,State Senate,20,WF,Eric Adams,3
+Kings,56075,State Senate,20,WF,Eric Adams,2
+Kings,56076,State Senate,20,WF,Eric Adams,2
+Kings,56077,State Senate,20,WF,Eric Adams,17
+Kings,56078,State Senate,20,WF,Eric Adams,17
+Kings,57067,State Senate,20,WF,Eric Adams,58
+Kings,57068,State Senate,20,WF,Eric Adams,60
+Kings,57069,State Senate,20,WF,Eric Adams,58
+Kings,57070,State Senate,20,WF,Eric Adams,79
+Kings,57071,State Senate,20,WF,Eric Adams,68
+Kings,57072,State Senate,20,WF,Eric Adams,82
+Kings,57073,State Senate,20,WF,Eric Adams,45
+Kings,57074,State Senate,20,WF,Eric Adams,67
+Kings,57075,State Senate,20,WF,Eric Adams,75
+Kings,57076,State Senate,20,WF,Eric Adams,94
+Kings,57077,State Senate,20,WF,Eric Adams,31
+Kings,57078,State Senate,20,WF,Eric Adams,65
+Kings,57079,State Senate,20,WF,Eric Adams,50
+Kings,57080,State Senate,20,WF,Eric Adams,64
+Kings,57081,State Senate,20,WF,Eric Adams,59
+Kings,57082,State Senate,20,WF,Eric Adams,12
+Kings,57083,State Senate,20,WF,Eric Adams,15
+Kings,57084,State Senate,20,WF,Eric Adams,17
+Kings,57085,State Senate,20,WF,Eric Adams,42
+Kings,57088,State Senate,20,WF,Eric Adams,29
+Kings,57089,State Senate,20,WF,Eric Adams,17
+Kings,57090,State Senate,20,WF,Eric Adams,8
+Kings,57091,State Senate,20,WF,Eric Adams,14
+Kings,57092,State Senate,20,WF,Eric Adams,19
+Kings,57093,State Senate,20,WF,Eric Adams,9
+Kings,58001,State Senate,20,WF,Eric Adams,5
+Kings,58002,State Senate,20,WF,Eric Adams,9
+Kings,58003,State Senate,20,WF,Eric Adams,13
+Kings,58004,State Senate,20,WF,Eric Adams,6
+Kings,58005,State Senate,20,WF,Eric Adams,10
+Kings,58006,State Senate,20,WF,Eric Adams,0
+Kings,58007,State Senate,20,WF,Eric Adams,4
+Kings,58008,State Senate,20,WF,Eric Adams,9
+Kings,58009,State Senate,20,WF,Eric Adams,2
+Kings,58010,State Senate,20,WF,Eric Adams,6
+Kings,58011,State Senate,20,WF,Eric Adams,0
+Kings,58012,State Senate,20,WF,Eric Adams,3
+Kings,58013,State Senate,20,WF,Eric Adams,3
+Kings,58014,State Senate,20,WF,Eric Adams,2
+Kings,58015,State Senate,20,WF,Eric Adams,3
+Kings,58045,State Senate,20,WF,Eric Adams,3
+Kings,58046,State Senate,20,WF,Eric Adams,4
+Kings,58047,State Senate,20,WF,Eric Adams,6
+Kings,58048,State Senate,20,WF,Eric Adams,2
+Kings,58052,State Senate,20,WF,Eric Adams,8
+Kings,58053,State Senate,20,WF,Eric Adams,2
+Kings,58054,State Senate,20,WF,Eric Adams,5
+Kings,42068,State Senate,20,Rep,Rose Leary,3
+Kings,43014,State Senate,20,Rep,Rose Leary,6
+Kings,43015,State Senate,20,Rep,Rose Leary,13
+Kings,43016,State Senate,20,Rep,Rose Leary,10
+Kings,43017,State Senate,20,Rep,Rose Leary,17
+Kings,43018,State Senate,20,Rep,Rose Leary,6
+Kings,43019,State Senate,20,Rep,Rose Leary,7
+Kings,43020,State Senate,20,Rep,Rose Leary,5
+Kings,43021,State Senate,20,Rep,Rose Leary,6
+Kings,43022,State Senate,20,Rep,Rose Leary,7
+Kings,43023,State Senate,20,Rep,Rose Leary,3
+Kings,43024,State Senate,20,Rep,Rose Leary,8
+Kings,43025,State Senate,20,Rep,Rose Leary,7
+Kings,43026,State Senate,20,Rep,Rose Leary,5
+Kings,43027,State Senate,20,Rep,Rose Leary,4
+Kings,43028,State Senate,20,Rep,Rose Leary,5
+Kings,43029,State Senate,20,Rep,Rose Leary,18
+Kings,43030,State Senate,20,Rep,Rose Leary,2
+Kings,43031,State Senate,20,Rep,Rose Leary,10
+Kings,43032,State Senate,20,Rep,Rose Leary,2
+Kings,43033,State Senate,20,Rep,Rose Leary,5
+Kings,43034,State Senate,20,Rep,Rose Leary,8
+Kings,43035,State Senate,20,Rep,Rose Leary,23
+Kings,43036,State Senate,20,Rep,Rose Leary,10
+Kings,43037,State Senate,20,Rep,Rose Leary,17
+Kings,43038,State Senate,20,Rep,Rose Leary,22
+Kings,43039,State Senate,20,Rep,Rose Leary,22
+Kings,43040,State Senate,20,Rep,Rose Leary,111
+Kings,43041,State Senate,20,Rep,Rose Leary,4
+Kings,43042,State Senate,20,Rep,Rose Leary,7
+Kings,43043,State Senate,20,Rep,Rose Leary,25
+Kings,43044,State Senate,20,Rep,Rose Leary,6
+Kings,43052,State Senate,20,Rep,Rose Leary,9
+Kings,43053,State Senate,20,Rep,Rose Leary,16
+Kings,43054,State Senate,20,Rep,Rose Leary,30
+Kings,43055,State Senate,20,Rep,Rose Leary,15
+Kings,43056,State Senate,20,Rep,Rose Leary,40
+Kings,43057,State Senate,20,Rep,Rose Leary,114
+Kings,43058,State Senate,20,Rep,Rose Leary,76
+Kings,43059,State Senate,20,Rep,Rose Leary,78
+Kings,43060,State Senate,20,Rep,Rose Leary,82
+Kings,43061,State Senate,20,Rep,Rose Leary,5
+Kings,43062,State Senate,20,Rep,Rose Leary,58
+Kings,43063,State Senate,20,Rep,Rose Leary,81
+Kings,43064,State Senate,20,Rep,Rose Leary,44
+Kings,43065,State Senate,20,Rep,Rose Leary,12
+Kings,43066,State Senate,20,Rep,Rose Leary,2
+Kings,43067,State Senate,20,Rep,Rose Leary,34
+Kings,43068,State Senate,20,Rep,Rose Leary,20
+Kings,43069,State Senate,20,Rep,Rose Leary,1
+Kings,43070,State Senate,20,Rep,Rose Leary,3
+Kings,43071,State Senate,20,Rep,Rose Leary,3
+Kings,49001,State Senate,20,Rep,Rose Leary,27
+Kings,49002,State Senate,20,Rep,Rose Leary,22
+Kings,49003,State Senate,20,Rep,Rose Leary,31
+Kings,49004,State Senate,20,Rep,Rose Leary,48
+Kings,49005,State Senate,20,Rep,Rose Leary,42
+Kings,49014,State Senate,20,Rep,Rose Leary,3
+Kings,51020,State Senate,20,Rep,Rose Leary,25
+Kings,51028,State Senate,20,Rep,Rose Leary,9
+Kings,51029,State Senate,20,Rep,Rose Leary,40
+Kings,51030,State Senate,20,Rep,Rose Leary,46
+Kings,51031,State Senate,20,Rep,Rose Leary,39
+Kings,51032,State Senate,20,Rep,Rose Leary,36
+Kings,51033,State Senate,20,Rep,Rose Leary,25
+Kings,51034,State Senate,20,Rep,Rose Leary,15
+Kings,51035,State Senate,20,Rep,Rose Leary,15
+Kings,51036,State Senate,20,Rep,Rose Leary,20
+Kings,51037,State Senate,20,Rep,Rose Leary,26
+Kings,51038,State Senate,20,Rep,Rose Leary,37
+Kings,51039,State Senate,20,Rep,Rose Leary,16
+Kings,51040,State Senate,20,Rep,Rose Leary,38
+Kings,51041,State Senate,20,Rep,Rose Leary,39
+Kings,51042,State Senate,20,Rep,Rose Leary,20
+Kings,51043,State Senate,20,Rep,Rose Leary,12
+Kings,51063,State Senate,20,Rep,Rose Leary,41
+Kings,51064,State Senate,20,Rep,Rose Leary,26
+Kings,51065,State Senate,20,Rep,Rose Leary,32
+Kings,51066,State Senate,20,Rep,Rose Leary,23
+Kings,51067,State Senate,20,Rep,Rose Leary,26
+Kings,52064,State Senate,20,Rep,Rose Leary,34
+Kings,52065,State Senate,20,Rep,Rose Leary,22
+Kings,52066,State Senate,20,Rep,Rose Leary,35
+Kings,52067,State Senate,20,Rep,Rose Leary,27
+Kings,52072,State Senate,20,Rep,Rose Leary,12
+Kings,52073,State Senate,20,Rep,Rose Leary,33
+Kings,52074,State Senate,20,Rep,Rose Leary,24
+Kings,52075,State Senate,20,Rep,Rose Leary,23
+Kings,52079,State Senate,20,Rep,Rose Leary,12
+Kings,52087,State Senate,20,Rep,Rose Leary,28
+Kings,52088,State Senate,20,Rep,Rose Leary,35
+Kings,52092,State Senate,20,Rep,Rose Leary,0
+Kings,52093,State Senate,20,Rep,Rose Leary,20
+Kings,52094,State Senate,20,Rep,Rose Leary,29
+Kings,55035,State Senate,20,Rep,Rose Leary,0
+Kings,55057,State Senate,20,Rep,Rose Leary,3
+Kings,55058,State Senate,20,Rep,Rose Leary,2
+Kings,55059,State Senate,20,Rep,Rose Leary,4
+Kings,55061,State Senate,20,Rep,Rose Leary,1
+Kings,55065,State Senate,20,Rep,Rose Leary,2
+Kings,55066,State Senate,20,Rep,Rose Leary,13
+Kings,55067,State Senate,20,Rep,Rose Leary,4
+Kings,55068,State Senate,20,Rep,Rose Leary,2
+Kings,55069,State Senate,20,Rep,Rose Leary,4
+Kings,55070,State Senate,20,Rep,Rose Leary,5
+Kings,55071,State Senate,20,Rep,Rose Leary,2
+Kings,55072,State Senate,20,Rep,Rose Leary,9
+Kings,55073,State Senate,20,Rep,Rose Leary,0
+Kings,55076,State Senate,20,Rep,Rose Leary,3
+Kings,55078,State Senate,20,Rep,Rose Leary,11
+Kings,55079,State Senate,20,Rep,Rose Leary,9
+Kings,55080,State Senate,20,Rep,Rose Leary,0
+Kings,55081,State Senate,20,Rep,Rose Leary,9
+Kings,55082,State Senate,20,Rep,Rose Leary,5
+Kings,55083,State Senate,20,Rep,Rose Leary,3
+Kings,55084,State Senate,20,Rep,Rose Leary,2
+Kings,55085,State Senate,20,Rep,Rose Leary,7
+Kings,55086,State Senate,20,Rep,Rose Leary,3
+Kings,55087,State Senate,20,Rep,Rose Leary,6
+Kings,55088,State Senate,20,Rep,Rose Leary,2
+Kings,55089,State Senate,20,Rep,Rose Leary,4
+Kings,55090,State Senate,20,Rep,Rose Leary,5
+Kings,55091,State Senate,20,Rep,Rose Leary,5
+Kings,55092,State Senate,20,Rep,Rose Leary,3
+Kings,55093,State Senate,20,Rep,Rose Leary,6
+Kings,55094,State Senate,20,Rep,Rose Leary,3
+Kings,55095,State Senate,20,Rep,Rose Leary,1
+Kings,55096,State Senate,20,Rep,Rose Leary,2
+Kings,55097,State Senate,20,Rep,Rose Leary,0
+Kings,55100,State Senate,20,Rep,Rose Leary,7
+Kings,56073,State Senate,20,Rep,Rose Leary,3
+Kings,56075,State Senate,20,Rep,Rose Leary,3
+Kings,56076,State Senate,20,Rep,Rose Leary,2
+Kings,56077,State Senate,20,Rep,Rose Leary,13
+Kings,56078,State Senate,20,Rep,Rose Leary,15
+Kings,57067,State Senate,20,Rep,Rose Leary,8
+Kings,57068,State Senate,20,Rep,Rose Leary,10
+Kings,57069,State Senate,20,Rep,Rose Leary,11
+Kings,57070,State Senate,20,Rep,Rose Leary,16
+Kings,57071,State Senate,20,Rep,Rose Leary,9
+Kings,57072,State Senate,20,Rep,Rose Leary,16
+Kings,57073,State Senate,20,Rep,Rose Leary,10
+Kings,57074,State Senate,20,Rep,Rose Leary,14
+Kings,57075,State Senate,20,Rep,Rose Leary,7
+Kings,57076,State Senate,20,Rep,Rose Leary,13
+Kings,57077,State Senate,20,Rep,Rose Leary,9
+Kings,57078,State Senate,20,Rep,Rose Leary,20
+Kings,57079,State Senate,20,Rep,Rose Leary,7
+Kings,57080,State Senate,20,Rep,Rose Leary,8
+Kings,57081,State Senate,20,Rep,Rose Leary,7
+Kings,57082,State Senate,20,Rep,Rose Leary,4
+Kings,57083,State Senate,20,Rep,Rose Leary,1
+Kings,57084,State Senate,20,Rep,Rose Leary,4
+Kings,57085,State Senate,20,Rep,Rose Leary,12
+Kings,57088,State Senate,20,Rep,Rose Leary,4
+Kings,57089,State Senate,20,Rep,Rose Leary,5
+Kings,57090,State Senate,20,Rep,Rose Leary,4
+Kings,57091,State Senate,20,Rep,Rose Leary,7
+Kings,57092,State Senate,20,Rep,Rose Leary,5
+Kings,57093,State Senate,20,Rep,Rose Leary,3
+Kings,58001,State Senate,20,Rep,Rose Leary,7
+Kings,58002,State Senate,20,Rep,Rose Leary,6
+Kings,58003,State Senate,20,Rep,Rose Leary,7
+Kings,58004,State Senate,20,Rep,Rose Leary,5
+Kings,58005,State Senate,20,Rep,Rose Leary,3
+Kings,58006,State Senate,20,Rep,Rose Leary,1
+Kings,58007,State Senate,20,Rep,Rose Leary,2
+Kings,58008,State Senate,20,Rep,Rose Leary,2
+Kings,58009,State Senate,20,Rep,Rose Leary,6
+Kings,58010,State Senate,20,Rep,Rose Leary,2
+Kings,58011,State Senate,20,Rep,Rose Leary,2
+Kings,58012,State Senate,20,Rep,Rose Leary,2
+Kings,58013,State Senate,20,Rep,Rose Leary,3
+Kings,58014,State Senate,20,Rep,Rose Leary,6
+Kings,58015,State Senate,20,Rep,Rose Leary,6
+Kings,58045,State Senate,20,Rep,Rose Leary,5
+Kings,58046,State Senate,20,Rep,Rose Leary,2
+Kings,58047,State Senate,20,Rep,Rose Leary,2
+Kings,58048,State Senate,20,Rep,Rose Leary,4
+Kings,58052,State Senate,20,Rep,Rose Leary,3
+Kings,58053,State Senate,20,Rep,Rose Leary,2
+Kings,58054,State Senate,20,Rep,Rose Leary,3
+Kings,42068,State Senate,20,Ind,writein,0
+Kings,43014,State Senate,20,Ind,writein,0
+Kings,43015,State Senate,20,Ind,writein,0
+Kings,43016,State Senate,20,Ind,writein,0
+Kings,43017,State Senate,20,Ind,writein,0
+Kings,43018,State Senate,20,Ind,writein,0
+Kings,43019,State Senate,20,Ind,writein,1
+Kings,43020,State Senate,20,Ind,writein,0
+Kings,43021,State Senate,20,Ind,writein,0
+Kings,43022,State Senate,20,Ind,writein,0
+Kings,43023,State Senate,20,Ind,writein,0
+Kings,43024,State Senate,20,Ind,writein,0
+Kings,43025,State Senate,20,Ind,writein,0
+Kings,43026,State Senate,20,Ind,writein,0
+Kings,43027,State Senate,20,Ind,writein,0
+Kings,43028,State Senate,20,Ind,writein,0
+Kings,43029,State Senate,20,Ind,writein,0
+Kings,43030,State Senate,20,Ind,writein,0
+Kings,43031,State Senate,20,Ind,writein,0
+Kings,43032,State Senate,20,Ind,writein,1
+Kings,43033,State Senate,20,Ind,writein,0
+Kings,43034,State Senate,20,Ind,writein,0
+Kings,43035,State Senate,20,Ind,writein,1
+Kings,43036,State Senate,20,Ind,writein,0
+Kings,43037,State Senate,20,Ind,writein,0
+Kings,43038,State Senate,20,Ind,writein,0
+Kings,43039,State Senate,20,Ind,writein,0
+Kings,43040,State Senate,20,Ind,writein,0
+Kings,43041,State Senate,20,Ind,writein,0
+Kings,43042,State Senate,20,Ind,writein,0
+Kings,43043,State Senate,20,Ind,writein,0
+Kings,43044,State Senate,20,Ind,writein,0
+Kings,43052,State Senate,20,Ind,writein,0
+Kings,43053,State Senate,20,Ind,writein,0
+Kings,43054,State Senate,20,Ind,writein,0
+Kings,43055,State Senate,20,Ind,writein,0
+Kings,43056,State Senate,20,Ind,writein,0
+Kings,43057,State Senate,20,Ind,writein,0
+Kings,43058,State Senate,20,Ind,writein,0
+Kings,43059,State Senate,20,Ind,writein,1
+Kings,43060,State Senate,20,Ind,writein,1
+Kings,43061,State Senate,20,Ind,writein,0
+Kings,43062,State Senate,20,Ind,writein,0
+Kings,43063,State Senate,20,Ind,writein,0
+Kings,43064,State Senate,20,Ind,writein,0
+Kings,43065,State Senate,20,Ind,writein,0
+Kings,43066,State Senate,20,Ind,writein,0
+Kings,43067,State Senate,20,Ind,writein,2
+Kings,43068,State Senate,20,Ind,writein,0
+Kings,43069,State Senate,20,Ind,writein,0
+Kings,43070,State Senate,20,Ind,writein,0
+Kings,43071,State Senate,20,Ind,writein,0
+Kings,49001,State Senate,20,Ind,writein,0
+Kings,49002,State Senate,20,Ind,writein,1
+Kings,49003,State Senate,20,Ind,writein,0
+Kings,49004,State Senate,20,Ind,writein,2
+Kings,49005,State Senate,20,Ind,writein,0
+Kings,49014,State Senate,20,Ind,writein,0
+Kings,51020,State Senate,20,Ind,writein,0
+Kings,51028,State Senate,20,Ind,writein,0
+Kings,51029,State Senate,20,Ind,writein,0
+Kings,51030,State Senate,20,Ind,writein,2
+Kings,51031,State Senate,20,Ind,writein,2
+Kings,51032,State Senate,20,Ind,writein,0
+Kings,51033,State Senate,20,Ind,writein,1
+Kings,51034,State Senate,20,Ind,writein,0
+Kings,51035,State Senate,20,Ind,writein,0
+Kings,51036,State Senate,20,Ind,writein,0
+Kings,51037,State Senate,20,Ind,writein,0
+Kings,51038,State Senate,20,Ind,writein,1
+Kings,51039,State Senate,20,Ind,writein,2
+Kings,51040,State Senate,20,Ind,writein,0
+Kings,51041,State Senate,20,Ind,writein,0
+Kings,51042,State Senate,20,Ind,writein,1
+Kings,51043,State Senate,20,Ind,writein,1
+Kings,51063,State Senate,20,Ind,writein,0
+Kings,51064,State Senate,20,Ind,writein,1
+Kings,51065,State Senate,20,Ind,writein,0
+Kings,51066,State Senate,20,Ind,writein,0
+Kings,51067,State Senate,20,Ind,writein,1
+Kings,52064,State Senate,20,Ind,writein,1
+Kings,52065,State Senate,20,Ind,writein,1
+Kings,52066,State Senate,20,Ind,writein,0
+Kings,52067,State Senate,20,Ind,writein,1
+Kings,52072,State Senate,20,Ind,writein,0
+Kings,52073,State Senate,20,Ind,writein,0
+Kings,52074,State Senate,20,Ind,writein,0
+Kings,52075,State Senate,20,Ind,writein,1
+Kings,52079,State Senate,20,Ind,writein,0
+Kings,52087,State Senate,20,Ind,writein,0
+Kings,52088,State Senate,20,Ind,writein,0
+Kings,52092,State Senate,20,Ind,writein,0
+Kings,52093,State Senate,20,Ind,writein,0
+Kings,52094,State Senate,20,Ind,writein,0
+Kings,55035,State Senate,20,Ind,writein,0
+Kings,55057,State Senate,20,Ind,writein,0
+Kings,55058,State Senate,20,Ind,writein,0
+Kings,55059,State Senate,20,Ind,writein,0
+Kings,55061,State Senate,20,Ind,writein,0
+Kings,55065,State Senate,20,Ind,writein,0
+Kings,55066,State Senate,20,Ind,writein,0
+Kings,55067,State Senate,20,Ind,writein,0
+Kings,55068,State Senate,20,Ind,writein,0
+Kings,55069,State Senate,20,Ind,writein,0
+Kings,55070,State Senate,20,Ind,writein,1
+Kings,55071,State Senate,20,Ind,writein,0
+Kings,55072,State Senate,20,Ind,writein,0
+Kings,55073,State Senate,20,Ind,writein,0
+Kings,55076,State Senate,20,Ind,writein,1
+Kings,55078,State Senate,20,Ind,writein,0
+Kings,55079,State Senate,20,Ind,writein,0
+Kings,55080,State Senate,20,Ind,writein,0
+Kings,55081,State Senate,20,Ind,writein,0
+Kings,55082,State Senate,20,Ind,writein,0
+Kings,55083,State Senate,20,Ind,writein,1
+Kings,55084,State Senate,20,Ind,writein,1
+Kings,55085,State Senate,20,Ind,writein,0
+Kings,55086,State Senate,20,Ind,writein,0
+Kings,55087,State Senate,20,Ind,writein,0
+Kings,55088,State Senate,20,Ind,writein,0
+Kings,55089,State Senate,20,Ind,writein,0
+Kings,55090,State Senate,20,Ind,writein,0
+Kings,55091,State Senate,20,Ind,writein,1
+Kings,55092,State Senate,20,Ind,writein,0
+Kings,55093,State Senate,20,Ind,writein,0
+Kings,55094,State Senate,20,Ind,writein,0
+Kings,55095,State Senate,20,Ind,writein,0
+Kings,55096,State Senate,20,Ind,writein,0
+Kings,55097,State Senate,20,Ind,writein,0
+Kings,55100,State Senate,20,Ind,writein,0
+Kings,56073,State Senate,20,Ind,writein,0
+Kings,56075,State Senate,20,Ind,writein,0
+Kings,56076,State Senate,20,Ind,writein,0
+Kings,56077,State Senate,20,Ind,writein,0
+Kings,56078,State Senate,20,Ind,writein,0
+Kings,57067,State Senate,20,Ind,writein,1
+Kings,57068,State Senate,20,Ind,writein,0
+Kings,57069,State Senate,20,Ind,writein,0
+Kings,57070,State Senate,20,Ind,writein,1
+Kings,57071,State Senate,20,Ind,writein,1
+Kings,57072,State Senate,20,Ind,writein,0
+Kings,57073,State Senate,20,Ind,writein,0
+Kings,57074,State Senate,20,Ind,writein,0
+Kings,57075,State Senate,20,Ind,writein,1
+Kings,57076,State Senate,20,Ind,writein,0
+Kings,57077,State Senate,20,Ind,writein,0
+Kings,57078,State Senate,20,Ind,writein,0
+Kings,57079,State Senate,20,Ind,writein,1
+Kings,57080,State Senate,20,Ind,writein,0
+Kings,57081,State Senate,20,Ind,writein,0
+Kings,57082,State Senate,20,Ind,writein,0
+Kings,57083,State Senate,20,Ind,writein,1
+Kings,57084,State Senate,20,Ind,writein,0
+Kings,57085,State Senate,20,Ind,writein,0
+Kings,57088,State Senate,20,Ind,writein,0
+Kings,57089,State Senate,20,Ind,writein,1
+Kings,57090,State Senate,20,Ind,writein,0
+Kings,57091,State Senate,20,Ind,writein,0
+Kings,57092,State Senate,20,Ind,writein,0
+Kings,57093,State Senate,20,Ind,writein,0
+Kings,58001,State Senate,20,Ind,writein,0
+Kings,58002,State Senate,20,Ind,writein,0
+Kings,58003,State Senate,20,Ind,writein,0
+Kings,58004,State Senate,20,Ind,writein,0
+Kings,58005,State Senate,20,Ind,writein,0
+Kings,58006,State Senate,20,Ind,writein,0
+Kings,58007,State Senate,20,Ind,writein,0
+Kings,58008,State Senate,20,Ind,writein,0
+Kings,58009,State Senate,20,Ind,writein,0
+Kings,58010,State Senate,20,Ind,writein,0
+Kings,58011,State Senate,20,Ind,writein,0
+Kings,58012,State Senate,20,Ind,writein,0
+Kings,58013,State Senate,20,Ind,writein,0
+Kings,58014,State Senate,20,Ind,writein,0
+Kings,58015,State Senate,20,Ind,writein,0
+Kings,58045,State Senate,20,Ind,writein,0
+Kings,58046,State Senate,20,Ind,writein,0
+Kings,58047,State Senate,20,Ind,writein,0
+Kings,58048,State Senate,20,Ind,writein,0
+Kings,58052,State Senate,20,Ind,writein,0
+Kings,58053,State Senate,20,Ind,writein,0
+Kings,58054,State Senate,20,Ind,writein,0
+Kings,41023,State Senate,21,Dem,Kevin Parker,71
+Kings,41030,State Senate,21,Dem,Kevin Parker,549
+Kings,41031,State Senate,21,Dem,Kevin Parker,674
+Kings,41032,State Senate,21,Dem,Kevin Parker,569
+Kings,41033,State Senate,21,Dem,Kevin Parker,475
+Kings,41034,State Senate,21,Dem,Kevin Parker,401
+Kings,41036,State Senate,21,Dem,Kevin Parker,107
+Kings,41037,State Senate,21,Dem,Kevin Parker,463
+Kings,41038,State Senate,21,Dem,Kevin Parker,665
+Kings,41039,State Senate,21,Dem,Kevin Parker,610
+Kings,41040,State Senate,21,Dem,Kevin Parker,111
+Kings,41041,State Senate,21,Dem,Kevin Parker,735
+Kings,41042,State Senate,21,Dem,Kevin Parker,55
+Kings,41043,State Senate,21,Dem,Kevin Parker,455
+Kings,41045,State Senate,21,Dem,Kevin Parker,670
+Kings,41046,State Senate,21,Dem,Kevin Parker,1
+Kings,41047,State Senate,21,Dem,Kevin Parker,673
+Kings,41048,State Senate,21,Dem,Kevin Parker,261
+Kings,41049,State Senate,21,Dem,Kevin Parker,514
+Kings,41053,State Senate,21,Dem,Kevin Parker,473
+Kings,41054,State Senate,21,Dem,Kevin Parker,527
+Kings,41055,State Senate,21,Dem,Kevin Parker,496
+Kings,42001,State Senate,21,Dem,Kevin Parker,28
+Kings,42002,State Senate,21,Dem,Kevin Parker,524
+Kings,42003,State Senate,21,Dem,Kevin Parker,541
+Kings,42004,State Senate,21,Dem,Kevin Parker,574
+Kings,42005,State Senate,21,Dem,Kevin Parker,424
+Kings,42006,State Senate,21,Dem,Kevin Parker,437
+Kings,42007,State Senate,21,Dem,Kevin Parker,610
+Kings,42008,State Senate,21,Dem,Kevin Parker,332
+Kings,42009,State Senate,21,Dem,Kevin Parker,584
+Kings,42010,State Senate,21,Dem,Kevin Parker,583
+Kings,42011,State Senate,21,Dem,Kevin Parker,574
+Kings,42012,State Senate,21,Dem,Kevin Parker,622
+Kings,42013,State Senate,21,Dem,Kevin Parker,490
+Kings,42014,State Senate,21,Dem,Kevin Parker,233
+Kings,42015,State Senate,21,Dem,Kevin Parker,607
+Kings,42016,State Senate,21,Dem,Kevin Parker,550
+Kings,42017,State Senate,21,Dem,Kevin Parker,511
+Kings,42018,State Senate,21,Dem,Kevin Parker,575
+Kings,42019,State Senate,21,Dem,Kevin Parker,354
+Kings,42020,State Senate,21,Dem,Kevin Parker,516
+Kings,42021,State Senate,21,Dem,Kevin Parker,586
+Kings,42022,State Senate,21,Dem,Kevin Parker,522
+Kings,42023,State Senate,21,Dem,Kevin Parker,564
+Kings,42024,State Senate,21,Dem,Kevin Parker,562
+Kings,42025,State Senate,21,Dem,Kevin Parker,516
+Kings,42026,State Senate,21,Dem,Kevin Parker,558
+Kings,42027,State Senate,21,Dem,Kevin Parker,534
+Kings,42028,State Senate,21,Dem,Kevin Parker,559
+Kings,42029,State Senate,21,Dem,Kevin Parker,571
+Kings,42030,State Senate,21,Dem,Kevin Parker,332
+Kings,42031,State Senate,21,Dem,Kevin Parker,530
+Kings,42032,State Senate,21,Dem,Kevin Parker,144
+Kings,42033,State Senate,21,Dem,Kevin Parker,35
+Kings,42039,State Senate,21,Dem,Kevin Parker,763
+Kings,42040,State Senate,21,Dem,Kevin Parker,527
+Kings,42041,State Senate,21,Dem,Kevin Parker,619
+Kings,42042,State Senate,21,Dem,Kevin Parker,551
+Kings,42043,State Senate,21,Dem,Kevin Parker,567
+Kings,42044,State Senate,21,Dem,Kevin Parker,609
+Kings,42045,State Senate,21,Dem,Kevin Parker,531
+Kings,42046,State Senate,21,Dem,Kevin Parker,614
+Kings,42047,State Senate,21,Dem,Kevin Parker,652
+Kings,42048,State Senate,21,Dem,Kevin Parker,613
+Kings,42049,State Senate,21,Dem,Kevin Parker,539
+Kings,42050,State Senate,21,Dem,Kevin Parker,606
+Kings,42051,State Senate,21,Dem,Kevin Parker,543
+Kings,42052,State Senate,21,Dem,Kevin Parker,553
+Kings,42053,State Senate,21,Dem,Kevin Parker,569
+Kings,42054,State Senate,21,Dem,Kevin Parker,565
+Kings,42055,State Senate,21,Dem,Kevin Parker,569
+Kings,42056,State Senate,21,Dem,Kevin Parker,568
+Kings,42057,State Senate,21,Dem,Kevin Parker,536
+Kings,42058,State Senate,21,Dem,Kevin Parker,27
+Kings,43001,State Senate,21,Dem,Kevin Parker,452
+Kings,43002,State Senate,21,Dem,Kevin Parker,542
+Kings,43003,State Senate,21,Dem,Kevin Parker,606
+Kings,43004,State Senate,21,Dem,Kevin Parker,528
+Kings,43005,State Senate,21,Dem,Kevin Parker,309
+Kings,43006,State Senate,21,Dem,Kevin Parker,622
+Kings,43007,State Senate,21,Dem,Kevin Parker,293
+Kings,43008,State Senate,21,Dem,Kevin Parker,584
+Kings,43009,State Senate,21,Dem,Kevin Parker,580
+Kings,43010,State Senate,21,Dem,Kevin Parker,226
+Kings,44011,State Senate,21,Dem,Kevin Parker,132
+Kings,44012,State Senate,21,Dem,Kevin Parker,79
+Kings,44014,State Senate,21,Dem,Kevin Parker,460
+Kings,44015,State Senate,21,Dem,Kevin Parker,417
+Kings,44016,State Senate,21,Dem,Kevin Parker,488
+Kings,44017,State Senate,21,Dem,Kevin Parker,444
+Kings,44018,State Senate,21,Dem,Kevin Parker,320
+Kings,44019,State Senate,21,Dem,Kevin Parker,351
+Kings,44020,State Senate,21,Dem,Kevin Parker,243
+Kings,44034,State Senate,21,Dem,Kevin Parker,297
+Kings,44036,State Senate,21,Dem,Kevin Parker,554
+Kings,44037,State Senate,21,Dem,Kevin Parker,207
+Kings,44040,State Senate,21,Dem,Kevin Parker,86
+Kings,44046,State Senate,21,Dem,Kevin Parker,197
+Kings,44047,State Senate,21,Dem,Kevin Parker,100
+Kings,44048,State Senate,21,Dem,Kevin Parker,265
+Kings,44049,State Senate,21,Dem,Kevin Parker,446
+Kings,44050,State Senate,21,Dem,Kevin Parker,422
+Kings,44051,State Senate,21,Dem,Kevin Parker,420
+Kings,44052,State Senate,21,Dem,Kevin Parker,436
+Kings,44053,State Senate,21,Dem,Kevin Parker,361
+Kings,44054,State Senate,21,Dem,Kevin Parker,483
+Kings,44055,State Senate,21,Dem,Kevin Parker,470
+Kings,44056,State Senate,21,Dem,Kevin Parker,325
+Kings,44057,State Senate,21,Dem,Kevin Parker,586
+Kings,44058,State Senate,21,Dem,Kevin Parker,468
+Kings,44059,State Senate,21,Dem,Kevin Parker,439
+Kings,44060,State Senate,21,Dem,Kevin Parker,338
+Kings,44061,State Senate,21,Dem,Kevin Parker,269
+Kings,44062,State Senate,21,Dem,Kevin Parker,276
+Kings,44063,State Senate,21,Dem,Kevin Parker,314
+Kings,44064,State Senate,21,Dem,Kevin Parker,150
+Kings,44065,State Senate,21,Dem,Kevin Parker,511
+Kings,44066,State Senate,21,Dem,Kevin Parker,223
+Kings,44067,State Senate,21,Dem,Kevin Parker,8
+Kings,44068,State Senate,21,Dem,Kevin Parker,0
+Kings,44069,State Senate,21,Dem,Kevin Parker,484
+Kings,44070,State Senate,21,Dem,Kevin Parker,597
+Kings,44071,State Senate,21,Dem,Kevin Parker,472
+Kings,44072,State Senate,21,Dem,Kevin Parker,423
+Kings,44073,State Senate,21,Dem,Kevin Parker,476
+Kings,44074,State Senate,21,Dem,Kevin Parker,494
+Kings,44075,State Senate,21,Dem,Kevin Parker,435
+Kings,44076,State Senate,21,Dem,Kevin Parker,417
+Kings,44077,State Senate,21,Dem,Kevin Parker,421
+Kings,44078,State Senate,21,Dem,Kevin Parker,513
+Kings,44079,State Senate,21,Dem,Kevin Parker,491
+Kings,44080,State Senate,21,Dem,Kevin Parker,333
+Kings,51010,State Senate,21,Dem,Kevin Parker,135
+Kings,51011,State Senate,21,Dem,Kevin Parker,498
+Kings,51012,State Senate,21,Dem,Kevin Parker,476
+Kings,51013,State Senate,21,Dem,Kevin Parker,328
+Kings,51019,State Senate,21,Dem,Kevin Parker,40
+Kings,51021,State Senate,21,Dem,Kevin Parker,81
+Kings,51022,State Senate,21,Dem,Kevin Parker,59
+Kings,52068,State Senate,21,Dem,Kevin Parker,626
+Kings,52069,State Senate,21,Dem,Kevin Parker,529
+Kings,52070,State Senate,21,Dem,Kevin Parker,612
+Kings,52071,State Senate,21,Dem,Kevin Parker,462
+Kings,52076,State Senate,21,Dem,Kevin Parker,131
+Kings,52077,State Senate,21,Dem,Kevin Parker,24
+Kings,52078,State Senate,21,Dem,Kevin Parker,273
+Kings,52080,State Senate,21,Dem,Kevin Parker,152
+Kings,52081,State Senate,21,Dem,Kevin Parker,504
+Kings,52082,State Senate,21,Dem,Kevin Parker,431
+Kings,52083,State Senate,21,Dem,Kevin Parker,515
+Kings,52084,State Senate,21,Dem,Kevin Parker,412
+Kings,52085,State Senate,21,Dem,Kevin Parker,364
+Kings,52086,State Senate,21,Dem,Kevin Parker,571
+Kings,52113,State Senate,21,Dem,Kevin Parker,351
+Kings,52114,State Senate,21,Dem,Kevin Parker,376
+Kings,52115,State Senate,21,Dem,Kevin Parker,468
+Kings,57086,State Senate,21,Dem,Kevin Parker,707
+Kings,57087,State Senate,21,Dem,Kevin Parker,150
+Kings,58016,State Senate,21,Dem,Kevin Parker,367
+Kings,58017,State Senate,21,Dem,Kevin Parker,404
+Kings,58018,State Senate,21,Dem,Kevin Parker,554
+Kings,58019,State Senate,21,Dem,Kevin Parker,669
+Kings,58020,State Senate,21,Dem,Kevin Parker,548
+Kings,58021,State Senate,21,Dem,Kevin Parker,529
+Kings,58022,State Senate,21,Dem,Kevin Parker,303
+Kings,58023,State Senate,21,Dem,Kevin Parker,499
+Kings,58024,State Senate,21,Dem,Kevin Parker,639
+Kings,58025,State Senate,21,Dem,Kevin Parker,570
+Kings,58026,State Senate,21,Dem,Kevin Parker,639
+Kings,58027,State Senate,21,Dem,Kevin Parker,461
+Kings,58028,State Senate,21,Dem,Kevin Parker,540
+Kings,58029,State Senate,21,Dem,Kevin Parker,454
+Kings,58030,State Senate,21,Dem,Kevin Parker,683
+Kings,58031,State Senate,21,Dem,Kevin Parker,580
+Kings,58032,State Senate,21,Dem,Kevin Parker,545
+Kings,58033,State Senate,21,Dem,Kevin Parker,662
+Kings,58034,State Senate,21,Dem,Kevin Parker,562
+Kings,58035,State Senate,21,Dem,Kevin Parker,430
+Kings,58036,State Senate,21,Dem,Kevin Parker,625
+Kings,58037,State Senate,21,Dem,Kevin Parker,681
+Kings,58038,State Senate,21,Dem,Kevin Parker,538
+Kings,58039,State Senate,21,Dem,Kevin Parker,557
+Kings,58040,State Senate,21,Dem,Kevin Parker,618
+Kings,58041,State Senate,21,Dem,Kevin Parker,551
+Kings,58042,State Senate,21,Dem,Kevin Parker,275
+Kings,58049,State Senate,21,Dem,Kevin Parker,417
+Kings,58050,State Senate,21,Dem,Kevin Parker,450
+Kings,58051,State Senate,21,Dem,Kevin Parker,630
+Kings,58055,State Senate,21,Dem,Kevin Parker,481
+Kings,58056,State Senate,21,Dem,Kevin Parker,279
+Kings,58061,State Senate,21,Dem,Kevin Parker,581
+Kings,58062,State Senate,21,Dem,Kevin Parker,521
+Kings,58063,State Senate,21,Dem,Kevin Parker,349
+Kings,58064,State Senate,21,Dem,Kevin Parker,324
+Kings,59001,State Senate,21,Dem,Kevin Parker,364
+Kings,59002,State Senate,21,Dem,Kevin Parker,311
+Kings,59003,State Senate,21,Dem,Kevin Parker,328
+Kings,59004,State Senate,21,Dem,Kevin Parker,366
+Kings,59017,State Senate,21,Dem,Kevin Parker,541
+Kings,59018,State Senate,21,Dem,Kevin Parker,233
+Kings,59019,State Senate,21,Dem,Kevin Parker,152
+Kings,59020,State Senate,21,Dem,Kevin Parker,610
+Kings,59021,State Senate,21,Dem,Kevin Parker,404
+Kings,59022,State Senate,21,Dem,Kevin Parker,333
+Kings,59023,State Senate,21,Dem,Kevin Parker,460
+Kings,59025,State Senate,21,Dem,Kevin Parker,84
+Kings,41023,State Senate,21,Con,Kevin Parker,0
+Kings,41030,State Senate,21,Con,Kevin Parker,6
+Kings,41031,State Senate,21,Con,Kevin Parker,10
+Kings,41032,State Senate,21,Con,Kevin Parker,12
+Kings,41033,State Senate,21,Con,Kevin Parker,10
+Kings,41034,State Senate,21,Con,Kevin Parker,5
+Kings,41036,State Senate,21,Con,Kevin Parker,0
+Kings,41037,State Senate,21,Con,Kevin Parker,2
+Kings,41038,State Senate,21,Con,Kevin Parker,6
+Kings,41039,State Senate,21,Con,Kevin Parker,5
+Kings,41040,State Senate,21,Con,Kevin Parker,3
+Kings,41041,State Senate,21,Con,Kevin Parker,10
+Kings,41042,State Senate,21,Con,Kevin Parker,1
+Kings,41043,State Senate,21,Con,Kevin Parker,7
+Kings,41045,State Senate,21,Con,Kevin Parker,7
+Kings,41046,State Senate,21,Con,Kevin Parker,0
+Kings,41047,State Senate,21,Con,Kevin Parker,7
+Kings,41048,State Senate,21,Con,Kevin Parker,2
+Kings,41049,State Senate,21,Con,Kevin Parker,3
+Kings,41053,State Senate,21,Con,Kevin Parker,11
+Kings,41054,State Senate,21,Con,Kevin Parker,7
+Kings,41055,State Senate,21,Con,Kevin Parker,10
+Kings,42001,State Senate,21,Con,Kevin Parker,3
+Kings,42002,State Senate,21,Con,Kevin Parker,17
+Kings,42003,State Senate,21,Con,Kevin Parker,36
+Kings,42004,State Senate,21,Con,Kevin Parker,21
+Kings,42005,State Senate,21,Con,Kevin Parker,31
+Kings,42006,State Senate,21,Con,Kevin Parker,42
+Kings,42007,State Senate,21,Con,Kevin Parker,26
+Kings,42008,State Senate,21,Con,Kevin Parker,3
+Kings,42009,State Senate,21,Con,Kevin Parker,7
+Kings,42010,State Senate,21,Con,Kevin Parker,2
+Kings,42011,State Senate,21,Con,Kevin Parker,4
+Kings,42012,State Senate,21,Con,Kevin Parker,7
+Kings,42013,State Senate,21,Con,Kevin Parker,4
+Kings,42014,State Senate,21,Con,Kevin Parker,8
+Kings,42015,State Senate,21,Con,Kevin Parker,13
+Kings,42016,State Senate,21,Con,Kevin Parker,9
+Kings,42017,State Senate,21,Con,Kevin Parker,10
+Kings,42018,State Senate,21,Con,Kevin Parker,38
+Kings,42019,State Senate,21,Con,Kevin Parker,8
+Kings,42020,State Senate,21,Con,Kevin Parker,7
+Kings,42021,State Senate,21,Con,Kevin Parker,14
+Kings,42022,State Senate,21,Con,Kevin Parker,9
+Kings,42023,State Senate,21,Con,Kevin Parker,45
+Kings,42024,State Senate,21,Con,Kevin Parker,15
+Kings,42025,State Senate,21,Con,Kevin Parker,54
+Kings,42026,State Senate,21,Con,Kevin Parker,11
+Kings,42027,State Senate,21,Con,Kevin Parker,9
+Kings,42028,State Senate,21,Con,Kevin Parker,13
+Kings,42029,State Senate,21,Con,Kevin Parker,7
+Kings,42030,State Senate,21,Con,Kevin Parker,21
+Kings,42031,State Senate,21,Con,Kevin Parker,21
+Kings,42032,State Senate,21,Con,Kevin Parker,0
+Kings,42033,State Senate,21,Con,Kevin Parker,4
+Kings,42039,State Senate,21,Con,Kevin Parker,8
+Kings,42040,State Senate,21,Con,Kevin Parker,3
+Kings,42041,State Senate,21,Con,Kevin Parker,6
+Kings,42042,State Senate,21,Con,Kevin Parker,2
+Kings,42043,State Senate,21,Con,Kevin Parker,12
+Kings,42044,State Senate,21,Con,Kevin Parker,4
+Kings,42045,State Senate,21,Con,Kevin Parker,3
+Kings,42046,State Senate,21,Con,Kevin Parker,1
+Kings,42047,State Senate,21,Con,Kevin Parker,6
+Kings,42048,State Senate,21,Con,Kevin Parker,16
+Kings,42049,State Senate,21,Con,Kevin Parker,20
+Kings,42050,State Senate,21,Con,Kevin Parker,4
+Kings,42051,State Senate,21,Con,Kevin Parker,9
+Kings,42052,State Senate,21,Con,Kevin Parker,13
+Kings,42053,State Senate,21,Con,Kevin Parker,13
+Kings,42054,State Senate,21,Con,Kevin Parker,14
+Kings,42055,State Senate,21,Con,Kevin Parker,14
+Kings,42056,State Senate,21,Con,Kevin Parker,6
+Kings,42057,State Senate,21,Con,Kevin Parker,9
+Kings,42058,State Senate,21,Con,Kevin Parker,1
+Kings,43001,State Senate,21,Con,Kevin Parker,32
+Kings,43002,State Senate,21,Con,Kevin Parker,43
+Kings,43003,State Senate,21,Con,Kevin Parker,18
+Kings,43004,State Senate,21,Con,Kevin Parker,23
+Kings,43005,State Senate,21,Con,Kevin Parker,21
+Kings,43006,State Senate,21,Con,Kevin Parker,30
+Kings,43007,State Senate,21,Con,Kevin Parker,13
+Kings,43008,State Senate,21,Con,Kevin Parker,24
+Kings,43009,State Senate,21,Con,Kevin Parker,18
+Kings,43010,State Senate,21,Con,Kevin Parker,1
+Kings,44011,State Senate,21,Con,Kevin Parker,14
+Kings,44012,State Senate,21,Con,Kevin Parker,10
+Kings,44014,State Senate,21,Con,Kevin Parker,39
+Kings,44015,State Senate,21,Con,Kevin Parker,48
+Kings,44016,State Senate,21,Con,Kevin Parker,37
+Kings,44017,State Senate,21,Con,Kevin Parker,57
+Kings,44018,State Senate,21,Con,Kevin Parker,42
+Kings,44019,State Senate,21,Con,Kevin Parker,17
+Kings,44020,State Senate,21,Con,Kevin Parker,12
+Kings,44034,State Senate,21,Con,Kevin Parker,20
+Kings,44036,State Senate,21,Con,Kevin Parker,49
+Kings,44037,State Senate,21,Con,Kevin Parker,17
+Kings,44040,State Senate,21,Con,Kevin Parker,3
+Kings,44046,State Senate,21,Con,Kevin Parker,21
+Kings,44047,State Senate,21,Con,Kevin Parker,7
+Kings,44048,State Senate,21,Con,Kevin Parker,28
+Kings,44049,State Senate,21,Con,Kevin Parker,65
+Kings,44050,State Senate,21,Con,Kevin Parker,59
+Kings,44051,State Senate,21,Con,Kevin Parker,57
+Kings,44052,State Senate,21,Con,Kevin Parker,70
+Kings,44053,State Senate,21,Con,Kevin Parker,74
+Kings,44054,State Senate,21,Con,Kevin Parker,110
+Kings,44055,State Senate,21,Con,Kevin Parker,118
+Kings,44056,State Senate,21,Con,Kevin Parker,69
+Kings,44057,State Senate,21,Con,Kevin Parker,91
+Kings,44058,State Senate,21,Con,Kevin Parker,95
+Kings,44059,State Senate,21,Con,Kevin Parker,73
+Kings,44060,State Senate,21,Con,Kevin Parker,62
+Kings,44061,State Senate,21,Con,Kevin Parker,51
+Kings,44062,State Senate,21,Con,Kevin Parker,50
+Kings,44063,State Senate,21,Con,Kevin Parker,55
+Kings,44064,State Senate,21,Con,Kevin Parker,27
+Kings,44065,State Senate,21,Con,Kevin Parker,88
+Kings,44066,State Senate,21,Con,Kevin Parker,34
+Kings,44067,State Senate,21,Con,Kevin Parker,2
+Kings,44068,State Senate,21,Con,Kevin Parker,1
+Kings,44069,State Senate,21,Con,Kevin Parker,108
+Kings,44070,State Senate,21,Con,Kevin Parker,100
+Kings,44071,State Senate,21,Con,Kevin Parker,87
+Kings,44072,State Senate,21,Con,Kevin Parker,89
+Kings,44073,State Senate,21,Con,Kevin Parker,80
+Kings,44074,State Senate,21,Con,Kevin Parker,83
+Kings,44075,State Senate,21,Con,Kevin Parker,83
+Kings,44076,State Senate,21,Con,Kevin Parker,58
+Kings,44077,State Senate,21,Con,Kevin Parker,71
+Kings,44078,State Senate,21,Con,Kevin Parker,112
+Kings,44079,State Senate,21,Con,Kevin Parker,59
+Kings,44080,State Senate,21,Con,Kevin Parker,70
+Kings,51010,State Senate,21,Con,Kevin Parker,7
+Kings,51011,State Senate,21,Con,Kevin Parker,71
+Kings,51012,State Senate,21,Con,Kevin Parker,66
+Kings,51013,State Senate,21,Con,Kevin Parker,35
+Kings,51019,State Senate,21,Con,Kevin Parker,2
+Kings,51021,State Senate,21,Con,Kevin Parker,11
+Kings,51022,State Senate,21,Con,Kevin Parker,15
+Kings,52068,State Senate,21,Con,Kevin Parker,95
+Kings,52069,State Senate,21,Con,Kevin Parker,75
+Kings,52070,State Senate,21,Con,Kevin Parker,115
+Kings,52071,State Senate,21,Con,Kevin Parker,69
+Kings,52076,State Senate,21,Con,Kevin Parker,36
+Kings,52077,State Senate,21,Con,Kevin Parker,5
+Kings,52078,State Senate,21,Con,Kevin Parker,47
+Kings,52080,State Senate,21,Con,Kevin Parker,25
+Kings,52081,State Senate,21,Con,Kevin Parker,115
+Kings,52082,State Senate,21,Con,Kevin Parker,82
+Kings,52083,State Senate,21,Con,Kevin Parker,82
+Kings,52084,State Senate,21,Con,Kevin Parker,86
+Kings,52085,State Senate,21,Con,Kevin Parker,72
+Kings,52086,State Senate,21,Con,Kevin Parker,92
+Kings,52113,State Senate,21,Con,Kevin Parker,52
+Kings,52114,State Senate,21,Con,Kevin Parker,52
+Kings,52115,State Senate,21,Con,Kevin Parker,74
+Kings,57086,State Senate,21,Con,Kevin Parker,40
+Kings,57087,State Senate,21,Con,Kevin Parker,10
+Kings,58016,State Senate,21,Con,Kevin Parker,4
+Kings,58017,State Senate,21,Con,Kevin Parker,6
+Kings,58018,State Senate,21,Con,Kevin Parker,5
+Kings,58019,State Senate,21,Con,Kevin Parker,8
+Kings,58020,State Senate,21,Con,Kevin Parker,6
+Kings,58021,State Senate,21,Con,Kevin Parker,8
+Kings,58022,State Senate,21,Con,Kevin Parker,9
+Kings,58023,State Senate,21,Con,Kevin Parker,9
+Kings,58024,State Senate,21,Con,Kevin Parker,16
+Kings,58025,State Senate,21,Con,Kevin Parker,6
+Kings,58026,State Senate,21,Con,Kevin Parker,5
+Kings,58027,State Senate,21,Con,Kevin Parker,6
+Kings,58028,State Senate,21,Con,Kevin Parker,5
+Kings,58029,State Senate,21,Con,Kevin Parker,5
+Kings,58030,State Senate,21,Con,Kevin Parker,10
+Kings,58031,State Senate,21,Con,Kevin Parker,3
+Kings,58032,State Senate,21,Con,Kevin Parker,6
+Kings,58033,State Senate,21,Con,Kevin Parker,4
+Kings,58034,State Senate,21,Con,Kevin Parker,1
+Kings,58035,State Senate,21,Con,Kevin Parker,6
+Kings,58036,State Senate,21,Con,Kevin Parker,6
+Kings,58037,State Senate,21,Con,Kevin Parker,8
+Kings,58038,State Senate,21,Con,Kevin Parker,6
+Kings,58039,State Senate,21,Con,Kevin Parker,3
+Kings,58040,State Senate,21,Con,Kevin Parker,3
+Kings,58041,State Senate,21,Con,Kevin Parker,10
+Kings,58042,State Senate,21,Con,Kevin Parker,3
+Kings,58049,State Senate,21,Con,Kevin Parker,7
+Kings,58050,State Senate,21,Con,Kevin Parker,11
+Kings,58051,State Senate,21,Con,Kevin Parker,9
+Kings,58055,State Senate,21,Con,Kevin Parker,1
+Kings,58056,State Senate,21,Con,Kevin Parker,3
+Kings,58061,State Senate,21,Con,Kevin Parker,6
+Kings,58062,State Senate,21,Con,Kevin Parker,7
+Kings,58063,State Senate,21,Con,Kevin Parker,1
+Kings,58064,State Senate,21,Con,Kevin Parker,6
+Kings,59001,State Senate,21,Con,Kevin Parker,9
+Kings,59002,State Senate,21,Con,Kevin Parker,3
+Kings,59003,State Senate,21,Con,Kevin Parker,8
+Kings,59004,State Senate,21,Con,Kevin Parker,3
+Kings,59017,State Senate,21,Con,Kevin Parker,1
+Kings,59018,State Senate,21,Con,Kevin Parker,0
+Kings,59019,State Senate,21,Con,Kevin Parker,1
+Kings,59020,State Senate,21,Con,Kevin Parker,6
+Kings,59021,State Senate,21,Con,Kevin Parker,5
+Kings,59022,State Senate,21,Con,Kevin Parker,3
+Kings,59023,State Senate,21,Con,Kevin Parker,3
+Kings,59025,State Senate,21,Con,Kevin Parker,2
+Kings,41023,State Senate,21,Rep,Mindy Meyer,5
+Kings,41030,State Senate,21,Rep,Mindy Meyer,23
+Kings,41031,State Senate,21,Rep,Mindy Meyer,13
+Kings,41032,State Senate,21,Rep,Mindy Meyer,9
+Kings,41033,State Senate,21,Rep,Mindy Meyer,8
+Kings,41034,State Senate,21,Rep,Mindy Meyer,10
+Kings,41036,State Senate,21,Rep,Mindy Meyer,1
+Kings,41037,State Senate,21,Rep,Mindy Meyer,2
+Kings,41038,State Senate,21,Rep,Mindy Meyer,15
+Kings,41039,State Senate,21,Rep,Mindy Meyer,11
+Kings,41040,State Senate,21,Rep,Mindy Meyer,4
+Kings,41041,State Senate,21,Rep,Mindy Meyer,17
+Kings,41042,State Senate,21,Rep,Mindy Meyer,1
+Kings,41043,State Senate,21,Rep,Mindy Meyer,13
+Kings,41045,State Senate,21,Rep,Mindy Meyer,8
+Kings,41046,State Senate,21,Rep,Mindy Meyer,0
+Kings,41047,State Senate,21,Rep,Mindy Meyer,13
+Kings,41048,State Senate,21,Rep,Mindy Meyer,1
+Kings,41049,State Senate,21,Rep,Mindy Meyer,4
+Kings,41053,State Senate,21,Rep,Mindy Meyer,39
+Kings,41054,State Senate,21,Rep,Mindy Meyer,9
+Kings,41055,State Senate,21,Rep,Mindy Meyer,8
+Kings,42001,State Senate,21,Rep,Mindy Meyer,1
+Kings,42002,State Senate,21,Rep,Mindy Meyer,8
+Kings,42003,State Senate,21,Rep,Mindy Meyer,4
+Kings,42004,State Senate,21,Rep,Mindy Meyer,9
+Kings,42005,State Senate,21,Rep,Mindy Meyer,7
+Kings,42006,State Senate,21,Rep,Mindy Meyer,14
+Kings,42007,State Senate,21,Rep,Mindy Meyer,2
+Kings,42008,State Senate,21,Rep,Mindy Meyer,1
+Kings,42009,State Senate,21,Rep,Mindy Meyer,2
+Kings,42010,State Senate,21,Rep,Mindy Meyer,4
+Kings,42011,State Senate,21,Rep,Mindy Meyer,3
+Kings,42012,State Senate,21,Rep,Mindy Meyer,8
+Kings,42013,State Senate,21,Rep,Mindy Meyer,0
+Kings,42014,State Senate,21,Rep,Mindy Meyer,1
+Kings,42015,State Senate,21,Rep,Mindy Meyer,2
+Kings,42016,State Senate,21,Rep,Mindy Meyer,2
+Kings,42017,State Senate,21,Rep,Mindy Meyer,2
+Kings,42018,State Senate,21,Rep,Mindy Meyer,20
+Kings,42019,State Senate,21,Rep,Mindy Meyer,0
+Kings,42020,State Senate,21,Rep,Mindy Meyer,4
+Kings,42021,State Senate,21,Rep,Mindy Meyer,8
+Kings,42022,State Senate,21,Rep,Mindy Meyer,1
+Kings,42023,State Senate,21,Rep,Mindy Meyer,12
+Kings,42024,State Senate,21,Rep,Mindy Meyer,19
+Kings,42025,State Senate,21,Rep,Mindy Meyer,8
+Kings,42026,State Senate,21,Rep,Mindy Meyer,1
+Kings,42027,State Senate,21,Rep,Mindy Meyer,7
+Kings,42028,State Senate,21,Rep,Mindy Meyer,4
+Kings,42029,State Senate,21,Rep,Mindy Meyer,6
+Kings,42030,State Senate,21,Rep,Mindy Meyer,5
+Kings,42031,State Senate,21,Rep,Mindy Meyer,8
+Kings,42032,State Senate,21,Rep,Mindy Meyer,0
+Kings,42033,State Senate,21,Rep,Mindy Meyer,1
+Kings,42039,State Senate,21,Rep,Mindy Meyer,3
+Kings,42040,State Senate,21,Rep,Mindy Meyer,2
+Kings,42041,State Senate,21,Rep,Mindy Meyer,2
+Kings,42042,State Senate,21,Rep,Mindy Meyer,1
+Kings,42043,State Senate,21,Rep,Mindy Meyer,3
+Kings,42044,State Senate,21,Rep,Mindy Meyer,3
+Kings,42045,State Senate,21,Rep,Mindy Meyer,3
+Kings,42046,State Senate,21,Rep,Mindy Meyer,3
+Kings,42047,State Senate,21,Rep,Mindy Meyer,9
+Kings,42048,State Senate,21,Rep,Mindy Meyer,11
+Kings,42049,State Senate,21,Rep,Mindy Meyer,11
+Kings,42050,State Senate,21,Rep,Mindy Meyer,5
+Kings,42051,State Senate,21,Rep,Mindy Meyer,51
+Kings,42052,State Senate,21,Rep,Mindy Meyer,21
+Kings,42053,State Senate,21,Rep,Mindy Meyer,8
+Kings,42054,State Senate,21,Rep,Mindy Meyer,7
+Kings,42055,State Senate,21,Rep,Mindy Meyer,18
+Kings,42056,State Senate,21,Rep,Mindy Meyer,3
+Kings,42057,State Senate,21,Rep,Mindy Meyer,13
+Kings,42058,State Senate,21,Rep,Mindy Meyer,0
+Kings,43001,State Senate,21,Rep,Mindy Meyer,3
+Kings,43002,State Senate,21,Rep,Mindy Meyer,10
+Kings,43003,State Senate,21,Rep,Mindy Meyer,6
+Kings,43004,State Senate,21,Rep,Mindy Meyer,2
+Kings,43005,State Senate,21,Rep,Mindy Meyer,2
+Kings,43006,State Senate,21,Rep,Mindy Meyer,4
+Kings,43007,State Senate,21,Rep,Mindy Meyer,2
+Kings,43008,State Senate,21,Rep,Mindy Meyer,8
+Kings,43009,State Senate,21,Rep,Mindy Meyer,3
+Kings,43010,State Senate,21,Rep,Mindy Meyer,2
+Kings,44011,State Senate,21,Rep,Mindy Meyer,13
+Kings,44012,State Senate,21,Rep,Mindy Meyer,1
+Kings,44014,State Senate,21,Rep,Mindy Meyer,40
+Kings,44015,State Senate,21,Rep,Mindy Meyer,41
+Kings,44016,State Senate,21,Rep,Mindy Meyer,38
+Kings,44017,State Senate,21,Rep,Mindy Meyer,33
+Kings,44018,State Senate,21,Rep,Mindy Meyer,39
+Kings,44019,State Senate,21,Rep,Mindy Meyer,59
+Kings,44020,State Senate,21,Rep,Mindy Meyer,46
+Kings,44034,State Senate,21,Rep,Mindy Meyer,5
+Kings,44036,State Senate,21,Rep,Mindy Meyer,12
+Kings,44037,State Senate,21,Rep,Mindy Meyer,9
+Kings,44040,State Senate,21,Rep,Mindy Meyer,4
+Kings,44046,State Senate,21,Rep,Mindy Meyer,6
+Kings,44047,State Senate,21,Rep,Mindy Meyer,5
+Kings,44048,State Senate,21,Rep,Mindy Meyer,28
+Kings,44049,State Senate,21,Rep,Mindy Meyer,44
+Kings,44050,State Senate,21,Rep,Mindy Meyer,19
+Kings,44051,State Senate,21,Rep,Mindy Meyer,47
+Kings,44052,State Senate,21,Rep,Mindy Meyer,56
+Kings,44053,State Senate,21,Rep,Mindy Meyer,61
+Kings,44054,State Senate,21,Rep,Mindy Meyer,30
+Kings,44055,State Senate,21,Rep,Mindy Meyer,58
+Kings,44056,State Senate,21,Rep,Mindy Meyer,38
+Kings,44057,State Senate,21,Rep,Mindy Meyer,69
+Kings,44058,State Senate,21,Rep,Mindy Meyer,68
+Kings,44059,State Senate,21,Rep,Mindy Meyer,46
+Kings,44060,State Senate,21,Rep,Mindy Meyer,33
+Kings,44061,State Senate,21,Rep,Mindy Meyer,9
+Kings,44062,State Senate,21,Rep,Mindy Meyer,20
+Kings,44063,State Senate,21,Rep,Mindy Meyer,13
+Kings,44064,State Senate,21,Rep,Mindy Meyer,10
+Kings,44065,State Senate,21,Rep,Mindy Meyer,29
+Kings,44066,State Senate,21,Rep,Mindy Meyer,11
+Kings,44067,State Senate,21,Rep,Mindy Meyer,1
+Kings,44068,State Senate,21,Rep,Mindy Meyer,0
+Kings,44069,State Senate,21,Rep,Mindy Meyer,36
+Kings,44070,State Senate,21,Rep,Mindy Meyer,43
+Kings,44071,State Senate,21,Rep,Mindy Meyer,33
+Kings,44072,State Senate,21,Rep,Mindy Meyer,18
+Kings,44073,State Senate,21,Rep,Mindy Meyer,32
+Kings,44074,State Senate,21,Rep,Mindy Meyer,27
+Kings,44075,State Senate,21,Rep,Mindy Meyer,29
+Kings,44076,State Senate,21,Rep,Mindy Meyer,22
+Kings,44077,State Senate,21,Rep,Mindy Meyer,28
+Kings,44078,State Senate,21,Rep,Mindy Meyer,26
+Kings,44079,State Senate,21,Rep,Mindy Meyer,35
+Kings,44080,State Senate,21,Rep,Mindy Meyer,19
+Kings,51010,State Senate,21,Rep,Mindy Meyer,3
+Kings,51011,State Senate,21,Rep,Mindy Meyer,25
+Kings,51012,State Senate,21,Rep,Mindy Meyer,19
+Kings,51013,State Senate,21,Rep,Mindy Meyer,20
+Kings,51019,State Senate,21,Rep,Mindy Meyer,6
+Kings,51021,State Senate,21,Rep,Mindy Meyer,3
+Kings,51022,State Senate,21,Rep,Mindy Meyer,2
+Kings,52068,State Senate,21,Rep,Mindy Meyer,43
+Kings,52069,State Senate,21,Rep,Mindy Meyer,29
+Kings,52070,State Senate,21,Rep,Mindy Meyer,55
+Kings,52071,State Senate,21,Rep,Mindy Meyer,10
+Kings,52076,State Senate,21,Rep,Mindy Meyer,6
+Kings,52077,State Senate,21,Rep,Mindy Meyer,2
+Kings,52078,State Senate,21,Rep,Mindy Meyer,24
+Kings,52080,State Senate,21,Rep,Mindy Meyer,7
+Kings,52081,State Senate,21,Rep,Mindy Meyer,33
+Kings,52082,State Senate,21,Rep,Mindy Meyer,24
+Kings,52083,State Senate,21,Rep,Mindy Meyer,22
+Kings,52084,State Senate,21,Rep,Mindy Meyer,27
+Kings,52085,State Senate,21,Rep,Mindy Meyer,20
+Kings,52086,State Senate,21,Rep,Mindy Meyer,31
+Kings,52113,State Senate,21,Rep,Mindy Meyer,22
+Kings,52114,State Senate,21,Rep,Mindy Meyer,35
+Kings,52115,State Senate,21,Rep,Mindy Meyer,37
+Kings,57086,State Senate,21,Rep,Mindy Meyer,4
+Kings,57087,State Senate,21,Rep,Mindy Meyer,2
+Kings,58016,State Senate,21,Rep,Mindy Meyer,2
+Kings,58017,State Senate,21,Rep,Mindy Meyer,2
+Kings,58018,State Senate,21,Rep,Mindy Meyer,1
+Kings,58019,State Senate,21,Rep,Mindy Meyer,3
+Kings,58020,State Senate,21,Rep,Mindy Meyer,2
+Kings,58021,State Senate,21,Rep,Mindy Meyer,5
+Kings,58022,State Senate,21,Rep,Mindy Meyer,1
+Kings,58023,State Senate,21,Rep,Mindy Meyer,1
+Kings,58024,State Senate,21,Rep,Mindy Meyer,4
+Kings,58025,State Senate,21,Rep,Mindy Meyer,7
+Kings,58026,State Senate,21,Rep,Mindy Meyer,7
+Kings,58027,State Senate,21,Rep,Mindy Meyer,10
+Kings,58028,State Senate,21,Rep,Mindy Meyer,10
+Kings,58029,State Senate,21,Rep,Mindy Meyer,5
+Kings,58030,State Senate,21,Rep,Mindy Meyer,6
+Kings,58031,State Senate,21,Rep,Mindy Meyer,8
+Kings,58032,State Senate,21,Rep,Mindy Meyer,5
+Kings,58033,State Senate,21,Rep,Mindy Meyer,2
+Kings,58034,State Senate,21,Rep,Mindy Meyer,2
+Kings,58035,State Senate,21,Rep,Mindy Meyer,2
+Kings,58036,State Senate,21,Rep,Mindy Meyer,2
+Kings,58037,State Senate,21,Rep,Mindy Meyer,1
+Kings,58038,State Senate,21,Rep,Mindy Meyer,9
+Kings,58039,State Senate,21,Rep,Mindy Meyer,5
+Kings,58040,State Senate,21,Rep,Mindy Meyer,6
+Kings,58041,State Senate,21,Rep,Mindy Meyer,2
+Kings,58042,State Senate,21,Rep,Mindy Meyer,1
+Kings,58049,State Senate,21,Rep,Mindy Meyer,7
+Kings,58050,State Senate,21,Rep,Mindy Meyer,7
+Kings,58051,State Senate,21,Rep,Mindy Meyer,10
+Kings,58055,State Senate,21,Rep,Mindy Meyer,0
+Kings,58056,State Senate,21,Rep,Mindy Meyer,2
+Kings,58061,State Senate,21,Rep,Mindy Meyer,4
+Kings,58062,State Senate,21,Rep,Mindy Meyer,5
+Kings,58063,State Senate,21,Rep,Mindy Meyer,3
+Kings,58064,State Senate,21,Rep,Mindy Meyer,9
+Kings,59001,State Senate,21,Rep,Mindy Meyer,6
+Kings,59002,State Senate,21,Rep,Mindy Meyer,3
+Kings,59003,State Senate,21,Rep,Mindy Meyer,5
+Kings,59004,State Senate,21,Rep,Mindy Meyer,7
+Kings,59017,State Senate,21,Rep,Mindy Meyer,6
+Kings,59018,State Senate,21,Rep,Mindy Meyer,2
+Kings,59019,State Senate,21,Rep,Mindy Meyer,0
+Kings,59020,State Senate,21,Rep,Mindy Meyer,7
+Kings,59021,State Senate,21,Rep,Mindy Meyer,4
+Kings,59022,State Senate,21,Rep,Mindy Meyer,19
+Kings,59023,State Senate,21,Rep,Mindy Meyer,21
+Kings,59025,State Senate,21,Rep,Mindy Meyer,4
+Kings,41023,State Senate,21,Ind,writein,0
+Kings,41030,State Senate,21,Ind,writein,1
+Kings,41031,State Senate,21,Ind,writein,1
+Kings,41032,State Senate,21,Ind,writein,1
+Kings,41033,State Senate,21,Ind,writein,0
+Kings,41034,State Senate,21,Ind,writein,1
+Kings,41036,State Senate,21,Ind,writein,0
+Kings,41037,State Senate,21,Ind,writein,0
+Kings,41038,State Senate,21,Ind,writein,0
+Kings,41039,State Senate,21,Ind,writein,0
+Kings,41040,State Senate,21,Ind,writein,0
+Kings,41041,State Senate,21,Ind,writein,0
+Kings,41042,State Senate,21,Ind,writein,0
+Kings,41043,State Senate,21,Ind,writein,0
+Kings,41045,State Senate,21,Ind,writein,1
+Kings,41046,State Senate,21,Ind,writein,0
+Kings,41047,State Senate,21,Ind,writein,1
+Kings,41048,State Senate,21,Ind,writein,1
+Kings,41049,State Senate,21,Ind,writein,1
+Kings,41053,State Senate,21,Ind,writein,1
+Kings,41054,State Senate,21,Ind,writein,0
+Kings,41055,State Senate,21,Ind,writein,0
+Kings,42001,State Senate,21,Ind,writein,0
+Kings,42002,State Senate,21,Ind,writein,0
+Kings,42003,State Senate,21,Ind,writein,4
+Kings,42004,State Senate,21,Ind,writein,0
+Kings,42005,State Senate,21,Ind,writein,0
+Kings,42006,State Senate,21,Ind,writein,0
+Kings,42007,State Senate,21,Ind,writein,0
+Kings,42008,State Senate,21,Ind,writein,1
+Kings,42009,State Senate,21,Ind,writein,0
+Kings,42010,State Senate,21,Ind,writein,0
+Kings,42011,State Senate,21,Ind,writein,1
+Kings,42012,State Senate,21,Ind,writein,0
+Kings,42013,State Senate,21,Ind,writein,0
+Kings,42014,State Senate,21,Ind,writein,0
+Kings,42015,State Senate,21,Ind,writein,0
+Kings,42016,State Senate,21,Ind,writein,0
+Kings,42017,State Senate,21,Ind,writein,1
+Kings,42018,State Senate,21,Ind,writein,0
+Kings,42019,State Senate,21,Ind,writein,0
+Kings,42020,State Senate,21,Ind,writein,1
+Kings,42021,State Senate,21,Ind,writein,0
+Kings,42022,State Senate,21,Ind,writein,0
+Kings,42023,State Senate,21,Ind,writein,0
+Kings,42024,State Senate,21,Ind,writein,1
+Kings,42025,State Senate,21,Ind,writein,0
+Kings,42026,State Senate,21,Ind,writein,0
+Kings,42027,State Senate,21,Ind,writein,0
+Kings,42028,State Senate,21,Ind,writein,0
+Kings,42029,State Senate,21,Ind,writein,0
+Kings,42030,State Senate,21,Ind,writein,0
+Kings,42031,State Senate,21,Ind,writein,0
+Kings,42032,State Senate,21,Ind,writein,0
+Kings,42033,State Senate,21,Ind,writein,1
+Kings,42039,State Senate,21,Ind,writein,0
+Kings,42040,State Senate,21,Ind,writein,0
+Kings,42041,State Senate,21,Ind,writein,0
+Kings,42042,State Senate,21,Ind,writein,0
+Kings,42043,State Senate,21,Ind,writein,0
+Kings,42044,State Senate,21,Ind,writein,0
+Kings,42045,State Senate,21,Ind,writein,0
+Kings,42046,State Senate,21,Ind,writein,0
+Kings,42047,State Senate,21,Ind,writein,0
+Kings,42048,State Senate,21,Ind,writein,0
+Kings,42049,State Senate,21,Ind,writein,0
+Kings,42050,State Senate,21,Ind,writein,0
+Kings,42051,State Senate,21,Ind,writein,0
+Kings,42052,State Senate,21,Ind,writein,4
+Kings,42053,State Senate,21,Ind,writein,0
+Kings,42054,State Senate,21,Ind,writein,0
+Kings,42055,State Senate,21,Ind,writein,0
+Kings,42056,State Senate,21,Ind,writein,0
+Kings,42057,State Senate,21,Ind,writein,0
+Kings,42058,State Senate,21,Ind,writein,0
+Kings,43001,State Senate,21,Ind,writein,0
+Kings,43002,State Senate,21,Ind,writein,0
+Kings,43003,State Senate,21,Ind,writein,0
+Kings,43004,State Senate,21,Ind,writein,0
+Kings,43005,State Senate,21,Ind,writein,0
+Kings,43006,State Senate,21,Ind,writein,0
+Kings,43007,State Senate,21,Ind,writein,0
+Kings,43008,State Senate,21,Ind,writein,0
+Kings,43009,State Senate,21,Ind,writein,0
+Kings,43010,State Senate,21,Ind,writein,0
+Kings,44011,State Senate,21,Ind,writein,0
+Kings,44012,State Senate,21,Ind,writein,0
+Kings,44014,State Senate,21,Ind,writein,0
+Kings,44015,State Senate,21,Ind,writein,0
+Kings,44016,State Senate,21,Ind,writein,0
+Kings,44017,State Senate,21,Ind,writein,1
+Kings,44018,State Senate,21,Ind,writein,0
+Kings,44019,State Senate,21,Ind,writein,2
+Kings,44020,State Senate,21,Ind,writein,0
+Kings,44034,State Senate,21,Ind,writein,0
+Kings,44036,State Senate,21,Ind,writein,2
+Kings,44037,State Senate,21,Ind,writein,0
+Kings,44040,State Senate,21,Ind,writein,0
+Kings,44046,State Senate,21,Ind,writein,1
+Kings,44047,State Senate,21,Ind,writein,0
+Kings,44048,State Senate,21,Ind,writein,0
+Kings,44049,State Senate,21,Ind,writein,1
+Kings,44050,State Senate,21,Ind,writein,1
+Kings,44051,State Senate,21,Ind,writein,0
+Kings,44052,State Senate,21,Ind,writein,0
+Kings,44053,State Senate,21,Ind,writein,1
+Kings,44054,State Senate,21,Ind,writein,0
+Kings,44055,State Senate,21,Ind,writein,0
+Kings,44056,State Senate,21,Ind,writein,1
+Kings,44057,State Senate,21,Ind,writein,0
+Kings,44058,State Senate,21,Ind,writein,2
+Kings,44059,State Senate,21,Ind,writein,0
+Kings,44060,State Senate,21,Ind,writein,0
+Kings,44061,State Senate,21,Ind,writein,0
+Kings,44062,State Senate,21,Ind,writein,0
+Kings,44063,State Senate,21,Ind,writein,0
+Kings,44064,State Senate,21,Ind,writein,0
+Kings,44065,State Senate,21,Ind,writein,1
+Kings,44066,State Senate,21,Ind,writein,0
+Kings,44067,State Senate,21,Ind,writein,0
+Kings,44068,State Senate,21,Ind,writein,0
+Kings,44069,State Senate,21,Ind,writein,1
+Kings,44070,State Senate,21,Ind,writein,1
+Kings,44071,State Senate,21,Ind,writein,0
+Kings,44072,State Senate,21,Ind,writein,0
+Kings,44073,State Senate,21,Ind,writein,3
+Kings,44074,State Senate,21,Ind,writein,0
+Kings,44075,State Senate,21,Ind,writein,0
+Kings,44076,State Senate,21,Ind,writein,0
+Kings,44077,State Senate,21,Ind,writein,4
+Kings,44078,State Senate,21,Ind,writein,0
+Kings,44079,State Senate,21,Ind,writein,0
+Kings,44080,State Senate,21,Ind,writein,0
+Kings,51010,State Senate,21,Ind,writein,0
+Kings,51011,State Senate,21,Ind,writein,0
+Kings,51012,State Senate,21,Ind,writein,0
+Kings,51013,State Senate,21,Ind,writein,1
+Kings,51019,State Senate,21,Ind,writein,0
+Kings,51021,State Senate,21,Ind,writein,0
+Kings,51022,State Senate,21,Ind,writein,0
+Kings,52068,State Senate,21,Ind,writein,0
+Kings,52069,State Senate,21,Ind,writein,0
+Kings,52070,State Senate,21,Ind,writein,1
+Kings,52071,State Senate,21,Ind,writein,3
+Kings,52076,State Senate,21,Ind,writein,0
+Kings,52077,State Senate,21,Ind,writein,0
+Kings,52078,State Senate,21,Ind,writein,0
+Kings,52080,State Senate,21,Ind,writein,0
+Kings,52081,State Senate,21,Ind,writein,1
+Kings,52082,State Senate,21,Ind,writein,0
+Kings,52083,State Senate,21,Ind,writein,2
+Kings,52084,State Senate,21,Ind,writein,0
+Kings,52085,State Senate,21,Ind,writein,0
+Kings,52086,State Senate,21,Ind,writein,0
+Kings,52113,State Senate,21,Ind,writein,0
+Kings,52114,State Senate,21,Ind,writein,0
+Kings,52115,State Senate,21,Ind,writein,1
+Kings,57086,State Senate,21,Ind,writein,0
+Kings,57087,State Senate,21,Ind,writein,0
+Kings,58016,State Senate,21,Ind,writein,0
+Kings,58017,State Senate,21,Ind,writein,0
+Kings,58018,State Senate,21,Ind,writein,1
+Kings,58019,State Senate,21,Ind,writein,0
+Kings,58020,State Senate,21,Ind,writein,0
+Kings,58021,State Senate,21,Ind,writein,1
+Kings,58022,State Senate,21,Ind,writein,1
+Kings,58023,State Senate,21,Ind,writein,0
+Kings,58024,State Senate,21,Ind,writein,0
+Kings,58025,State Senate,21,Ind,writein,0
+Kings,58026,State Senate,21,Ind,writein,0
+Kings,58027,State Senate,21,Ind,writein,0
+Kings,58028,State Senate,21,Ind,writein,0
+Kings,58029,State Senate,21,Ind,writein,0
+Kings,58030,State Senate,21,Ind,writein,0
+Kings,58031,State Senate,21,Ind,writein,0
+Kings,58032,State Senate,21,Ind,writein,0
+Kings,58033,State Senate,21,Ind,writein,0
+Kings,58034,State Senate,21,Ind,writein,0
+Kings,58035,State Senate,21,Ind,writein,0
+Kings,58036,State Senate,21,Ind,writein,0
+Kings,58037,State Senate,21,Ind,writein,0
+Kings,58038,State Senate,21,Ind,writein,2
+Kings,58039,State Senate,21,Ind,writein,0
+Kings,58040,State Senate,21,Ind,writein,0
+Kings,58041,State Senate,21,Ind,writein,0
+Kings,58042,State Senate,21,Ind,writein,0
+Kings,58049,State Senate,21,Ind,writein,0
+Kings,58050,State Senate,21,Ind,writein,1
+Kings,58051,State Senate,21,Ind,writein,0
+Kings,58055,State Senate,21,Ind,writein,0
+Kings,58056,State Senate,21,Ind,writein,0
+Kings,58061,State Senate,21,Ind,writein,0
+Kings,58062,State Senate,21,Ind,writein,0
+Kings,58063,State Senate,21,Ind,writein,0
+Kings,58064,State Senate,21,Ind,writein,0
+Kings,59001,State Senate,21,Ind,writein,0
+Kings,59002,State Senate,21,Ind,writein,0
+Kings,59003,State Senate,21,Ind,writein,0
+Kings,59004,State Senate,21,Ind,writein,0
+Kings,59017,State Senate,21,Ind,writein,0
+Kings,59018,State Senate,21,Ind,writein,0
+Kings,59019,State Senate,21,Ind,writein,0
+Kings,59020,State Senate,21,Ind,writein,0
+Kings,59021,State Senate,21,Ind,writein,0
+Kings,59022,State Senate,21,Ind,writein,0
+Kings,59023,State Senate,21,Ind,writein,0
+Kings,59025,State Senate,21,Ind,writein,0
+Kings,41016,State Senate,22,WF,Andrew Gounardes,8
+Kings,41017,State Senate,22,WF,Andrew Gounardes,9
+Kings,41018,State Senate,22,WF,Andrew Gounardes,9
+Kings,41056,State Senate,22,WF,Andrew Gounardes,3
+Kings,41081,State Senate,22,WF,Andrew Gounardes,7
+Kings,41082,State Senate,22,WF,Andrew Gounardes,13
+Kings,41083,State Senate,22,WF,Andrew Gounardes,6
+Kings,41086,State Senate,22,WF,Andrew Gounardes,0
+Kings,41090,State Senate,22,WF,Andrew Gounardes,1
+Kings,41093,State Senate,22,WF,Andrew Gounardes,9
+Kings,41094,State Senate,22,WF,Andrew Gounardes,10
+Kings,41095,State Senate,22,WF,Andrew Gounardes,7
+Kings,45006,State Senate,22,WF,Andrew Gounardes,3
+Kings,45008,State Senate,22,WF,Andrew Gounardes,4
+Kings,45009,State Senate,22,WF,Andrew Gounardes,6
+Kings,45015,State Senate,22,WF,Andrew Gounardes,0
+Kings,45016,State Senate,22,WF,Andrew Gounardes,5
+Kings,45017,State Senate,22,WF,Andrew Gounardes,5
+Kings,45019,State Senate,22,WF,Andrew Gounardes,9
+Kings,45020,State Senate,22,WF,Andrew Gounardes,2
+Kings,45021,State Senate,22,WF,Andrew Gounardes,2
+Kings,45022,State Senate,22,WF,Andrew Gounardes,4
+Kings,45031,State Senate,22,WF,Andrew Gounardes,3
+Kings,45032,State Senate,22,WF,Andrew Gounardes,2
+Kings,45033,State Senate,22,WF,Andrew Gounardes,5
+Kings,45034,State Senate,22,WF,Andrew Gounardes,6
+Kings,45035,State Senate,22,WF,Andrew Gounardes,7
+Kings,45036,State Senate,22,WF,Andrew Gounardes,3
+Kings,45037,State Senate,22,WF,Andrew Gounardes,5
+Kings,45041,State Senate,22,WF,Andrew Gounardes,3
+Kings,45049,State Senate,22,WF,Andrew Gounardes,3
+Kings,45051,State Senate,22,WF,Andrew Gounardes,8
+Kings,45052,State Senate,22,WF,Andrew Gounardes,1
+Kings,45068,State Senate,22,WF,Andrew Gounardes,7
+Kings,45069,State Senate,22,WF,Andrew Gounardes,2
+Kings,45070,State Senate,22,WF,Andrew Gounardes,6
+Kings,45072,State Senate,22,WF,Andrew Gounardes,2
+Kings,45080,State Senate,22,WF,Andrew Gounardes,5
+Kings,45081,State Senate,22,WF,Andrew Gounardes,4
+Kings,46048,State Senate,22,WF,Andrew Gounardes,21
+Kings,46049,State Senate,22,WF,Andrew Gounardes,25
+Kings,46050,State Senate,22,WF,Andrew Gounardes,20
+Kings,46051,State Senate,22,WF,Andrew Gounardes,21
+Kings,46052,State Senate,22,WF,Andrew Gounardes,10
+Kings,46053,State Senate,22,WF,Andrew Gounardes,17
+Kings,46054,State Senate,22,WF,Andrew Gounardes,34
+Kings,46055,State Senate,22,WF,Andrew Gounardes,12
+Kings,46056,State Senate,22,WF,Andrew Gounardes,30
+Kings,46057,State Senate,22,WF,Andrew Gounardes,24
+Kings,46058,State Senate,22,WF,Andrew Gounardes,29
+Kings,46059,State Senate,22,WF,Andrew Gounardes,19
+Kings,46060,State Senate,22,WF,Andrew Gounardes,19
+Kings,46061,State Senate,22,WF,Andrew Gounardes,29
+Kings,46062,State Senate,22,WF,Andrew Gounardes,17
+Kings,46063,State Senate,22,WF,Andrew Gounardes,30
+Kings,46064,State Senate,22,WF,Andrew Gounardes,23
+Kings,46065,State Senate,22,WF,Andrew Gounardes,18
+Kings,46066,State Senate,22,WF,Andrew Gounardes,14
+Kings,46067,State Senate,22,WF,Andrew Gounardes,8
+Kings,46068,State Senate,22,WF,Andrew Gounardes,17
+Kings,46069,State Senate,22,WF,Andrew Gounardes,12
+Kings,46070,State Senate,22,WF,Andrew Gounardes,9
+Kings,46071,State Senate,22,WF,Andrew Gounardes,13
+Kings,46072,State Senate,22,WF,Andrew Gounardes,17
+Kings,46073,State Senate,22,WF,Andrew Gounardes,8
+Kings,46074,State Senate,22,WF,Andrew Gounardes,3
+Kings,46075,State Senate,22,WF,Andrew Gounardes,12
+Kings,46081,State Senate,22,WF,Andrew Gounardes,9
+Kings,47001,State Senate,22,WF,Andrew Gounardes,10
+Kings,47002,State Senate,22,WF,Andrew Gounardes,11
+Kings,47003,State Senate,22,WF,Andrew Gounardes,19
+Kings,47005,State Senate,22,WF,Andrew Gounardes,12
+Kings,47006,State Senate,22,WF,Andrew Gounardes,12
+Kings,47007,State Senate,22,WF,Andrew Gounardes,8
+Kings,47008,State Senate,22,WF,Andrew Gounardes,2
+Kings,47009,State Senate,22,WF,Andrew Gounardes,5
+Kings,47019,State Senate,22,WF,Andrew Gounardes,2
+Kings,47020,State Senate,22,WF,Andrew Gounardes,6
+Kings,47021,State Senate,22,WF,Andrew Gounardes,8
+Kings,47022,State Senate,22,WF,Andrew Gounardes,9
+Kings,47034,State Senate,22,WF,Andrew Gounardes,11
+Kings,47038,State Senate,22,WF,Andrew Gounardes,3
+Kings,47039,State Senate,22,WF,Andrew Gounardes,1
+Kings,47043,State Senate,22,WF,Andrew Gounardes,4
+Kings,47044,State Senate,22,WF,Andrew Gounardes,13
+Kings,47045,State Senate,22,WF,Andrew Gounardes,5
+Kings,47046,State Senate,22,WF,Andrew Gounardes,15
+Kings,47047,State Senate,22,WF,Andrew Gounardes,10
+Kings,47048,State Senate,22,WF,Andrew Gounardes,3
+Kings,47049,State Senate,22,WF,Andrew Gounardes,10
+Kings,47050,State Senate,22,WF,Andrew Gounardes,6
+Kings,47051,State Senate,22,WF,Andrew Gounardes,2
+Kings,47052,State Senate,22,WF,Andrew Gounardes,3
+Kings,47055,State Senate,22,WF,Andrew Gounardes,1
+Kings,47056,State Senate,22,WF,Andrew Gounardes,9
+Kings,47065,State Senate,22,WF,Andrew Gounardes,2
+Kings,48034,State Senate,22,WF,Andrew Gounardes,3
+Kings,48035,State Senate,22,WF,Andrew Gounardes,2
+Kings,48037,State Senate,22,WF,Andrew Gounardes,1
+Kings,48046,State Senate,22,WF,Andrew Gounardes,4
+Kings,48047,State Senate,22,WF,Andrew Gounardes,7
+Kings,48048,State Senate,22,WF,Andrew Gounardes,1
+Kings,48050,State Senate,22,WF,Andrew Gounardes,2
+Kings,48051,State Senate,22,WF,Andrew Gounardes,5
+Kings,48052,State Senate,22,WF,Andrew Gounardes,5
+Kings,48059,State Senate,22,WF,Andrew Gounardes,2
+Kings,49016,State Senate,22,WF,Andrew Gounardes,1
+Kings,49017,State Senate,22,WF,Andrew Gounardes,2
+Kings,49018,State Senate,22,WF,Andrew Gounardes,0
+Kings,49019,State Senate,22,WF,Andrew Gounardes,10
+Kings,49020,State Senate,22,WF,Andrew Gounardes,16
+Kings,49021,State Senate,22,WF,Andrew Gounardes,7
+Kings,49022,State Senate,22,WF,Andrew Gounardes,4
+Kings,49023,State Senate,22,WF,Andrew Gounardes,8
+Kings,49024,State Senate,22,WF,Andrew Gounardes,10
+Kings,49025,State Senate,22,WF,Andrew Gounardes,14
+Kings,49026,State Senate,22,WF,Andrew Gounardes,9
+Kings,49027,State Senate,22,WF,Andrew Gounardes,11
+Kings,49028,State Senate,22,WF,Andrew Gounardes,2
+Kings,49029,State Senate,22,WF,Andrew Gounardes,0
+Kings,49035,State Senate,22,WF,Andrew Gounardes,9
+Kings,49037,State Senate,22,WF,Andrew Gounardes,12
+Kings,49038,State Senate,22,WF,Andrew Gounardes,10
+Kings,49039,State Senate,22,WF,Andrew Gounardes,16
+Kings,49040,State Senate,22,WF,Andrew Gounardes,8
+Kings,49041,State Senate,22,WF,Andrew Gounardes,15
+Kings,49045,State Senate,22,WF,Andrew Gounardes,3
+Kings,49047,State Senate,22,WF,Andrew Gounardes,17
+Kings,49048,State Senate,22,WF,Andrew Gounardes,12
+Kings,49049,State Senate,22,WF,Andrew Gounardes,5
+Kings,49050,State Senate,22,WF,Andrew Gounardes,11
+Kings,49051,State Senate,22,WF,Andrew Gounardes,9
+Kings,49052,State Senate,22,WF,Andrew Gounardes,8
+Kings,49053,State Senate,22,WF,Andrew Gounardes,12
+Kings,49054,State Senate,22,WF,Andrew Gounardes,17
+Kings,49056,State Senate,22,WF,Andrew Gounardes,2
+Kings,49057,State Senate,22,WF,Andrew Gounardes,1
+Kings,51059,State Senate,22,WF,Andrew Gounardes,27
+Kings,51061,State Senate,22,WF,Andrew Gounardes,21
+Kings,51062,State Senate,22,WF,Andrew Gounardes,29
+Kings,59033,State Senate,22,WF,Andrew Gounardes,7
+Kings,59034,State Senate,22,WF,Andrew Gounardes,5
+Kings,59035,State Senate,22,WF,Andrew Gounardes,13
+Kings,59036,State Senate,22,WF,Andrew Gounardes,18
+Kings,59037,State Senate,22,WF,Andrew Gounardes,4
+Kings,59038,State Senate,22,WF,Andrew Gounardes,11
+Kings,59039,State Senate,22,WF,Andrew Gounardes,10
+Kings,59040,State Senate,22,WF,Andrew Gounardes,7
+Kings,59041,State Senate,22,WF,Andrew Gounardes,2
+Kings,59042,State Senate,22,WF,Andrew Gounardes,8
+Kings,59043,State Senate,22,WF,Andrew Gounardes,9
+Kings,59044,State Senate,22,WF,Andrew Gounardes,9
+Kings,59045,State Senate,22,WF,Andrew Gounardes,7
+Kings,59046,State Senate,22,WF,Andrew Gounardes,2
+Kings,59048,State Senate,22,WF,Andrew Gounardes,0
+Kings,64075,State Senate,22,WF,Andrew Gounardes,17
+Kings,64076,State Senate,22,WF,Andrew Gounardes,21
+Kings,64077,State Senate,22,WF,Andrew Gounardes,30
+Kings,64078,State Senate,22,WF,Andrew Gounardes,27
+Kings,64079,State Senate,22,WF,Andrew Gounardes,19
+Kings,64080,State Senate,22,WF,Andrew Gounardes,23
+Kings,64083,State Senate,22,WF,Andrew Gounardes,39
+Kings,64084,State Senate,22,WF,Andrew Gounardes,31
+Kings,64085,State Senate,22,WF,Andrew Gounardes,22
+Kings,64086,State Senate,22,WF,Andrew Gounardes,24
+Kings,64087,State Senate,22,WF,Andrew Gounardes,14
+Kings,64088,State Senate,22,WF,Andrew Gounardes,27
+Kings,64089,State Senate,22,WF,Andrew Gounardes,6
+Kings,64090,State Senate,22,WF,Andrew Gounardes,15
+Kings,64091,State Senate,22,WF,Andrew Gounardes,5
+Kings,41016,State Senate,22,Dem,Andrew Gournardes,159
+Kings,41017,State Senate,22,Dem,Andrew Gournardes,183
+Kings,41018,State Senate,22,Dem,Andrew Gournardes,73
+Kings,41056,State Senate,22,Dem,Andrew Gournardes,66
+Kings,41081,State Senate,22,Dem,Andrew Gournardes,183
+Kings,41082,State Senate,22,Dem,Andrew Gournardes,135
+Kings,41083,State Senate,22,Dem,Andrew Gournardes,205
+Kings,41086,State Senate,22,Dem,Andrew Gournardes,22
+Kings,41090,State Senate,22,Dem,Andrew Gournardes,34
+Kings,41093,State Senate,22,Dem,Andrew Gournardes,142
+Kings,41094,State Senate,22,Dem,Andrew Gournardes,200
+Kings,41095,State Senate,22,Dem,Andrew Gournardes,98
+Kings,45006,State Senate,22,Dem,Andrew Gournardes,74
+Kings,45008,State Senate,22,Dem,Andrew Gournardes,114
+Kings,45009,State Senate,22,Dem,Andrew Gournardes,69
+Kings,45015,State Senate,22,Dem,Andrew Gournardes,6
+Kings,45016,State Senate,22,Dem,Andrew Gournardes,81
+Kings,45017,State Senate,22,Dem,Andrew Gournardes,39
+Kings,45019,State Senate,22,Dem,Andrew Gournardes,85
+Kings,45020,State Senate,22,Dem,Andrew Gournardes,33
+Kings,45021,State Senate,22,Dem,Andrew Gournardes,47
+Kings,45022,State Senate,22,Dem,Andrew Gournardes,67
+Kings,45031,State Senate,22,Dem,Andrew Gournardes,52
+Kings,45032,State Senate,22,Dem,Andrew Gournardes,49
+Kings,45033,State Senate,22,Dem,Andrew Gournardes,103
+Kings,45034,State Senate,22,Dem,Andrew Gournardes,155
+Kings,45035,State Senate,22,Dem,Andrew Gournardes,78
+Kings,45036,State Senate,22,Dem,Andrew Gournardes,69
+Kings,45037,State Senate,22,Dem,Andrew Gournardes,95
+Kings,45041,State Senate,22,Dem,Andrew Gournardes,41
+Kings,45049,State Senate,22,Dem,Andrew Gournardes,33
+Kings,45051,State Senate,22,Dem,Andrew Gournardes,100
+Kings,45052,State Senate,22,Dem,Andrew Gournardes,14
+Kings,45068,State Senate,22,Dem,Andrew Gournardes,61
+Kings,45069,State Senate,22,Dem,Andrew Gournardes,85
+Kings,45070,State Senate,22,Dem,Andrew Gournardes,78
+Kings,45072,State Senate,22,Dem,Andrew Gournardes,33
+Kings,45080,State Senate,22,Dem,Andrew Gournardes,72
+Kings,45081,State Senate,22,Dem,Andrew Gournardes,147
+Kings,46048,State Senate,22,Dem,Andrew Gournardes,296
+Kings,46049,State Senate,22,Dem,Andrew Gournardes,372
+Kings,46050,State Senate,22,Dem,Andrew Gournardes,283
+Kings,46051,State Senate,22,Dem,Andrew Gournardes,187
+Kings,46052,State Senate,22,Dem,Andrew Gournardes,211
+Kings,46053,State Senate,22,Dem,Andrew Gournardes,279
+Kings,46054,State Senate,22,Dem,Andrew Gournardes,339
+Kings,46055,State Senate,22,Dem,Andrew Gournardes,305
+Kings,46056,State Senate,22,Dem,Andrew Gournardes,315
+Kings,46057,State Senate,22,Dem,Andrew Gournardes,292
+Kings,46058,State Senate,22,Dem,Andrew Gournardes,286
+Kings,46059,State Senate,22,Dem,Andrew Gournardes,284
+Kings,46060,State Senate,22,Dem,Andrew Gournardes,273
+Kings,46061,State Senate,22,Dem,Andrew Gournardes,335
+Kings,46062,State Senate,22,Dem,Andrew Gournardes,347
+Kings,46063,State Senate,22,Dem,Andrew Gournardes,320
+Kings,46064,State Senate,22,Dem,Andrew Gournardes,308
+Kings,46065,State Senate,22,Dem,Andrew Gournardes,350
+Kings,46066,State Senate,22,Dem,Andrew Gournardes,267
+Kings,46067,State Senate,22,Dem,Andrew Gournardes,165
+Kings,46068,State Senate,22,Dem,Andrew Gournardes,161
+Kings,46069,State Senate,22,Dem,Andrew Gournardes,194
+Kings,46070,State Senate,22,Dem,Andrew Gournardes,137
+Kings,46071,State Senate,22,Dem,Andrew Gournardes,173
+Kings,46072,State Senate,22,Dem,Andrew Gournardes,261
+Kings,46073,State Senate,22,Dem,Andrew Gournardes,181
+Kings,46074,State Senate,22,Dem,Andrew Gournardes,89
+Kings,46075,State Senate,22,Dem,Andrew Gournardes,266
+Kings,46081,State Senate,22,Dem,Andrew Gournardes,179
+Kings,47001,State Senate,22,Dem,Andrew Gournardes,150
+Kings,47002,State Senate,22,Dem,Andrew Gournardes,185
+Kings,47003,State Senate,22,Dem,Andrew Gournardes,189
+Kings,47005,State Senate,22,Dem,Andrew Gournardes,144
+Kings,47006,State Senate,22,Dem,Andrew Gournardes,200
+Kings,47007,State Senate,22,Dem,Andrew Gournardes,141
+Kings,47008,State Senate,22,Dem,Andrew Gournardes,126
+Kings,47009,State Senate,22,Dem,Andrew Gournardes,191
+Kings,47019,State Senate,22,Dem,Andrew Gournardes,66
+Kings,47020,State Senate,22,Dem,Andrew Gournardes,143
+Kings,47021,State Senate,22,Dem,Andrew Gournardes,189
+Kings,47022,State Senate,22,Dem,Andrew Gournardes,163
+Kings,47034,State Senate,22,Dem,Andrew Gournardes,176
+Kings,47038,State Senate,22,Dem,Andrew Gournardes,51
+Kings,47039,State Senate,22,Dem,Andrew Gournardes,50
+Kings,47043,State Senate,22,Dem,Andrew Gournardes,119
+Kings,47044,State Senate,22,Dem,Andrew Gournardes,163
+Kings,47045,State Senate,22,Dem,Andrew Gournardes,121
+Kings,47046,State Senate,22,Dem,Andrew Gournardes,163
+Kings,47047,State Senate,22,Dem,Andrew Gournardes,176
+Kings,47048,State Senate,22,Dem,Andrew Gournardes,112
+Kings,47049,State Senate,22,Dem,Andrew Gournardes,169
+Kings,47050,State Senate,22,Dem,Andrew Gournardes,187
+Kings,47051,State Senate,22,Dem,Andrew Gournardes,149
+Kings,47052,State Senate,22,Dem,Andrew Gournardes,30
+Kings,47055,State Senate,22,Dem,Andrew Gournardes,118
+Kings,47056,State Senate,22,Dem,Andrew Gournardes,153
+Kings,47065,State Senate,22,Dem,Andrew Gournardes,65
+Kings,48034,State Senate,22,Dem,Andrew Gournardes,72
+Kings,48035,State Senate,22,Dem,Andrew Gournardes,22
+Kings,48037,State Senate,22,Dem,Andrew Gournardes,93
+Kings,48046,State Senate,22,Dem,Andrew Gournardes,63
+Kings,48047,State Senate,22,Dem,Andrew Gournardes,150
+Kings,48048,State Senate,22,Dem,Andrew Gournardes,52
+Kings,48050,State Senate,22,Dem,Andrew Gournardes,28
+Kings,48051,State Senate,22,Dem,Andrew Gournardes,54
+Kings,48052,State Senate,22,Dem,Andrew Gournardes,85
+Kings,48059,State Senate,22,Dem,Andrew Gournardes,53
+Kings,49016,State Senate,22,Dem,Andrew Gournardes,51
+Kings,49017,State Senate,22,Dem,Andrew Gournardes,27
+Kings,49018,State Senate,22,Dem,Andrew Gournardes,34
+Kings,49019,State Senate,22,Dem,Andrew Gournardes,197
+Kings,49020,State Senate,22,Dem,Andrew Gournardes,205
+Kings,49021,State Senate,22,Dem,Andrew Gournardes,206
+Kings,49022,State Senate,22,Dem,Andrew Gournardes,177
+Kings,49023,State Senate,22,Dem,Andrew Gournardes,177
+Kings,49024,State Senate,22,Dem,Andrew Gournardes,167
+Kings,49025,State Senate,22,Dem,Andrew Gournardes,210
+Kings,49026,State Senate,22,Dem,Andrew Gournardes,170
+Kings,49027,State Senate,22,Dem,Andrew Gournardes,212
+Kings,49028,State Senate,22,Dem,Andrew Gournardes,105
+Kings,49029,State Senate,22,Dem,Andrew Gournardes,20
+Kings,49035,State Senate,22,Dem,Andrew Gournardes,137
+Kings,49037,State Senate,22,Dem,Andrew Gournardes,202
+Kings,49038,State Senate,22,Dem,Andrew Gournardes,154
+Kings,49039,State Senate,22,Dem,Andrew Gournardes,222
+Kings,49040,State Senate,22,Dem,Andrew Gournardes,211
+Kings,49041,State Senate,22,Dem,Andrew Gournardes,182
+Kings,49045,State Senate,22,Dem,Andrew Gournardes,52
+Kings,49047,State Senate,22,Dem,Andrew Gournardes,202
+Kings,49048,State Senate,22,Dem,Andrew Gournardes,170
+Kings,49049,State Senate,22,Dem,Andrew Gournardes,149
+Kings,49050,State Senate,22,Dem,Andrew Gournardes,239
+Kings,49051,State Senate,22,Dem,Andrew Gournardes,168
+Kings,49052,State Senate,22,Dem,Andrew Gournardes,208
+Kings,49053,State Senate,22,Dem,Andrew Gournardes,184
+Kings,49054,State Senate,22,Dem,Andrew Gournardes,187
+Kings,49056,State Senate,22,Dem,Andrew Gournardes,11
+Kings,49057,State Senate,22,Dem,Andrew Gournardes,24
+Kings,51059,State Senate,22,Dem,Andrew Gournardes,321
+Kings,51061,State Senate,22,Dem,Andrew Gournardes,323
+Kings,51062,State Senate,22,Dem,Andrew Gournardes,279
+Kings,59033,State Senate,22,Dem,Andrew Gournardes,146
+Kings,59034,State Senate,22,Dem,Andrew Gournardes,119
+Kings,59035,State Senate,22,Dem,Andrew Gournardes,181
+Kings,59036,State Senate,22,Dem,Andrew Gournardes,162
+Kings,59037,State Senate,22,Dem,Andrew Gournardes,132
+Kings,59038,State Senate,22,Dem,Andrew Gournardes,177
+Kings,59039,State Senate,22,Dem,Andrew Gournardes,115
+Kings,59040,State Senate,22,Dem,Andrew Gournardes,150
+Kings,59041,State Senate,22,Dem,Andrew Gournardes,52
+Kings,59042,State Senate,22,Dem,Andrew Gournardes,83
+Kings,59043,State Senate,22,Dem,Andrew Gournardes,48
+Kings,59044,State Senate,22,Dem,Andrew Gournardes,104
+Kings,59045,State Senate,22,Dem,Andrew Gournardes,53
+Kings,59046,State Senate,22,Dem,Andrew Gournardes,4
+Kings,59048,State Senate,22,Dem,Andrew Gournardes,29
+Kings,64075,State Senate,22,Dem,Andrew Gournardes,342
+Kings,64076,State Senate,22,Dem,Andrew Gournardes,303
+Kings,64077,State Senate,22,Dem,Andrew Gournardes,300
+Kings,64078,State Senate,22,Dem,Andrew Gournardes,369
+Kings,64079,State Senate,22,Dem,Andrew Gournardes,285
+Kings,64080,State Senate,22,Dem,Andrew Gournardes,270
+Kings,64083,State Senate,22,Dem,Andrew Gournardes,324
+Kings,64084,State Senate,22,Dem,Andrew Gournardes,247
+Kings,64085,State Senate,22,Dem,Andrew Gournardes,260
+Kings,64086,State Senate,22,Dem,Andrew Gournardes,325
+Kings,64087,State Senate,22,Dem,Andrew Gournardes,232
+Kings,64088,State Senate,22,Dem,Andrew Gournardes,283
+Kings,64089,State Senate,22,Dem,Andrew Gournardes,148
+Kings,64090,State Senate,22,Dem,Andrew Gournardes,255
+Kings,64091,State Senate,22,Dem,Andrew Gournardes,76
+Kings,41016,State Senate,22,Rep,Martin Golden,213
+Kings,41017,State Senate,22,Rep,Martin Golden,339
+Kings,41018,State Senate,22,Rep,Martin Golden,198
+Kings,41056,State Senate,22,Rep,Martin Golden,142
+Kings,41081,State Senate,22,Rep,Martin Golden,190
+Kings,41082,State Senate,22,Rep,Martin Golden,252
+Kings,41083,State Senate,22,Rep,Martin Golden,223
+Kings,41086,State Senate,22,Rep,Martin Golden,40
+Kings,41090,State Senate,22,Rep,Martin Golden,13
+Kings,41093,State Senate,22,Rep,Martin Golden,364
+Kings,41094,State Senate,22,Rep,Martin Golden,241
+Kings,41095,State Senate,22,Rep,Martin Golden,240
+Kings,45006,State Senate,22,Rep,Martin Golden,332
+Kings,45008,State Senate,22,Rep,Martin Golden,181
+Kings,45009,State Senate,22,Rep,Martin Golden,294
+Kings,45015,State Senate,22,Rep,Martin Golden,124
+Kings,45016,State Senate,22,Rep,Martin Golden,334
+Kings,45017,State Senate,22,Rep,Martin Golden,233
+Kings,45019,State Senate,22,Rep,Martin Golden,252
+Kings,45020,State Senate,22,Rep,Martin Golden,305
+Kings,45021,State Senate,22,Rep,Martin Golden,299
+Kings,45022,State Senate,22,Rep,Martin Golden,215
+Kings,45031,State Senate,22,Rep,Martin Golden,189
+Kings,45032,State Senate,22,Rep,Martin Golden,180
+Kings,45033,State Senate,22,Rep,Martin Golden,153
+Kings,45034,State Senate,22,Rep,Martin Golden,179
+Kings,45035,State Senate,22,Rep,Martin Golden,149
+Kings,45036,State Senate,22,Rep,Martin Golden,168
+Kings,45037,State Senate,22,Rep,Martin Golden,270
+Kings,45041,State Senate,22,Rep,Martin Golden,77
+Kings,45049,State Senate,22,Rep,Martin Golden,49
+Kings,45051,State Senate,22,Rep,Martin Golden,93
+Kings,45052,State Senate,22,Rep,Martin Golden,29
+Kings,45068,State Senate,22,Rep,Martin Golden,174
+Kings,45069,State Senate,22,Rep,Martin Golden,187
+Kings,45070,State Senate,22,Rep,Martin Golden,193
+Kings,45072,State Senate,22,Rep,Martin Golden,91
+Kings,45080,State Senate,22,Rep,Martin Golden,158
+Kings,45081,State Senate,22,Rep,Martin Golden,169
+Kings,46048,State Senate,22,Rep,Martin Golden,184
+Kings,46049,State Senate,22,Rep,Martin Golden,222
+Kings,46050,State Senate,22,Rep,Martin Golden,301
+Kings,46051,State Senate,22,Rep,Martin Golden,345
+Kings,46052,State Senate,22,Rep,Martin Golden,329
+Kings,46053,State Senate,22,Rep,Martin Golden,236
+Kings,46054,State Senate,22,Rep,Martin Golden,216
+Kings,46055,State Senate,22,Rep,Martin Golden,168
+Kings,46056,State Senate,22,Rep,Martin Golden,190
+Kings,46057,State Senate,22,Rep,Martin Golden,288
+Kings,46058,State Senate,22,Rep,Martin Golden,160
+Kings,46059,State Senate,22,Rep,Martin Golden,174
+Kings,46060,State Senate,22,Rep,Martin Golden,293
+Kings,46061,State Senate,22,Rep,Martin Golden,295
+Kings,46062,State Senate,22,Rep,Martin Golden,285
+Kings,46063,State Senate,22,Rep,Martin Golden,193
+Kings,46064,State Senate,22,Rep,Martin Golden,292
+Kings,46065,State Senate,22,Rep,Martin Golden,267
+Kings,46066,State Senate,22,Rep,Martin Golden,223
+Kings,46067,State Senate,22,Rep,Martin Golden,337
+Kings,46068,State Senate,22,Rep,Martin Golden,302
+Kings,46069,State Senate,22,Rep,Martin Golden,363
+Kings,46070,State Senate,22,Rep,Martin Golden,384
+Kings,46071,State Senate,22,Rep,Martin Golden,355
+Kings,46072,State Senate,22,Rep,Martin Golden,267
+Kings,46073,State Senate,22,Rep,Martin Golden,228
+Kings,46074,State Senate,22,Rep,Martin Golden,115
+Kings,46075,State Senate,22,Rep,Martin Golden,247
+Kings,46081,State Senate,22,Rep,Martin Golden,295
+Kings,47001,State Senate,22,Rep,Martin Golden,227
+Kings,47002,State Senate,22,Rep,Martin Golden,167
+Kings,47003,State Senate,22,Rep,Martin Golden,147
+Kings,47005,State Senate,22,Rep,Martin Golden,172
+Kings,47006,State Senate,22,Rep,Martin Golden,117
+Kings,47007,State Senate,22,Rep,Martin Golden,118
+Kings,47008,State Senate,22,Rep,Martin Golden,155
+Kings,47009,State Senate,22,Rep,Martin Golden,238
+Kings,47019,State Senate,22,Rep,Martin Golden,107
+Kings,47020,State Senate,22,Rep,Martin Golden,163
+Kings,47021,State Senate,22,Rep,Martin Golden,169
+Kings,47022,State Senate,22,Rep,Martin Golden,177
+Kings,47034,State Senate,22,Rep,Martin Golden,174
+Kings,47038,State Senate,22,Rep,Martin Golden,56
+Kings,47039,State Senate,22,Rep,Martin Golden,68
+Kings,47043,State Senate,22,Rep,Martin Golden,153
+Kings,47044,State Senate,22,Rep,Martin Golden,186
+Kings,47045,State Senate,22,Rep,Martin Golden,125
+Kings,47046,State Senate,22,Rep,Martin Golden,186
+Kings,47047,State Senate,22,Rep,Martin Golden,178
+Kings,47048,State Senate,22,Rep,Martin Golden,188
+Kings,47049,State Senate,22,Rep,Martin Golden,264
+Kings,47050,State Senate,22,Rep,Martin Golden,164
+Kings,47051,State Senate,22,Rep,Martin Golden,130
+Kings,47052,State Senate,22,Rep,Martin Golden,24
+Kings,47055,State Senate,22,Rep,Martin Golden,113
+Kings,47056,State Senate,22,Rep,Martin Golden,155
+Kings,47065,State Senate,22,Rep,Martin Golden,109
+Kings,48034,State Senate,22,Rep,Martin Golden,97
+Kings,48035,State Senate,22,Rep,Martin Golden,14
+Kings,48037,State Senate,22,Rep,Martin Golden,106
+Kings,48046,State Senate,22,Rep,Martin Golden,154
+Kings,48047,State Senate,22,Rep,Martin Golden,242
+Kings,48048,State Senate,22,Rep,Martin Golden,296
+Kings,48050,State Senate,22,Rep,Martin Golden,247
+Kings,48051,State Senate,22,Rep,Martin Golden,189
+Kings,48052,State Senate,22,Rep,Martin Golden,243
+Kings,48059,State Senate,22,Rep,Martin Golden,333
+Kings,49016,State Senate,22,Rep,Martin Golden,25
+Kings,49017,State Senate,22,Rep,Martin Golden,38
+Kings,49018,State Senate,22,Rep,Martin Golden,21
+Kings,49019,State Senate,22,Rep,Martin Golden,211
+Kings,49020,State Senate,22,Rep,Martin Golden,203
+Kings,49021,State Senate,22,Rep,Martin Golden,162
+Kings,49022,State Senate,22,Rep,Martin Golden,192
+Kings,49023,State Senate,22,Rep,Martin Golden,150
+Kings,49024,State Senate,22,Rep,Martin Golden,142
+Kings,49025,State Senate,22,Rep,Martin Golden,167
+Kings,49026,State Senate,22,Rep,Martin Golden,135
+Kings,49027,State Senate,22,Rep,Martin Golden,216
+Kings,49028,State Senate,22,Rep,Martin Golden,172
+Kings,49029,State Senate,22,Rep,Martin Golden,43
+Kings,49035,State Senate,22,Rep,Martin Golden,129
+Kings,49037,State Senate,22,Rep,Martin Golden,185
+Kings,49038,State Senate,22,Rep,Martin Golden,169
+Kings,49039,State Senate,22,Rep,Martin Golden,223
+Kings,49040,State Senate,22,Rep,Martin Golden,175
+Kings,49041,State Senate,22,Rep,Martin Golden,172
+Kings,49045,State Senate,22,Rep,Martin Golden,62
+Kings,49047,State Senate,22,Rep,Martin Golden,110
+Kings,49048,State Senate,22,Rep,Martin Golden,243
+Kings,49049,State Senate,22,Rep,Martin Golden,174
+Kings,49050,State Senate,22,Rep,Martin Golden,205
+Kings,49051,State Senate,22,Rep,Martin Golden,174
+Kings,49052,State Senate,22,Rep,Martin Golden,237
+Kings,49053,State Senate,22,Rep,Martin Golden,281
+Kings,49054,State Senate,22,Rep,Martin Golden,354
+Kings,49056,State Senate,22,Rep,Martin Golden,10
+Kings,49057,State Senate,22,Rep,Martin Golden,20
+Kings,51059,State Senate,22,Rep,Martin Golden,167
+Kings,51061,State Senate,22,Rep,Martin Golden,199
+Kings,51062,State Senate,22,Rep,Martin Golden,200
+Kings,59033,State Senate,22,Rep,Martin Golden,261
+Kings,59034,State Senate,22,Rep,Martin Golden,205
+Kings,59035,State Senate,22,Rep,Martin Golden,343
+Kings,59036,State Senate,22,Rep,Martin Golden,270
+Kings,59037,State Senate,22,Rep,Martin Golden,274
+Kings,59038,State Senate,22,Rep,Martin Golden,386
+Kings,59039,State Senate,22,Rep,Martin Golden,219
+Kings,59040,State Senate,22,Rep,Martin Golden,266
+Kings,59041,State Senate,22,Rep,Martin Golden,61
+Kings,59042,State Senate,22,Rep,Martin Golden,234
+Kings,59043,State Senate,22,Rep,Martin Golden,121
+Kings,59044,State Senate,22,Rep,Martin Golden,192
+Kings,59045,State Senate,22,Rep,Martin Golden,137
+Kings,59046,State Senate,22,Rep,Martin Golden,6
+Kings,59048,State Senate,22,Rep,Martin Golden,8
+Kings,64075,State Senate,22,Rep,Martin Golden,235
+Kings,64076,State Senate,22,Rep,Martin Golden,255
+Kings,64077,State Senate,22,Rep,Martin Golden,259
+Kings,64078,State Senate,22,Rep,Martin Golden,252
+Kings,64079,State Senate,22,Rep,Martin Golden,173
+Kings,64080,State Senate,22,Rep,Martin Golden,146
+Kings,64083,State Senate,22,Rep,Martin Golden,187
+Kings,64084,State Senate,22,Rep,Martin Golden,216
+Kings,64085,State Senate,22,Rep,Martin Golden,217
+Kings,64086,State Senate,22,Rep,Martin Golden,173
+Kings,64087,State Senate,22,Rep,Martin Golden,167
+Kings,64088,State Senate,22,Rep,Martin Golden,210
+Kings,64089,State Senate,22,Rep,Martin Golden,339
+Kings,64090,State Senate,22,Rep,Martin Golden,265
+Kings,64091,State Senate,22,Rep,Martin Golden,174
+Kings,41016,State Senate,22,Con,Martin Golden,23
+Kings,41017,State Senate,22,Con,Martin Golden,52
+Kings,41018,State Senate,22,Con,Martin Golden,13
+Kings,41056,State Senate,22,Con,Martin Golden,18
+Kings,41081,State Senate,22,Con,Martin Golden,14
+Kings,41082,State Senate,22,Con,Martin Golden,23
+Kings,41083,State Senate,22,Con,Martin Golden,11
+Kings,41086,State Senate,22,Con,Martin Golden,2
+Kings,41090,State Senate,22,Con,Martin Golden,1
+Kings,41093,State Senate,22,Con,Martin Golden,37
+Kings,41094,State Senate,22,Con,Martin Golden,36
+Kings,41095,State Senate,22,Con,Martin Golden,27
+Kings,45006,State Senate,22,Con,Martin Golden,53
+Kings,45008,State Senate,22,Con,Martin Golden,28
+Kings,45009,State Senate,22,Con,Martin Golden,28
+Kings,45015,State Senate,22,Con,Martin Golden,10
+Kings,45016,State Senate,22,Con,Martin Golden,49
+Kings,45017,State Senate,22,Con,Martin Golden,12
+Kings,45019,State Senate,22,Con,Martin Golden,23
+Kings,45020,State Senate,22,Con,Martin Golden,12
+Kings,45021,State Senate,22,Con,Martin Golden,17
+Kings,45022,State Senate,22,Con,Martin Golden,22
+Kings,45031,State Senate,22,Con,Martin Golden,10
+Kings,45032,State Senate,22,Con,Martin Golden,16
+Kings,45033,State Senate,22,Con,Martin Golden,15
+Kings,45034,State Senate,22,Con,Martin Golden,20
+Kings,45035,State Senate,22,Con,Martin Golden,13
+Kings,45036,State Senate,22,Con,Martin Golden,13
+Kings,45037,State Senate,22,Con,Martin Golden,12
+Kings,45041,State Senate,22,Con,Martin Golden,10
+Kings,45049,State Senate,22,Con,Martin Golden,4
+Kings,45051,State Senate,22,Con,Martin Golden,11
+Kings,45052,State Senate,22,Con,Martin Golden,3
+Kings,45068,State Senate,22,Con,Martin Golden,16
+Kings,45069,State Senate,22,Con,Martin Golden,13
+Kings,45070,State Senate,22,Con,Martin Golden,10
+Kings,45072,State Senate,22,Con,Martin Golden,1
+Kings,45080,State Senate,22,Con,Martin Golden,6
+Kings,45081,State Senate,22,Con,Martin Golden,14
+Kings,46048,State Senate,22,Con,Martin Golden,23
+Kings,46049,State Senate,22,Con,Martin Golden,44
+Kings,46050,State Senate,22,Con,Martin Golden,49
+Kings,46051,State Senate,22,Con,Martin Golden,45
+Kings,46052,State Senate,22,Con,Martin Golden,42
+Kings,46053,State Senate,22,Con,Martin Golden,34
+Kings,46054,State Senate,22,Con,Martin Golden,37
+Kings,46055,State Senate,22,Con,Martin Golden,31
+Kings,46056,State Senate,22,Con,Martin Golden,31
+Kings,46057,State Senate,22,Con,Martin Golden,33
+Kings,46058,State Senate,22,Con,Martin Golden,27
+Kings,46059,State Senate,22,Con,Martin Golden,37
+Kings,46060,State Senate,22,Con,Martin Golden,44
+Kings,46061,State Senate,22,Con,Martin Golden,45
+Kings,46062,State Senate,22,Con,Martin Golden,36
+Kings,46063,State Senate,22,Con,Martin Golden,21
+Kings,46064,State Senate,22,Con,Martin Golden,46
+Kings,46065,State Senate,22,Con,Martin Golden,52
+Kings,46066,State Senate,22,Con,Martin Golden,28
+Kings,46067,State Senate,22,Con,Martin Golden,46
+Kings,46068,State Senate,22,Con,Martin Golden,51
+Kings,46069,State Senate,22,Con,Martin Golden,57
+Kings,46070,State Senate,22,Con,Martin Golden,50
+Kings,46071,State Senate,22,Con,Martin Golden,39
+Kings,46072,State Senate,22,Con,Martin Golden,36
+Kings,46073,State Senate,22,Con,Martin Golden,32
+Kings,46074,State Senate,22,Con,Martin Golden,14
+Kings,46075,State Senate,22,Con,Martin Golden,31
+Kings,46081,State Senate,22,Con,Martin Golden,33
+Kings,47001,State Senate,22,Con,Martin Golden,24
+Kings,47002,State Senate,22,Con,Martin Golden,20
+Kings,47003,State Senate,22,Con,Martin Golden,20
+Kings,47005,State Senate,22,Con,Martin Golden,19
+Kings,47006,State Senate,22,Con,Martin Golden,10
+Kings,47007,State Senate,22,Con,Martin Golden,17
+Kings,47008,State Senate,22,Con,Martin Golden,11
+Kings,47009,State Senate,22,Con,Martin Golden,25
+Kings,47019,State Senate,22,Con,Martin Golden,6
+Kings,47020,State Senate,22,Con,Martin Golden,23
+Kings,47021,State Senate,22,Con,Martin Golden,10
+Kings,47022,State Senate,22,Con,Martin Golden,20
+Kings,47034,State Senate,22,Con,Martin Golden,21
+Kings,47038,State Senate,22,Con,Martin Golden,3
+Kings,47039,State Senate,22,Con,Martin Golden,11
+Kings,47043,State Senate,22,Con,Martin Golden,11
+Kings,47044,State Senate,22,Con,Martin Golden,13
+Kings,47045,State Senate,22,Con,Martin Golden,8
+Kings,47046,State Senate,22,Con,Martin Golden,21
+Kings,47047,State Senate,22,Con,Martin Golden,17
+Kings,47048,State Senate,22,Con,Martin Golden,12
+Kings,47049,State Senate,22,Con,Martin Golden,28
+Kings,47050,State Senate,22,Con,Martin Golden,9
+Kings,47051,State Senate,22,Con,Martin Golden,13
+Kings,47052,State Senate,22,Con,Martin Golden,3
+Kings,47055,State Senate,22,Con,Martin Golden,20
+Kings,47056,State Senate,22,Con,Martin Golden,15
+Kings,47065,State Senate,22,Con,Martin Golden,10
+Kings,48034,State Senate,22,Con,Martin Golden,12
+Kings,48035,State Senate,22,Con,Martin Golden,2
+Kings,48037,State Senate,22,Con,Martin Golden,17
+Kings,48046,State Senate,22,Con,Martin Golden,19
+Kings,48047,State Senate,22,Con,Martin Golden,37
+Kings,48048,State Senate,22,Con,Martin Golden,35
+Kings,48050,State Senate,22,Con,Martin Golden,33
+Kings,48051,State Senate,22,Con,Martin Golden,19
+Kings,48052,State Senate,22,Con,Martin Golden,20
+Kings,48059,State Senate,22,Con,Martin Golden,43
+Kings,49016,State Senate,22,Con,Martin Golden,6
+Kings,49017,State Senate,22,Con,Martin Golden,2
+Kings,49018,State Senate,22,Con,Martin Golden,7
+Kings,49019,State Senate,22,Con,Martin Golden,22
+Kings,49020,State Senate,22,Con,Martin Golden,24
+Kings,49021,State Senate,22,Con,Martin Golden,22
+Kings,49022,State Senate,22,Con,Martin Golden,31
+Kings,49023,State Senate,22,Con,Martin Golden,14
+Kings,49024,State Senate,22,Con,Martin Golden,26
+Kings,49025,State Senate,22,Con,Martin Golden,16
+Kings,49026,State Senate,22,Con,Martin Golden,14
+Kings,49027,State Senate,22,Con,Martin Golden,21
+Kings,49028,State Senate,22,Con,Martin Golden,25
+Kings,49029,State Senate,22,Con,Martin Golden,8
+Kings,49035,State Senate,22,Con,Martin Golden,9
+Kings,49037,State Senate,22,Con,Martin Golden,32
+Kings,49038,State Senate,22,Con,Martin Golden,23
+Kings,49039,State Senate,22,Con,Martin Golden,22
+Kings,49040,State Senate,22,Con,Martin Golden,24
+Kings,49041,State Senate,22,Con,Martin Golden,14
+Kings,49045,State Senate,22,Con,Martin Golden,7
+Kings,49047,State Senate,22,Con,Martin Golden,21
+Kings,49048,State Senate,22,Con,Martin Golden,29
+Kings,49049,State Senate,22,Con,Martin Golden,22
+Kings,49050,State Senate,22,Con,Martin Golden,27
+Kings,49051,State Senate,22,Con,Martin Golden,27
+Kings,49052,State Senate,22,Con,Martin Golden,29
+Kings,49053,State Senate,22,Con,Martin Golden,44
+Kings,49054,State Senate,22,Con,Martin Golden,47
+Kings,49056,State Senate,22,Con,Martin Golden,2
+Kings,49057,State Senate,22,Con,Martin Golden,2
+Kings,51059,State Senate,22,Con,Martin Golden,34
+Kings,51061,State Senate,22,Con,Martin Golden,28
+Kings,51062,State Senate,22,Con,Martin Golden,27
+Kings,59033,State Senate,22,Con,Martin Golden,32
+Kings,59034,State Senate,22,Con,Martin Golden,34
+Kings,59035,State Senate,22,Con,Martin Golden,50
+Kings,59036,State Senate,22,Con,Martin Golden,42
+Kings,59037,State Senate,22,Con,Martin Golden,36
+Kings,59038,State Senate,22,Con,Martin Golden,52
+Kings,59039,State Senate,22,Con,Martin Golden,46
+Kings,59040,State Senate,22,Con,Martin Golden,40
+Kings,59041,State Senate,22,Con,Martin Golden,12
+Kings,59042,State Senate,22,Con,Martin Golden,49
+Kings,59043,State Senate,22,Con,Martin Golden,23
+Kings,59044,State Senate,22,Con,Martin Golden,32
+Kings,59045,State Senate,22,Con,Martin Golden,21
+Kings,59046,State Senate,22,Con,Martin Golden,1
+Kings,59048,State Senate,22,Con,Martin Golden,1
+Kings,64075,State Senate,22,Con,Martin Golden,53
+Kings,64076,State Senate,22,Con,Martin Golden,31
+Kings,64077,State Senate,22,Con,Martin Golden,40
+Kings,64078,State Senate,22,Con,Martin Golden,37
+Kings,64079,State Senate,22,Con,Martin Golden,28
+Kings,64080,State Senate,22,Con,Martin Golden,28
+Kings,64083,State Senate,22,Con,Martin Golden,36
+Kings,64084,State Senate,22,Con,Martin Golden,53
+Kings,64085,State Senate,22,Con,Martin Golden,43
+Kings,64086,State Senate,22,Con,Martin Golden,25
+Kings,64087,State Senate,22,Con,Martin Golden,32
+Kings,64088,State Senate,22,Con,Martin Golden,35
+Kings,64089,State Senate,22,Con,Martin Golden,52
+Kings,64090,State Senate,22,Con,Martin Golden,35
+Kings,64091,State Senate,22,Con,Martin Golden,26
+Kings,41016,State Senate,22,Ind,Martin Golden,11
+Kings,41017,State Senate,22,Ind,Martin Golden,14
+Kings,41018,State Senate,22,Ind,Martin Golden,8
+Kings,41056,State Senate,22,Ind,Martin Golden,6
+Kings,41081,State Senate,22,Ind,Martin Golden,7
+Kings,41082,State Senate,22,Ind,Martin Golden,11
+Kings,41083,State Senate,22,Ind,Martin Golden,6
+Kings,41086,State Senate,22,Ind,Martin Golden,3
+Kings,41090,State Senate,22,Ind,Martin Golden,1
+Kings,41093,State Senate,22,Ind,Martin Golden,19
+Kings,41094,State Senate,22,Ind,Martin Golden,15
+Kings,41095,State Senate,22,Ind,Martin Golden,13
+Kings,45006,State Senate,22,Ind,Martin Golden,4
+Kings,45008,State Senate,22,Ind,Martin Golden,11
+Kings,45009,State Senate,22,Ind,Martin Golden,2
+Kings,45015,State Senate,22,Ind,Martin Golden,0
+Kings,45016,State Senate,22,Ind,Martin Golden,9
+Kings,45017,State Senate,22,Ind,Martin Golden,8
+Kings,45019,State Senate,22,Ind,Martin Golden,6
+Kings,45020,State Senate,22,Ind,Martin Golden,3
+Kings,45021,State Senate,22,Ind,Martin Golden,10
+Kings,45022,State Senate,22,Ind,Martin Golden,6
+Kings,45031,State Senate,22,Ind,Martin Golden,5
+Kings,45032,State Senate,22,Ind,Martin Golden,7
+Kings,45033,State Senate,22,Ind,Martin Golden,5
+Kings,45034,State Senate,22,Ind,Martin Golden,9
+Kings,45035,State Senate,22,Ind,Martin Golden,5
+Kings,45036,State Senate,22,Ind,Martin Golden,8
+Kings,45037,State Senate,22,Ind,Martin Golden,5
+Kings,45041,State Senate,22,Ind,Martin Golden,1
+Kings,45049,State Senate,22,Ind,Martin Golden,3
+Kings,45051,State Senate,22,Ind,Martin Golden,10
+Kings,45052,State Senate,22,Ind,Martin Golden,0
+Kings,45068,State Senate,22,Ind,Martin Golden,8
+Kings,45069,State Senate,22,Ind,Martin Golden,4
+Kings,45070,State Senate,22,Ind,Martin Golden,7
+Kings,45072,State Senate,22,Ind,Martin Golden,4
+Kings,45080,State Senate,22,Ind,Martin Golden,5
+Kings,45081,State Senate,22,Ind,Martin Golden,11
+Kings,46048,State Senate,22,Ind,Martin Golden,13
+Kings,46049,State Senate,22,Ind,Martin Golden,15
+Kings,46050,State Senate,22,Ind,Martin Golden,12
+Kings,46051,State Senate,22,Ind,Martin Golden,8
+Kings,46052,State Senate,22,Ind,Martin Golden,75
+Kings,46053,State Senate,22,Ind,Martin Golden,14
+Kings,46054,State Senate,22,Ind,Martin Golden,13
+Kings,46055,State Senate,22,Ind,Martin Golden,7
+Kings,46056,State Senate,22,Ind,Martin Golden,14
+Kings,46057,State Senate,22,Ind,Martin Golden,13
+Kings,46058,State Senate,22,Ind,Martin Golden,11
+Kings,46059,State Senate,22,Ind,Martin Golden,10
+Kings,46060,State Senate,22,Ind,Martin Golden,16
+Kings,46061,State Senate,22,Ind,Martin Golden,13
+Kings,46062,State Senate,22,Ind,Martin Golden,15
+Kings,46063,State Senate,22,Ind,Martin Golden,11
+Kings,46064,State Senate,22,Ind,Martin Golden,20
+Kings,46065,State Senate,22,Ind,Martin Golden,11
+Kings,46066,State Senate,22,Ind,Martin Golden,21
+Kings,46067,State Senate,22,Ind,Martin Golden,13
+Kings,46068,State Senate,22,Ind,Martin Golden,12
+Kings,46069,State Senate,22,Ind,Martin Golden,12
+Kings,46070,State Senate,22,Ind,Martin Golden,9
+Kings,46071,State Senate,22,Ind,Martin Golden,8
+Kings,46072,State Senate,22,Ind,Martin Golden,12
+Kings,46073,State Senate,22,Ind,Martin Golden,10
+Kings,46074,State Senate,22,Ind,Martin Golden,3
+Kings,46075,State Senate,22,Ind,Martin Golden,11
+Kings,46081,State Senate,22,Ind,Martin Golden,10
+Kings,47001,State Senate,22,Ind,Martin Golden,10
+Kings,47002,State Senate,22,Ind,Martin Golden,14
+Kings,47003,State Senate,22,Ind,Martin Golden,22
+Kings,47005,State Senate,22,Ind,Martin Golden,9
+Kings,47006,State Senate,22,Ind,Martin Golden,14
+Kings,47007,State Senate,22,Ind,Martin Golden,5
+Kings,47008,State Senate,22,Ind,Martin Golden,12
+Kings,47009,State Senate,22,Ind,Martin Golden,6
+Kings,47019,State Senate,22,Ind,Martin Golden,7
+Kings,47020,State Senate,22,Ind,Martin Golden,7
+Kings,47021,State Senate,22,Ind,Martin Golden,10
+Kings,47022,State Senate,22,Ind,Martin Golden,6
+Kings,47034,State Senate,22,Ind,Martin Golden,10
+Kings,47038,State Senate,22,Ind,Martin Golden,3
+Kings,47039,State Senate,22,Ind,Martin Golden,2
+Kings,47043,State Senate,22,Ind,Martin Golden,7
+Kings,47044,State Senate,22,Ind,Martin Golden,10
+Kings,47045,State Senate,22,Ind,Martin Golden,5
+Kings,47046,State Senate,22,Ind,Martin Golden,8
+Kings,47047,State Senate,22,Ind,Martin Golden,11
+Kings,47048,State Senate,22,Ind,Martin Golden,3
+Kings,47049,State Senate,22,Ind,Martin Golden,10
+Kings,47050,State Senate,22,Ind,Martin Golden,11
+Kings,47051,State Senate,22,Ind,Martin Golden,6
+Kings,47052,State Senate,22,Ind,Martin Golden,1
+Kings,47055,State Senate,22,Ind,Martin Golden,4
+Kings,47056,State Senate,22,Ind,Martin Golden,13
+Kings,47065,State Senate,22,Ind,Martin Golden,3
+Kings,48034,State Senate,22,Ind,Martin Golden,5
+Kings,48035,State Senate,22,Ind,Martin Golden,2
+Kings,48037,State Senate,22,Ind,Martin Golden,3
+Kings,48046,State Senate,22,Ind,Martin Golden,6
+Kings,48047,State Senate,22,Ind,Martin Golden,5
+Kings,48048,State Senate,22,Ind,Martin Golden,4
+Kings,48050,State Senate,22,Ind,Martin Golden,13
+Kings,48051,State Senate,22,Ind,Martin Golden,6
+Kings,48052,State Senate,22,Ind,Martin Golden,5
+Kings,48059,State Senate,22,Ind,Martin Golden,6
+Kings,49016,State Senate,22,Ind,Martin Golden,4
+Kings,49017,State Senate,22,Ind,Martin Golden,1
+Kings,49018,State Senate,22,Ind,Martin Golden,3
+Kings,49019,State Senate,22,Ind,Martin Golden,7
+Kings,49020,State Senate,22,Ind,Martin Golden,10
+Kings,49021,State Senate,22,Ind,Martin Golden,7
+Kings,49022,State Senate,22,Ind,Martin Golden,5
+Kings,49023,State Senate,22,Ind,Martin Golden,8
+Kings,49024,State Senate,22,Ind,Martin Golden,5
+Kings,49025,State Senate,22,Ind,Martin Golden,9
+Kings,49026,State Senate,22,Ind,Martin Golden,11
+Kings,49027,State Senate,22,Ind,Martin Golden,8
+Kings,49028,State Senate,22,Ind,Martin Golden,4
+Kings,49029,State Senate,22,Ind,Martin Golden,3
+Kings,49035,State Senate,22,Ind,Martin Golden,12
+Kings,49037,State Senate,22,Ind,Martin Golden,7
+Kings,49038,State Senate,22,Ind,Martin Golden,13
+Kings,49039,State Senate,22,Ind,Martin Golden,15
+Kings,49040,State Senate,22,Ind,Martin Golden,11
+Kings,49041,State Senate,22,Ind,Martin Golden,10
+Kings,49045,State Senate,22,Ind,Martin Golden,2
+Kings,49047,State Senate,22,Ind,Martin Golden,5
+Kings,49048,State Senate,22,Ind,Martin Golden,10
+Kings,49049,State Senate,22,Ind,Martin Golden,13
+Kings,49050,State Senate,22,Ind,Martin Golden,9
+Kings,49051,State Senate,22,Ind,Martin Golden,10
+Kings,49052,State Senate,22,Ind,Martin Golden,13
+Kings,49053,State Senate,22,Ind,Martin Golden,10
+Kings,49054,State Senate,22,Ind,Martin Golden,14
+Kings,49056,State Senate,22,Ind,Martin Golden,1
+Kings,49057,State Senate,22,Ind,Martin Golden,4
+Kings,51059,State Senate,22,Ind,Martin Golden,11
+Kings,51061,State Senate,22,Ind,Martin Golden,21
+Kings,51062,State Senate,22,Ind,Martin Golden,9
+Kings,59033,State Senate,22,Ind,Martin Golden,19
+Kings,59034,State Senate,22,Ind,Martin Golden,7
+Kings,59035,State Senate,22,Ind,Martin Golden,17
+Kings,59036,State Senate,22,Ind,Martin Golden,19
+Kings,59037,State Senate,22,Ind,Martin Golden,15
+Kings,59038,State Senate,22,Ind,Martin Golden,14
+Kings,59039,State Senate,22,Ind,Martin Golden,11
+Kings,59040,State Senate,22,Ind,Martin Golden,11
+Kings,59041,State Senate,22,Ind,Martin Golden,6
+Kings,59042,State Senate,22,Ind,Martin Golden,16
+Kings,59043,State Senate,22,Ind,Martin Golden,14
+Kings,59044,State Senate,22,Ind,Martin Golden,8
+Kings,59045,State Senate,22,Ind,Martin Golden,10
+Kings,59046,State Senate,22,Ind,Martin Golden,2
+Kings,59048,State Senate,22,Ind,Martin Golden,2
+Kings,64075,State Senate,22,Ind,Martin Golden,18
+Kings,64076,State Senate,22,Ind,Martin Golden,22
+Kings,64077,State Senate,22,Ind,Martin Golden,19
+Kings,64078,State Senate,22,Ind,Martin Golden,19
+Kings,64079,State Senate,22,Ind,Martin Golden,8
+Kings,64080,State Senate,22,Ind,Martin Golden,18
+Kings,64083,State Senate,22,Ind,Martin Golden,17
+Kings,64084,State Senate,22,Ind,Martin Golden,12
+Kings,64085,State Senate,22,Ind,Martin Golden,16
+Kings,64086,State Senate,22,Ind,Martin Golden,9
+Kings,64087,State Senate,22,Ind,Martin Golden,4
+Kings,64088,State Senate,22,Ind,Martin Golden,15
+Kings,64089,State Senate,22,Ind,Martin Golden,13
+Kings,64090,State Senate,22,Ind,Martin Golden,11
+Kings,64091,State Senate,22,Ind,Martin Golden,14
+Kings,41016,State Senate,22,Ind,writein,1
+Kings,41017,State Senate,22,Ind,writein,3
+Kings,41018,State Senate,22,Ind,writein,0
+Kings,41056,State Senate,22,Ind,writein,0
+Kings,41081,State Senate,22,Ind,writein,0
+Kings,41082,State Senate,22,Ind,writein,1
+Kings,41083,State Senate,22,Ind,writein,0
+Kings,41086,State Senate,22,Ind,writein,0
+Kings,41090,State Senate,22,Ind,writein,0
+Kings,41093,State Senate,22,Ind,writein,0
+Kings,41094,State Senate,22,Ind,writein,0
+Kings,41095,State Senate,22,Ind,writein,1
+Kings,45006,State Senate,22,Ind,writein,1
+Kings,45008,State Senate,22,Ind,writein,0
+Kings,45009,State Senate,22,Ind,writein,1
+Kings,45015,State Senate,22,Ind,writein,0
+Kings,45016,State Senate,22,Ind,writein,0
+Kings,45017,State Senate,22,Ind,writein,0
+Kings,45019,State Senate,22,Ind,writein,2
+Kings,45020,State Senate,22,Ind,writein,0
+Kings,45021,State Senate,22,Ind,writein,0
+Kings,45022,State Senate,22,Ind,writein,0
+Kings,45031,State Senate,22,Ind,writein,0
+Kings,45032,State Senate,22,Ind,writein,0
+Kings,45033,State Senate,22,Ind,writein,0
+Kings,45034,State Senate,22,Ind,writein,0
+Kings,45035,State Senate,22,Ind,writein,0
+Kings,45036,State Senate,22,Ind,writein,0
+Kings,45037,State Senate,22,Ind,writein,2
+Kings,45041,State Senate,22,Ind,writein,0
+Kings,45049,State Senate,22,Ind,writein,0
+Kings,45051,State Senate,22,Ind,writein,0
+Kings,45052,State Senate,22,Ind,writein,0
+Kings,45068,State Senate,22,Ind,writein,0
+Kings,45069,State Senate,22,Ind,writein,2
+Kings,45070,State Senate,22,Ind,writein,0
+Kings,45072,State Senate,22,Ind,writein,0
+Kings,45080,State Senate,22,Ind,writein,1
+Kings,45081,State Senate,22,Ind,writein,2
+Kings,46048,State Senate,22,Ind,writein,2
+Kings,46049,State Senate,22,Ind,writein,0
+Kings,46050,State Senate,22,Ind,writein,0
+Kings,46051,State Senate,22,Ind,writein,0
+Kings,46052,State Senate,22,Ind,writein,0
+Kings,46053,State Senate,22,Ind,writein,0
+Kings,46054,State Senate,22,Ind,writein,0
+Kings,46055,State Senate,22,Ind,writein,0
+Kings,46056,State Senate,22,Ind,writein,0
+Kings,46057,State Senate,22,Ind,writein,0
+Kings,46058,State Senate,22,Ind,writein,1
+Kings,46059,State Senate,22,Ind,writein,1
+Kings,46060,State Senate,22,Ind,writein,0
+Kings,46061,State Senate,22,Ind,writein,1
+Kings,46062,State Senate,22,Ind,writein,1
+Kings,46063,State Senate,22,Ind,writein,0
+Kings,46064,State Senate,22,Ind,writein,0
+Kings,46065,State Senate,22,Ind,writein,0
+Kings,46066,State Senate,22,Ind,writein,0
+Kings,46067,State Senate,22,Ind,writein,0
+Kings,46068,State Senate,22,Ind,writein,0
+Kings,46069,State Senate,22,Ind,writein,0
+Kings,46070,State Senate,22,Ind,writein,1
+Kings,46071,State Senate,22,Ind,writein,0
+Kings,46072,State Senate,22,Ind,writein,0
+Kings,46073,State Senate,22,Ind,writein,3
+Kings,46074,State Senate,22,Ind,writein,0
+Kings,46075,State Senate,22,Ind,writein,0
+Kings,46081,State Senate,22,Ind,writein,0
+Kings,47001,State Senate,22,Ind,writein,0
+Kings,47002,State Senate,22,Ind,writein,0
+Kings,47003,State Senate,22,Ind,writein,1
+Kings,47005,State Senate,22,Ind,writein,0
+Kings,47006,State Senate,22,Ind,writein,0
+Kings,47007,State Senate,22,Ind,writein,0
+Kings,47008,State Senate,22,Ind,writein,0
+Kings,47009,State Senate,22,Ind,writein,0
+Kings,47019,State Senate,22,Ind,writein,2
+Kings,47020,State Senate,22,Ind,writein,0
+Kings,47021,State Senate,22,Ind,writein,0
+Kings,47022,State Senate,22,Ind,writein,0
+Kings,47034,State Senate,22,Ind,writein,1
+Kings,47038,State Senate,22,Ind,writein,0
+Kings,47039,State Senate,22,Ind,writein,0
+Kings,47043,State Senate,22,Ind,writein,0
+Kings,47044,State Senate,22,Ind,writein,0
+Kings,47045,State Senate,22,Ind,writein,1
+Kings,47046,State Senate,22,Ind,writein,0
+Kings,47047,State Senate,22,Ind,writein,1
+Kings,47048,State Senate,22,Ind,writein,1
+Kings,47049,State Senate,22,Ind,writein,0
+Kings,47050,State Senate,22,Ind,writein,0
+Kings,47051,State Senate,22,Ind,writein,0
+Kings,47052,State Senate,22,Ind,writein,0
+Kings,47055,State Senate,22,Ind,writein,0
+Kings,47056,State Senate,22,Ind,writein,0
+Kings,47065,State Senate,22,Ind,writein,0
+Kings,48034,State Senate,22,Ind,writein,1
+Kings,48035,State Senate,22,Ind,writein,0
+Kings,48037,State Senate,22,Ind,writein,1
+Kings,48046,State Senate,22,Ind,writein,0
+Kings,48047,State Senate,22,Ind,writein,0
+Kings,48048,State Senate,22,Ind,writein,1
+Kings,48050,State Senate,22,Ind,writein,0
+Kings,48051,State Senate,22,Ind,writein,1
+Kings,48052,State Senate,22,Ind,writein,2
+Kings,48059,State Senate,22,Ind,writein,0
+Kings,49016,State Senate,22,Ind,writein,0
+Kings,49017,State Senate,22,Ind,writein,0
+Kings,49018,State Senate,22,Ind,writein,0
+Kings,49019,State Senate,22,Ind,writein,0
+Kings,49020,State Senate,22,Ind,writein,0
+Kings,49021,State Senate,22,Ind,writein,0
+Kings,49022,State Senate,22,Ind,writein,0
+Kings,49023,State Senate,22,Ind,writein,0
+Kings,49024,State Senate,22,Ind,writein,0
+Kings,49025,State Senate,22,Ind,writein,0
+Kings,49026,State Senate,22,Ind,writein,0
+Kings,49027,State Senate,22,Ind,writein,0
+Kings,49028,State Senate,22,Ind,writein,0
+Kings,49029,State Senate,22,Ind,writein,2
+Kings,49035,State Senate,22,Ind,writein,0
+Kings,49037,State Senate,22,Ind,writein,0
+Kings,49038,State Senate,22,Ind,writein,0
+Kings,49039,State Senate,22,Ind,writein,0
+Kings,49040,State Senate,22,Ind,writein,0
+Kings,49041,State Senate,22,Ind,writein,0
+Kings,49045,State Senate,22,Ind,writein,0
+Kings,49047,State Senate,22,Ind,writein,0
+Kings,49048,State Senate,22,Ind,writein,0
+Kings,49049,State Senate,22,Ind,writein,0
+Kings,49050,State Senate,22,Ind,writein,0
+Kings,49051,State Senate,22,Ind,writein,0
+Kings,49052,State Senate,22,Ind,writein,0
+Kings,49053,State Senate,22,Ind,writein,0
+Kings,49054,State Senate,22,Ind,writein,0
+Kings,49056,State Senate,22,Ind,writein,0
+Kings,49057,State Senate,22,Ind,writein,0
+Kings,51059,State Senate,22,Ind,writein,0
+Kings,51061,State Senate,22,Ind,writein,0
+Kings,51062,State Senate,22,Ind,writein,1
+Kings,59033,State Senate,22,Ind,writein,1
+Kings,59034,State Senate,22,Ind,writein,1
+Kings,59035,State Senate,22,Ind,writein,0
+Kings,59036,State Senate,22,Ind,writein,0
+Kings,59037,State Senate,22,Ind,writein,0
+Kings,59038,State Senate,22,Ind,writein,0
+Kings,59039,State Senate,22,Ind,writein,0
+Kings,59040,State Senate,22,Ind,writein,0
+Kings,59041,State Senate,22,Ind,writein,0
+Kings,59042,State Senate,22,Ind,writein,0
+Kings,59043,State Senate,22,Ind,writein,0
+Kings,59044,State Senate,22,Ind,writein,0
+Kings,59045,State Senate,22,Ind,writein,0
+Kings,59046,State Senate,22,Ind,writein,0
+Kings,59048,State Senate,22,Ind,writein,0
+Kings,64075,State Senate,22,Ind,writein,0
+Kings,64076,State Senate,22,Ind,writein,2
+Kings,64077,State Senate,22,Ind,writein,0
+Kings,64078,State Senate,22,Ind,writein,0
+Kings,64079,State Senate,22,Ind,writein,0
+Kings,64080,State Senate,22,Ind,writein,0
+Kings,64083,State Senate,22,Ind,writein,0
+Kings,64084,State Senate,22,Ind,writein,0
+Kings,64085,State Senate,22,Ind,writein,0
+Kings,64086,State Senate,22,Ind,writein,0
+Kings,64087,State Senate,22,Ind,writein,3
+Kings,64088,State Senate,22,Ind,writein,0
+Kings,64089,State Senate,22,Ind,writein,1
+Kings,64090,State Senate,22,Ind,writein,0
+Kings,64091,State Senate,22,Ind,writein,0
+Kings,41085,State Senate,23,Dem,Diane Savino,171
+Kings,41087,State Senate,23,Dem,Diane Savino,134
+Kings,41088,State Senate,23,Dem,Diane Savino,92
+Kings,41089,State Senate,23,Dem,Diane Savino,126
+Kings,41092,State Senate,23,Dem,Diane Savino,82
+Kings,45040,State Senate,23,Dem,Diane Savino,180
+Kings,45042,State Senate,23,Dem,Diane Savino,157
+Kings,45043,State Senate,23,Dem,Diane Savino,210
+Kings,45044,State Senate,23,Dem,Diane Savino,70
+Kings,45045,State Senate,23,Dem,Diane Savino,354
+Kings,45046,State Senate,23,Dem,Diane Savino,457
+Kings,45047,State Senate,23,Dem,Diane Savino,29
+Kings,45048,State Senate,23,Dem,Diane Savino,264
+Kings,45050,State Senate,23,Dem,Diane Savino,190
+Kings,45053,State Senate,23,Dem,Diane Savino,90
+Kings,45054,State Senate,23,Dem,Diane Savino,77
+Kings,45057,State Senate,23,Dem,Diane Savino,14
+Kings,45058,State Senate,23,Dem,Diane Savino,64
+Kings,45059,State Senate,23,Dem,Diane Savino,139
+Kings,45060,State Senate,23,Dem,Diane Savino,129
+Kings,45061,State Senate,23,Dem,Diane Savino,77
+Kings,45062,State Senate,23,Dem,Diane Savino,186
+Kings,45063,State Senate,23,Dem,Diane Savino,97
+Kings,45064,State Senate,23,Dem,Diane Savino,121
+Kings,45065,State Senate,23,Dem,Diane Savino,83
+Kings,45066,State Senate,23,Dem,Diane Savino,120
+Kings,45074,State Senate,23,Dem,Diane Savino,80
+Kings,45075,State Senate,23,Dem,Diane Savino,138
+Kings,45076,State Senate,23,Dem,Diane Savino,19
+Kings,45077,State Senate,23,Dem,Diane Savino,110
+Kings,45078,State Senate,23,Dem,Diane Savino,92
+Kings,46001,State Senate,23,Dem,Diane Savino,64
+Kings,46002,State Senate,23,Dem,Diane Savino,149
+Kings,46003,State Senate,23,Dem,Diane Savino,40
+Kings,46004,State Senate,23,Dem,Diane Savino,353
+Kings,46005,State Senate,23,Dem,Diane Savino,386
+Kings,46006,State Senate,23,Dem,Diane Savino,291
+Kings,46007,State Senate,23,Dem,Diane Savino,251
+Kings,46008,State Senate,23,Dem,Diane Savino,185
+Kings,46009,State Senate,23,Dem,Diane Savino,435
+Kings,46010,State Senate,23,Dem,Diane Savino,202
+Kings,46011,State Senate,23,Dem,Diane Savino,298
+Kings,46012,State Senate,23,Dem,Diane Savino,316
+Kings,46013,State Senate,23,Dem,Diane Savino,328
+Kings,46014,State Senate,23,Dem,Diane Savino,296
+Kings,46015,State Senate,23,Dem,Diane Savino,433
+Kings,46016,State Senate,23,Dem,Diane Savino,188
+Kings,46017,State Senate,23,Dem,Diane Savino,95
+Kings,46018,State Senate,23,Dem,Diane Savino,97
+Kings,46019,State Senate,23,Dem,Diane Savino,192
+Kings,46020,State Senate,23,Dem,Diane Savino,245
+Kings,46021,State Senate,23,Dem,Diane Savino,141
+Kings,46022,State Senate,23,Dem,Diane Savino,190
+Kings,46023,State Senate,23,Dem,Diane Savino,128
+Kings,46024,State Senate,23,Dem,Diane Savino,159
+Kings,46025,State Senate,23,Dem,Diane Savino,185
+Kings,46026,State Senate,23,Dem,Diane Savino,67
+Kings,46027,State Senate,23,Dem,Diane Savino,76
+Kings,46028,State Senate,23,Dem,Diane Savino,84
+Kings,46029,State Senate,23,Dem,Diane Savino,85
+Kings,46030,State Senate,23,Dem,Diane Savino,101
+Kings,46037,State Senate,23,Dem,Diane Savino,10
+Kings,46038,State Senate,23,Dem,Diane Savino,196
+Kings,46039,State Senate,23,Dem,Diane Savino,244
+Kings,46040,State Senate,23,Dem,Diane Savino,57
+Kings,46043,State Senate,23,Dem,Diane Savino,142
+Kings,46044,State Senate,23,Dem,Diane Savino,178
+Kings,46045,State Senate,23,Dem,Diane Savino,130
+Kings,46046,State Senate,23,Dem,Diane Savino,91
+Kings,46077,State Senate,23,Dem,Diane Savino,14
+Kings,47004,State Senate,23,Dem,Diane Savino,23
+Kings,47010,State Senate,23,Dem,Diane Savino,38
+Kings,47011,State Senate,23,Dem,Diane Savino,180
+Kings,47012,State Senate,23,Dem,Diane Savino,177
+Kings,47013,State Senate,23,Dem,Diane Savino,170
+Kings,47014,State Senate,23,Dem,Diane Savino,224
+Kings,47015,State Senate,23,Dem,Diane Savino,297
+Kings,47016,State Senate,23,Dem,Diane Savino,188
+Kings,47017,State Senate,23,Dem,Diane Savino,155
+Kings,47018,State Senate,23,Dem,Diane Savino,187
+Kings,47035,State Senate,23,Dem,Diane Savino,5
+Kings,47036,State Senate,23,Dem,Diane Savino,165
+Kings,47037,State Senate,23,Dem,Diane Savino,144
+Kings,47040,State Senate,23,Dem,Diane Savino,92
+Kings,47041,State Senate,23,Dem,Diane Savino,224
+Kings,47042,State Senate,23,Dem,Diane Savino,80
+Kings,47053,State Senate,23,Dem,Diane Savino,292
+Kings,47054,State Senate,23,Dem,Diane Savino,285
+Kings,47057,State Senate,23,Dem,Diane Savino,234
+Kings,47058,State Senate,23,Dem,Diane Savino,197
+Kings,47059,State Senate,23,Dem,Diane Savino,176
+Kings,47060,State Senate,23,Dem,Diane Savino,92
+Kings,47061,State Senate,23,Dem,Diane Savino,162
+Kings,47062,State Senate,23,Dem,Diane Savino,180
+Kings,47063,State Senate,23,Dem,Diane Savino,234
+Kings,47064,State Senate,23,Dem,Diane Savino,190
+Kings,49034,State Senate,23,Dem,Diane Savino,72
+Kings,49036,State Senate,23,Dem,Diane Savino,75
+Kings,49044,State Senate,23,Dem,Diane Savino,63
+Kings,49055,State Senate,23,Dem,Diane Savino,95
+Kings,51025,State Senate,23,Dem,Diane Savino,12
+Kings,51026,State Senate,23,Dem,Diane Savino,349
+Kings,51027,State Senate,23,Dem,Diane Savino,112
+Kings,51056,State Senate,23,Dem,Diane Savino,6
+Kings,51057,State Senate,23,Dem,Diane Savino,40
+Kings,51058,State Senate,23,Dem,Diane Savino,81
+Kings,51060,State Senate,23,Dem,Diane Savino,345
+Kings,64081,State Senate,23,Dem,Diane Savino,137
+Kings,64082,State Senate,23,Dem,Diane Savino,66
+Kings,41085,State Senate,23,WF,Diane Savino,4
+Kings,41087,State Senate,23,WF,Diane Savino,5
+Kings,41088,State Senate,23,WF,Diane Savino,4
+Kings,41089,State Senate,23,WF,Diane Savino,10
+Kings,41092,State Senate,23,WF,Diane Savino,2
+Kings,45040,State Senate,23,WF,Diane Savino,7
+Kings,45042,State Senate,23,WF,Diane Savino,8
+Kings,45043,State Senate,23,WF,Diane Savino,10
+Kings,45044,State Senate,23,WF,Diane Savino,8
+Kings,45045,State Senate,23,WF,Diane Savino,5
+Kings,45046,State Senate,23,WF,Diane Savino,6
+Kings,45047,State Senate,23,WF,Diane Savino,2
+Kings,45048,State Senate,23,WF,Diane Savino,13
+Kings,45050,State Senate,23,WF,Diane Savino,15
+Kings,45053,State Senate,23,WF,Diane Savino,7
+Kings,45054,State Senate,23,WF,Diane Savino,6
+Kings,45057,State Senate,23,WF,Diane Savino,1
+Kings,45058,State Senate,23,WF,Diane Savino,4
+Kings,45059,State Senate,23,WF,Diane Savino,4
+Kings,45060,State Senate,23,WF,Diane Savino,6
+Kings,45061,State Senate,23,WF,Diane Savino,1
+Kings,45062,State Senate,23,WF,Diane Savino,4
+Kings,45063,State Senate,23,WF,Diane Savino,3
+Kings,45064,State Senate,23,WF,Diane Savino,11
+Kings,45065,State Senate,23,WF,Diane Savino,6
+Kings,45066,State Senate,23,WF,Diane Savino,10
+Kings,45074,State Senate,23,WF,Diane Savino,8
+Kings,45075,State Senate,23,WF,Diane Savino,8
+Kings,45076,State Senate,23,WF,Diane Savino,1
+Kings,45077,State Senate,23,WF,Diane Savino,8
+Kings,45078,State Senate,23,WF,Diane Savino,6
+Kings,46001,State Senate,23,WF,Diane Savino,4
+Kings,46002,State Senate,23,WF,Diane Savino,10
+Kings,46003,State Senate,23,WF,Diane Savino,0
+Kings,46004,State Senate,23,WF,Diane Savino,5
+Kings,46005,State Senate,23,WF,Diane Savino,5
+Kings,46006,State Senate,23,WF,Diane Savino,4
+Kings,46007,State Senate,23,WF,Diane Savino,3
+Kings,46008,State Senate,23,WF,Diane Savino,0
+Kings,46009,State Senate,23,WF,Diane Savino,9
+Kings,46010,State Senate,23,WF,Diane Savino,1
+Kings,46011,State Senate,23,WF,Diane Savino,12
+Kings,46012,State Senate,23,WF,Diane Savino,0
+Kings,46013,State Senate,23,WF,Diane Savino,8
+Kings,46014,State Senate,23,WF,Diane Savino,4
+Kings,46015,State Senate,23,WF,Diane Savino,5
+Kings,46016,State Senate,23,WF,Diane Savino,9
+Kings,46017,State Senate,23,WF,Diane Savino,7
+Kings,46018,State Senate,23,WF,Diane Savino,4
+Kings,46019,State Senate,23,WF,Diane Savino,10
+Kings,46020,State Senate,23,WF,Diane Savino,7
+Kings,46021,State Senate,23,WF,Diane Savino,5
+Kings,46022,State Senate,23,WF,Diane Savino,6
+Kings,46023,State Senate,23,WF,Diane Savino,9
+Kings,46024,State Senate,23,WF,Diane Savino,11
+Kings,46025,State Senate,23,WF,Diane Savino,6
+Kings,46026,State Senate,23,WF,Diane Savino,2
+Kings,46027,State Senate,23,WF,Diane Savino,8
+Kings,46028,State Senate,23,WF,Diane Savino,5
+Kings,46029,State Senate,23,WF,Diane Savino,6
+Kings,46030,State Senate,23,WF,Diane Savino,4
+Kings,46037,State Senate,23,WF,Diane Savino,0
+Kings,46038,State Senate,23,WF,Diane Savino,8
+Kings,46039,State Senate,23,WF,Diane Savino,12
+Kings,46040,State Senate,23,WF,Diane Savino,9
+Kings,46043,State Senate,23,WF,Diane Savino,9
+Kings,46044,State Senate,23,WF,Diane Savino,10
+Kings,46045,State Senate,23,WF,Diane Savino,15
+Kings,46046,State Senate,23,WF,Diane Savino,4
+Kings,46077,State Senate,23,WF,Diane Savino,1
+Kings,47004,State Senate,23,WF,Diane Savino,1
+Kings,47010,State Senate,23,WF,Diane Savino,2
+Kings,47011,State Senate,23,WF,Diane Savino,15
+Kings,47012,State Senate,23,WF,Diane Savino,11
+Kings,47013,State Senate,23,WF,Diane Savino,8
+Kings,47014,State Senate,23,WF,Diane Savino,8
+Kings,47015,State Senate,23,WF,Diane Savino,15
+Kings,47016,State Senate,23,WF,Diane Savino,17
+Kings,47017,State Senate,23,WF,Diane Savino,10
+Kings,47018,State Senate,23,WF,Diane Savino,11
+Kings,47035,State Senate,23,WF,Diane Savino,0
+Kings,47036,State Senate,23,WF,Diane Savino,10
+Kings,47037,State Senate,23,WF,Diane Savino,3
+Kings,47040,State Senate,23,WF,Diane Savino,3
+Kings,47041,State Senate,23,WF,Diane Savino,10
+Kings,47042,State Senate,23,WF,Diane Savino,6
+Kings,47053,State Senate,23,WF,Diane Savino,0
+Kings,47054,State Senate,23,WF,Diane Savino,2
+Kings,47057,State Senate,23,WF,Diane Savino,21
+Kings,47058,State Senate,23,WF,Diane Savino,15
+Kings,47059,State Senate,23,WF,Diane Savino,4
+Kings,47060,State Senate,23,WF,Diane Savino,2
+Kings,47061,State Senate,23,WF,Diane Savino,8
+Kings,47062,State Senate,23,WF,Diane Savino,16
+Kings,47063,State Senate,23,WF,Diane Savino,21
+Kings,47064,State Senate,23,WF,Diane Savino,12
+Kings,49034,State Senate,23,WF,Diane Savino,4
+Kings,49036,State Senate,23,WF,Diane Savino,5
+Kings,49044,State Senate,23,WF,Diane Savino,3
+Kings,49055,State Senate,23,WF,Diane Savino,2
+Kings,51025,State Senate,23,WF,Diane Savino,2
+Kings,51026,State Senate,23,WF,Diane Savino,25
+Kings,51027,State Senate,23,WF,Diane Savino,5
+Kings,51056,State Senate,23,WF,Diane Savino,1
+Kings,51057,State Senate,23,WF,Diane Savino,1
+Kings,51058,State Senate,23,WF,Diane Savino,5
+Kings,51060,State Senate,23,WF,Diane Savino,20
+Kings,64081,State Senate,23,WF,Diane Savino,9
+Kings,64082,State Senate,23,WF,Diane Savino,2
+Kings,41085,State Senate,23,Ind,Diane Savino,3
+Kings,41087,State Senate,23,Ind,Diane Savino,2
+Kings,41088,State Senate,23,Ind,Diane Savino,6
+Kings,41089,State Senate,23,Ind,Diane Savino,2
+Kings,41092,State Senate,23,Ind,Diane Savino,1
+Kings,45040,State Senate,23,Ind,Diane Savino,5
+Kings,45042,State Senate,23,Ind,Diane Savino,7
+Kings,45043,State Senate,23,Ind,Diane Savino,5
+Kings,45044,State Senate,23,Ind,Diane Savino,1
+Kings,45045,State Senate,23,Ind,Diane Savino,3
+Kings,45046,State Senate,23,Ind,Diane Savino,2
+Kings,45047,State Senate,23,Ind,Diane Savino,0
+Kings,45048,State Senate,23,Ind,Diane Savino,9
+Kings,45050,State Senate,23,Ind,Diane Savino,7
+Kings,45053,State Senate,23,Ind,Diane Savino,8
+Kings,45054,State Senate,23,Ind,Diane Savino,4
+Kings,45057,State Senate,23,Ind,Diane Savino,0
+Kings,45058,State Senate,23,Ind,Diane Savino,2
+Kings,45059,State Senate,23,Ind,Diane Savino,5
+Kings,45060,State Senate,23,Ind,Diane Savino,1
+Kings,45061,State Senate,23,Ind,Diane Savino,0
+Kings,45062,State Senate,23,Ind,Diane Savino,5
+Kings,45063,State Senate,23,Ind,Diane Savino,0
+Kings,45064,State Senate,23,Ind,Diane Savino,7
+Kings,45065,State Senate,23,Ind,Diane Savino,11
+Kings,45066,State Senate,23,Ind,Diane Savino,16
+Kings,45074,State Senate,23,Ind,Diane Savino,10
+Kings,45075,State Senate,23,Ind,Diane Savino,5
+Kings,45076,State Senate,23,Ind,Diane Savino,0
+Kings,45077,State Senate,23,Ind,Diane Savino,12
+Kings,45078,State Senate,23,Ind,Diane Savino,8
+Kings,46001,State Senate,23,Ind,Diane Savino,4
+Kings,46002,State Senate,23,Ind,Diane Savino,0
+Kings,46003,State Senate,23,Ind,Diane Savino,0
+Kings,46004,State Senate,23,Ind,Diane Savino,2
+Kings,46005,State Senate,23,Ind,Diane Savino,1
+Kings,46006,State Senate,23,Ind,Diane Savino,0
+Kings,46007,State Senate,23,Ind,Diane Savino,0
+Kings,46008,State Senate,23,Ind,Diane Savino,0
+Kings,46009,State Senate,23,Ind,Diane Savino,1
+Kings,46010,State Senate,23,Ind,Diane Savino,1
+Kings,46011,State Senate,23,Ind,Diane Savino,2
+Kings,46012,State Senate,23,Ind,Diane Savino,0
+Kings,46013,State Senate,23,Ind,Diane Savino,1
+Kings,46014,State Senate,23,Ind,Diane Savino,0
+Kings,46015,State Senate,23,Ind,Diane Savino,0
+Kings,46016,State Senate,23,Ind,Diane Savino,8
+Kings,46017,State Senate,23,Ind,Diane Savino,5
+Kings,46018,State Senate,23,Ind,Diane Savino,5
+Kings,46019,State Senate,23,Ind,Diane Savino,2
+Kings,46020,State Senate,23,Ind,Diane Savino,6
+Kings,46021,State Senate,23,Ind,Diane Savino,11
+Kings,46022,State Senate,23,Ind,Diane Savino,2
+Kings,46023,State Senate,23,Ind,Diane Savino,2
+Kings,46024,State Senate,23,Ind,Diane Savino,1
+Kings,46025,State Senate,23,Ind,Diane Savino,3
+Kings,46026,State Senate,23,Ind,Diane Savino,0
+Kings,46027,State Senate,23,Ind,Diane Savino,4
+Kings,46028,State Senate,23,Ind,Diane Savino,1
+Kings,46029,State Senate,23,Ind,Diane Savino,3
+Kings,46030,State Senate,23,Ind,Diane Savino,3
+Kings,46037,State Senate,23,Ind,Diane Savino,1
+Kings,46038,State Senate,23,Ind,Diane Savino,3
+Kings,46039,State Senate,23,Ind,Diane Savino,5
+Kings,46040,State Senate,23,Ind,Diane Savino,0
+Kings,46043,State Senate,23,Ind,Diane Savino,6
+Kings,46044,State Senate,23,Ind,Diane Savino,5
+Kings,46045,State Senate,23,Ind,Diane Savino,5
+Kings,46046,State Senate,23,Ind,Diane Savino,2
+Kings,46077,State Senate,23,Ind,Diane Savino,0
+Kings,47004,State Senate,23,Ind,Diane Savino,3
+Kings,47010,State Senate,23,Ind,Diane Savino,4
+Kings,47011,State Senate,23,Ind,Diane Savino,7
+Kings,47012,State Senate,23,Ind,Diane Savino,9
+Kings,47013,State Senate,23,Ind,Diane Savino,5
+Kings,47014,State Senate,23,Ind,Diane Savino,4
+Kings,47015,State Senate,23,Ind,Diane Savino,2
+Kings,47016,State Senate,23,Ind,Diane Savino,5
+Kings,47017,State Senate,23,Ind,Diane Savino,1
+Kings,47018,State Senate,23,Ind,Diane Savino,3
+Kings,47035,State Senate,23,Ind,Diane Savino,0
+Kings,47036,State Senate,23,Ind,Diane Savino,11
+Kings,47037,State Senate,23,Ind,Diane Savino,0
+Kings,47040,State Senate,23,Ind,Diane Savino,0
+Kings,47041,State Senate,23,Ind,Diane Savino,9
+Kings,47042,State Senate,23,Ind,Diane Savino,2
+Kings,47053,State Senate,23,Ind,Diane Savino,0
+Kings,47054,State Senate,23,Ind,Diane Savino,0
+Kings,47057,State Senate,23,Ind,Diane Savino,4
+Kings,47058,State Senate,23,Ind,Diane Savino,2
+Kings,47059,State Senate,23,Ind,Diane Savino,4
+Kings,47060,State Senate,23,Ind,Diane Savino,0
+Kings,47061,State Senate,23,Ind,Diane Savino,2
+Kings,47062,State Senate,23,Ind,Diane Savino,6
+Kings,47063,State Senate,23,Ind,Diane Savino,5
+Kings,47064,State Senate,23,Ind,Diane Savino,3
+Kings,49034,State Senate,23,Ind,Diane Savino,0
+Kings,49036,State Senate,23,Ind,Diane Savino,2
+Kings,49044,State Senate,23,Ind,Diane Savino,1
+Kings,49055,State Senate,23,Ind,Diane Savino,1
+Kings,51025,State Senate,23,Ind,Diane Savino,0
+Kings,51026,State Senate,23,Ind,Diane Savino,8
+Kings,51027,State Senate,23,Ind,Diane Savino,1
+Kings,51056,State Senate,23,Ind,Diane Savino,1
+Kings,51057,State Senate,23,Ind,Diane Savino,0
+Kings,51058,State Senate,23,Ind,Diane Savino,1
+Kings,51060,State Senate,23,Ind,Diane Savino,5
+Kings,64081,State Senate,23,Ind,Diane Savino,2
+Kings,64082,State Senate,23,Ind,Diane Savino,1
+Kings,41085,State Senate,23,Rep,Lisa Grey,74
+Kings,41087,State Senate,23,Rep,Lisa Grey,100
+Kings,41088,State Senate,23,Rep,Lisa Grey,174
+Kings,41089,State Senate,23,Rep,Lisa Grey,62
+Kings,41092,State Senate,23,Rep,Lisa Grey,61
+Kings,45040,State Senate,23,Rep,Lisa Grey,174
+Kings,45042,State Senate,23,Rep,Lisa Grey,124
+Kings,45043,State Senate,23,Rep,Lisa Grey,149
+Kings,45044,State Senate,23,Rep,Lisa Grey,52
+Kings,45045,State Senate,23,Rep,Lisa Grey,24
+Kings,45046,State Senate,23,Rep,Lisa Grey,30
+Kings,45047,State Senate,23,Rep,Lisa Grey,6
+Kings,45048,State Senate,23,Rep,Lisa Grey,199
+Kings,45050,State Senate,23,Rep,Lisa Grey,112
+Kings,45053,State Senate,23,Rep,Lisa Grey,96
+Kings,45054,State Senate,23,Rep,Lisa Grey,66
+Kings,45057,State Senate,23,Rep,Lisa Grey,10
+Kings,45058,State Senate,23,Rep,Lisa Grey,58
+Kings,45059,State Senate,23,Rep,Lisa Grey,85
+Kings,45060,State Senate,23,Rep,Lisa Grey,43
+Kings,45061,State Senate,23,Rep,Lisa Grey,10
+Kings,45062,State Senate,23,Rep,Lisa Grey,48
+Kings,45063,State Senate,23,Rep,Lisa Grey,16
+Kings,45064,State Senate,23,Rep,Lisa Grey,138
+Kings,45065,State Senate,23,Rep,Lisa Grey,67
+Kings,45066,State Senate,23,Rep,Lisa Grey,121
+Kings,45074,State Senate,23,Rep,Lisa Grey,288
+Kings,45075,State Senate,23,Rep,Lisa Grey,209
+Kings,45076,State Senate,23,Rep,Lisa Grey,26
+Kings,45077,State Senate,23,Rep,Lisa Grey,88
+Kings,45078,State Senate,23,Rep,Lisa Grey,75
+Kings,46001,State Senate,23,Rep,Lisa Grey,43
+Kings,46002,State Senate,23,Rep,Lisa Grey,34
+Kings,46003,State Senate,23,Rep,Lisa Grey,24
+Kings,46004,State Senate,23,Rep,Lisa Grey,10
+Kings,46005,State Senate,23,Rep,Lisa Grey,16
+Kings,46006,State Senate,23,Rep,Lisa Grey,8
+Kings,46007,State Senate,23,Rep,Lisa Grey,43
+Kings,46008,State Senate,23,Rep,Lisa Grey,9
+Kings,46009,State Senate,23,Rep,Lisa Grey,29
+Kings,46010,State Senate,23,Rep,Lisa Grey,6
+Kings,46011,State Senate,23,Rep,Lisa Grey,44
+Kings,46012,State Senate,23,Rep,Lisa Grey,12
+Kings,46013,State Senate,23,Rep,Lisa Grey,9
+Kings,46014,State Senate,23,Rep,Lisa Grey,14
+Kings,46015,State Senate,23,Rep,Lisa Grey,16
+Kings,46016,State Senate,23,Rep,Lisa Grey,76
+Kings,46017,State Senate,23,Rep,Lisa Grey,127
+Kings,46018,State Senate,23,Rep,Lisa Grey,98
+Kings,46019,State Senate,23,Rep,Lisa Grey,168
+Kings,46020,State Senate,23,Rep,Lisa Grey,165
+Kings,46021,State Senate,23,Rep,Lisa Grey,183
+Kings,46022,State Senate,23,Rep,Lisa Grey,147
+Kings,46023,State Senate,23,Rep,Lisa Grey,128
+Kings,46024,State Senate,23,Rep,Lisa Grey,130
+Kings,46025,State Senate,23,Rep,Lisa Grey,153
+Kings,46026,State Senate,23,Rep,Lisa Grey,58
+Kings,46027,State Senate,23,Rep,Lisa Grey,80
+Kings,46028,State Senate,23,Rep,Lisa Grey,92
+Kings,46029,State Senate,23,Rep,Lisa Grey,100
+Kings,46030,State Senate,23,Rep,Lisa Grey,90
+Kings,46037,State Senate,23,Rep,Lisa Grey,10
+Kings,46038,State Senate,23,Rep,Lisa Grey,213
+Kings,46039,State Senate,23,Rep,Lisa Grey,127
+Kings,46040,State Senate,23,Rep,Lisa Grey,28
+Kings,46043,State Senate,23,Rep,Lisa Grey,118
+Kings,46044,State Senate,23,Rep,Lisa Grey,172
+Kings,46045,State Senate,23,Rep,Lisa Grey,75
+Kings,46046,State Senate,23,Rep,Lisa Grey,120
+Kings,46077,State Senate,23,Rep,Lisa Grey,20
+Kings,47004,State Senate,23,Rep,Lisa Grey,6
+Kings,47010,State Senate,23,Rep,Lisa Grey,25
+Kings,47011,State Senate,23,Rep,Lisa Grey,90
+Kings,47012,State Senate,23,Rep,Lisa Grey,102
+Kings,47013,State Senate,23,Rep,Lisa Grey,69
+Kings,47014,State Senate,23,Rep,Lisa Grey,103
+Kings,47015,State Senate,23,Rep,Lisa Grey,93
+Kings,47016,State Senate,23,Rep,Lisa Grey,98
+Kings,47017,State Senate,23,Rep,Lisa Grey,64
+Kings,47018,State Senate,23,Rep,Lisa Grey,132
+Kings,47035,State Senate,23,Rep,Lisa Grey,3
+Kings,47036,State Senate,23,Rep,Lisa Grey,80
+Kings,47037,State Senate,23,Rep,Lisa Grey,59
+Kings,47040,State Senate,23,Rep,Lisa Grey,43
+Kings,47041,State Senate,23,Rep,Lisa Grey,67
+Kings,47042,State Senate,23,Rep,Lisa Grey,28
+Kings,47053,State Senate,23,Rep,Lisa Grey,10
+Kings,47054,State Senate,23,Rep,Lisa Grey,7
+Kings,47057,State Senate,23,Rep,Lisa Grey,121
+Kings,47058,State Senate,23,Rep,Lisa Grey,78
+Kings,47059,State Senate,23,Rep,Lisa Grey,123
+Kings,47060,State Senate,23,Rep,Lisa Grey,34
+Kings,47061,State Senate,23,Rep,Lisa Grey,61
+Kings,47062,State Senate,23,Rep,Lisa Grey,87
+Kings,47063,State Senate,23,Rep,Lisa Grey,105
+Kings,47064,State Senate,23,Rep,Lisa Grey,99
+Kings,49034,State Senate,23,Rep,Lisa Grey,15
+Kings,49036,State Senate,23,Rep,Lisa Grey,20
+Kings,49044,State Senate,23,Rep,Lisa Grey,38
+Kings,49055,State Senate,23,Rep,Lisa Grey,22
+Kings,51025,State Senate,23,Rep,Lisa Grey,0
+Kings,51026,State Senate,23,Rep,Lisa Grey,130
+Kings,51027,State Senate,23,Rep,Lisa Grey,32
+Kings,51056,State Senate,23,Rep,Lisa Grey,0
+Kings,51057,State Senate,23,Rep,Lisa Grey,7
+Kings,51058,State Senate,23,Rep,Lisa Grey,9
+Kings,51060,State Senate,23,Rep,Lisa Grey,78
+Kings,64081,State Senate,23,Rep,Lisa Grey,50
+Kings,64082,State Senate,23,Rep,Lisa Grey,26
+Kings,41085,State Senate,23,Con,Lisa Grey,11
+Kings,41087,State Senate,23,Con,Lisa Grey,6
+Kings,41088,State Senate,23,Con,Lisa Grey,13
+Kings,41089,State Senate,23,Con,Lisa Grey,7
+Kings,41092,State Senate,23,Con,Lisa Grey,3
+Kings,45040,State Senate,23,Con,Lisa Grey,15
+Kings,45042,State Senate,23,Con,Lisa Grey,20
+Kings,45043,State Senate,23,Con,Lisa Grey,10
+Kings,45044,State Senate,23,Con,Lisa Grey,4
+Kings,45045,State Senate,23,Con,Lisa Grey,3
+Kings,45046,State Senate,23,Con,Lisa Grey,4
+Kings,45047,State Senate,23,Con,Lisa Grey,2
+Kings,45048,State Senate,23,Con,Lisa Grey,19
+Kings,45050,State Senate,23,Con,Lisa Grey,4
+Kings,45053,State Senate,23,Con,Lisa Grey,6
+Kings,45054,State Senate,23,Con,Lisa Grey,0
+Kings,45057,State Senate,23,Con,Lisa Grey,2
+Kings,45058,State Senate,23,Con,Lisa Grey,8
+Kings,45059,State Senate,23,Con,Lisa Grey,6
+Kings,45060,State Senate,23,Con,Lisa Grey,8
+Kings,45061,State Senate,23,Con,Lisa Grey,0
+Kings,45062,State Senate,23,Con,Lisa Grey,7
+Kings,45063,State Senate,23,Con,Lisa Grey,5
+Kings,45064,State Senate,23,Con,Lisa Grey,6
+Kings,45065,State Senate,23,Con,Lisa Grey,6
+Kings,45066,State Senate,23,Con,Lisa Grey,6
+Kings,45074,State Senate,23,Con,Lisa Grey,12
+Kings,45075,State Senate,23,Con,Lisa Grey,7
+Kings,45076,State Senate,23,Con,Lisa Grey,2
+Kings,45077,State Senate,23,Con,Lisa Grey,9
+Kings,45078,State Senate,23,Con,Lisa Grey,4
+Kings,46001,State Senate,23,Con,Lisa Grey,6
+Kings,46002,State Senate,23,Con,Lisa Grey,5
+Kings,46003,State Senate,23,Con,Lisa Grey,2
+Kings,46004,State Senate,23,Con,Lisa Grey,1
+Kings,46005,State Senate,23,Con,Lisa Grey,1
+Kings,46006,State Senate,23,Con,Lisa Grey,0
+Kings,46007,State Senate,23,Con,Lisa Grey,6
+Kings,46008,State Senate,23,Con,Lisa Grey,0
+Kings,46009,State Senate,23,Con,Lisa Grey,4
+Kings,46010,State Senate,23,Con,Lisa Grey,2
+Kings,46011,State Senate,23,Con,Lisa Grey,3
+Kings,46012,State Senate,23,Con,Lisa Grey,2
+Kings,46013,State Senate,23,Con,Lisa Grey,1
+Kings,46014,State Senate,23,Con,Lisa Grey,0
+Kings,46015,State Senate,23,Con,Lisa Grey,2
+Kings,46016,State Senate,23,Con,Lisa Grey,5
+Kings,46017,State Senate,23,Con,Lisa Grey,6
+Kings,46018,State Senate,23,Con,Lisa Grey,5
+Kings,46019,State Senate,23,Con,Lisa Grey,9
+Kings,46020,State Senate,23,Con,Lisa Grey,11
+Kings,46021,State Senate,23,Con,Lisa Grey,5
+Kings,46022,State Senate,23,Con,Lisa Grey,8
+Kings,46023,State Senate,23,Con,Lisa Grey,6
+Kings,46024,State Senate,23,Con,Lisa Grey,3
+Kings,46025,State Senate,23,Con,Lisa Grey,13
+Kings,46026,State Senate,23,Con,Lisa Grey,1
+Kings,46027,State Senate,23,Con,Lisa Grey,4
+Kings,46028,State Senate,23,Con,Lisa Grey,6
+Kings,46029,State Senate,23,Con,Lisa Grey,3
+Kings,46030,State Senate,23,Con,Lisa Grey,4
+Kings,46037,State Senate,23,Con,Lisa Grey,1
+Kings,46038,State Senate,23,Con,Lisa Grey,11
+Kings,46039,State Senate,23,Con,Lisa Grey,7
+Kings,46040,State Senate,23,Con,Lisa Grey,4
+Kings,46043,State Senate,23,Con,Lisa Grey,14
+Kings,46044,State Senate,23,Con,Lisa Grey,10
+Kings,46045,State Senate,23,Con,Lisa Grey,2
+Kings,46046,State Senate,23,Con,Lisa Grey,1
+Kings,46077,State Senate,23,Con,Lisa Grey,0
+Kings,47004,State Senate,23,Con,Lisa Grey,1
+Kings,47010,State Senate,23,Con,Lisa Grey,2
+Kings,47011,State Senate,23,Con,Lisa Grey,16
+Kings,47012,State Senate,23,Con,Lisa Grey,12
+Kings,47013,State Senate,23,Con,Lisa Grey,12
+Kings,47014,State Senate,23,Con,Lisa Grey,14
+Kings,47015,State Senate,23,Con,Lisa Grey,9
+Kings,47016,State Senate,23,Con,Lisa Grey,6
+Kings,47017,State Senate,23,Con,Lisa Grey,6
+Kings,47018,State Senate,23,Con,Lisa Grey,22
+Kings,47035,State Senate,23,Con,Lisa Grey,0
+Kings,47036,State Senate,23,Con,Lisa Grey,6
+Kings,47037,State Senate,23,Con,Lisa Grey,3
+Kings,47040,State Senate,23,Con,Lisa Grey,3
+Kings,47041,State Senate,23,Con,Lisa Grey,10
+Kings,47042,State Senate,23,Con,Lisa Grey,3
+Kings,47053,State Senate,23,Con,Lisa Grey,3
+Kings,47054,State Senate,23,Con,Lisa Grey,0
+Kings,47057,State Senate,23,Con,Lisa Grey,13
+Kings,47058,State Senate,23,Con,Lisa Grey,11
+Kings,47059,State Senate,23,Con,Lisa Grey,4
+Kings,47060,State Senate,23,Con,Lisa Grey,2
+Kings,47061,State Senate,23,Con,Lisa Grey,4
+Kings,47062,State Senate,23,Con,Lisa Grey,8
+Kings,47063,State Senate,23,Con,Lisa Grey,10
+Kings,47064,State Senate,23,Con,Lisa Grey,13
+Kings,49034,State Senate,23,Con,Lisa Grey,0
+Kings,49036,State Senate,23,Con,Lisa Grey,0
+Kings,49044,State Senate,23,Con,Lisa Grey,1
+Kings,49055,State Senate,23,Con,Lisa Grey,9
+Kings,51025,State Senate,23,Con,Lisa Grey,0
+Kings,51026,State Senate,23,Con,Lisa Grey,25
+Kings,51027,State Senate,23,Con,Lisa Grey,4
+Kings,51056,State Senate,23,Con,Lisa Grey,1
+Kings,51057,State Senate,23,Con,Lisa Grey,0
+Kings,51058,State Senate,23,Con,Lisa Grey,1
+Kings,51060,State Senate,23,Con,Lisa Grey,13
+Kings,64081,State Senate,23,Con,Lisa Grey,10
+Kings,64082,State Senate,23,Con,Lisa Grey,1
+Kings,41085,State Senate,23,Ind,writein,0
+Kings,41087,State Senate,23,Ind,writein,0
+Kings,41088,State Senate,23,Ind,writein,0
+Kings,41089,State Senate,23,Ind,writein,0
+Kings,41092,State Senate,23,Ind,writein,0
+Kings,45040,State Senate,23,Ind,writein,1
+Kings,45042,State Senate,23,Ind,writein,0
+Kings,45043,State Senate,23,Ind,writein,0
+Kings,45044,State Senate,23,Ind,writein,0
+Kings,45045,State Senate,23,Ind,writein,0
+Kings,45046,State Senate,23,Ind,writein,0
+Kings,45047,State Senate,23,Ind,writein,0
+Kings,45048,State Senate,23,Ind,writein,0
+Kings,45050,State Senate,23,Ind,writein,0
+Kings,45053,State Senate,23,Ind,writein,0
+Kings,45054,State Senate,23,Ind,writein,0
+Kings,45057,State Senate,23,Ind,writein,0
+Kings,45058,State Senate,23,Ind,writein,0
+Kings,45059,State Senate,23,Ind,writein,0
+Kings,45060,State Senate,23,Ind,writein,1
+Kings,45061,State Senate,23,Ind,writein,0
+Kings,45062,State Senate,23,Ind,writein,0
+Kings,45063,State Senate,23,Ind,writein,0
+Kings,45064,State Senate,23,Ind,writein,0
+Kings,45065,State Senate,23,Ind,writein,0
+Kings,45066,State Senate,23,Ind,writein,0
+Kings,45074,State Senate,23,Ind,writein,0
+Kings,45075,State Senate,23,Ind,writein,0
+Kings,45076,State Senate,23,Ind,writein,0
+Kings,45077,State Senate,23,Ind,writein,0
+Kings,45078,State Senate,23,Ind,writein,0
+Kings,46001,State Senate,23,Ind,writein,0
+Kings,46002,State Senate,23,Ind,writein,1
+Kings,46003,State Senate,23,Ind,writein,1
+Kings,46004,State Senate,23,Ind,writein,0
+Kings,46005,State Senate,23,Ind,writein,0
+Kings,46006,State Senate,23,Ind,writein,0
+Kings,46007,State Senate,23,Ind,writein,0
+Kings,46008,State Senate,23,Ind,writein,0
+Kings,46009,State Senate,23,Ind,writein,0
+Kings,46010,State Senate,23,Ind,writein,0
+Kings,46011,State Senate,23,Ind,writein,1
+Kings,46012,State Senate,23,Ind,writein,0
+Kings,46013,State Senate,23,Ind,writein,0
+Kings,46014,State Senate,23,Ind,writein,0
+Kings,46015,State Senate,23,Ind,writein,0
+Kings,46016,State Senate,23,Ind,writein,0
+Kings,46017,State Senate,23,Ind,writein,0
+Kings,46018,State Senate,23,Ind,writein,0
+Kings,46019,State Senate,23,Ind,writein,0
+Kings,46020,State Senate,23,Ind,writein,0
+Kings,46021,State Senate,23,Ind,writein,0
+Kings,46022,State Senate,23,Ind,writein,1
+Kings,46023,State Senate,23,Ind,writein,0
+Kings,46024,State Senate,23,Ind,writein,0
+Kings,46025,State Senate,23,Ind,writein,0
+Kings,46026,State Senate,23,Ind,writein,0
+Kings,46027,State Senate,23,Ind,writein,0
+Kings,46028,State Senate,23,Ind,writein,0
+Kings,46029,State Senate,23,Ind,writein,0
+Kings,46030,State Senate,23,Ind,writein,0
+Kings,46037,State Senate,23,Ind,writein,0
+Kings,46038,State Senate,23,Ind,writein,2
+Kings,46039,State Senate,23,Ind,writein,0
+Kings,46040,State Senate,23,Ind,writein,0
+Kings,46043,State Senate,23,Ind,writein,0
+Kings,46044,State Senate,23,Ind,writein,0
+Kings,46045,State Senate,23,Ind,writein,0
+Kings,46046,State Senate,23,Ind,writein,0
+Kings,46077,State Senate,23,Ind,writein,0
+Kings,47004,State Senate,23,Ind,writein,0
+Kings,47010,State Senate,23,Ind,writein,1
+Kings,47011,State Senate,23,Ind,writein,0
+Kings,47012,State Senate,23,Ind,writein,3
+Kings,47013,State Senate,23,Ind,writein,0
+Kings,47014,State Senate,23,Ind,writein,0
+Kings,47015,State Senate,23,Ind,writein,0
+Kings,47016,State Senate,23,Ind,writein,0
+Kings,47017,State Senate,23,Ind,writein,0
+Kings,47018,State Senate,23,Ind,writein,0
+Kings,47035,State Senate,23,Ind,writein,0
+Kings,47036,State Senate,23,Ind,writein,0
+Kings,47037,State Senate,23,Ind,writein,1
+Kings,47040,State Senate,23,Ind,writein,0
+Kings,47041,State Senate,23,Ind,writein,0
+Kings,47042,State Senate,23,Ind,writein,0
+Kings,47053,State Senate,23,Ind,writein,0
+Kings,47054,State Senate,23,Ind,writein,1
+Kings,47057,State Senate,23,Ind,writein,0
+Kings,47058,State Senate,23,Ind,writein,0
+Kings,47059,State Senate,23,Ind,writein,0
+Kings,47060,State Senate,23,Ind,writein,0
+Kings,47061,State Senate,23,Ind,writein,0
+Kings,47062,State Senate,23,Ind,writein,1
+Kings,47063,State Senate,23,Ind,writein,0
+Kings,47064,State Senate,23,Ind,writein,2
+Kings,49034,State Senate,23,Ind,writein,0
+Kings,49036,State Senate,23,Ind,writein,0
+Kings,49044,State Senate,23,Ind,writein,0
+Kings,49055,State Senate,23,Ind,writein,0
+Kings,51025,State Senate,23,Ind,writein,0
+Kings,51026,State Senate,23,Ind,writein,0
+Kings,51027,State Senate,23,Ind,writein,1
+Kings,51056,State Senate,23,Ind,writein,0
+Kings,51057,State Senate,23,Ind,writein,0
+Kings,51058,State Senate,23,Ind,writein,0
+Kings,51060,State Senate,23,Ind,writein,1
+Kings,64081,State Senate,23,Ind,writein,0
+Kings,64082,State Senate,23,Ind,writein,0
+Kings,43045,State Senate,25,Rep,John Jasilli,11
+Kings,43046,State Senate,25,Rep,John Jasilli,4
+Kings,43047,State Senate,25,Rep,John Jasilli,5
+Kings,43048,State Senate,25,Rep,John Jasilli,9
+Kings,43049,State Senate,25,Rep,John Jasilli,4
+Kings,43050,State Senate,25,Rep,John Jasilli,4
+Kings,43051,State Senate,25,Rep,John Jasilli,11
+Kings,50083,State Senate,25,Rep,John Jasilli,52
+Kings,50085,State Senate,25,Rep,John Jasilli,5
+Kings,50086,State Senate,25,Rep,John Jasilli,0
+Kings,50089,State Senate,25,Rep,John Jasilli,13
+Kings,50090,State Senate,25,Rep,John Jasilli,4
+Kings,50091,State Senate,25,Rep,John Jasilli,20
+Kings,50092,State Senate,25,Rep,John Jasilli,12
+Kings,50093,State Senate,25,Rep,John Jasilli,2
+Kings,50095,State Senate,25,Rep,John Jasilli,1
+Kings,50097,State Senate,25,Rep,John Jasilli,1
+Kings,51008,State Senate,25,Rep,John Jasilli,12
+Kings,51044,State Senate,25,Rep,John Jasilli,6
+Kings,51045,State Senate,25,Rep,John Jasilli,0
+Kings,51046,State Senate,25,Rep,John Jasilli,2
+Kings,51048,State Senate,25,Rep,John Jasilli,1
+Kings,51049,State Senate,25,Rep,John Jasilli,2
+Kings,51050,State Senate,25,Rep,John Jasilli,5
+Kings,51051,State Senate,25,Rep,John Jasilli,34
+Kings,51052,State Senate,25,Rep,John Jasilli,17
+Kings,51053,State Senate,25,Rep,John Jasilli,20
+Kings,51055,State Senate,25,Rep,John Jasilli,26
+Kings,51069,State Senate,25,Rep,John Jasilli,4
+Kings,51070,State Senate,25,Rep,John Jasilli,10
+Kings,51071,State Senate,25,Rep,John Jasilli,6
+Kings,51072,State Senate,25,Rep,John Jasilli,4
+Kings,51073,State Senate,25,Rep,John Jasilli,7
+Kings,51074,State Senate,25,Rep,John Jasilli,4
+Kings,51075,State Senate,25,Rep,John Jasilli,6
+Kings,51076,State Senate,25,Rep,John Jasilli,6
+Kings,51078,State Senate,25,Rep,John Jasilli,6
+Kings,52022,State Senate,25,Rep,John Jasilli,17
+Kings,52023,State Senate,25,Rep,John Jasilli,73
+Kings,52024,State Senate,25,Rep,John Jasilli,48
+Kings,52025,State Senate,25,Rep,John Jasilli,56
+Kings,52026,State Senate,25,Rep,John Jasilli,1
+Kings,52027,State Senate,25,Rep,John Jasilli,5
+Kings,52028,State Senate,25,Rep,John Jasilli,38
+Kings,52029,State Senate,25,Rep,John Jasilli,59
+Kings,52030,State Senate,25,Rep,John Jasilli,51
+Kings,52031,State Senate,25,Rep,John Jasilli,24
+Kings,52032,State Senate,25,Rep,John Jasilli,32
+Kings,52033,State Senate,25,Rep,John Jasilli,21
+Kings,52048,State Senate,25,Rep,John Jasilli,29
+Kings,52049,State Senate,25,Rep,John Jasilli,34
+Kings,52050,State Senate,25,Rep,John Jasilli,15
+Kings,52051,State Senate,25,Rep,John Jasilli,5
+Kings,52052,State Senate,25,Rep,John Jasilli,8
+Kings,52053,State Senate,25,Rep,John Jasilli,15
+Kings,52054,State Senate,25,Rep,John Jasilli,7
+Kings,52055,State Senate,25,Rep,John Jasilli,22
+Kings,52056,State Senate,25,Rep,John Jasilli,16
+Kings,52057,State Senate,25,Rep,John Jasilli,26
+Kings,52058,State Senate,25,Rep,John Jasilli,33
+Kings,52059,State Senate,25,Rep,John Jasilli,24
+Kings,52060,State Senate,25,Rep,John Jasilli,18
+Kings,52061,State Senate,25,Rep,John Jasilli,24
+Kings,52062,State Senate,25,Rep,John Jasilli,25
+Kings,52063,State Senate,25,Rep,John Jasilli,2
+Kings,52089,State Senate,25,Rep,John Jasilli,42
+Kings,52090,State Senate,25,Rep,John Jasilli,29
+Kings,52091,State Senate,25,Rep,John Jasilli,29
+Kings,52095,State Senate,25,Rep,John Jasilli,2
+Kings,52096,State Senate,25,Rep,John Jasilli,39
+Kings,52097,State Senate,25,Rep,John Jasilli,32
+Kings,52098,State Senate,25,Rep,John Jasilli,75
+Kings,52099,State Senate,25,Rep,John Jasilli,53
+Kings,52100,State Senate,25,Rep,John Jasilli,48
+Kings,52102,State Senate,25,Rep,John Jasilli,0
+Kings,52108,State Senate,25,Rep,John Jasilli,0
+Kings,52109,State Senate,25,Rep,John Jasilli,0
+Kings,52112,State Senate,25,Rep,John Jasilli,27
+Kings,54015,State Senate,25,Rep,John Jasilli,3
+Kings,54026,State Senate,25,Rep,John Jasilli,0
+Kings,55002,State Senate,25,Rep,John Jasilli,3
+Kings,55004,State Senate,25,Rep,John Jasilli,3
+Kings,55008,State Senate,25,Rep,John Jasilli,0
+Kings,55009,State Senate,25,Rep,John Jasilli,3
+Kings,55010,State Senate,25,Rep,John Jasilli,2
+Kings,55011,State Senate,25,Rep,John Jasilli,5
+Kings,55012,State Senate,25,Rep,John Jasilli,3
+Kings,55017,State Senate,25,Rep,John Jasilli,1
+Kings,55018,State Senate,25,Rep,John Jasilli,5
+Kings,55019,State Senate,25,Rep,John Jasilli,2
+Kings,55020,State Senate,25,Rep,John Jasilli,6
+Kings,55021,State Senate,25,Rep,John Jasilli,3
+Kings,55022,State Senate,25,Rep,John Jasilli,1
+Kings,55023,State Senate,25,Rep,John Jasilli,4
+Kings,55024,State Senate,25,Rep,John Jasilli,4
+Kings,55025,State Senate,25,Rep,John Jasilli,3
+Kings,55028,State Senate,25,Rep,John Jasilli,3
+Kings,55029,State Senate,25,Rep,John Jasilli,0
+Kings,55030,State Senate,25,Rep,John Jasilli,2
+Kings,55031,State Senate,25,Rep,John Jasilli,3
+Kings,55032,State Senate,25,Rep,John Jasilli,2
+Kings,55033,State Senate,25,Rep,John Jasilli,5
+Kings,55034,State Senate,25,Rep,John Jasilli,3
+Kings,55101,State Senate,25,Rep,John Jasilli,4
+Kings,55102,State Senate,25,Rep,John Jasilli,3
+Kings,55103,State Senate,25,Rep,John Jasilli,2
+Kings,55104,State Senate,25,Rep,John Jasilli,5
+Kings,56012,State Senate,25,Rep,John Jasilli,4
+Kings,56013,State Senate,25,Rep,John Jasilli,6
+Kings,56014,State Senate,25,Rep,John Jasilli,10
+Kings,56015,State Senate,25,Rep,John Jasilli,5
+Kings,56016,State Senate,25,Rep,John Jasilli,10
+Kings,56018,State Senate,25,Rep,John Jasilli,4
+Kings,56019,State Senate,25,Rep,John Jasilli,2
+Kings,56021,State Senate,25,Rep,John Jasilli,0
+Kings,56022,State Senate,25,Rep,John Jasilli,1
+Kings,56023,State Senate,25,Rep,John Jasilli,0
+Kings,56024,State Senate,25,Rep,John Jasilli,8
+Kings,56025,State Senate,25,Rep,John Jasilli,5
+Kings,56026,State Senate,25,Rep,John Jasilli,8
+Kings,56027,State Senate,25,Rep,John Jasilli,2
+Kings,56028,State Senate,25,Rep,John Jasilli,4
+Kings,56029,State Senate,25,Rep,John Jasilli,6
+Kings,56030,State Senate,25,Rep,John Jasilli,0
+Kings,56031,State Senate,25,Rep,John Jasilli,9
+Kings,56032,State Senate,25,Rep,John Jasilli,7
+Kings,56033,State Senate,25,Rep,John Jasilli,4
+Kings,56034,State Senate,25,Rep,John Jasilli,4
+Kings,56035,State Senate,25,Rep,John Jasilli,6
+Kings,56036,State Senate,25,Rep,John Jasilli,3
+Kings,56037,State Senate,25,Rep,John Jasilli,6
+Kings,56038,State Senate,25,Rep,John Jasilli,4
+Kings,56039,State Senate,25,Rep,John Jasilli,4
+Kings,56040,State Senate,25,Rep,John Jasilli,9
+Kings,56041,State Senate,25,Rep,John Jasilli,6
+Kings,56042,State Senate,25,Rep,John Jasilli,3
+Kings,56043,State Senate,25,Rep,John Jasilli,3
+Kings,56044,State Senate,25,Rep,John Jasilli,0
+Kings,56045,State Senate,25,Rep,John Jasilli,1
+Kings,56046,State Senate,25,Rep,John Jasilli,7
+Kings,56047,State Senate,25,Rep,John Jasilli,8
+Kings,56048,State Senate,25,Rep,John Jasilli,5
+Kings,56049,State Senate,25,Rep,John Jasilli,4
+Kings,56050,State Senate,25,Rep,John Jasilli,7
+Kings,56051,State Senate,25,Rep,John Jasilli,9
+Kings,56052,State Senate,25,Rep,John Jasilli,2
+Kings,56053,State Senate,25,Rep,John Jasilli,6
+Kings,56054,State Senate,25,Rep,John Jasilli,8
+Kings,56055,State Senate,25,Rep,John Jasilli,15
+Kings,56056,State Senate,25,Rep,John Jasilli,2
+Kings,56057,State Senate,25,Rep,John Jasilli,7
+Kings,56058,State Senate,25,Rep,John Jasilli,5
+Kings,56059,State Senate,25,Rep,John Jasilli,4
+Kings,56060,State Senate,25,Rep,John Jasilli,1
+Kings,56061,State Senate,25,Rep,John Jasilli,0
+Kings,56062,State Senate,25,Rep,John Jasilli,1
+Kings,56063,State Senate,25,Rep,John Jasilli,0
+Kings,56064,State Senate,25,Rep,John Jasilli,6
+Kings,56065,State Senate,25,Rep,John Jasilli,2
+Kings,56066,State Senate,25,Rep,John Jasilli,0
+Kings,56068,State Senate,25,Rep,John Jasilli,7
+Kings,56069,State Senate,25,Rep,John Jasilli,4
+Kings,56070,State Senate,25,Rep,John Jasilli,9
+Kings,56071,State Senate,25,Rep,John Jasilli,9
+Kings,56072,State Senate,25,Rep,John Jasilli,4
+Kings,56074,State Senate,25,Rep,John Jasilli,1
+Kings,57001,State Senate,25,Rep,John Jasilli,6
+Kings,57002,State Senate,25,Rep,John Jasilli,3
+Kings,57003,State Senate,25,Rep,John Jasilli,4
+Kings,57004,State Senate,25,Rep,John Jasilli,25
+Kings,57006,State Senate,25,Rep,John Jasilli,2
+Kings,57007,State Senate,25,Rep,John Jasilli,6
+Kings,57008,State Senate,25,Rep,John Jasilli,5
+Kings,57009,State Senate,25,Rep,John Jasilli,42
+Kings,57010,State Senate,25,Rep,John Jasilli,26
+Kings,57011,State Senate,25,Rep,John Jasilli,16
+Kings,57012,State Senate,25,Rep,John Jasilli,0
+Kings,57013,State Senate,25,Rep,John Jasilli,2
+Kings,57014,State Senate,25,Rep,John Jasilli,4
+Kings,57015,State Senate,25,Rep,John Jasilli,12
+Kings,57016,State Senate,25,Rep,John Jasilli,17
+Kings,57017,State Senate,25,Rep,John Jasilli,22
+Kings,57018,State Senate,25,Rep,John Jasilli,12
+Kings,57019,State Senate,25,Rep,John Jasilli,14
+Kings,57020,State Senate,25,Rep,John Jasilli,1
+Kings,57021,State Senate,25,Rep,John Jasilli,18
+Kings,57022,State Senate,25,Rep,John Jasilli,16
+Kings,57023,State Senate,25,Rep,John Jasilli,22
+Kings,57024,State Senate,25,Rep,John Jasilli,19
+Kings,57025,State Senate,25,Rep,John Jasilli,30
+Kings,57026,State Senate,25,Rep,John Jasilli,18
+Kings,57027,State Senate,25,Rep,John Jasilli,25
+Kings,57028,State Senate,25,Rep,John Jasilli,17
+Kings,57029,State Senate,25,Rep,John Jasilli,13
+Kings,57030,State Senate,25,Rep,John Jasilli,2
+Kings,57031,State Senate,25,Rep,John Jasilli,9
+Kings,57032,State Senate,25,Rep,John Jasilli,6
+Kings,57033,State Senate,25,Rep,John Jasilli,8
+Kings,57034,State Senate,25,Rep,John Jasilli,9
+Kings,57035,State Senate,25,Rep,John Jasilli,6
+Kings,57036,State Senate,25,Rep,John Jasilli,10
+Kings,57037,State Senate,25,Rep,John Jasilli,9
+Kings,57038,State Senate,25,Rep,John Jasilli,12
+Kings,57039,State Senate,25,Rep,John Jasilli,7
+Kings,57040,State Senate,25,Rep,John Jasilli,13
+Kings,57041,State Senate,25,Rep,John Jasilli,14
+Kings,57042,State Senate,25,Rep,John Jasilli,12
+Kings,57043,State Senate,25,Rep,John Jasilli,23
+Kings,57044,State Senate,25,Rep,John Jasilli,9
+Kings,57045,State Senate,25,Rep,John Jasilli,8
+Kings,57046,State Senate,25,Rep,John Jasilli,3
+Kings,57047,State Senate,25,Rep,John Jasilli,12
+Kings,57048,State Senate,25,Rep,John Jasilli,9
+Kings,57049,State Senate,25,Rep,John Jasilli,2
+Kings,57050,State Senate,25,Rep,John Jasilli,6
+Kings,57051,State Senate,25,Rep,John Jasilli,13
+Kings,57052,State Senate,25,Rep,John Jasilli,7
+Kings,57053,State Senate,25,Rep,John Jasilli,8
+Kings,57054,State Senate,25,Rep,John Jasilli,5
+Kings,57055,State Senate,25,Rep,John Jasilli,9
+Kings,57056,State Senate,25,Rep,John Jasilli,3
+Kings,57057,State Senate,25,Rep,John Jasilli,11
+Kings,57058,State Senate,25,Rep,John Jasilli,7
+Kings,57059,State Senate,25,Rep,John Jasilli,8
+Kings,57060,State Senate,25,Rep,John Jasilli,18
+Kings,57061,State Senate,25,Rep,John Jasilli,28
+Kings,57062,State Senate,25,Rep,John Jasilli,5
+Kings,57063,State Senate,25,Rep,John Jasilli,13
+Kings,57064,State Senate,25,Rep,John Jasilli,12
+Kings,57065,State Senate,25,Rep,John Jasilli,11
+Kings,57066,State Senate,25,Rep,John Jasilli,6
+Kings,43045,State Senate,25,Con,John Jasilli,0
+Kings,43046,State Senate,25,Con,John Jasilli,0
+Kings,43047,State Senate,25,Con,John Jasilli,0
+Kings,43048,State Senate,25,Con,John Jasilli,3
+Kings,43049,State Senate,25,Con,John Jasilli,0
+Kings,43050,State Senate,25,Con,John Jasilli,2
+Kings,43051,State Senate,25,Con,John Jasilli,1
+Kings,50083,State Senate,25,Con,John Jasilli,7
+Kings,50085,State Senate,25,Con,John Jasilli,0
+Kings,50086,State Senate,25,Con,John Jasilli,0
+Kings,50089,State Senate,25,Con,John Jasilli,3
+Kings,50090,State Senate,25,Con,John Jasilli,2
+Kings,50091,State Senate,25,Con,John Jasilli,5
+Kings,50092,State Senate,25,Con,John Jasilli,1
+Kings,50093,State Senate,25,Con,John Jasilli,0
+Kings,50095,State Senate,25,Con,John Jasilli,0
+Kings,50097,State Senate,25,Con,John Jasilli,0
+Kings,51008,State Senate,25,Con,John Jasilli,0
+Kings,51044,State Senate,25,Con,John Jasilli,4
+Kings,51045,State Senate,25,Con,John Jasilli,0
+Kings,51046,State Senate,25,Con,John Jasilli,0
+Kings,51048,State Senate,25,Con,John Jasilli,0
+Kings,51049,State Senate,25,Con,John Jasilli,0
+Kings,51050,State Senate,25,Con,John Jasilli,3
+Kings,51051,State Senate,25,Con,John Jasilli,8
+Kings,51052,State Senate,25,Con,John Jasilli,6
+Kings,51053,State Senate,25,Con,John Jasilli,3
+Kings,51055,State Senate,25,Con,John Jasilli,0
+Kings,51069,State Senate,25,Con,John Jasilli,0
+Kings,51070,State Senate,25,Con,John Jasilli,0
+Kings,51071,State Senate,25,Con,John Jasilli,3
+Kings,51072,State Senate,25,Con,John Jasilli,0
+Kings,51073,State Senate,25,Con,John Jasilli,3
+Kings,51074,State Senate,25,Con,John Jasilli,1
+Kings,51075,State Senate,25,Con,John Jasilli,0
+Kings,51076,State Senate,25,Con,John Jasilli,2
+Kings,51078,State Senate,25,Con,John Jasilli,0
+Kings,52022,State Senate,25,Con,John Jasilli,0
+Kings,52023,State Senate,25,Con,John Jasilli,12
+Kings,52024,State Senate,25,Con,John Jasilli,2
+Kings,52025,State Senate,25,Con,John Jasilli,4
+Kings,52026,State Senate,25,Con,John Jasilli,0
+Kings,52027,State Senate,25,Con,John Jasilli,0
+Kings,52028,State Senate,25,Con,John Jasilli,5
+Kings,52029,State Senate,25,Con,John Jasilli,9
+Kings,52030,State Senate,25,Con,John Jasilli,5
+Kings,52031,State Senate,25,Con,John Jasilli,9
+Kings,52032,State Senate,25,Con,John Jasilli,9
+Kings,52033,State Senate,25,Con,John Jasilli,2
+Kings,52048,State Senate,25,Con,John Jasilli,6
+Kings,52049,State Senate,25,Con,John Jasilli,11
+Kings,52050,State Senate,25,Con,John Jasilli,2
+Kings,52051,State Senate,25,Con,John Jasilli,1
+Kings,52052,State Senate,25,Con,John Jasilli,1
+Kings,52053,State Senate,25,Con,John Jasilli,6
+Kings,52054,State Senate,25,Con,John Jasilli,0
+Kings,52055,State Senate,25,Con,John Jasilli,4
+Kings,52056,State Senate,25,Con,John Jasilli,5
+Kings,52057,State Senate,25,Con,John Jasilli,5
+Kings,52058,State Senate,25,Con,John Jasilli,6
+Kings,52059,State Senate,25,Con,John Jasilli,1
+Kings,52060,State Senate,25,Con,John Jasilli,4
+Kings,52061,State Senate,25,Con,John Jasilli,3
+Kings,52062,State Senate,25,Con,John Jasilli,4
+Kings,52063,State Senate,25,Con,John Jasilli,0
+Kings,52089,State Senate,25,Con,John Jasilli,7
+Kings,52090,State Senate,25,Con,John Jasilli,4
+Kings,52091,State Senate,25,Con,John Jasilli,4
+Kings,52095,State Senate,25,Con,John Jasilli,0
+Kings,52096,State Senate,25,Con,John Jasilli,4
+Kings,52097,State Senate,25,Con,John Jasilli,5
+Kings,52098,State Senate,25,Con,John Jasilli,19
+Kings,52099,State Senate,25,Con,John Jasilli,9
+Kings,52100,State Senate,25,Con,John Jasilli,3
+Kings,52102,State Senate,25,Con,John Jasilli,0
+Kings,52108,State Senate,25,Con,John Jasilli,0
+Kings,52109,State Senate,25,Con,John Jasilli,0
+Kings,52112,State Senate,25,Con,John Jasilli,7
+Kings,54015,State Senate,25,Con,John Jasilli,1
+Kings,54026,State Senate,25,Con,John Jasilli,0
+Kings,55002,State Senate,25,Con,John Jasilli,0
+Kings,55004,State Senate,25,Con,John Jasilli,1
+Kings,55008,State Senate,25,Con,John Jasilli,1
+Kings,55009,State Senate,25,Con,John Jasilli,0
+Kings,55010,State Senate,25,Con,John Jasilli,2
+Kings,55011,State Senate,25,Con,John Jasilli,2
+Kings,55012,State Senate,25,Con,John Jasilli,0
+Kings,55017,State Senate,25,Con,John Jasilli,2
+Kings,55018,State Senate,25,Con,John Jasilli,2
+Kings,55019,State Senate,25,Con,John Jasilli,0
+Kings,55020,State Senate,25,Con,John Jasilli,0
+Kings,55021,State Senate,25,Con,John Jasilli,1
+Kings,55022,State Senate,25,Con,John Jasilli,2
+Kings,55023,State Senate,25,Con,John Jasilli,1
+Kings,55024,State Senate,25,Con,John Jasilli,1
+Kings,55025,State Senate,25,Con,John Jasilli,0
+Kings,55028,State Senate,25,Con,John Jasilli,2
+Kings,55029,State Senate,25,Con,John Jasilli,1
+Kings,55030,State Senate,25,Con,John Jasilli,1
+Kings,55031,State Senate,25,Con,John Jasilli,1
+Kings,55032,State Senate,25,Con,John Jasilli,0
+Kings,55033,State Senate,25,Con,John Jasilli,3
+Kings,55034,State Senate,25,Con,John Jasilli,0
+Kings,55101,State Senate,25,Con,John Jasilli,1
+Kings,55102,State Senate,25,Con,John Jasilli,2
+Kings,55103,State Senate,25,Con,John Jasilli,2
+Kings,55104,State Senate,25,Con,John Jasilli,0
+Kings,56012,State Senate,25,Con,John Jasilli,3
+Kings,56013,State Senate,25,Con,John Jasilli,1
+Kings,56014,State Senate,25,Con,John Jasilli,1
+Kings,56015,State Senate,25,Con,John Jasilli,4
+Kings,56016,State Senate,25,Con,John Jasilli,4
+Kings,56018,State Senate,25,Con,John Jasilli,1
+Kings,56019,State Senate,25,Con,John Jasilli,0
+Kings,56021,State Senate,25,Con,John Jasilli,1
+Kings,56022,State Senate,25,Con,John Jasilli,3
+Kings,56023,State Senate,25,Con,John Jasilli,0
+Kings,56024,State Senate,25,Con,John Jasilli,2
+Kings,56025,State Senate,25,Con,John Jasilli,2
+Kings,56026,State Senate,25,Con,John Jasilli,0
+Kings,56027,State Senate,25,Con,John Jasilli,3
+Kings,56028,State Senate,25,Con,John Jasilli,1
+Kings,56029,State Senate,25,Con,John Jasilli,2
+Kings,56030,State Senate,25,Con,John Jasilli,2
+Kings,56031,State Senate,25,Con,John Jasilli,2
+Kings,56032,State Senate,25,Con,John Jasilli,2
+Kings,56033,State Senate,25,Con,John Jasilli,2
+Kings,56034,State Senate,25,Con,John Jasilli,0
+Kings,56035,State Senate,25,Con,John Jasilli,4
+Kings,56036,State Senate,25,Con,John Jasilli,1
+Kings,56037,State Senate,25,Con,John Jasilli,1
+Kings,56038,State Senate,25,Con,John Jasilli,0
+Kings,56039,State Senate,25,Con,John Jasilli,1
+Kings,56040,State Senate,25,Con,John Jasilli,4
+Kings,56041,State Senate,25,Con,John Jasilli,1
+Kings,56042,State Senate,25,Con,John Jasilli,1
+Kings,56043,State Senate,25,Con,John Jasilli,1
+Kings,56044,State Senate,25,Con,John Jasilli,2
+Kings,56045,State Senate,25,Con,John Jasilli,1
+Kings,56046,State Senate,25,Con,John Jasilli,3
+Kings,56047,State Senate,25,Con,John Jasilli,1
+Kings,56048,State Senate,25,Con,John Jasilli,2
+Kings,56049,State Senate,25,Con,John Jasilli,2
+Kings,56050,State Senate,25,Con,John Jasilli,3
+Kings,56051,State Senate,25,Con,John Jasilli,0
+Kings,56052,State Senate,25,Con,John Jasilli,3
+Kings,56053,State Senate,25,Con,John Jasilli,3
+Kings,56054,State Senate,25,Con,John Jasilli,1
+Kings,56055,State Senate,25,Con,John Jasilli,3
+Kings,56056,State Senate,25,Con,John Jasilli,0
+Kings,56057,State Senate,25,Con,John Jasilli,2
+Kings,56058,State Senate,25,Con,John Jasilli,0
+Kings,56059,State Senate,25,Con,John Jasilli,0
+Kings,56060,State Senate,25,Con,John Jasilli,0
+Kings,56061,State Senate,25,Con,John Jasilli,0
+Kings,56062,State Senate,25,Con,John Jasilli,1
+Kings,56063,State Senate,25,Con,John Jasilli,0
+Kings,56064,State Senate,25,Con,John Jasilli,2
+Kings,56065,State Senate,25,Con,John Jasilli,0
+Kings,56066,State Senate,25,Con,John Jasilli,1
+Kings,56068,State Senate,25,Con,John Jasilli,0
+Kings,56069,State Senate,25,Con,John Jasilli,2
+Kings,56070,State Senate,25,Con,John Jasilli,0
+Kings,56071,State Senate,25,Con,John Jasilli,2
+Kings,56072,State Senate,25,Con,John Jasilli,1
+Kings,56074,State Senate,25,Con,John Jasilli,0
+Kings,57001,State Senate,25,Con,John Jasilli,2
+Kings,57002,State Senate,25,Con,John Jasilli,1
+Kings,57003,State Senate,25,Con,John Jasilli,3
+Kings,57004,State Senate,25,Con,John Jasilli,1
+Kings,57006,State Senate,25,Con,John Jasilli,1
+Kings,57007,State Senate,25,Con,John Jasilli,0
+Kings,57008,State Senate,25,Con,John Jasilli,0
+Kings,57009,State Senate,25,Con,John Jasilli,2
+Kings,57010,State Senate,25,Con,John Jasilli,2
+Kings,57011,State Senate,25,Con,John Jasilli,2
+Kings,57012,State Senate,25,Con,John Jasilli,1
+Kings,57013,State Senate,25,Con,John Jasilli,1
+Kings,57014,State Senate,25,Con,John Jasilli,1
+Kings,57015,State Senate,25,Con,John Jasilli,3
+Kings,57016,State Senate,25,Con,John Jasilli,4
+Kings,57017,State Senate,25,Con,John Jasilli,3
+Kings,57018,State Senate,25,Con,John Jasilli,2
+Kings,57019,State Senate,25,Con,John Jasilli,1
+Kings,57020,State Senate,25,Con,John Jasilli,0
+Kings,57021,State Senate,25,Con,John Jasilli,6
+Kings,57022,State Senate,25,Con,John Jasilli,0
+Kings,57023,State Senate,25,Con,John Jasilli,3
+Kings,57024,State Senate,25,Con,John Jasilli,5
+Kings,57025,State Senate,25,Con,John Jasilli,6
+Kings,57026,State Senate,25,Con,John Jasilli,3
+Kings,57027,State Senate,25,Con,John Jasilli,2
+Kings,57028,State Senate,25,Con,John Jasilli,0
+Kings,57029,State Senate,25,Con,John Jasilli,4
+Kings,57030,State Senate,25,Con,John Jasilli,2
+Kings,57031,State Senate,25,Con,John Jasilli,4
+Kings,57032,State Senate,25,Con,John Jasilli,0
+Kings,57033,State Senate,25,Con,John Jasilli,3
+Kings,57034,State Senate,25,Con,John Jasilli,1
+Kings,57035,State Senate,25,Con,John Jasilli,3
+Kings,57036,State Senate,25,Con,John Jasilli,2
+Kings,57037,State Senate,25,Con,John Jasilli,0
+Kings,57038,State Senate,25,Con,John Jasilli,3
+Kings,57039,State Senate,25,Con,John Jasilli,2
+Kings,57040,State Senate,25,Con,John Jasilli,1
+Kings,57041,State Senate,25,Con,John Jasilli,1
+Kings,57042,State Senate,25,Con,John Jasilli,1
+Kings,57043,State Senate,25,Con,John Jasilli,2
+Kings,57044,State Senate,25,Con,John Jasilli,4
+Kings,57045,State Senate,25,Con,John Jasilli,0
+Kings,57046,State Senate,25,Con,John Jasilli,0
+Kings,57047,State Senate,25,Con,John Jasilli,0
+Kings,57048,State Senate,25,Con,John Jasilli,1
+Kings,57049,State Senate,25,Con,John Jasilli,1
+Kings,57050,State Senate,25,Con,John Jasilli,1
+Kings,57051,State Senate,25,Con,John Jasilli,1
+Kings,57052,State Senate,25,Con,John Jasilli,1
+Kings,57053,State Senate,25,Con,John Jasilli,1
+Kings,57054,State Senate,25,Con,John Jasilli,4
+Kings,57055,State Senate,25,Con,John Jasilli,1
+Kings,57056,State Senate,25,Con,John Jasilli,1
+Kings,57057,State Senate,25,Con,John Jasilli,0
+Kings,57058,State Senate,25,Con,John Jasilli,1
+Kings,57059,State Senate,25,Con,John Jasilli,2
+Kings,57060,State Senate,25,Con,John Jasilli,5
+Kings,57061,State Senate,25,Con,John Jasilli,0
+Kings,57062,State Senate,25,Con,John Jasilli,0
+Kings,57063,State Senate,25,Con,John Jasilli,0
+Kings,57064,State Senate,25,Con,John Jasilli,0
+Kings,57065,State Senate,25,Con,John Jasilli,2
+Kings,57066,State Senate,25,Con,John Jasilli,1
+Kings,43045,State Senate,25,Dem,Velmanette Montgomery,623
+Kings,43046,State Senate,25,Dem,Velmanette Montgomery,612
+Kings,43047,State Senate,25,Dem,Velmanette Montgomery,407
+Kings,43048,State Senate,25,Dem,Velmanette Montgomery,537
+Kings,43049,State Senate,25,Dem,Velmanette Montgomery,593
+Kings,43050,State Senate,25,Dem,Velmanette Montgomery,599
+Kings,43051,State Senate,25,Dem,Velmanette Montgomery,588
+Kings,50083,State Senate,25,Dem,Velmanette Montgomery,275
+Kings,50085,State Senate,25,Dem,Velmanette Montgomery,131
+Kings,50086,State Senate,25,Dem,Velmanette Montgomery,56
+Kings,50089,State Senate,25,Dem,Velmanette Montgomery,453
+Kings,50090,State Senate,25,Dem,Velmanette Montgomery,257
+Kings,50091,State Senate,25,Dem,Velmanette Montgomery,587
+Kings,50092,State Senate,25,Dem,Velmanette Montgomery,333
+Kings,50093,State Senate,25,Dem,Velmanette Montgomery,80
+Kings,50095,State Senate,25,Dem,Velmanette Montgomery,111
+Kings,50097,State Senate,25,Dem,Velmanette Montgomery,195
+Kings,51008,State Senate,25,Dem,Velmanette Montgomery,146
+Kings,51044,State Senate,25,Dem,Velmanette Montgomery,100
+Kings,51045,State Senate,25,Dem,Velmanette Montgomery,22
+Kings,51046,State Senate,25,Dem,Velmanette Montgomery,34
+Kings,51048,State Senate,25,Dem,Velmanette Montgomery,2
+Kings,51049,State Senate,25,Dem,Velmanette Montgomery,32
+Kings,51050,State Senate,25,Dem,Velmanette Montgomery,113
+Kings,51051,State Senate,25,Dem,Velmanette Montgomery,257
+Kings,51052,State Senate,25,Dem,Velmanette Montgomery,312
+Kings,51053,State Senate,25,Dem,Velmanette Montgomery,180
+Kings,51055,State Senate,25,Dem,Velmanette Montgomery,297
+Kings,51069,State Senate,25,Dem,Velmanette Montgomery,277
+Kings,51070,State Senate,25,Dem,Velmanette Montgomery,459
+Kings,51071,State Senate,25,Dem,Velmanette Montgomery,412
+Kings,51072,State Senate,25,Dem,Velmanette Montgomery,162
+Kings,51073,State Senate,25,Dem,Velmanette Montgomery,314
+Kings,51074,State Senate,25,Dem,Velmanette Montgomery,345
+Kings,51075,State Senate,25,Dem,Velmanette Montgomery,131
+Kings,51076,State Senate,25,Dem,Velmanette Montgomery,240
+Kings,51078,State Senate,25,Dem,Velmanette Montgomery,70
+Kings,52022,State Senate,25,Dem,Velmanette Montgomery,220
+Kings,52023,State Senate,25,Dem,Velmanette Montgomery,665
+Kings,52024,State Senate,25,Dem,Velmanette Montgomery,249
+Kings,52025,State Senate,25,Dem,Velmanette Montgomery,358
+Kings,52026,State Senate,25,Dem,Velmanette Montgomery,12
+Kings,52027,State Senate,25,Dem,Velmanette Montgomery,76
+Kings,52028,State Senate,25,Dem,Velmanette Montgomery,400
+Kings,52029,State Senate,25,Dem,Velmanette Montgomery,628
+Kings,52030,State Senate,25,Dem,Velmanette Montgomery,663
+Kings,52031,State Senate,25,Dem,Velmanette Montgomery,502
+Kings,52032,State Senate,25,Dem,Velmanette Montgomery,532
+Kings,52033,State Senate,25,Dem,Velmanette Montgomery,570
+Kings,52048,State Senate,25,Dem,Velmanette Montgomery,483
+Kings,52049,State Senate,25,Dem,Velmanette Montgomery,560
+Kings,52050,State Senate,25,Dem,Velmanette Montgomery,173
+Kings,52051,State Senate,25,Dem,Velmanette Montgomery,500
+Kings,52052,State Senate,25,Dem,Velmanette Montgomery,489
+Kings,52053,State Senate,25,Dem,Velmanette Montgomery,466
+Kings,52054,State Senate,25,Dem,Velmanette Montgomery,363
+Kings,52055,State Senate,25,Dem,Velmanette Montgomery,556
+Kings,52056,State Senate,25,Dem,Velmanette Montgomery,308
+Kings,52057,State Senate,25,Dem,Velmanette Montgomery,331
+Kings,52058,State Senate,25,Dem,Velmanette Montgomery,497
+Kings,52059,State Senate,25,Dem,Velmanette Montgomery,337
+Kings,52060,State Senate,25,Dem,Velmanette Montgomery,539
+Kings,52061,State Senate,25,Dem,Velmanette Montgomery,538
+Kings,52062,State Senate,25,Dem,Velmanette Montgomery,548
+Kings,52063,State Senate,25,Dem,Velmanette Montgomery,31
+Kings,52089,State Senate,25,Dem,Velmanette Montgomery,587
+Kings,52090,State Senate,25,Dem,Velmanette Montgomery,451
+Kings,52091,State Senate,25,Dem,Velmanette Montgomery,222
+Kings,52095,State Senate,25,Dem,Velmanette Montgomery,76
+Kings,52096,State Senate,25,Dem,Velmanette Montgomery,452
+Kings,52097,State Senate,25,Dem,Velmanette Montgomery,321
+Kings,52098,State Senate,25,Dem,Velmanette Montgomery,481
+Kings,52099,State Senate,25,Dem,Velmanette Montgomery,528
+Kings,52100,State Senate,25,Dem,Velmanette Montgomery,289
+Kings,52102,State Senate,25,Dem,Velmanette Montgomery,6
+Kings,52108,State Senate,25,Dem,Velmanette Montgomery,10
+Kings,52109,State Senate,25,Dem,Velmanette Montgomery,8
+Kings,52112,State Senate,25,Dem,Velmanette Montgomery,262
+Kings,54015,State Senate,25,Dem,Velmanette Montgomery,171
+Kings,54026,State Senate,25,Dem,Velmanette Montgomery,56
+Kings,55002,State Senate,25,Dem,Velmanette Montgomery,217
+Kings,55004,State Senate,25,Dem,Velmanette Montgomery,591
+Kings,55008,State Senate,25,Dem,Velmanette Montgomery,50
+Kings,55009,State Senate,25,Dem,Velmanette Montgomery,468
+Kings,55010,State Senate,25,Dem,Velmanette Montgomery,478
+Kings,55011,State Senate,25,Dem,Velmanette Montgomery,476
+Kings,55012,State Senate,25,Dem,Velmanette Montgomery,445
+Kings,55017,State Senate,25,Dem,Velmanette Montgomery,241
+Kings,55018,State Senate,25,Dem,Velmanette Montgomery,569
+Kings,55019,State Senate,25,Dem,Velmanette Montgomery,590
+Kings,55020,State Senate,25,Dem,Velmanette Montgomery,397
+Kings,55021,State Senate,25,Dem,Velmanette Montgomery,503
+Kings,55022,State Senate,25,Dem,Velmanette Montgomery,464
+Kings,55023,State Senate,25,Dem,Velmanette Montgomery,500
+Kings,55024,State Senate,25,Dem,Velmanette Montgomery,337
+Kings,55025,State Senate,25,Dem,Velmanette Montgomery,407
+Kings,55028,State Senate,25,Dem,Velmanette Montgomery,177
+Kings,55029,State Senate,25,Dem,Velmanette Montgomery,152
+Kings,55030,State Senate,25,Dem,Velmanette Montgomery,240
+Kings,55031,State Senate,25,Dem,Velmanette Montgomery,679
+Kings,55032,State Senate,25,Dem,Velmanette Montgomery,189
+Kings,55033,State Senate,25,Dem,Velmanette Montgomery,520
+Kings,55034,State Senate,25,Dem,Velmanette Montgomery,592
+Kings,55101,State Senate,25,Dem,Velmanette Montgomery,290
+Kings,55102,State Senate,25,Dem,Velmanette Montgomery,482
+Kings,55103,State Senate,25,Dem,Velmanette Montgomery,471
+Kings,55104,State Senate,25,Dem,Velmanette Montgomery,496
+Kings,56012,State Senate,25,Dem,Velmanette Montgomery,488
+Kings,56013,State Senate,25,Dem,Velmanette Montgomery,540
+Kings,56014,State Senate,25,Dem,Velmanette Montgomery,475
+Kings,56015,State Senate,25,Dem,Velmanette Montgomery,553
+Kings,56016,State Senate,25,Dem,Velmanette Montgomery,656
+Kings,56018,State Senate,25,Dem,Velmanette Montgomery,511
+Kings,56019,State Senate,25,Dem,Velmanette Montgomery,517
+Kings,56021,State Senate,25,Dem,Velmanette Montgomery,567
+Kings,56022,State Senate,25,Dem,Velmanette Montgomery,527
+Kings,56023,State Senate,25,Dem,Velmanette Montgomery,605
+Kings,56024,State Senate,25,Dem,Velmanette Montgomery,483
+Kings,56025,State Senate,25,Dem,Velmanette Montgomery,533
+Kings,56026,State Senate,25,Dem,Velmanette Montgomery,497
+Kings,56027,State Senate,25,Dem,Velmanette Montgomery,435
+Kings,56028,State Senate,25,Dem,Velmanette Montgomery,478
+Kings,56029,State Senate,25,Dem,Velmanette Montgomery,557
+Kings,56030,State Senate,25,Dem,Velmanette Montgomery,497
+Kings,56031,State Senate,25,Dem,Velmanette Montgomery,521
+Kings,56032,State Senate,25,Dem,Velmanette Montgomery,573
+Kings,56033,State Senate,25,Dem,Velmanette Montgomery,532
+Kings,56034,State Senate,25,Dem,Velmanette Montgomery,459
+Kings,56035,State Senate,25,Dem,Velmanette Montgomery,488
+Kings,56036,State Senate,25,Dem,Velmanette Montgomery,495
+Kings,56037,State Senate,25,Dem,Velmanette Montgomery,516
+Kings,56038,State Senate,25,Dem,Velmanette Montgomery,508
+Kings,56039,State Senate,25,Dem,Velmanette Montgomery,584
+Kings,56040,State Senate,25,Dem,Velmanette Montgomery,523
+Kings,56041,State Senate,25,Dem,Velmanette Montgomery,644
+Kings,56042,State Senate,25,Dem,Velmanette Montgomery,515
+Kings,56043,State Senate,25,Dem,Velmanette Montgomery,585
+Kings,56044,State Senate,25,Dem,Velmanette Montgomery,510
+Kings,56045,State Senate,25,Dem,Velmanette Montgomery,551
+Kings,56046,State Senate,25,Dem,Velmanette Montgomery,563
+Kings,56047,State Senate,25,Dem,Velmanette Montgomery,561
+Kings,56048,State Senate,25,Dem,Velmanette Montgomery,432
+Kings,56049,State Senate,25,Dem,Velmanette Montgomery,588
+Kings,56050,State Senate,25,Dem,Velmanette Montgomery,534
+Kings,56051,State Senate,25,Dem,Velmanette Montgomery,587
+Kings,56052,State Senate,25,Dem,Velmanette Montgomery,555
+Kings,56053,State Senate,25,Dem,Velmanette Montgomery,492
+Kings,56054,State Senate,25,Dem,Velmanette Montgomery,554
+Kings,56055,State Senate,25,Dem,Velmanette Montgomery,717
+Kings,56056,State Senate,25,Dem,Velmanette Montgomery,177
+Kings,56057,State Senate,25,Dem,Velmanette Montgomery,631
+Kings,56058,State Senate,25,Dem,Velmanette Montgomery,519
+Kings,56059,State Senate,25,Dem,Velmanette Montgomery,446
+Kings,56060,State Senate,25,Dem,Velmanette Montgomery,280
+Kings,56061,State Senate,25,Dem,Velmanette Montgomery,61
+Kings,56062,State Senate,25,Dem,Velmanette Montgomery,621
+Kings,56063,State Senate,25,Dem,Velmanette Montgomery,458
+Kings,56064,State Senate,25,Dem,Velmanette Montgomery,695
+Kings,56065,State Senate,25,Dem,Velmanette Montgomery,268
+Kings,56066,State Senate,25,Dem,Velmanette Montgomery,199
+Kings,56068,State Senate,25,Dem,Velmanette Montgomery,580
+Kings,56069,State Senate,25,Dem,Velmanette Montgomery,574
+Kings,56070,State Senate,25,Dem,Velmanette Montgomery,462
+Kings,56071,State Senate,25,Dem,Velmanette Montgomery,617
+Kings,56072,State Senate,25,Dem,Velmanette Montgomery,796
+Kings,56074,State Senate,25,Dem,Velmanette Montgomery,300
+Kings,57001,State Senate,25,Dem,Velmanette Montgomery,274
+Kings,57002,State Senate,25,Dem,Velmanette Montgomery,469
+Kings,57003,State Senate,25,Dem,Velmanette Montgomery,424
+Kings,57004,State Senate,25,Dem,Velmanette Montgomery,184
+Kings,57006,State Senate,25,Dem,Velmanette Montgomery,464
+Kings,57007,State Senate,25,Dem,Velmanette Montgomery,479
+Kings,57008,State Senate,25,Dem,Velmanette Montgomery,407
+Kings,57009,State Senate,25,Dem,Velmanette Montgomery,472
+Kings,57010,State Senate,25,Dem,Velmanette Montgomery,411
+Kings,57011,State Senate,25,Dem,Velmanette Montgomery,451
+Kings,57012,State Senate,25,Dem,Velmanette Montgomery,458
+Kings,57013,State Senate,25,Dem,Velmanette Montgomery,150
+Kings,57014,State Senate,25,Dem,Velmanette Montgomery,94
+Kings,57015,State Senate,25,Dem,Velmanette Montgomery,466
+Kings,57016,State Senate,25,Dem,Velmanette Montgomery,566
+Kings,57017,State Senate,25,Dem,Velmanette Montgomery,656
+Kings,57018,State Senate,25,Dem,Velmanette Montgomery,652
+Kings,57019,State Senate,25,Dem,Velmanette Montgomery,70
+Kings,57020,State Senate,25,Dem,Velmanette Montgomery,15
+Kings,57021,State Senate,25,Dem,Velmanette Montgomery,611
+Kings,57022,State Senate,25,Dem,Velmanette Montgomery,474
+Kings,57023,State Senate,25,Dem,Velmanette Montgomery,471
+Kings,57024,State Senate,25,Dem,Velmanette Montgomery,553
+Kings,57025,State Senate,25,Dem,Velmanette Montgomery,689
+Kings,57026,State Senate,25,Dem,Velmanette Montgomery,559
+Kings,57027,State Senate,25,Dem,Velmanette Montgomery,673
+Kings,57028,State Senate,25,Dem,Velmanette Montgomery,486
+Kings,57029,State Senate,25,Dem,Velmanette Montgomery,471
+Kings,57030,State Senate,25,Dem,Velmanette Montgomery,446
+Kings,57031,State Senate,25,Dem,Velmanette Montgomery,661
+Kings,57032,State Senate,25,Dem,Velmanette Montgomery,362
+Kings,57033,State Senate,25,Dem,Velmanette Montgomery,566
+Kings,57034,State Senate,25,Dem,Velmanette Montgomery,630
+Kings,57035,State Senate,25,Dem,Velmanette Montgomery,615
+Kings,57036,State Senate,25,Dem,Velmanette Montgomery,546
+Kings,57037,State Senate,25,Dem,Velmanette Montgomery,506
+Kings,57038,State Senate,25,Dem,Velmanette Montgomery,615
+Kings,57039,State Senate,25,Dem,Velmanette Montgomery,677
+Kings,57040,State Senate,25,Dem,Velmanette Montgomery,501
+Kings,57041,State Senate,25,Dem,Velmanette Montgomery,566
+Kings,57042,State Senate,25,Dem,Velmanette Montgomery,505
+Kings,57043,State Senate,25,Dem,Velmanette Montgomery,526
+Kings,57044,State Senate,25,Dem,Velmanette Montgomery,587
+Kings,57045,State Senate,25,Dem,Velmanette Montgomery,491
+Kings,57046,State Senate,25,Dem,Velmanette Montgomery,358
+Kings,57047,State Senate,25,Dem,Velmanette Montgomery,570
+Kings,57048,State Senate,25,Dem,Velmanette Montgomery,538
+Kings,57049,State Senate,25,Dem,Velmanette Montgomery,310
+Kings,57050,State Senate,25,Dem,Velmanette Montgomery,613
+Kings,57051,State Senate,25,Dem,Velmanette Montgomery,529
+Kings,57052,State Senate,25,Dem,Velmanette Montgomery,537
+Kings,57053,State Senate,25,Dem,Velmanette Montgomery,607
+Kings,57054,State Senate,25,Dem,Velmanette Montgomery,469
+Kings,57055,State Senate,25,Dem,Velmanette Montgomery,444
+Kings,57056,State Senate,25,Dem,Velmanette Montgomery,608
+Kings,57057,State Senate,25,Dem,Velmanette Montgomery,539
+Kings,57058,State Senate,25,Dem,Velmanette Montgomery,365
+Kings,57059,State Senate,25,Dem,Velmanette Montgomery,351
+Kings,57060,State Senate,25,Dem,Velmanette Montgomery,358
+Kings,57061,State Senate,25,Dem,Velmanette Montgomery,365
+Kings,57062,State Senate,25,Dem,Velmanette Montgomery,53
+Kings,57063,State Senate,25,Dem,Velmanette Montgomery,556
+Kings,57064,State Senate,25,Dem,Velmanette Montgomery,425
+Kings,57065,State Senate,25,Dem,Velmanette Montgomery,663
+Kings,57066,State Senate,25,Dem,Velmanette Montgomery,475
+Kings,43045,State Senate,25,WF,Velmanette Montgomery,41
+Kings,43046,State Senate,25,WF,Velmanette Montgomery,28
+Kings,43047,State Senate,25,WF,Velmanette Montgomery,19
+Kings,43048,State Senate,25,WF,Velmanette Montgomery,21
+Kings,43049,State Senate,25,WF,Velmanette Montgomery,12
+Kings,43050,State Senate,25,WF,Velmanette Montgomery,34
+Kings,43051,State Senate,25,WF,Velmanette Montgomery,12
+Kings,50083,State Senate,25,WF,Velmanette Montgomery,31
+Kings,50085,State Senate,25,WF,Velmanette Montgomery,23
+Kings,50086,State Senate,25,WF,Velmanette Montgomery,5
+Kings,50089,State Senate,25,WF,Velmanette Montgomery,76
+Kings,50090,State Senate,25,WF,Velmanette Montgomery,28
+Kings,50091,State Senate,25,WF,Velmanette Montgomery,75
+Kings,50092,State Senate,25,WF,Velmanette Montgomery,50
+Kings,50093,State Senate,25,WF,Velmanette Montgomery,6
+Kings,50095,State Senate,25,WF,Velmanette Montgomery,10
+Kings,50097,State Senate,25,WF,Velmanette Montgomery,2
+Kings,51008,State Senate,25,WF,Velmanette Montgomery,15
+Kings,51044,State Senate,25,WF,Velmanette Montgomery,15
+Kings,51045,State Senate,25,WF,Velmanette Montgomery,3
+Kings,51046,State Senate,25,WF,Velmanette Montgomery,2
+Kings,51048,State Senate,25,WF,Velmanette Montgomery,1
+Kings,51049,State Senate,25,WF,Velmanette Montgomery,1
+Kings,51050,State Senate,25,WF,Velmanette Montgomery,5
+Kings,51051,State Senate,25,WF,Velmanette Montgomery,15
+Kings,51052,State Senate,25,WF,Velmanette Montgomery,19
+Kings,51053,State Senate,25,WF,Velmanette Montgomery,14
+Kings,51055,State Senate,25,WF,Velmanette Montgomery,31
+Kings,51069,State Senate,25,WF,Velmanette Montgomery,12
+Kings,51070,State Senate,25,WF,Velmanette Montgomery,7
+Kings,51071,State Senate,25,WF,Velmanette Montgomery,11
+Kings,51072,State Senate,25,WF,Velmanette Montgomery,31
+Kings,51073,State Senate,25,WF,Velmanette Montgomery,16
+Kings,51074,State Senate,25,WF,Velmanette Montgomery,5
+Kings,51075,State Senate,25,WF,Velmanette Montgomery,13
+Kings,51076,State Senate,25,WF,Velmanette Montgomery,48
+Kings,51078,State Senate,25,WF,Velmanette Montgomery,15
+Kings,52022,State Senate,25,WF,Velmanette Montgomery,24
+Kings,52023,State Senate,25,WF,Velmanette Montgomery,76
+Kings,52024,State Senate,25,WF,Velmanette Montgomery,24
+Kings,52025,State Senate,25,WF,Velmanette Montgomery,23
+Kings,52026,State Senate,25,WF,Velmanette Montgomery,2
+Kings,52027,State Senate,25,WF,Velmanette Montgomery,6
+Kings,52028,State Senate,25,WF,Velmanette Montgomery,43
+Kings,52029,State Senate,25,WF,Velmanette Montgomery,71
+Kings,52030,State Senate,25,WF,Velmanette Montgomery,74
+Kings,52031,State Senate,25,WF,Velmanette Montgomery,58
+Kings,52032,State Senate,25,WF,Velmanette Montgomery,74
+Kings,52033,State Senate,25,WF,Velmanette Montgomery,68
+Kings,52048,State Senate,25,WF,Velmanette Montgomery,83
+Kings,52049,State Senate,25,WF,Velmanette Montgomery,75
+Kings,52050,State Senate,25,WF,Velmanette Montgomery,18
+Kings,52051,State Senate,25,WF,Velmanette Montgomery,17
+Kings,52052,State Senate,25,WF,Velmanette Montgomery,11
+Kings,52053,State Senate,25,WF,Velmanette Montgomery,76
+Kings,52054,State Senate,25,WF,Velmanette Montgomery,18
+Kings,52055,State Senate,25,WF,Velmanette Montgomery,75
+Kings,52056,State Senate,25,WF,Velmanette Montgomery,22
+Kings,52057,State Senate,25,WF,Velmanette Montgomery,75
+Kings,52058,State Senate,25,WF,Velmanette Montgomery,74
+Kings,52059,State Senate,25,WF,Velmanette Montgomery,52
+Kings,52060,State Senate,25,WF,Velmanette Montgomery,80
+Kings,52061,State Senate,25,WF,Velmanette Montgomery,69
+Kings,52062,State Senate,25,WF,Velmanette Montgomery,82
+Kings,52063,State Senate,25,WF,Velmanette Montgomery,3
+Kings,52089,State Senate,25,WF,Velmanette Montgomery,128
+Kings,52090,State Senate,25,WF,Velmanette Montgomery,67
+Kings,52091,State Senate,25,WF,Velmanette Montgomery,35
+Kings,52095,State Senate,25,WF,Velmanette Montgomery,17
+Kings,52096,State Senate,25,WF,Velmanette Montgomery,71
+Kings,52097,State Senate,25,WF,Velmanette Montgomery,31
+Kings,52098,State Senate,25,WF,Velmanette Montgomery,62
+Kings,52099,State Senate,25,WF,Velmanette Montgomery,78
+Kings,52100,State Senate,25,WF,Velmanette Montgomery,46
+Kings,52102,State Senate,25,WF,Velmanette Montgomery,1
+Kings,52108,State Senate,25,WF,Velmanette Montgomery,5
+Kings,52109,State Senate,25,WF,Velmanette Montgomery,2
+Kings,52112,State Senate,25,WF,Velmanette Montgomery,28
+Kings,54015,State Senate,25,WF,Velmanette Montgomery,9
+Kings,54026,State Senate,25,WF,Velmanette Montgomery,1
+Kings,55002,State Senate,25,WF,Velmanette Montgomery,7
+Kings,55004,State Senate,25,WF,Velmanette Montgomery,17
+Kings,55008,State Senate,25,WF,Velmanette Montgomery,1
+Kings,55009,State Senate,25,WF,Velmanette Montgomery,6
+Kings,55010,State Senate,25,WF,Velmanette Montgomery,11
+Kings,55011,State Senate,25,WF,Velmanette Montgomery,15
+Kings,55012,State Senate,25,WF,Velmanette Montgomery,9
+Kings,55017,State Senate,25,WF,Velmanette Montgomery,7
+Kings,55018,State Senate,25,WF,Velmanette Montgomery,9
+Kings,55019,State Senate,25,WF,Velmanette Montgomery,20
+Kings,55020,State Senate,25,WF,Velmanette Montgomery,8
+Kings,55021,State Senate,25,WF,Velmanette Montgomery,7
+Kings,55022,State Senate,25,WF,Velmanette Montgomery,5
+Kings,55023,State Senate,25,WF,Velmanette Montgomery,3
+Kings,55024,State Senate,25,WF,Velmanette Montgomery,6
+Kings,55025,State Senate,25,WF,Velmanette Montgomery,6
+Kings,55028,State Senate,25,WF,Velmanette Montgomery,3
+Kings,55029,State Senate,25,WF,Velmanette Montgomery,2
+Kings,55030,State Senate,25,WF,Velmanette Montgomery,8
+Kings,55031,State Senate,25,WF,Velmanette Montgomery,10
+Kings,55032,State Senate,25,WF,Velmanette Montgomery,6
+Kings,55033,State Senate,25,WF,Velmanette Montgomery,14
+Kings,55034,State Senate,25,WF,Velmanette Montgomery,9
+Kings,55101,State Senate,25,WF,Velmanette Montgomery,2
+Kings,55102,State Senate,25,WF,Velmanette Montgomery,6
+Kings,55103,State Senate,25,WF,Velmanette Montgomery,7
+Kings,55104,State Senate,25,WF,Velmanette Montgomery,10
+Kings,56012,State Senate,25,WF,Velmanette Montgomery,23
+Kings,56013,State Senate,25,WF,Velmanette Montgomery,29
+Kings,56014,State Senate,25,WF,Velmanette Montgomery,19
+Kings,56015,State Senate,25,WF,Velmanette Montgomery,22
+Kings,56016,State Senate,25,WF,Velmanette Montgomery,35
+Kings,56018,State Senate,25,WF,Velmanette Montgomery,27
+Kings,56019,State Senate,25,WF,Velmanette Montgomery,18
+Kings,56021,State Senate,25,WF,Velmanette Montgomery,15
+Kings,56022,State Senate,25,WF,Velmanette Montgomery,10
+Kings,56023,State Senate,25,WF,Velmanette Montgomery,18
+Kings,56024,State Senate,25,WF,Velmanette Montgomery,8
+Kings,56025,State Senate,25,WF,Velmanette Montgomery,9
+Kings,56026,State Senate,25,WF,Velmanette Montgomery,29
+Kings,56027,State Senate,25,WF,Velmanette Montgomery,10
+Kings,56028,State Senate,25,WF,Velmanette Montgomery,18
+Kings,56029,State Senate,25,WF,Velmanette Montgomery,20
+Kings,56030,State Senate,25,WF,Velmanette Montgomery,6
+Kings,56031,State Senate,25,WF,Velmanette Montgomery,8
+Kings,56032,State Senate,25,WF,Velmanette Montgomery,16
+Kings,56033,State Senate,25,WF,Velmanette Montgomery,16
+Kings,56034,State Senate,25,WF,Velmanette Montgomery,16
+Kings,56035,State Senate,25,WF,Velmanette Montgomery,23
+Kings,56036,State Senate,25,WF,Velmanette Montgomery,18
+Kings,56037,State Senate,25,WF,Velmanette Montgomery,33
+Kings,56038,State Senate,25,WF,Velmanette Montgomery,34
+Kings,56039,State Senate,25,WF,Velmanette Montgomery,26
+Kings,56040,State Senate,25,WF,Velmanette Montgomery,27
+Kings,56041,State Senate,25,WF,Velmanette Montgomery,25
+Kings,56042,State Senate,25,WF,Velmanette Montgomery,23
+Kings,56043,State Senate,25,WF,Velmanette Montgomery,25
+Kings,56044,State Senate,25,WF,Velmanette Montgomery,16
+Kings,56045,State Senate,25,WF,Velmanette Montgomery,16
+Kings,56046,State Senate,25,WF,Velmanette Montgomery,21
+Kings,56047,State Senate,25,WF,Velmanette Montgomery,12
+Kings,56048,State Senate,25,WF,Velmanette Montgomery,18
+Kings,56049,State Senate,25,WF,Velmanette Montgomery,27
+Kings,56050,State Senate,25,WF,Velmanette Montgomery,33
+Kings,56051,State Senate,25,WF,Velmanette Montgomery,17
+Kings,56052,State Senate,25,WF,Velmanette Montgomery,29
+Kings,56053,State Senate,25,WF,Velmanette Montgomery,18
+Kings,56054,State Senate,25,WF,Velmanette Montgomery,15
+Kings,56055,State Senate,25,WF,Velmanette Montgomery,48
+Kings,56056,State Senate,25,WF,Velmanette Montgomery,11
+Kings,56057,State Senate,25,WF,Velmanette Montgomery,13
+Kings,56058,State Senate,25,WF,Velmanette Montgomery,18
+Kings,56059,State Senate,25,WF,Velmanette Montgomery,9
+Kings,56060,State Senate,25,WF,Velmanette Montgomery,6
+Kings,56061,State Senate,25,WF,Velmanette Montgomery,0
+Kings,56062,State Senate,25,WF,Velmanette Montgomery,17
+Kings,56063,State Senate,25,WF,Velmanette Montgomery,5
+Kings,56064,State Senate,25,WF,Velmanette Montgomery,9
+Kings,56065,State Senate,25,WF,Velmanette Montgomery,6
+Kings,56066,State Senate,25,WF,Velmanette Montgomery,1
+Kings,56068,State Senate,25,WF,Velmanette Montgomery,12
+Kings,56069,State Senate,25,WF,Velmanette Montgomery,17
+Kings,56070,State Senate,25,WF,Velmanette Montgomery,10
+Kings,56071,State Senate,25,WF,Velmanette Montgomery,6
+Kings,56072,State Senate,25,WF,Velmanette Montgomery,22
+Kings,56074,State Senate,25,WF,Velmanette Montgomery,5
+Kings,57001,State Senate,25,WF,Velmanette Montgomery,5
+Kings,57002,State Senate,25,WF,Velmanette Montgomery,10
+Kings,57003,State Senate,25,WF,Velmanette Montgomery,7
+Kings,57004,State Senate,25,WF,Velmanette Montgomery,16
+Kings,57006,State Senate,25,WF,Velmanette Montgomery,4
+Kings,57007,State Senate,25,WF,Velmanette Montgomery,6
+Kings,57008,State Senate,25,WF,Velmanette Montgomery,8
+Kings,57009,State Senate,25,WF,Velmanette Montgomery,25
+Kings,57010,State Senate,25,WF,Velmanette Montgomery,29
+Kings,57011,State Senate,25,WF,Velmanette Montgomery,19
+Kings,57012,State Senate,25,WF,Velmanette Montgomery,7
+Kings,57013,State Senate,25,WF,Velmanette Montgomery,1
+Kings,57014,State Senate,25,WF,Velmanette Montgomery,6
+Kings,57015,State Senate,25,WF,Velmanette Montgomery,78
+Kings,57016,State Senate,25,WF,Velmanette Montgomery,73
+Kings,57017,State Senate,25,WF,Velmanette Montgomery,71
+Kings,57018,State Senate,25,WF,Velmanette Montgomery,31
+Kings,57019,State Senate,25,WF,Velmanette Montgomery,12
+Kings,57020,State Senate,25,WF,Velmanette Montgomery,2
+Kings,57021,State Senate,25,WF,Velmanette Montgomery,45
+Kings,57022,State Senate,25,WF,Velmanette Montgomery,56
+Kings,57023,State Senate,25,WF,Velmanette Montgomery,29
+Kings,57024,State Senate,25,WF,Velmanette Montgomery,62
+Kings,57025,State Senate,25,WF,Velmanette Montgomery,89
+Kings,57026,State Senate,25,WF,Velmanette Montgomery,71
+Kings,57027,State Senate,25,WF,Velmanette Montgomery,83
+Kings,57028,State Senate,25,WF,Velmanette Montgomery,56
+Kings,57029,State Senate,25,WF,Velmanette Montgomery,78
+Kings,57030,State Senate,25,WF,Velmanette Montgomery,20
+Kings,57031,State Senate,25,WF,Velmanette Montgomery,21
+Kings,57032,State Senate,25,WF,Velmanette Montgomery,3
+Kings,57033,State Senate,25,WF,Velmanette Montgomery,4
+Kings,57034,State Senate,25,WF,Velmanette Montgomery,76
+Kings,57035,State Senate,25,WF,Velmanette Montgomery,44
+Kings,57036,State Senate,25,WF,Velmanette Montgomery,60
+Kings,57037,State Senate,25,WF,Velmanette Montgomery,51
+Kings,57038,State Senate,25,WF,Velmanette Montgomery,49
+Kings,57039,State Senate,25,WF,Velmanette Montgomery,82
+Kings,57040,State Senate,25,WF,Velmanette Montgomery,54
+Kings,57041,State Senate,25,WF,Velmanette Montgomery,59
+Kings,57042,State Senate,25,WF,Velmanette Montgomery,49
+Kings,57043,State Senate,25,WF,Velmanette Montgomery,73
+Kings,57044,State Senate,25,WF,Velmanette Montgomery,31
+Kings,57045,State Senate,25,WF,Velmanette Montgomery,28
+Kings,57046,State Senate,25,WF,Velmanette Montgomery,8
+Kings,57047,State Senate,25,WF,Velmanette Montgomery,76
+Kings,57048,State Senate,25,WF,Velmanette Montgomery,68
+Kings,57049,State Senate,25,WF,Velmanette Montgomery,30
+Kings,57050,State Senate,25,WF,Velmanette Montgomery,68
+Kings,57051,State Senate,25,WF,Velmanette Montgomery,44
+Kings,57052,State Senate,25,WF,Velmanette Montgomery,35
+Kings,57053,State Senate,25,WF,Velmanette Montgomery,36
+Kings,57054,State Senate,25,WF,Velmanette Montgomery,32
+Kings,57055,State Senate,25,WF,Velmanette Montgomery,36
+Kings,57056,State Senate,25,WF,Velmanette Montgomery,48
+Kings,57057,State Senate,25,WF,Velmanette Montgomery,39
+Kings,57058,State Senate,25,WF,Velmanette Montgomery,25
+Kings,57059,State Senate,25,WF,Velmanette Montgomery,22
+Kings,57060,State Senate,25,WF,Velmanette Montgomery,45
+Kings,57061,State Senate,25,WF,Velmanette Montgomery,40
+Kings,57062,State Senate,25,WF,Velmanette Montgomery,5
+Kings,57063,State Senate,25,WF,Velmanette Montgomery,83
+Kings,57064,State Senate,25,WF,Velmanette Montgomery,64
+Kings,57065,State Senate,25,WF,Velmanette Montgomery,90
+Kings,57066,State Senate,25,WF,Velmanette Montgomery,57
+Kings,43045,State Senate,25,Ind,writein,0
+Kings,43046,State Senate,25,Ind,writein,0
+Kings,43047,State Senate,25,Ind,writein,0
+Kings,43048,State Senate,25,Ind,writein,0
+Kings,43049,State Senate,25,Ind,writein,0
+Kings,43050,State Senate,25,Ind,writein,0
+Kings,43051,State Senate,25,Ind,writein,0
+Kings,50083,State Senate,25,Ind,writein,0
+Kings,50085,State Senate,25,Ind,writein,0
+Kings,50086,State Senate,25,Ind,writein,0
+Kings,50089,State Senate,25,Ind,writein,1
+Kings,50090,State Senate,25,Ind,writein,1
+Kings,50091,State Senate,25,Ind,writein,0
+Kings,50092,State Senate,25,Ind,writein,1
+Kings,50093,State Senate,25,Ind,writein,0
+Kings,50095,State Senate,25,Ind,writein,0
+Kings,50097,State Senate,25,Ind,writein,0
+Kings,51008,State Senate,25,Ind,writein,0
+Kings,51044,State Senate,25,Ind,writein,0
+Kings,51045,State Senate,25,Ind,writein,0
+Kings,51046,State Senate,25,Ind,writein,0
+Kings,51048,State Senate,25,Ind,writein,0
+Kings,51049,State Senate,25,Ind,writein,0
+Kings,51050,State Senate,25,Ind,writein,0
+Kings,51051,State Senate,25,Ind,writein,2
+Kings,51052,State Senate,25,Ind,writein,0
+Kings,51053,State Senate,25,Ind,writein,0
+Kings,51055,State Senate,25,Ind,writein,0
+Kings,51069,State Senate,25,Ind,writein,0
+Kings,51070,State Senate,25,Ind,writein,0
+Kings,51071,State Senate,25,Ind,writein,0
+Kings,51072,State Senate,25,Ind,writein,0
+Kings,51073,State Senate,25,Ind,writein,0
+Kings,51074,State Senate,25,Ind,writein,1
+Kings,51075,State Senate,25,Ind,writein,0
+Kings,51076,State Senate,25,Ind,writein,3
+Kings,51078,State Senate,25,Ind,writein,0
+Kings,52022,State Senate,25,Ind,writein,0
+Kings,52023,State Senate,25,Ind,writein,1
+Kings,52024,State Senate,25,Ind,writein,0
+Kings,52025,State Senate,25,Ind,writein,0
+Kings,52026,State Senate,25,Ind,writein,0
+Kings,52027,State Senate,25,Ind,writein,0
+Kings,52028,State Senate,25,Ind,writein,0
+Kings,52029,State Senate,25,Ind,writein,3
+Kings,52030,State Senate,25,Ind,writein,0
+Kings,52031,State Senate,25,Ind,writein,0
+Kings,52032,State Senate,25,Ind,writein,0
+Kings,52033,State Senate,25,Ind,writein,0
+Kings,52048,State Senate,25,Ind,writein,0
+Kings,52049,State Senate,25,Ind,writein,1
+Kings,52050,State Senate,25,Ind,writein,0
+Kings,52051,State Senate,25,Ind,writein,0
+Kings,52052,State Senate,25,Ind,writein,0
+Kings,52053,State Senate,25,Ind,writein,0
+Kings,52054,State Senate,25,Ind,writein,0
+Kings,52055,State Senate,25,Ind,writein,0
+Kings,52056,State Senate,25,Ind,writein,0
+Kings,52057,State Senate,25,Ind,writein,1
+Kings,52058,State Senate,25,Ind,writein,0
+Kings,52059,State Senate,25,Ind,writein,1
+Kings,52060,State Senate,25,Ind,writein,0
+Kings,52061,State Senate,25,Ind,writein,0
+Kings,52062,State Senate,25,Ind,writein,1
+Kings,52063,State Senate,25,Ind,writein,1
+Kings,52089,State Senate,25,Ind,writein,1
+Kings,52090,State Senate,25,Ind,writein,1
+Kings,52091,State Senate,25,Ind,writein,0
+Kings,52095,State Senate,25,Ind,writein,0
+Kings,52096,State Senate,25,Ind,writein,0
+Kings,52097,State Senate,25,Ind,writein,0
+Kings,52098,State Senate,25,Ind,writein,0
+Kings,52099,State Senate,25,Ind,writein,1
+Kings,52100,State Senate,25,Ind,writein,0
+Kings,52102,State Senate,25,Ind,writein,0
+Kings,52108,State Senate,25,Ind,writein,0
+Kings,52109,State Senate,25,Ind,writein,0
+Kings,52112,State Senate,25,Ind,writein,0
+Kings,54015,State Senate,25,Ind,writein,0
+Kings,54026,State Senate,25,Ind,writein,0
+Kings,55002,State Senate,25,Ind,writein,0
+Kings,55004,State Senate,25,Ind,writein,0
+Kings,55008,State Senate,25,Ind,writein,0
+Kings,55009,State Senate,25,Ind,writein,0
+Kings,55010,State Senate,25,Ind,writein,0
+Kings,55011,State Senate,25,Ind,writein,0
+Kings,55012,State Senate,25,Ind,writein,0
+Kings,55017,State Senate,25,Ind,writein,0
+Kings,55018,State Senate,25,Ind,writein,0
+Kings,55019,State Senate,25,Ind,writein,0
+Kings,55020,State Senate,25,Ind,writein,0
+Kings,55021,State Senate,25,Ind,writein,0
+Kings,55022,State Senate,25,Ind,writein,0
+Kings,55023,State Senate,25,Ind,writein,0
+Kings,55024,State Senate,25,Ind,writein,0
+Kings,55025,State Senate,25,Ind,writein,0
+Kings,55028,State Senate,25,Ind,writein,0
+Kings,55029,State Senate,25,Ind,writein,1
+Kings,55030,State Senate,25,Ind,writein,0
+Kings,55031,State Senate,25,Ind,writein,0
+Kings,55032,State Senate,25,Ind,writein,0
+Kings,55033,State Senate,25,Ind,writein,0
+Kings,55034,State Senate,25,Ind,writein,0
+Kings,55101,State Senate,25,Ind,writein,0
+Kings,55102,State Senate,25,Ind,writein,0
+Kings,55103,State Senate,25,Ind,writein,0
+Kings,55104,State Senate,25,Ind,writein,0
+Kings,56012,State Senate,25,Ind,writein,0
+Kings,56013,State Senate,25,Ind,writein,0
+Kings,56014,State Senate,25,Ind,writein,0
+Kings,56015,State Senate,25,Ind,writein,1
+Kings,56016,State Senate,25,Ind,writein,0
+Kings,56018,State Senate,25,Ind,writein,1
+Kings,56019,State Senate,25,Ind,writein,0
+Kings,56021,State Senate,25,Ind,writein,0
+Kings,56022,State Senate,25,Ind,writein,0
+Kings,56023,State Senate,25,Ind,writein,0
+Kings,56024,State Senate,25,Ind,writein,0
+Kings,56025,State Senate,25,Ind,writein,0
+Kings,56026,State Senate,25,Ind,writein,0
+Kings,56027,State Senate,25,Ind,writein,0
+Kings,56028,State Senate,25,Ind,writein,1
+Kings,56029,State Senate,25,Ind,writein,1
+Kings,56030,State Senate,25,Ind,writein,0
+Kings,56031,State Senate,25,Ind,writein,0
+Kings,56032,State Senate,25,Ind,writein,0
+Kings,56033,State Senate,25,Ind,writein,0
+Kings,56034,State Senate,25,Ind,writein,0
+Kings,56035,State Senate,25,Ind,writein,1
+Kings,56036,State Senate,25,Ind,writein,0
+Kings,56037,State Senate,25,Ind,writein,0
+Kings,56038,State Senate,25,Ind,writein,0
+Kings,56039,State Senate,25,Ind,writein,0
+Kings,56040,State Senate,25,Ind,writein,0
+Kings,56041,State Senate,25,Ind,writein,0
+Kings,56042,State Senate,25,Ind,writein,0
+Kings,56043,State Senate,25,Ind,writein,0
+Kings,56044,State Senate,25,Ind,writein,0
+Kings,56045,State Senate,25,Ind,writein,0
+Kings,56046,State Senate,25,Ind,writein,0
+Kings,56047,State Senate,25,Ind,writein,0
+Kings,56048,State Senate,25,Ind,writein,0
+Kings,56049,State Senate,25,Ind,writein,0
+Kings,56050,State Senate,25,Ind,writein,0
+Kings,56051,State Senate,25,Ind,writein,0
+Kings,56052,State Senate,25,Ind,writein,0
+Kings,56053,State Senate,25,Ind,writein,0
+Kings,56054,State Senate,25,Ind,writein,0
+Kings,56055,State Senate,25,Ind,writein,1
+Kings,56056,State Senate,25,Ind,writein,1
+Kings,56057,State Senate,25,Ind,writein,0
+Kings,56058,State Senate,25,Ind,writein,0
+Kings,56059,State Senate,25,Ind,writein,0
+Kings,56060,State Senate,25,Ind,writein,0
+Kings,56061,State Senate,25,Ind,writein,0
+Kings,56062,State Senate,25,Ind,writein,0
+Kings,56063,State Senate,25,Ind,writein,0
+Kings,56064,State Senate,25,Ind,writein,0
+Kings,56065,State Senate,25,Ind,writein,0
+Kings,56066,State Senate,25,Ind,writein,0
+Kings,56068,State Senate,25,Ind,writein,0
+Kings,56069,State Senate,25,Ind,writein,0
+Kings,56070,State Senate,25,Ind,writein,0
+Kings,56071,State Senate,25,Ind,writein,0
+Kings,56072,State Senate,25,Ind,writein,0
+Kings,56074,State Senate,25,Ind,writein,0
+Kings,57001,State Senate,25,Ind,writein,0
+Kings,57002,State Senate,25,Ind,writein,0
+Kings,57003,State Senate,25,Ind,writein,0
+Kings,57004,State Senate,25,Ind,writein,0
+Kings,57006,State Senate,25,Ind,writein,0
+Kings,57007,State Senate,25,Ind,writein,0
+Kings,57008,State Senate,25,Ind,writein,0
+Kings,57009,State Senate,25,Ind,writein,1
+Kings,57010,State Senate,25,Ind,writein,1
+Kings,57011,State Senate,25,Ind,writein,0
+Kings,57012,State Senate,25,Ind,writein,0
+Kings,57013,State Senate,25,Ind,writein,0
+Kings,57014,State Senate,25,Ind,writein,0
+Kings,57015,State Senate,25,Ind,writein,0
+Kings,57016,State Senate,25,Ind,writein,0
+Kings,57017,State Senate,25,Ind,writein,0
+Kings,57018,State Senate,25,Ind,writein,0
+Kings,57019,State Senate,25,Ind,writein,0
+Kings,57020,State Senate,25,Ind,writein,0
+Kings,57021,State Senate,25,Ind,writein,0
+Kings,57022,State Senate,25,Ind,writein,1
+Kings,57023,State Senate,25,Ind,writein,2
+Kings,57024,State Senate,25,Ind,writein,0
+Kings,57025,State Senate,25,Ind,writein,0
+Kings,57026,State Senate,25,Ind,writein,0
+Kings,57027,State Senate,25,Ind,writein,0
+Kings,57028,State Senate,25,Ind,writein,1
+Kings,57029,State Senate,25,Ind,writein,1
+Kings,57030,State Senate,25,Ind,writein,0
+Kings,57031,State Senate,25,Ind,writein,0
+Kings,57032,State Senate,25,Ind,writein,0
+Kings,57033,State Senate,25,Ind,writein,0
+Kings,57034,State Senate,25,Ind,writein,0
+Kings,57035,State Senate,25,Ind,writein,0
+Kings,57036,State Senate,25,Ind,writein,0
+Kings,57037,State Senate,25,Ind,writein,0
+Kings,57038,State Senate,25,Ind,writein,0
+Kings,57039,State Senate,25,Ind,writein,0
+Kings,57040,State Senate,25,Ind,writein,0
+Kings,57041,State Senate,25,Ind,writein,0
+Kings,57042,State Senate,25,Ind,writein,1
+Kings,57043,State Senate,25,Ind,writein,0
+Kings,57044,State Senate,25,Ind,writein,1
+Kings,57045,State Senate,25,Ind,writein,0
+Kings,57046,State Senate,25,Ind,writein,1
+Kings,57047,State Senate,25,Ind,writein,1
+Kings,57048,State Senate,25,Ind,writein,0
+Kings,57049,State Senate,25,Ind,writein,0
+Kings,57050,State Senate,25,Ind,writein,0
+Kings,57051,State Senate,25,Ind,writein,0
+Kings,57052,State Senate,25,Ind,writein,0
+Kings,57053,State Senate,25,Ind,writein,0
+Kings,57054,State Senate,25,Ind,writein,0
+Kings,57055,State Senate,25,Ind,writein,2
+Kings,57056,State Senate,25,Ind,writein,0
+Kings,57057,State Senate,25,Ind,writein,0
+Kings,57058,State Senate,25,Ind,writein,0
+Kings,57059,State Senate,25,Ind,writein,0
+Kings,57060,State Senate,25,Ind,writein,2
+Kings,57061,State Senate,25,Ind,writein,0
+Kings,57062,State Senate,25,Ind,writein,0
+Kings,57063,State Senate,25,Ind,writein,0
+Kings,57064,State Senate,25,Ind,writein,0
+Kings,57065,State Senate,25,Ind,writein,0
+Kings,57066,State Senate,25,Ind,writein,0
+Kings,50024,State Senate,26,Dem,Daniel Squadron,54
+Kings,50026,State Senate,26,Dem,Daniel Squadron,321
+Kings,50027,State Senate,26,Dem,Daniel Squadron,479
+Kings,50028,State Senate,26,Dem,Daniel Squadron,358
+Kings,50029,State Senate,26,Dem,Daniel Squadron,436
+Kings,50030,State Senate,26,Dem,Daniel Squadron,343
+Kings,50031,State Senate,26,Dem,Daniel Squadron,396
+Kings,50032,State Senate,26,Dem,Daniel Squadron,412
+Kings,50033,State Senate,26,Dem,Daniel Squadron,503
+Kings,50034,State Senate,26,Dem,Daniel Squadron,288
+Kings,50035,State Senate,26,Dem,Daniel Squadron,444
+Kings,50036,State Senate,26,Dem,Daniel Squadron,92
+Kings,50037,State Senate,26,Dem,Daniel Squadron,935
+Kings,50038,State Senate,26,Dem,Daniel Squadron,519
+Kings,50039,State Senate,26,Dem,Daniel Squadron,337
+Kings,50040,State Senate,26,Dem,Daniel Squadron,384
+Kings,50041,State Senate,26,Dem,Daniel Squadron,567
+Kings,50042,State Senate,26,Dem,Daniel Squadron,412
+Kings,50047,State Senate,26,Dem,Daniel Squadron,283
+Kings,50048,State Senate,26,Dem,Daniel Squadron,319
+Kings,50055,State Senate,26,Dem,Daniel Squadron,93
+Kings,50064,State Senate,26,Dem,Daniel Squadron,83
+Kings,50065,State Senate,26,Dem,Daniel Squadron,113
+Kings,50066,State Senate,26,Dem,Daniel Squadron,97
+Kings,50067,State Senate,26,Dem,Daniel Squadron,73
+Kings,50068,State Senate,26,Dem,Daniel Squadron,123
+Kings,50069,State Senate,26,Dem,Daniel Squadron,138
+Kings,50070,State Senate,26,Dem,Daniel Squadron,44
+Kings,50071,State Senate,26,Dem,Daniel Squadron,35
+Kings,50072,State Senate,26,Dem,Daniel Squadron,148
+Kings,50073,State Senate,26,Dem,Daniel Squadron,87
+Kings,50074,State Senate,26,Dem,Daniel Squadron,90
+Kings,50075,State Senate,26,Dem,Daniel Squadron,163
+Kings,50076,State Senate,26,Dem,Daniel Squadron,109
+Kings,50077,State Senate,26,Dem,Daniel Squadron,111
+Kings,50078,State Senate,26,Dem,Daniel Squadron,106
+Kings,50079,State Senate,26,Dem,Daniel Squadron,102
+Kings,50080,State Senate,26,Dem,Daniel Squadron,90
+Kings,50082,State Senate,26,Dem,Daniel Squadron,65
+Kings,50087,State Senate,26,Dem,Daniel Squadron,80
+Kings,50094,State Senate,26,Dem,Daniel Squadron,72
+Kings,50099,State Senate,26,Dem,Daniel Squadron,11
+Kings,51007,State Senate,26,Dem,Daniel Squadron,427
+Kings,52001,State Senate,26,Dem,Daniel Squadron,525
+Kings,52002,State Senate,26,Dem,Daniel Squadron,143
+Kings,52004,State Senate,26,Dem,Daniel Squadron,297
+Kings,52005,State Senate,26,Dem,Daniel Squadron,335
+Kings,52006,State Senate,26,Dem,Daniel Squadron,126
+Kings,52007,State Senate,26,Dem,Daniel Squadron,540
+Kings,52008,State Senate,26,Dem,Daniel Squadron,565
+Kings,52009,State Senate,26,Dem,Daniel Squadron,497
+Kings,52010,State Senate,26,Dem,Daniel Squadron,616
+Kings,52011,State Senate,26,Dem,Daniel Squadron,451
+Kings,52012,State Senate,26,Dem,Daniel Squadron,546
+Kings,52013,State Senate,26,Dem,Daniel Squadron,528
+Kings,52014,State Senate,26,Dem,Daniel Squadron,566
+Kings,52015,State Senate,26,Dem,Daniel Squadron,587
+Kings,52016,State Senate,26,Dem,Daniel Squadron,616
+Kings,52017,State Senate,26,Dem,Daniel Squadron,593
+Kings,52018,State Senate,26,Dem,Daniel Squadron,510
+Kings,52019,State Senate,26,Dem,Daniel Squadron,523
+Kings,52020,State Senate,26,Dem,Daniel Squadron,302
+Kings,52021,State Senate,26,Dem,Daniel Squadron,207
+Kings,52034,State Senate,26,Dem,Daniel Squadron,468
+Kings,52035,State Senate,26,Dem,Daniel Squadron,498
+Kings,52036,State Senate,26,Dem,Daniel Squadron,647
+Kings,52037,State Senate,26,Dem,Daniel Squadron,503
+Kings,52038,State Senate,26,Dem,Daniel Squadron,591
+Kings,52039,State Senate,26,Dem,Daniel Squadron,543
+Kings,52040,State Senate,26,Dem,Daniel Squadron,662
+Kings,52041,State Senate,26,Dem,Daniel Squadron,182
+Kings,52042,State Senate,26,Dem,Daniel Squadron,462
+Kings,52043,State Senate,26,Dem,Daniel Squadron,491
+Kings,52044,State Senate,26,Dem,Daniel Squadron,526
+Kings,52045,State Senate,26,Dem,Daniel Squadron,435
+Kings,52046,State Senate,26,Dem,Daniel Squadron,571
+Kings,52047,State Senate,26,Dem,Daniel Squadron,429
+Kings,52103,State Senate,26,Dem,Daniel Squadron,4
+Kings,52104,State Senate,26,Dem,Daniel Squadron,1
+Kings,52105,State Senate,26,Dem,Daniel Squadron,4
+Kings,52106,State Senate,26,Dem,Daniel Squadron,3
+Kings,52110,State Senate,26,Dem,Daniel Squadron,459
+Kings,53014,State Senate,26,Dem,Daniel Squadron,10
+Kings,53078,State Senate,26,Dem,Daniel Squadron,98
+Kings,50024,State Senate,26,WF,Daniel Squadron,7
+Kings,50026,State Senate,26,WF,Daniel Squadron,47
+Kings,50027,State Senate,26,WF,Daniel Squadron,94
+Kings,50028,State Senate,26,WF,Daniel Squadron,50
+Kings,50029,State Senate,26,WF,Daniel Squadron,71
+Kings,50030,State Senate,26,WF,Daniel Squadron,61
+Kings,50031,State Senate,26,WF,Daniel Squadron,64
+Kings,50032,State Senate,26,WF,Daniel Squadron,61
+Kings,50033,State Senate,26,WF,Daniel Squadron,71
+Kings,50034,State Senate,26,WF,Daniel Squadron,39
+Kings,50035,State Senate,26,WF,Daniel Squadron,76
+Kings,50036,State Senate,26,WF,Daniel Squadron,4
+Kings,50037,State Senate,26,WF,Daniel Squadron,54
+Kings,50038,State Senate,26,WF,Daniel Squadron,66
+Kings,50039,State Senate,26,WF,Daniel Squadron,34
+Kings,50040,State Senate,26,WF,Daniel Squadron,35
+Kings,50041,State Senate,26,WF,Daniel Squadron,62
+Kings,50042,State Senate,26,WF,Daniel Squadron,58
+Kings,50047,State Senate,26,WF,Daniel Squadron,27
+Kings,50048,State Senate,26,WF,Daniel Squadron,29
+Kings,50055,State Senate,26,WF,Daniel Squadron,11
+Kings,50064,State Senate,26,WF,Daniel Squadron,7
+Kings,50065,State Senate,26,WF,Daniel Squadron,3
+Kings,50066,State Senate,26,WF,Daniel Squadron,4
+Kings,50067,State Senate,26,WF,Daniel Squadron,5
+Kings,50068,State Senate,26,WF,Daniel Squadron,2
+Kings,50069,State Senate,26,WF,Daniel Squadron,10
+Kings,50070,State Senate,26,WF,Daniel Squadron,3
+Kings,50071,State Senate,26,WF,Daniel Squadron,1
+Kings,50072,State Senate,26,WF,Daniel Squadron,13
+Kings,50073,State Senate,26,WF,Daniel Squadron,1
+Kings,50074,State Senate,26,WF,Daniel Squadron,5
+Kings,50075,State Senate,26,WF,Daniel Squadron,7
+Kings,50076,State Senate,26,WF,Daniel Squadron,15
+Kings,50077,State Senate,26,WF,Daniel Squadron,6
+Kings,50078,State Senate,26,WF,Daniel Squadron,4
+Kings,50079,State Senate,26,WF,Daniel Squadron,6
+Kings,50080,State Senate,26,WF,Daniel Squadron,10
+Kings,50082,State Senate,26,WF,Daniel Squadron,2
+Kings,50087,State Senate,26,WF,Daniel Squadron,8
+Kings,50094,State Senate,26,WF,Daniel Squadron,0
+Kings,50099,State Senate,26,WF,Daniel Squadron,0
+Kings,51007,State Senate,26,WF,Daniel Squadron,57
+Kings,52001,State Senate,26,WF,Daniel Squadron,46
+Kings,52002,State Senate,26,WF,Daniel Squadron,10
+Kings,52004,State Senate,26,WF,Daniel Squadron,16
+Kings,52005,State Senate,26,WF,Daniel Squadron,17
+Kings,52006,State Senate,26,WF,Daniel Squadron,9
+Kings,52007,State Senate,26,WF,Daniel Squadron,64
+Kings,52008,State Senate,26,WF,Daniel Squadron,58
+Kings,52009,State Senate,26,WF,Daniel Squadron,47
+Kings,52010,State Senate,26,WF,Daniel Squadron,51
+Kings,52011,State Senate,26,WF,Daniel Squadron,32
+Kings,52012,State Senate,26,WF,Daniel Squadron,50
+Kings,52013,State Senate,26,WF,Daniel Squadron,31
+Kings,52014,State Senate,26,WF,Daniel Squadron,42
+Kings,52015,State Senate,26,WF,Daniel Squadron,50
+Kings,52016,State Senate,26,WF,Daniel Squadron,51
+Kings,52017,State Senate,26,WF,Daniel Squadron,53
+Kings,52018,State Senate,26,WF,Daniel Squadron,49
+Kings,52019,State Senate,26,WF,Daniel Squadron,51
+Kings,52020,State Senate,26,WF,Daniel Squadron,30
+Kings,52021,State Senate,26,WF,Daniel Squadron,13
+Kings,52034,State Senate,26,WF,Daniel Squadron,65
+Kings,52035,State Senate,26,WF,Daniel Squadron,68
+Kings,52036,State Senate,26,WF,Daniel Squadron,85
+Kings,52037,State Senate,26,WF,Daniel Squadron,65
+Kings,52038,State Senate,26,WF,Daniel Squadron,72
+Kings,52039,State Senate,26,WF,Daniel Squadron,68
+Kings,52040,State Senate,26,WF,Daniel Squadron,64
+Kings,52041,State Senate,26,WF,Daniel Squadron,42
+Kings,52042,State Senate,26,WF,Daniel Squadron,63
+Kings,52043,State Senate,26,WF,Daniel Squadron,53
+Kings,52044,State Senate,26,WF,Daniel Squadron,64
+Kings,52045,State Senate,26,WF,Daniel Squadron,57
+Kings,52046,State Senate,26,WF,Daniel Squadron,86
+Kings,52047,State Senate,26,WF,Daniel Squadron,45
+Kings,52103,State Senate,26,WF,Daniel Squadron,0
+Kings,52104,State Senate,26,WF,Daniel Squadron,0
+Kings,52105,State Senate,26,WF,Daniel Squadron,0
+Kings,52106,State Senate,26,WF,Daniel Squadron,1
+Kings,52110,State Senate,26,WF,Daniel Squadron,57
+Kings,53014,State Senate,26,WF,Daniel Squadron,1
+Kings,53078,State Senate,26,WF,Daniel Squadron,10
+Kings,50024,State Senate,26,Rep,Jacqueline Haro,1
+Kings,50026,State Senate,26,Rep,Jacqueline Haro,32
+Kings,50027,State Senate,26,Rep,Jacqueline Haro,80
+Kings,50028,State Senate,26,Rep,Jacqueline Haro,36
+Kings,50029,State Senate,26,Rep,Jacqueline Haro,71
+Kings,50030,State Senate,26,Rep,Jacqueline Haro,74
+Kings,50031,State Senate,26,Rep,Jacqueline Haro,63
+Kings,50032,State Senate,26,Rep,Jacqueline Haro,97
+Kings,50033,State Senate,26,Rep,Jacqueline Haro,95
+Kings,50034,State Senate,26,Rep,Jacqueline Haro,78
+Kings,50035,State Senate,26,Rep,Jacqueline Haro,64
+Kings,50036,State Senate,26,Rep,Jacqueline Haro,11
+Kings,50037,State Senate,26,Rep,Jacqueline Haro,123
+Kings,50038,State Senate,26,Rep,Jacqueline Haro,50
+Kings,50039,State Senate,26,Rep,Jacqueline Haro,35
+Kings,50040,State Senate,26,Rep,Jacqueline Haro,45
+Kings,50041,State Senate,26,Rep,Jacqueline Haro,78
+Kings,50042,State Senate,26,Rep,Jacqueline Haro,89
+Kings,50047,State Senate,26,Rep,Jacqueline Haro,13
+Kings,50048,State Senate,26,Rep,Jacqueline Haro,42
+Kings,50055,State Senate,26,Rep,Jacqueline Haro,8
+Kings,50064,State Senate,26,Rep,Jacqueline Haro,24
+Kings,50065,State Senate,26,Rep,Jacqueline Haro,26
+Kings,50066,State Senate,26,Rep,Jacqueline Haro,40
+Kings,50067,State Senate,26,Rep,Jacqueline Haro,20
+Kings,50068,State Senate,26,Rep,Jacqueline Haro,30
+Kings,50069,State Senate,26,Rep,Jacqueline Haro,28
+Kings,50070,State Senate,26,Rep,Jacqueline Haro,15
+Kings,50071,State Senate,26,Rep,Jacqueline Haro,13
+Kings,50072,State Senate,26,Rep,Jacqueline Haro,32
+Kings,50073,State Senate,26,Rep,Jacqueline Haro,48
+Kings,50074,State Senate,26,Rep,Jacqueline Haro,40
+Kings,50075,State Senate,26,Rep,Jacqueline Haro,47
+Kings,50076,State Senate,26,Rep,Jacqueline Haro,28
+Kings,50077,State Senate,26,Rep,Jacqueline Haro,56
+Kings,50078,State Senate,26,Rep,Jacqueline Haro,52
+Kings,50079,State Senate,26,Rep,Jacqueline Haro,52
+Kings,50080,State Senate,26,Rep,Jacqueline Haro,26
+Kings,50082,State Senate,26,Rep,Jacqueline Haro,25
+Kings,50087,State Senate,26,Rep,Jacqueline Haro,6
+Kings,50094,State Senate,26,Rep,Jacqueline Haro,4
+Kings,50099,State Senate,26,Rep,Jacqueline Haro,1
+Kings,51007,State Senate,26,Rep,Jacqueline Haro,35
+Kings,52001,State Senate,26,Rep,Jacqueline Haro,65
+Kings,52002,State Senate,26,Rep,Jacqueline Haro,12
+Kings,52004,State Senate,26,Rep,Jacqueline Haro,53
+Kings,52005,State Senate,26,Rep,Jacqueline Haro,41
+Kings,52006,State Senate,26,Rep,Jacqueline Haro,16
+Kings,52007,State Senate,26,Rep,Jacqueline Haro,83
+Kings,52008,State Senate,26,Rep,Jacqueline Haro,64
+Kings,52009,State Senate,26,Rep,Jacqueline Haro,67
+Kings,52010,State Senate,26,Rep,Jacqueline Haro,91
+Kings,52011,State Senate,26,Rep,Jacqueline Haro,73
+Kings,52012,State Senate,26,Rep,Jacqueline Haro,98
+Kings,52013,State Senate,26,Rep,Jacqueline Haro,52
+Kings,52014,State Senate,26,Rep,Jacqueline Haro,72
+Kings,52015,State Senate,26,Rep,Jacqueline Haro,85
+Kings,52016,State Senate,26,Rep,Jacqueline Haro,83
+Kings,52017,State Senate,26,Rep,Jacqueline Haro,69
+Kings,52018,State Senate,26,Rep,Jacqueline Haro,73
+Kings,52019,State Senate,26,Rep,Jacqueline Haro,58
+Kings,52020,State Senate,26,Rep,Jacqueline Haro,49
+Kings,52021,State Senate,26,Rep,Jacqueline Haro,39
+Kings,52034,State Senate,26,Rep,Jacqueline Haro,40
+Kings,52035,State Senate,26,Rep,Jacqueline Haro,57
+Kings,52036,State Senate,26,Rep,Jacqueline Haro,58
+Kings,52037,State Senate,26,Rep,Jacqueline Haro,54
+Kings,52038,State Senate,26,Rep,Jacqueline Haro,60
+Kings,52039,State Senate,26,Rep,Jacqueline Haro,51
+Kings,52040,State Senate,26,Rep,Jacqueline Haro,46
+Kings,52041,State Senate,26,Rep,Jacqueline Haro,13
+Kings,52042,State Senate,26,Rep,Jacqueline Haro,57
+Kings,52043,State Senate,26,Rep,Jacqueline Haro,46
+Kings,52044,State Senate,26,Rep,Jacqueline Haro,94
+Kings,52045,State Senate,26,Rep,Jacqueline Haro,76
+Kings,52046,State Senate,26,Rep,Jacqueline Haro,51
+Kings,52047,State Senate,26,Rep,Jacqueline Haro,36
+Kings,52103,State Senate,26,Rep,Jacqueline Haro,0
+Kings,52104,State Senate,26,Rep,Jacqueline Haro,0
+Kings,52105,State Senate,26,Rep,Jacqueline Haro,0
+Kings,52106,State Senate,26,Rep,Jacqueline Haro,0
+Kings,52110,State Senate,26,Rep,Jacqueline Haro,31
+Kings,53014,State Senate,26,Rep,Jacqueline Haro,5
+Kings,53078,State Senate,26,Rep,Jacqueline Haro,47
+Kings,50024,State Senate,26,Ind,writein,0
+Kings,50026,State Senate,26,Ind,writein,0
+Kings,50027,State Senate,26,Ind,writein,0
+Kings,50028,State Senate,26,Ind,writein,0
+Kings,50029,State Senate,26,Ind,writein,0
+Kings,50030,State Senate,26,Ind,writein,0
+Kings,50031,State Senate,26,Ind,writein,1
+Kings,50032,State Senate,26,Ind,writein,0
+Kings,50033,State Senate,26,Ind,writein,0
+Kings,50034,State Senate,26,Ind,writein,0
+Kings,50035,State Senate,26,Ind,writein,1
+Kings,50036,State Senate,26,Ind,writein,0
+Kings,50037,State Senate,26,Ind,writein,0
+Kings,50038,State Senate,26,Ind,writein,0
+Kings,50039,State Senate,26,Ind,writein,0
+Kings,50040,State Senate,26,Ind,writein,0
+Kings,50041,State Senate,26,Ind,writein,1
+Kings,50042,State Senate,26,Ind,writein,0
+Kings,50047,State Senate,26,Ind,writein,1
+Kings,50048,State Senate,26,Ind,writein,0
+Kings,50055,State Senate,26,Ind,writein,0
+Kings,50064,State Senate,26,Ind,writein,2
+Kings,50065,State Senate,26,Ind,writein,0
+Kings,50066,State Senate,26,Ind,writein,5
+Kings,50067,State Senate,26,Ind,writein,1
+Kings,50068,State Senate,26,Ind,writein,0
+Kings,50069,State Senate,26,Ind,writein,1
+Kings,50070,State Senate,26,Ind,writein,0
+Kings,50071,State Senate,26,Ind,writein,1
+Kings,50072,State Senate,26,Ind,writein,0
+Kings,50073,State Senate,26,Ind,writein,0
+Kings,50074,State Senate,26,Ind,writein,2
+Kings,50075,State Senate,26,Ind,writein,1
+Kings,50076,State Senate,26,Ind,writein,1
+Kings,50077,State Senate,26,Ind,writein,1
+Kings,50078,State Senate,26,Ind,writein,1
+Kings,50079,State Senate,26,Ind,writein,0
+Kings,50080,State Senate,26,Ind,writein,3
+Kings,50082,State Senate,26,Ind,writein,4
+Kings,50087,State Senate,26,Ind,writein,0
+Kings,50094,State Senate,26,Ind,writein,0
+Kings,50099,State Senate,26,Ind,writein,0
+Kings,51007,State Senate,26,Ind,writein,0
+Kings,52001,State Senate,26,Ind,writein,0
+Kings,52002,State Senate,26,Ind,writein,0
+Kings,52004,State Senate,26,Ind,writein,0
+Kings,52005,State Senate,26,Ind,writein,1
+Kings,52006,State Senate,26,Ind,writein,0
+Kings,52007,State Senate,26,Ind,writein,0
+Kings,52008,State Senate,26,Ind,writein,1
+Kings,52009,State Senate,26,Ind,writein,0
+Kings,52010,State Senate,26,Ind,writein,3
+Kings,52011,State Senate,26,Ind,writein,4
+Kings,52012,State Senate,26,Ind,writein,1
+Kings,52013,State Senate,26,Ind,writein,0
+Kings,52014,State Senate,26,Ind,writein,1
+Kings,52015,State Senate,26,Ind,writein,0
+Kings,52016,State Senate,26,Ind,writein,0
+Kings,52017,State Senate,26,Ind,writein,0
+Kings,52018,State Senate,26,Ind,writein,0
+Kings,52019,State Senate,26,Ind,writein,0
+Kings,52020,State Senate,26,Ind,writein,0
+Kings,52021,State Senate,26,Ind,writein,1
+Kings,52034,State Senate,26,Ind,writein,0
+Kings,52035,State Senate,26,Ind,writein,2
+Kings,52036,State Senate,26,Ind,writein,0
+Kings,52037,State Senate,26,Ind,writein,0
+Kings,52038,State Senate,26,Ind,writein,1
+Kings,52039,State Senate,26,Ind,writein,0
+Kings,52040,State Senate,26,Ind,writein,0
+Kings,52041,State Senate,26,Ind,writein,0
+Kings,52042,State Senate,26,Ind,writein,0
+Kings,52043,State Senate,26,Ind,writein,0
+Kings,52044,State Senate,26,Ind,writein,0
+Kings,52045,State Senate,26,Ind,writein,2
+Kings,52046,State Senate,26,Ind,writein,2
+Kings,52047,State Senate,26,Ind,writein,3
+Kings,52103,State Senate,26,Ind,writein,0
+Kings,52104,State Senate,26,Ind,writein,0
+Kings,52105,State Senate,26,Ind,writein,0
+Kings,52106,State Senate,26,Ind,writein,0
+Kings,52110,State Senate,26,Ind,writein,0
+Kings,53014,State Senate,26,Ind,writein,0
+Kings,53078,State Senate,26,Ind,writein,1
 Kings,44011,U.S. House,07,Dem,Nydia Velazquez,134
 Kings,44012,U.S. House,07,Dem,Nydia Velazquez,84
 Kings,44064,U.S. House,07,Dem,Nydia Velazquez,166

--- a/2012/counties/20121106__ny__general__new_york__precinct.csv
+++ b/2012/counties/20121106__ny__general__new_york__precinct.csv
@@ -13523,4046 +13523,4046 @@ New York,76084,President,,,writeins,0
 New York,76085,President,,,writeins,0
 New York,76086,President,,,writeins,0
 New York,76087,President,,,writeins,0
-New York,65001,State Senate,SD26,Dem,Daniel Squadron,413
-New York,65002,State Senate,SD26,Dem,Daniel Squadron,429
-New York,65003,State Senate,SD26,Dem,Daniel Squadron,296
-New York,65004,State Senate,SD26,Dem,Daniel Squadron,358
-New York,65005,State Senate,SD26,Dem,Daniel Squadron,278
-New York,65006,State Senate,SD26,Dem,Daniel Squadron,407
-New York,65007,State Senate,SD26,Dem,Daniel Squadron,237
-New York,65008,State Senate,SD26,Dem,Daniel Squadron,406
-New York,65009,State Senate,SD26,Dem,Daniel Squadron,432
-New York,65010,State Senate,SD26,Dem,Daniel Squadron,286
-New York,65011,State Senate,SD26,Dem,Daniel Squadron,375
-New York,65012,State Senate,SD26,Dem,Daniel Squadron,393
-New York,65013,State Senate,SD26,Dem,Daniel Squadron,557
-New York,65014,State Senate,SD26,Dem,Daniel Squadron,390
-New York,65015,State Senate,SD26,Dem,Daniel Squadron,235
-New York,65016,State Senate,SD26,Dem,Daniel Squadron,440
-New York,65017,State Senate,SD26,Dem,Daniel Squadron,5
-New York,65018,State Senate,SD26,Dem,Daniel Squadron,271
-New York,65019,State Senate,SD26,Dem,Daniel Squadron,247
-New York,65020,State Senate,SD26,Dem,Daniel Squadron,255
-New York,65021,State Senate,SD26,Dem,Daniel Squadron,284
-New York,65022,State Senate,SD26,Dem,Daniel Squadron,272
-New York,65023,State Senate,SD26,Dem,Daniel Squadron,172
-New York,65024,State Senate,SD26,Dem,Daniel Squadron,271
-New York,65025,State Senate,SD26,Dem,Daniel Squadron,81
-New York,65026,State Senate,SD26,Dem,Daniel Squadron,99
-New York,65027,State Senate,SD26,Dem,Daniel Squadron,194
-New York,65028,State Senate,SD26,Dem,Daniel Squadron,41
-New York,65029,State Senate,SD26,Dem,Daniel Squadron,227
-New York,65030,State Senate,SD26,Dem,Daniel Squadron,266
-New York,65031,State Senate,SD26,Dem,Daniel Squadron,296
-New York,65032,State Senate,SD26,Dem,Daniel Squadron,280
-New York,65033,State Senate,SD26,Dem,Daniel Squadron,283
-New York,65034,State Senate,SD26,Dem,Daniel Squadron,298
-New York,65035,State Senate,SD26,Dem,Daniel Squadron,222
-New York,65036,State Senate,SD26,Dem,Daniel Squadron,255
-New York,65037,State Senate,SD26,Dem,Daniel Squadron,315
-New York,65038,State Senate,SD26,Dem,Daniel Squadron,325
-New York,65039,State Senate,SD26,Dem,Daniel Squadron,190
-New York,65040,State Senate,SD26,Dem,Daniel Squadron,319
-New York,65041,State Senate,SD26,Dem,Daniel Squadron,283
-New York,65042,State Senate,SD26,Dem,Daniel Squadron,370
-New York,65043,State Senate,SD26,Dem,Daniel Squadron,400
-New York,65044,State Senate,SD26,Dem,Daniel Squadron,375
-New York,65045,State Senate,SD26,Dem,Daniel Squadron,396
-New York,65046,State Senate,SD26,Dem,Daniel Squadron,286
-New York,65047,State Senate,SD26,Dem,Daniel Squadron,243
-New York,65048,State Senate,SD26,Dem,Daniel Squadron,354
-New York,65049,State Senate,SD26,Dem,Daniel Squadron,18
-New York,65050,State Senate,SD26,Dem,Daniel Squadron,663
-New York,65051,State Senate,SD26,Dem,Daniel Squadron,322
-New York,65052,State Senate,SD26,Dem,Daniel Squadron,255
-New York,65053,State Senate,SD26,Dem,Daniel Squadron,288
-New York,65054,State Senate,SD26,Dem,Daniel Squadron,268
-New York,65055,State Senate,SD26,Dem,Daniel Squadron,292
-New York,65056,State Senate,SD26,Dem,Daniel Squadron,332
-New York,65057,State Senate,SD26,Dem,Daniel Squadron,225
-New York,65058,State Senate,SD26,Dem,Daniel Squadron,218
-New York,65059,State Senate,SD26,Dem,Daniel Squadron,381
-New York,65060,State Senate,SD26,Dem,Daniel Squadron,199
-New York,65061,State Senate,SD26,Dem,Daniel Squadron,285
-New York,65062,State Senate,SD26,Dem,Daniel Squadron,252
-New York,65063,State Senate,SD26,Dem,Daniel Squadron,273
-New York,65064,State Senate,SD26,Dem,Daniel Squadron,208
-New York,65065,State Senate,SD26,Dem,Daniel Squadron,130
-New York,65066,State Senate,SD26,Dem,Daniel Squadron,180
-New York,65067,State Senate,SD26,Dem,Daniel Squadron,94
-New York,65068,State Senate,SD26,Dem,Daniel Squadron,416
-New York,65069,State Senate,SD26,Dem,Daniel Squadron,263
-New York,65070,State Senate,SD26,Dem,Daniel Squadron,36
-New York,65071,State Senate,SD26,Dem,Daniel Squadron,308
-New York,65072,State Senate,SD26,Dem,Daniel Squadron,352
-New York,65073,State Senate,SD26,Dem,Daniel Squadron,396
-New York,65074,State Senate,SD26,Dem,Daniel Squadron,418
-New York,65075,State Senate,SD26,Dem,Daniel Squadron,352
-New York,65076,State Senate,SD26,Dem,Daniel Squadron,350
-New York,65077,State Senate,SD26,Dem,Daniel Squadron,431
-New York,65078,State Senate,SD26,Dem,Daniel Squadron,278
-New York,65080,State Senate,SD26,Dem,Daniel Squadron,345
-New York,65081,State Senate,SD26,Dem,Daniel Squadron,345
-New York,65082,State Senate,SD26,Dem,Daniel Squadron,1
-New York,66001,State Senate,SD26,Dem,Daniel Squadron,465
-New York,66002,State Senate,SD26,Dem,Daniel Squadron,490
-New York,66003,State Senate,SD26,Dem,Daniel Squadron,460
-New York,66004,State Senate,SD26,Dem,Daniel Squadron,358
-New York,66005,State Senate,SD26,Dem,Daniel Squadron,566
-New York,66006,State Senate,SD26,Dem,Daniel Squadron,550
-New York,66007,State Senate,SD26,Dem,Daniel Squadron,472
-New York,66008,State Senate,SD26,Dem,Daniel Squadron,546
-New York,66009,State Senate,SD26,Dem,Daniel Squadron,542
-New York,66010,State Senate,SD26,Dem,Daniel Squadron,550
-New York,66011,State Senate,SD26,Dem,Daniel Squadron,459
-New York,66012,State Senate,SD26,Dem,Daniel Squadron,397
-New York,66013,State Senate,SD26,Dem,Daniel Squadron,203
-New York,66014,State Senate,SD26,Dem,Daniel Squadron,262
-New York,66015,State Senate,SD26,Dem,Daniel Squadron,213
-New York,66016,State Senate,SD26,Dem,Daniel Squadron,8
-New York,66017,State Senate,SD26,Dem,Daniel Squadron,17
-New York,66018,State Senate,SD26,Dem,Daniel Squadron,520
-New York,66019,State Senate,SD26,Dem,Daniel Squadron,484
-New York,66020,State Senate,SD26,Dem,Daniel Squadron,331
-New York,66021,State Senate,SD26,Dem,Daniel Squadron,337
-New York,66022,State Senate,SD26,Dem,Daniel Squadron,548
-New York,66023,State Senate,SD26,Dem,Daniel Squadron,265
-New York,66024,State Senate,SD26,Dem,Daniel Squadron,318
-New York,66025,State Senate,SD26,Dem,Daniel Squadron,317
-New York,66026,State Senate,SD26,Dem,Daniel Squadron,65
-New York,66027,State Senate,SD26,Dem,Daniel Squadron,454
-New York,66040,State Senate,SD26,Dem,Daniel Squadron,96
-New York,66041,State Senate,SD26,Dem,Daniel Squadron,397
-New York,66042,State Senate,SD26,Dem,Daniel Squadron,76
-New York,66043,State Senate,SD26,Dem,Daniel Squadron,229
-New York,66044,State Senate,SD26,Dem,Daniel Squadron,330
-New York,66070,State Senate,SD26,Dem,Daniel Squadron,80
-New York,74001,State Senate,SD26,Dem,Daniel Squadron,282
-New York,74002,State Senate,SD26,Dem,Daniel Squadron,293
-New York,74003,State Senate,SD26,Dem,Daniel Squadron,296
-New York,74004,State Senate,SD26,Dem,Daniel Squadron,333
-New York,74005,State Senate,SD26,Dem,Daniel Squadron,121
-New York,74006,State Senate,SD26,Dem,Daniel Squadron,265
-New York,74007,State Senate,SD26,Dem,Daniel Squadron,248
-New York,74008,State Senate,SD26,Dem,Daniel Squadron,317
-New York,74009,State Senate,SD26,Dem,Daniel Squadron,118
-New York,74010,State Senate,SD26,Dem,Daniel Squadron,447
-New York,74011,State Senate,SD26,Dem,Daniel Squadron,356
-New York,74012,State Senate,SD26,Dem,Daniel Squadron,221
-New York,74013,State Senate,SD26,Dem,Daniel Squadron,277
-New York,74014,State Senate,SD26,Dem,Daniel Squadron,250
-New York,74015,State Senate,SD26,Dem,Daniel Squadron,392
-New York,74016,State Senate,SD26,Dem,Daniel Squadron,227
-New York,74017,State Senate,SD26,Dem,Daniel Squadron,181
-New York,74018,State Senate,SD26,Dem,Daniel Squadron,121
-New York,65001,State Senate,SD26,WF,Daniel Squadron,16
-New York,65002,State Senate,SD26,WF,Daniel Squadron,12
-New York,65003,State Senate,SD26,WF,Daniel Squadron,12
-New York,65004,State Senate,SD26,WF,Daniel Squadron,15
-New York,65005,State Senate,SD26,WF,Daniel Squadron,11
-New York,65006,State Senate,SD26,WF,Daniel Squadron,30
-New York,65007,State Senate,SD26,WF,Daniel Squadron,19
-New York,65008,State Senate,SD26,WF,Daniel Squadron,24
-New York,65009,State Senate,SD26,WF,Daniel Squadron,26
-New York,65010,State Senate,SD26,WF,Daniel Squadron,16
-New York,65011,State Senate,SD26,WF,Daniel Squadron,17
-New York,65012,State Senate,SD26,WF,Daniel Squadron,15
-New York,65013,State Senate,SD26,WF,Daniel Squadron,31
-New York,65014,State Senate,SD26,WF,Daniel Squadron,14
-New York,65015,State Senate,SD26,WF,Daniel Squadron,18
-New York,65016,State Senate,SD26,WF,Daniel Squadron,12
-New York,65017,State Senate,SD26,WF,Daniel Squadron,1
-New York,65018,State Senate,SD26,WF,Daniel Squadron,9
-New York,65019,State Senate,SD26,WF,Daniel Squadron,12
-New York,65020,State Senate,SD26,WF,Daniel Squadron,9
-New York,65021,State Senate,SD26,WF,Daniel Squadron,14
-New York,65022,State Senate,SD26,WF,Daniel Squadron,19
-New York,65023,State Senate,SD26,WF,Daniel Squadron,9
-New York,65024,State Senate,SD26,WF,Daniel Squadron,17
-New York,65025,State Senate,SD26,WF,Daniel Squadron,4
-New York,65026,State Senate,SD26,WF,Daniel Squadron,8
-New York,65027,State Senate,SD26,WF,Daniel Squadron,5
-New York,65028,State Senate,SD26,WF,Daniel Squadron,3
-New York,65029,State Senate,SD26,WF,Daniel Squadron,8
-New York,65030,State Senate,SD26,WF,Daniel Squadron,7
-New York,65031,State Senate,SD26,WF,Daniel Squadron,11
-New York,65032,State Senate,SD26,WF,Daniel Squadron,16
-New York,65033,State Senate,SD26,WF,Daniel Squadron,10
-New York,65034,State Senate,SD26,WF,Daniel Squadron,5
-New York,65035,State Senate,SD26,WF,Daniel Squadron,7
-New York,65036,State Senate,SD26,WF,Daniel Squadron,9
-New York,65037,State Senate,SD26,WF,Daniel Squadron,4
-New York,65038,State Senate,SD26,WF,Daniel Squadron,15
-New York,65039,State Senate,SD26,WF,Daniel Squadron,16
-New York,65040,State Senate,SD26,WF,Daniel Squadron,2
-New York,65041,State Senate,SD26,WF,Daniel Squadron,10
-New York,65042,State Senate,SD26,WF,Daniel Squadron,12
-New York,65043,State Senate,SD26,WF,Daniel Squadron,10
-New York,65044,State Senate,SD26,WF,Daniel Squadron,31
-New York,65045,State Senate,SD26,WF,Daniel Squadron,23
-New York,65046,State Senate,SD26,WF,Daniel Squadron,20
-New York,65047,State Senate,SD26,WF,Daniel Squadron,24
-New York,65048,State Senate,SD26,WF,Daniel Squadron,35
-New York,65049,State Senate,SD26,WF,Daniel Squadron,1
-New York,65050,State Senate,SD26,WF,Daniel Squadron,19
-New York,65051,State Senate,SD26,WF,Daniel Squadron,21
-New York,65052,State Senate,SD26,WF,Daniel Squadron,29
-New York,65053,State Senate,SD26,WF,Daniel Squadron,12
-New York,65054,State Senate,SD26,WF,Daniel Squadron,22
-New York,65055,State Senate,SD26,WF,Daniel Squadron,16
-New York,65056,State Senate,SD26,WF,Daniel Squadron,12
-New York,65057,State Senate,SD26,WF,Daniel Squadron,5
-New York,65058,State Senate,SD26,WF,Daniel Squadron,14
-New York,65059,State Senate,SD26,WF,Daniel Squadron,34
-New York,65060,State Senate,SD26,WF,Daniel Squadron,8
-New York,65061,State Senate,SD26,WF,Daniel Squadron,10
-New York,65062,State Senate,SD26,WF,Daniel Squadron,11
-New York,65063,State Senate,SD26,WF,Daniel Squadron,19
-New York,65064,State Senate,SD26,WF,Daniel Squadron,14
-New York,65065,State Senate,SD26,WF,Daniel Squadron,6
-New York,65066,State Senate,SD26,WF,Daniel Squadron,13
-New York,65067,State Senate,SD26,WF,Daniel Squadron,13
-New York,65068,State Senate,SD26,WF,Daniel Squadron,18
-New York,65069,State Senate,SD26,WF,Daniel Squadron,16
-New York,65070,State Senate,SD26,WF,Daniel Squadron,5
-New York,65071,State Senate,SD26,WF,Daniel Squadron,15
-New York,65072,State Senate,SD26,WF,Daniel Squadron,27
-New York,65073,State Senate,SD26,WF,Daniel Squadron,28
-New York,65074,State Senate,SD26,WF,Daniel Squadron,30
-New York,65075,State Senate,SD26,WF,Daniel Squadron,15
-New York,65076,State Senate,SD26,WF,Daniel Squadron,27
-New York,65077,State Senate,SD26,WF,Daniel Squadron,35
-New York,65078,State Senate,SD26,WF,Daniel Squadron,24
-New York,65080,State Senate,SD26,WF,Daniel Squadron,26
-New York,65081,State Senate,SD26,WF,Daniel Squadron,35
-New York,65082,State Senate,SD26,WF,Daniel Squadron,0
-New York,66001,State Senate,SD26,WF,Daniel Squadron,23
-New York,66002,State Senate,SD26,WF,Daniel Squadron,14
-New York,66003,State Senate,SD26,WF,Daniel Squadron,24
-New York,66004,State Senate,SD26,WF,Daniel Squadron,12
-New York,66005,State Senate,SD26,WF,Daniel Squadron,24
-New York,66006,State Senate,SD26,WF,Daniel Squadron,27
-New York,66007,State Senate,SD26,WF,Daniel Squadron,22
-New York,66008,State Senate,SD26,WF,Daniel Squadron,56
-New York,66009,State Senate,SD26,WF,Daniel Squadron,38
-New York,66010,State Senate,SD26,WF,Daniel Squadron,30
-New York,66011,State Senate,SD26,WF,Daniel Squadron,44
-New York,66012,State Senate,SD26,WF,Daniel Squadron,18
-New York,66013,State Senate,SD26,WF,Daniel Squadron,17
-New York,66014,State Senate,SD26,WF,Daniel Squadron,8
-New York,66015,State Senate,SD26,WF,Daniel Squadron,21
-New York,66016,State Senate,SD26,WF,Daniel Squadron,0
-New York,66017,State Senate,SD26,WF,Daniel Squadron,0
-New York,66018,State Senate,SD26,WF,Daniel Squadron,37
-New York,66019,State Senate,SD26,WF,Daniel Squadron,35
-New York,66020,State Senate,SD26,WF,Daniel Squadron,27
-New York,66021,State Senate,SD26,WF,Daniel Squadron,24
-New York,66022,State Senate,SD26,WF,Daniel Squadron,52
-New York,66023,State Senate,SD26,WF,Daniel Squadron,26
-New York,66024,State Senate,SD26,WF,Daniel Squadron,17
-New York,66025,State Senate,SD26,WF,Daniel Squadron,28
-New York,66026,State Senate,SD26,WF,Daniel Squadron,8
-New York,66027,State Senate,SD26,WF,Daniel Squadron,54
-New York,66040,State Senate,SD26,WF,Daniel Squadron,7
-New York,66041,State Senate,SD26,WF,Daniel Squadron,33
-New York,66042,State Senate,SD26,WF,Daniel Squadron,7
-New York,66043,State Senate,SD26,WF,Daniel Squadron,18
-New York,66044,State Senate,SD26,WF,Daniel Squadron,24
-New York,66070,State Senate,SD26,WF,Daniel Squadron,3
-New York,74001,State Senate,SD26,WF,Daniel Squadron,4
-New York,74002,State Senate,SD26,WF,Daniel Squadron,8
-New York,74003,State Senate,SD26,WF,Daniel Squadron,5
-New York,74004,State Senate,SD26,WF,Daniel Squadron,4
-New York,74005,State Senate,SD26,WF,Daniel Squadron,0
-New York,74006,State Senate,SD26,WF,Daniel Squadron,9
-New York,74007,State Senate,SD26,WF,Daniel Squadron,30
-New York,74008,State Senate,SD26,WF,Daniel Squadron,24
-New York,74009,State Senate,SD26,WF,Daniel Squadron,6
-New York,74010,State Senate,SD26,WF,Daniel Squadron,44
-New York,74011,State Senate,SD26,WF,Daniel Squadron,8
-New York,74012,State Senate,SD26,WF,Daniel Squadron,4
-New York,74013,State Senate,SD26,WF,Daniel Squadron,10
-New York,74014,State Senate,SD26,WF,Daniel Squadron,3
-New York,74015,State Senate,SD26,WF,Daniel Squadron,34
-New York,74016,State Senate,SD26,WF,Daniel Squadron,15
-New York,74017,State Senate,SD26,WF,Daniel Squadron,18
-New York,74018,State Senate,SD26,WF,Daniel Squadron,5
-New York,65001,State Senate,SD26,Rep,Jacqueline Haro,147
-New York,65002,State Senate,SD26,Rep,Jacqueline Haro,190
-New York,65003,State Senate,SD26,Rep,Jacqueline Haro,112
-New York,65004,State Senate,SD26,Rep,Jacqueline Haro,121
-New York,65005,State Senate,SD26,Rep,Jacqueline Haro,90
-New York,65006,State Senate,SD26,Rep,Jacqueline Haro,104
-New York,65007,State Senate,SD26,Rep,Jacqueline Haro,85
-New York,65008,State Senate,SD26,Rep,Jacqueline Haro,119
-New York,65009,State Senate,SD26,Rep,Jacqueline Haro,97
-New York,65010,State Senate,SD26,Rep,Jacqueline Haro,73
-New York,65011,State Senate,SD26,Rep,Jacqueline Haro,122
-New York,65012,State Senate,SD26,Rep,Jacqueline Haro,206
-New York,65013,State Senate,SD26,Rep,Jacqueline Haro,213
-New York,65014,State Senate,SD26,Rep,Jacqueline Haro,175
-New York,65015,State Senate,SD26,Rep,Jacqueline Haro,55
-New York,65016,State Senate,SD26,Rep,Jacqueline Haro,134
-New York,65017,State Senate,SD26,Rep,Jacqueline Haro,2
-New York,65018,State Senate,SD26,Rep,Jacqueline Haro,11
-New York,65019,State Senate,SD26,Rep,Jacqueline Haro,14
-New York,65020,State Senate,SD26,Rep,Jacqueline Haro,18
-New York,65021,State Senate,SD26,Rep,Jacqueline Haro,12
-New York,65022,State Senate,SD26,Rep,Jacqueline Haro,82
-New York,65023,State Senate,SD26,Rep,Jacqueline Haro,29
-New York,65024,State Senate,SD26,Rep,Jacqueline Haro,29
-New York,65025,State Senate,SD26,Rep,Jacqueline Haro,35
-New York,65026,State Senate,SD26,Rep,Jacqueline Haro,22
-New York,65027,State Senate,SD26,Rep,Jacqueline Haro,39
-New York,65028,State Senate,SD26,Rep,Jacqueline Haro,8
-New York,65029,State Senate,SD26,Rep,Jacqueline Haro,29
-New York,65030,State Senate,SD26,Rep,Jacqueline Haro,39
-New York,65031,State Senate,SD26,Rep,Jacqueline Haro,68
-New York,65032,State Senate,SD26,Rep,Jacqueline Haro,31
-New York,65033,State Senate,SD26,Rep,Jacqueline Haro,18
-New York,65034,State Senate,SD26,Rep,Jacqueline Haro,22
-New York,65035,State Senate,SD26,Rep,Jacqueline Haro,18
-New York,65036,State Senate,SD26,Rep,Jacqueline Haro,11
-New York,65037,State Senate,SD26,Rep,Jacqueline Haro,14
-New York,65038,State Senate,SD26,Rep,Jacqueline Haro,25
-New York,65039,State Senate,SD26,Rep,Jacqueline Haro,27
-New York,65040,State Senate,SD26,Rep,Jacqueline Haro,19
-New York,65041,State Senate,SD26,Rep,Jacqueline Haro,37
-New York,65042,State Senate,SD26,Rep,Jacqueline Haro,27
-New York,65043,State Senate,SD26,Rep,Jacqueline Haro,17
-New York,65044,State Senate,SD26,Rep,Jacqueline Haro,66
-New York,65045,State Senate,SD26,Rep,Jacqueline Haro,48
-New York,65046,State Senate,SD26,Rep,Jacqueline Haro,47
-New York,65047,State Senate,SD26,Rep,Jacqueline Haro,37
-New York,65048,State Senate,SD26,Rep,Jacqueline Haro,36
-New York,65049,State Senate,SD26,Rep,Jacqueline Haro,1
-New York,65050,State Senate,SD26,Rep,Jacqueline Haro,37
-New York,65051,State Senate,SD26,Rep,Jacqueline Haro,47
-New York,65052,State Senate,SD26,Rep,Jacqueline Haro,31
-New York,65053,State Senate,SD26,Rep,Jacqueline Haro,32
-New York,65054,State Senate,SD26,Rep,Jacqueline Haro,48
-New York,65055,State Senate,SD26,Rep,Jacqueline Haro,34
-New York,65056,State Senate,SD26,Rep,Jacqueline Haro,20
-New York,65057,State Senate,SD26,Rep,Jacqueline Haro,8
-New York,65058,State Senate,SD26,Rep,Jacqueline Haro,16
-New York,65059,State Senate,SD26,Rep,Jacqueline Haro,46
-New York,65060,State Senate,SD26,Rep,Jacqueline Haro,17
-New York,65061,State Senate,SD26,Rep,Jacqueline Haro,20
-New York,65062,State Senate,SD26,Rep,Jacqueline Haro,27
-New York,65063,State Senate,SD26,Rep,Jacqueline Haro,36
-New York,65064,State Senate,SD26,Rep,Jacqueline Haro,38
-New York,65065,State Senate,SD26,Rep,Jacqueline Haro,25
-New York,65066,State Senate,SD26,Rep,Jacqueline Haro,43
-New York,65067,State Senate,SD26,Rep,Jacqueline Haro,3
-New York,65068,State Senate,SD26,Rep,Jacqueline Haro,74
-New York,65069,State Senate,SD26,Rep,Jacqueline Haro,53
-New York,65070,State Senate,SD26,Rep,Jacqueline Haro,24
-New York,65071,State Senate,SD26,Rep,Jacqueline Haro,57
-New York,65072,State Senate,SD26,Rep,Jacqueline Haro,26
-New York,65073,State Senate,SD26,Rep,Jacqueline Haro,25
-New York,65074,State Senate,SD26,Rep,Jacqueline Haro,35
-New York,65075,State Senate,SD26,Rep,Jacqueline Haro,39
-New York,65076,State Senate,SD26,Rep,Jacqueline Haro,39
-New York,65077,State Senate,SD26,Rep,Jacqueline Haro,45
-New York,65078,State Senate,SD26,Rep,Jacqueline Haro,23
-New York,65080,State Senate,SD26,Rep,Jacqueline Haro,27
-New York,65081,State Senate,SD26,Rep,Jacqueline Haro,26
-New York,65082,State Senate,SD26,Rep,Jacqueline Haro,1
-New York,66001,State Senate,SD26,Rep,Jacqueline Haro,264
-New York,66002,State Senate,SD26,Rep,Jacqueline Haro,188
-New York,66003,State Senate,SD26,Rep,Jacqueline Haro,168
-New York,66004,State Senate,SD26,Rep,Jacqueline Haro,143
-New York,66005,State Senate,SD26,Rep,Jacqueline Haro,153
-New York,66006,State Senate,SD26,Rep,Jacqueline Haro,164
-New York,66007,State Senate,SD26,Rep,Jacqueline Haro,215
-New York,66008,State Senate,SD26,Rep,Jacqueline Haro,98
-New York,66009,State Senate,SD26,Rep,Jacqueline Haro,131
-New York,66010,State Senate,SD26,Rep,Jacqueline Haro,100
-New York,66011,State Senate,SD26,Rep,Jacqueline Haro,58
-New York,66012,State Senate,SD26,Rep,Jacqueline Haro,129
-New York,66013,State Senate,SD26,Rep,Jacqueline Haro,62
-New York,66014,State Senate,SD26,Rep,Jacqueline Haro,34
-New York,66015,State Senate,SD26,Rep,Jacqueline Haro,29
-New York,66016,State Senate,SD26,Rep,Jacqueline Haro,6
-New York,66017,State Senate,SD26,Rep,Jacqueline Haro,0
-New York,66018,State Senate,SD26,Rep,Jacqueline Haro,101
-New York,66019,State Senate,SD26,Rep,Jacqueline Haro,75
-New York,66020,State Senate,SD26,Rep,Jacqueline Haro,67
-New York,66021,State Senate,SD26,Rep,Jacqueline Haro,63
-New York,66022,State Senate,SD26,Rep,Jacqueline Haro,97
-New York,66023,State Senate,SD26,Rep,Jacqueline Haro,28
-New York,66024,State Senate,SD26,Rep,Jacqueline Haro,45
-New York,66025,State Senate,SD26,Rep,Jacqueline Haro,47
-New York,66026,State Senate,SD26,Rep,Jacqueline Haro,1
-New York,66027,State Senate,SD26,Rep,Jacqueline Haro,31
-New York,66040,State Senate,SD26,Rep,Jacqueline Haro,15
-New York,66041,State Senate,SD26,Rep,Jacqueline Haro,99
-New York,66042,State Senate,SD26,Rep,Jacqueline Haro,13
-New York,66043,State Senate,SD26,Rep,Jacqueline Haro,71
-New York,66044,State Senate,SD26,Rep,Jacqueline Haro,49
-New York,66070,State Senate,SD26,Rep,Jacqueline Haro,42
-New York,74001,State Senate,SD26,Rep,Jacqueline Haro,6
-New York,74002,State Senate,SD26,Rep,Jacqueline Haro,6
-New York,74003,State Senate,SD26,Rep,Jacqueline Haro,9
-New York,74004,State Senate,SD26,Rep,Jacqueline Haro,10
-New York,74005,State Senate,SD26,Rep,Jacqueline Haro,3
-New York,74006,State Senate,SD26,Rep,Jacqueline Haro,7
-New York,74007,State Senate,SD26,Rep,Jacqueline Haro,32
-New York,74008,State Senate,SD26,Rep,Jacqueline Haro,22
-New York,74009,State Senate,SD26,Rep,Jacqueline Haro,8
-New York,74010,State Senate,SD26,Rep,Jacqueline Haro,44
-New York,74011,State Senate,SD26,Rep,Jacqueline Haro,16
-New York,74012,State Senate,SD26,Rep,Jacqueline Haro,6
-New York,74013,State Senate,SD26,Rep,Jacqueline Haro,10
-New York,74014,State Senate,SD26,Rep,Jacqueline Haro,5
-New York,74015,State Senate,SD26,Rep,Jacqueline Haro,29
-New York,74016,State Senate,SD26,Rep,Jacqueline Haro,8
-New York,74017,State Senate,SD26,Rep,Jacqueline Haro,11
-New York,74018,State Senate,SD26,Rep,Jacqueline Haro,24
-New York,65001,State Senate,SD26,Ind,writein,0
-New York,65002,State Senate,SD26,Ind,writein,0
-New York,65003,State Senate,SD26,Ind,writein,0
-New York,65004,State Senate,SD26,Ind,writein,1
-New York,65005,State Senate,SD26,Ind,writein,0
-New York,65006,State Senate,SD26,Ind,writein,0
-New York,65007,State Senate,SD26,Ind,writein,0
-New York,65008,State Senate,SD26,Ind,writein,0
-New York,65009,State Senate,SD26,Ind,writein,2
-New York,65010,State Senate,SD26,Ind,writein,0
-New York,65011,State Senate,SD26,Ind,writein,0
-New York,65012,State Senate,SD26,Ind,writein,0
-New York,65013,State Senate,SD26,Ind,writein,0
-New York,65014,State Senate,SD26,Ind,writein,0
-New York,65015,State Senate,SD26,Ind,writein,0
-New York,65016,State Senate,SD26,Ind,writein,0
-New York,65017,State Senate,SD26,Ind,writein,0
-New York,65018,State Senate,SD26,Ind,writein,0
-New York,65019,State Senate,SD26,Ind,writein,0
-New York,65020,State Senate,SD26,Ind,writein,0
-New York,65021,State Senate,SD26,Ind,writein,0
-New York,65022,State Senate,SD26,Ind,writein,0
-New York,65023,State Senate,SD26,Ind,writein,0
-New York,65024,State Senate,SD26,Ind,writein,1
-New York,65025,State Senate,SD26,Ind,writein,0
-New York,65026,State Senate,SD26,Ind,writein,0
-New York,65027,State Senate,SD26,Ind,writein,0
-New York,65028,State Senate,SD26,Ind,writein,0
-New York,65029,State Senate,SD26,Ind,writein,0
-New York,65030,State Senate,SD26,Ind,writein,0
-New York,65031,State Senate,SD26,Ind,writein,0
-New York,65032,State Senate,SD26,Ind,writein,0
-New York,65033,State Senate,SD26,Ind,writein,0
-New York,65034,State Senate,SD26,Ind,writein,0
-New York,65035,State Senate,SD26,Ind,writein,0
-New York,65036,State Senate,SD26,Ind,writein,0
-New York,65037,State Senate,SD26,Ind,writein,0
-New York,65038,State Senate,SD26,Ind,writein,0
-New York,65039,State Senate,SD26,Ind,writein,0
-New York,65040,State Senate,SD26,Ind,writein,0
-New York,65041,State Senate,SD26,Ind,writein,1
-New York,65042,State Senate,SD26,Ind,writein,0
-New York,65043,State Senate,SD26,Ind,writein,0
-New York,65044,State Senate,SD26,Ind,writein,3
-New York,65045,State Senate,SD26,Ind,writein,1
-New York,65046,State Senate,SD26,Ind,writein,0
-New York,65047,State Senate,SD26,Ind,writein,0
-New York,65048,State Senate,SD26,Ind,writein,0
-New York,65049,State Senate,SD26,Ind,writein,0
-New York,65050,State Senate,SD26,Ind,writein,0
-New York,65051,State Senate,SD26,Ind,writein,0
-New York,65052,State Senate,SD26,Ind,writein,0
-New York,65053,State Senate,SD26,Ind,writein,0
-New York,65054,State Senate,SD26,Ind,writein,0
-New York,65055,State Senate,SD26,Ind,writein,0
-New York,65056,State Senate,SD26,Ind,writein,0
-New York,65057,State Senate,SD26,Ind,writein,0
-New York,65058,State Senate,SD26,Ind,writein,0
-New York,65059,State Senate,SD26,Ind,writein,0
-New York,65060,State Senate,SD26,Ind,writein,0
-New York,65061,State Senate,SD26,Ind,writein,0
-New York,65062,State Senate,SD26,Ind,writein,0
-New York,65063,State Senate,SD26,Ind,writein,0
-New York,65064,State Senate,SD26,Ind,writein,0
-New York,65065,State Senate,SD26,Ind,writein,0
-New York,65066,State Senate,SD26,Ind,writein,0
-New York,65067,State Senate,SD26,Ind,writein,0
-New York,65068,State Senate,SD26,Ind,writein,0
-New York,65069,State Senate,SD26,Ind,writein,0
-New York,65070,State Senate,SD26,Ind,writein,0
-New York,65071,State Senate,SD26,Ind,writein,1
-New York,65072,State Senate,SD26,Ind,writein,1
-New York,65073,State Senate,SD26,Ind,writein,0
-New York,65074,State Senate,SD26,Ind,writein,3
-New York,65075,State Senate,SD26,Ind,writein,1
-New York,65076,State Senate,SD26,Ind,writein,1
-New York,65077,State Senate,SD26,Ind,writein,0
-New York,65078,State Senate,SD26,Ind,writein,0
-New York,65080,State Senate,SD26,Ind,writein,0
-New York,65081,State Senate,SD26,Ind,writein,0
-New York,65082,State Senate,SD26,Ind,writein,0
-New York,66001,State Senate,SD26,Ind,writein,0
-New York,66002,State Senate,SD26,Ind,writein,0
-New York,66003,State Senate,SD26,Ind,writein,0
-New York,66004,State Senate,SD26,Ind,writein,1
-New York,66005,State Senate,SD26,Ind,writein,0
-New York,66006,State Senate,SD26,Ind,writein,0
-New York,66007,State Senate,SD26,Ind,writein,0
-New York,66008,State Senate,SD26,Ind,writein,0
-New York,66009,State Senate,SD26,Ind,writein,0
-New York,66010,State Senate,SD26,Ind,writein,0
-New York,66011,State Senate,SD26,Ind,writein,2
-New York,66012,State Senate,SD26,Ind,writein,1
-New York,66013,State Senate,SD26,Ind,writein,0
-New York,66014,State Senate,SD26,Ind,writein,0
-New York,66015,State Senate,SD26,Ind,writein,0
-New York,66016,State Senate,SD26,Ind,writein,0
-New York,66017,State Senate,SD26,Ind,writein,0
-New York,66018,State Senate,SD26,Ind,writein,0
-New York,66019,State Senate,SD26,Ind,writein,0
-New York,66020,State Senate,SD26,Ind,writein,1
-New York,66021,State Senate,SD26,Ind,writein,0
-New York,66022,State Senate,SD26,Ind,writein,1
-New York,66023,State Senate,SD26,Ind,writein,0
-New York,66024,State Senate,SD26,Ind,writein,0
-New York,66025,State Senate,SD26,Ind,writein,1
-New York,66026,State Senate,SD26,Ind,writein,0
-New York,66027,State Senate,SD26,Ind,writein,2
-New York,66040,State Senate,SD26,Ind,writein,0
-New York,66041,State Senate,SD26,Ind,writein,1
-New York,66042,State Senate,SD26,Ind,writein,0
-New York,66043,State Senate,SD26,Ind,writein,0
-New York,66044,State Senate,SD26,Ind,writein,0
-New York,66070,State Senate,SD26,Ind,writein,0
-New York,74001,State Senate,SD26,Ind,writein,0
-New York,74002,State Senate,SD26,Ind,writein,0
-New York,74003,State Senate,SD26,Ind,writein,0
-New York,74004,State Senate,SD26,Ind,writein,0
-New York,74005,State Senate,SD26,Ind,writein,0
-New York,74006,State Senate,SD26,Ind,writein,1
-New York,74007,State Senate,SD26,Ind,writein,0
-New York,74008,State Senate,SD26,Ind,writein,1
-New York,74009,State Senate,SD26,Ind,writein,0
-New York,74010,State Senate,SD26,Ind,writein,0
-New York,74011,State Senate,SD26,Ind,writein,0
-New York,74012,State Senate,SD26,Ind,writein,0
-New York,74013,State Senate,SD26,Ind,writein,0
-New York,74014,State Senate,SD26,Ind,writein,0
-New York,74015,State Senate,SD26,Ind,writein,1
-New York,74016,State Senate,SD26,Ind,writein,0
-New York,74017,State Senate,SD26,Ind,writein,0
-New York,74018,State Senate,SD26,Ind,writein,1
-New York,65079,State Senate,SD27,Dem,Brad Hoylman,425
-New York,66028,State Senate,SD27,Dem,Brad Hoylman,507
-New York,66029,State Senate,SD27,Dem,Brad Hoylman,475
-New York,66030,State Senate,SD27,Dem,Brad Hoylman,445
-New York,66031,State Senate,SD27,Dem,Brad Hoylman,424
-New York,66032,State Senate,SD27,Dem,Brad Hoylman,387
-New York,66033,State Senate,SD27,Dem,Brad Hoylman,265
-New York,66034,State Senate,SD27,Dem,Brad Hoylman,471
-New York,66035,State Senate,SD27,Dem,Brad Hoylman,462
-New York,66036,State Senate,SD27,Dem,Brad Hoylman,526
-New York,66037,State Senate,SD27,Dem,Brad Hoylman,475
-New York,66038,State Senate,SD27,Dem,Brad Hoylman,475
-New York,66039,State Senate,SD27,Dem,Brad Hoylman,554
-New York,66045,State Senate,SD27,Dem,Brad Hoylman,610
-New York,66046,State Senate,SD27,Dem,Brad Hoylman,378
-New York,66047,State Senate,SD27,Dem,Brad Hoylman,406
-New York,66048,State Senate,SD27,Dem,Brad Hoylman,546
-New York,66049,State Senate,SD27,Dem,Brad Hoylman,499
-New York,66050,State Senate,SD27,Dem,Brad Hoylman,345
-New York,66051,State Senate,SD27,Dem,Brad Hoylman,610
-New York,66052,State Senate,SD27,Dem,Brad Hoylman,432
-New York,66053,State Senate,SD27,Dem,Brad Hoylman,503
-New York,66054,State Senate,SD27,Dem,Brad Hoylman,474
-New York,66057,State Senate,SD27,Dem,Brad Hoylman,477
-New York,66058,State Senate,SD27,Dem,Brad Hoylman,221
-New York,66059,State Senate,SD27,Dem,Brad Hoylman,476
-New York,66060,State Senate,SD27,Dem,Brad Hoylman,461
-New York,66061,State Senate,SD27,Dem,Brad Hoylman,506
-New York,66062,State Senate,SD27,Dem,Brad Hoylman,304
-New York,66063,State Senate,SD27,Dem,Brad Hoylman,482
-New York,66064,State Senate,SD27,Dem,Brad Hoylman,509
-New York,66065,State Senate,SD27,Dem,Brad Hoylman,141
-New York,66066,State Senate,SD27,Dem,Brad Hoylman,435
-New York,66067,State Senate,SD27,Dem,Brad Hoylman,439
-New York,66068,State Senate,SD27,Dem,Brad Hoylman,373
-New York,66069,State Senate,SD27,Dem,Brad Hoylman,520
-New York,66071,State Senate,SD27,Dem,Brad Hoylman,250
-New York,66072,State Senate,SD27,Dem,Brad Hoylman,417
-New York,66073,State Senate,SD27,Dem,Brad Hoylman,519
-New York,66074,State Senate,SD27,Dem,Brad Hoylman,410
-New York,66075,State Senate,SD27,Dem,Brad Hoylman,443
-New York,66076,State Senate,SD27,Dem,Brad Hoylman,542
-New York,66077,State Senate,SD27,Dem,Brad Hoylman,562
-New York,66078,State Senate,SD27,Dem,Brad Hoylman,551
-New York,66079,State Senate,SD27,Dem,Brad Hoylman,566
-New York,66080,State Senate,SD27,Dem,Brad Hoylman,492
-New York,66081,State Senate,SD27,Dem,Brad Hoylman,598
-New York,66082,State Senate,SD27,Dem,Brad Hoylman,431
-New York,66083,State Senate,SD27,Dem,Brad Hoylman,386
-New York,66084,State Senate,SD27,Dem,Brad Hoylman,577
-New York,66085,State Senate,SD27,Dem,Brad Hoylman,519
-New York,66086,State Senate,SD27,Dem,Brad Hoylman,491
-New York,66087,State Senate,SD27,Dem,Brad Hoylman,463
-New York,66088,State Senate,SD27,Dem,Brad Hoylman,301
-New York,66089,State Senate,SD27,Dem,Brad Hoylman,355
-New York,66090,State Senate,SD27,Dem,Brad Hoylman,270
-New York,67002,State Senate,SD27,Dem,Brad Hoylman,329
-New York,67004,State Senate,SD27,Dem,Brad Hoylman,345
-New York,67006,State Senate,SD27,Dem,Brad Hoylman,589
-New York,67008,State Senate,SD27,Dem,Brad Hoylman,418
-New York,67009,State Senate,SD27,Dem,Brad Hoylman,438
-New York,67010,State Senate,SD27,Dem,Brad Hoylman,598
-New York,67011,State Senate,SD27,Dem,Brad Hoylman,223
-New York,67012,State Senate,SD27,Dem,Brad Hoylman,79
-New York,67013,State Senate,SD27,Dem,Brad Hoylman,335
-New York,67014,State Senate,SD27,Dem,Brad Hoylman,455
-New York,67015,State Senate,SD27,Dem,Brad Hoylman,423
-New York,67016,State Senate,SD27,Dem,Brad Hoylman,333
-New York,67017,State Senate,SD27,Dem,Brad Hoylman,370
-New York,67018,State Senate,SD27,Dem,Brad Hoylman,488
-New York,67019,State Senate,SD27,Dem,Brad Hoylman,352
-New York,67020,State Senate,SD27,Dem,Brad Hoylman,180
-New York,67021,State Senate,SD27,Dem,Brad Hoylman,424
-New York,67022,State Senate,SD27,Dem,Brad Hoylman,403
-New York,67023,State Senate,SD27,Dem,Brad Hoylman,166
-New York,67024,State Senate,SD27,Dem,Brad Hoylman,247
-New York,67031,State Senate,SD27,Dem,Brad Hoylman,466
-New York,67032,State Senate,SD27,Dem,Brad Hoylman,470
-New York,67033,State Senate,SD27,Dem,Brad Hoylman,352
-New York,67034,State Senate,SD27,Dem,Brad Hoylman,112
-New York,67035,State Senate,SD27,Dem,Brad Hoylman,295
-New York,67036,State Senate,SD27,Dem,Brad Hoylman,263
-New York,67037,State Senate,SD27,Dem,Brad Hoylman,441
-New York,67038,State Senate,SD27,Dem,Brad Hoylman,267
-New York,67039,State Senate,SD27,Dem,Brad Hoylman,288
-New York,67040,State Senate,SD27,Dem,Brad Hoylman,306
-New York,67041,State Senate,SD27,Dem,Brad Hoylman,420
-New York,67042,State Senate,SD27,Dem,Brad Hoylman,618
-New York,67043,State Senate,SD27,Dem,Brad Hoylman,635
-New York,67044,State Senate,SD27,Dem,Brad Hoylman,316
-New York,67045,State Senate,SD27,Dem,Brad Hoylman,488
-New York,67046,State Senate,SD27,Dem,Brad Hoylman,530
-New York,67047,State Senate,SD27,Dem,Brad Hoylman,355
-New York,67048,State Senate,SD27,Dem,Brad Hoylman,631
-New York,67049,State Senate,SD27,Dem,Brad Hoylman,334
-New York,67050,State Senate,SD27,Dem,Brad Hoylman,539
-New York,73006,State Senate,SD27,Dem,Brad Hoylman,331
-New York,73011,State Senate,SD27,Dem,Brad Hoylman,420
-New York,73012,State Senate,SD27,Dem,Brad Hoylman,67
-New York,73013,State Senate,SD27,Dem,Brad Hoylman,5
-New York,73015,State Senate,SD27,Dem,Brad Hoylman,123
-New York,73020,State Senate,SD27,Dem,Brad Hoylman,20
-New York,73043,State Senate,SD27,Dem,Brad Hoylman,54
-New York,74019,State Senate,SD27,Dem,Brad Hoylman,425
-New York,74020,State Senate,SD27,Dem,Brad Hoylman,329
-New York,74021,State Senate,SD27,Dem,Brad Hoylman,446
-New York,74022,State Senate,SD27,Dem,Brad Hoylman,371
-New York,74023,State Senate,SD27,Dem,Brad Hoylman,417
-New York,74024,State Senate,SD27,Dem,Brad Hoylman,414
-New York,74025,State Senate,SD27,Dem,Brad Hoylman,381
-New York,74026,State Senate,SD27,Dem,Brad Hoylman,298
-New York,74027,State Senate,SD27,Dem,Brad Hoylman,216
-New York,74028,State Senate,SD27,Dem,Brad Hoylman,154
-New York,74029,State Senate,SD27,Dem,Brad Hoylman,225
-New York,74030,State Senate,SD27,Dem,Brad Hoylman,135
-New York,74031,State Senate,SD27,Dem,Brad Hoylman,307
-New York,74032,State Senate,SD27,Dem,Brad Hoylman,380
-New York,74033,State Senate,SD27,Dem,Brad Hoylman,419
-New York,74034,State Senate,SD27,Dem,Brad Hoylman,424
-New York,74035,State Senate,SD27,Dem,Brad Hoylman,221
-New York,74036,State Senate,SD27,Dem,Brad Hoylman,467
-New York,74037,State Senate,SD27,Dem,Brad Hoylman,427
-New York,74038,State Senate,SD27,Dem,Brad Hoylman,236
-New York,74039,State Senate,SD27,Dem,Brad Hoylman,636
-New York,74040,State Senate,SD27,Dem,Brad Hoylman,422
-New York,74041,State Senate,SD27,Dem,Brad Hoylman,530
-New York,74042,State Senate,SD27,Dem,Brad Hoylman,440
-New York,74043,State Senate,SD27,Dem,Brad Hoylman,501
-New York,74044,State Senate,SD27,Dem,Brad Hoylman,423
-New York,74045,State Senate,SD27,Dem,Brad Hoylman,569
-New York,74046,State Senate,SD27,Dem,Brad Hoylman,582
-New York,74047,State Senate,SD27,Dem,Brad Hoylman,508
-New York,74048,State Senate,SD27,Dem,Brad Hoylman,370
-New York,74049,State Senate,SD27,Dem,Brad Hoylman,314
-New York,74050,State Senate,SD27,Dem,Brad Hoylman,446
-New York,74051,State Senate,SD27,Dem,Brad Hoylman,383
-New York,74052,State Senate,SD27,Dem,Brad Hoylman,318
-New York,74053,State Senate,SD27,Dem,Brad Hoylman,423
-New York,74054,State Senate,SD27,Dem,Brad Hoylman,403
-New York,74055,State Senate,SD27,Dem,Brad Hoylman,218
-New York,74071,State Senate,SD27,Dem,Brad Hoylman,309
-New York,74072,State Senate,SD27,Dem,Brad Hoylman,255
-New York,74073,State Senate,SD27,Dem,Brad Hoylman,445
-New York,74074,State Senate,SD27,Dem,Brad Hoylman,344
-New York,74075,State Senate,SD27,Dem,Brad Hoylman,412
-New York,74076,State Senate,SD27,Dem,Brad Hoylman,391
-New York,74077,State Senate,SD27,Dem,Brad Hoylman,332
-New York,74078,State Senate,SD27,Dem,Brad Hoylman,373
-New York,74079,State Senate,SD27,Dem,Brad Hoylman,304
-New York,74080,State Senate,SD27,Dem,Brad Hoylman,231
-New York,74081,State Senate,SD27,Dem,Brad Hoylman,108
-New York,74084,State Senate,SD27,Dem,Brad Hoylman,234
-New York,75001,State Senate,SD27,Dem,Brad Hoylman,613
-New York,75002,State Senate,SD27,Dem,Brad Hoylman,483
-New York,75003,State Senate,SD27,Dem,Brad Hoylman,301
-New York,75004,State Senate,SD27,Dem,Brad Hoylman,407
-New York,75005,State Senate,SD27,Dem,Brad Hoylman,545
-New York,75006,State Senate,SD27,Dem,Brad Hoylman,450
-New York,75007,State Senate,SD27,Dem,Brad Hoylman,155
-New York,75010,State Senate,SD27,Dem,Brad Hoylman,452
-New York,75011,State Senate,SD27,Dem,Brad Hoylman,538
-New York,75012,State Senate,SD27,Dem,Brad Hoylman,492
-New York,75013,State Senate,SD27,Dem,Brad Hoylman,302
-New York,75014,State Senate,SD27,Dem,Brad Hoylman,412
-New York,75015,State Senate,SD27,Dem,Brad Hoylman,390
-New York,75016,State Senate,SD27,Dem,Brad Hoylman,650
-New York,75017,State Senate,SD27,Dem,Brad Hoylman,449
-New York,75018,State Senate,SD27,Dem,Brad Hoylman,275
-New York,75019,State Senate,SD27,Dem,Brad Hoylman,367
-New York,75020,State Senate,SD27,Dem,Brad Hoylman,626
-New York,75021,State Senate,SD27,Dem,Brad Hoylman,288
-New York,75022,State Senate,SD27,Dem,Brad Hoylman,555
-New York,75023,State Senate,SD27,Dem,Brad Hoylman,309
-New York,75024,State Senate,SD27,Dem,Brad Hoylman,377
-New York,75025,State Senate,SD27,Dem,Brad Hoylman,449
-New York,75026,State Senate,SD27,Dem,Brad Hoylman,552
-New York,75027,State Senate,SD27,Dem,Brad Hoylman,575
-New York,75028,State Senate,SD27,Dem,Brad Hoylman,514
-New York,75036,State Senate,SD27,Dem,Brad Hoylman,517
-New York,75037,State Senate,SD27,Dem,Brad Hoylman,315
-New York,75038,State Senate,SD27,Dem,Brad Hoylman,433
-New York,75039,State Senate,SD27,Dem,Brad Hoylman,295
-New York,75040,State Senate,SD27,Dem,Brad Hoylman,307
-New York,75041,State Senate,SD27,Dem,Brad Hoylman,400
-New York,75042,State Senate,SD27,Dem,Brad Hoylman,500
-New York,75043,State Senate,SD27,Dem,Brad Hoylman,471
-New York,75044,State Senate,SD27,Dem,Brad Hoylman,496
-New York,75046,State Senate,SD27,Dem,Brad Hoylman,208
-New York,75047,State Senate,SD27,Dem,Brad Hoylman,312
-New York,75048,State Senate,SD27,Dem,Brad Hoylman,174
-New York,75049,State Senate,SD27,Dem,Brad Hoylman,272
-New York,75050,State Senate,SD27,Dem,Brad Hoylman,314
-New York,75058,State Senate,SD27,Dem,Brad Hoylman,266
-New York,75062,State Senate,SD27,Dem,Brad Hoylman,469
-New York,75063,State Senate,SD27,Dem,Brad Hoylman,350
-New York,75064,State Senate,SD27,Dem,Brad Hoylman,568
-New York,75068,State Senate,SD27,Dem,Brad Hoylman,114
-New York,75069,State Senate,SD27,Dem,Brad Hoylman,433
-New York,75070,State Senate,SD27,Dem,Brad Hoylman,384
-New York,75071,State Senate,SD27,Dem,Brad Hoylman,674
-New York,75072,State Senate,SD27,Dem,Brad Hoylman,695
-New York,75073,State Senate,SD27,Dem,Brad Hoylman,399
-New York,75074,State Senate,SD27,Dem,Brad Hoylman,297
-New York,75075,State Senate,SD27,Dem,Brad Hoylman,178
-New York,75076,State Senate,SD27,Dem,Brad Hoylman,280
-New York,75077,State Senate,SD27,Dem,Brad Hoylman,381
-New York,75078,State Senate,SD27,Dem,Brad Hoylman,257
-New York,75079,State Senate,SD27,Dem,Brad Hoylman,321
-New York,75080,State Senate,SD27,Dem,Brad Hoylman,536
-New York,75081,State Senate,SD27,Dem,Brad Hoylman,382
-New York,75082,State Senate,SD27,Dem,Brad Hoylman,396
-New York,75083,State Senate,SD27,Dem,Brad Hoylman,509
-New York,75084,State Senate,SD27,Dem,Brad Hoylman,465
-New York,75085,State Senate,SD27,Dem,Brad Hoylman,303
-New York,75089,State Senate,SD27,Dem,Brad Hoylman,148
-New York,75094,State Senate,SD27,Dem,Brad Hoylman,494
-New York,75095,State Senate,SD27,Dem,Brad Hoylman,363
-New York,75096,State Senate,SD27,Dem,Brad Hoylman,353
-New York,75097,State Senate,SD27,Dem,Brad Hoylman,461
-New York,75098,State Senate,SD27,Dem,Brad Hoylman,337
-New York,75099,State Senate,SD27,Dem,Brad Hoylman,378
-New York,65079,State Senate,SD27,WF,Brad Hoylman,44
-New York,66028,State Senate,SD27,WF,Brad Hoylman,56
-New York,66029,State Senate,SD27,WF,Brad Hoylman,49
-New York,66030,State Senate,SD27,WF,Brad Hoylman,43
-New York,66031,State Senate,SD27,WF,Brad Hoylman,67
-New York,66032,State Senate,SD27,WF,Brad Hoylman,44
-New York,66033,State Senate,SD27,WF,Brad Hoylman,11
-New York,66034,State Senate,SD27,WF,Brad Hoylman,45
-New York,66035,State Senate,SD27,WF,Brad Hoylman,59
-New York,66036,State Senate,SD27,WF,Brad Hoylman,39
-New York,66037,State Senate,SD27,WF,Brad Hoylman,38
-New York,66038,State Senate,SD27,WF,Brad Hoylman,29
-New York,66039,State Senate,SD27,WF,Brad Hoylman,22
-New York,66045,State Senate,SD27,WF,Brad Hoylman,59
-New York,66046,State Senate,SD27,WF,Brad Hoylman,41
-New York,66047,State Senate,SD27,WF,Brad Hoylman,27
-New York,66048,State Senate,SD27,WF,Brad Hoylman,22
-New York,66049,State Senate,SD27,WF,Brad Hoylman,27
-New York,66050,State Senate,SD27,WF,Brad Hoylman,31
-New York,66051,State Senate,SD27,WF,Brad Hoylman,35
-New York,66052,State Senate,SD27,WF,Brad Hoylman,14
-New York,66053,State Senate,SD27,WF,Brad Hoylman,38
-New York,66054,State Senate,SD27,WF,Brad Hoylman,22
-New York,66057,State Senate,SD27,WF,Brad Hoylman,20
-New York,66058,State Senate,SD27,WF,Brad Hoylman,8
-New York,66059,State Senate,SD27,WF,Brad Hoylman,26
-New York,66060,State Senate,SD27,WF,Brad Hoylman,31
-New York,66061,State Senate,SD27,WF,Brad Hoylman,29
-New York,66062,State Senate,SD27,WF,Brad Hoylman,16
-New York,66063,State Senate,SD27,WF,Brad Hoylman,29
-New York,66064,State Senate,SD27,WF,Brad Hoylman,28
-New York,66065,State Senate,SD27,WF,Brad Hoylman,12
-New York,66066,State Senate,SD27,WF,Brad Hoylman,21
-New York,66067,State Senate,SD27,WF,Brad Hoylman,42
-New York,66068,State Senate,SD27,WF,Brad Hoylman,28
-New York,66069,State Senate,SD27,WF,Brad Hoylman,37
-New York,66071,State Senate,SD27,WF,Brad Hoylman,26
-New York,66072,State Senate,SD27,WF,Brad Hoylman,22
-New York,66073,State Senate,SD27,WF,Brad Hoylman,46
-New York,66074,State Senate,SD27,WF,Brad Hoylman,25
-New York,66075,State Senate,SD27,WF,Brad Hoylman,39
-New York,66076,State Senate,SD27,WF,Brad Hoylman,44
-New York,66077,State Senate,SD27,WF,Brad Hoylman,32
-New York,66078,State Senate,SD27,WF,Brad Hoylman,44
-New York,66079,State Senate,SD27,WF,Brad Hoylman,48
-New York,66080,State Senate,SD27,WF,Brad Hoylman,33
-New York,66081,State Senate,SD27,WF,Brad Hoylman,40
-New York,66082,State Senate,SD27,WF,Brad Hoylman,29
-New York,66083,State Senate,SD27,WF,Brad Hoylman,29
-New York,66084,State Senate,SD27,WF,Brad Hoylman,37
-New York,66085,State Senate,SD27,WF,Brad Hoylman,44
-New York,66086,State Senate,SD27,WF,Brad Hoylman,44
-New York,66087,State Senate,SD27,WF,Brad Hoylman,20
-New York,66088,State Senate,SD27,WF,Brad Hoylman,24
-New York,66089,State Senate,SD27,WF,Brad Hoylman,30
-New York,66090,State Senate,SD27,WF,Brad Hoylman,17
-New York,67002,State Senate,SD27,WF,Brad Hoylman,27
-New York,67004,State Senate,SD27,WF,Brad Hoylman,27
-New York,67006,State Senate,SD27,WF,Brad Hoylman,44
-New York,67008,State Senate,SD27,WF,Brad Hoylman,20
-New York,67009,State Senate,SD27,WF,Brad Hoylman,20
-New York,67010,State Senate,SD27,WF,Brad Hoylman,43
-New York,67011,State Senate,SD27,WF,Brad Hoylman,17
-New York,67012,State Senate,SD27,WF,Brad Hoylman,1
-New York,67013,State Senate,SD27,WF,Brad Hoylman,23
-New York,67014,State Senate,SD27,WF,Brad Hoylman,25
-New York,67015,State Senate,SD27,WF,Brad Hoylman,37
-New York,67016,State Senate,SD27,WF,Brad Hoylman,16
-New York,67017,State Senate,SD27,WF,Brad Hoylman,24
-New York,67018,State Senate,SD27,WF,Brad Hoylman,33
-New York,67019,State Senate,SD27,WF,Brad Hoylman,14
-New York,67020,State Senate,SD27,WF,Brad Hoylman,8
-New York,67021,State Senate,SD27,WF,Brad Hoylman,15
-New York,67022,State Senate,SD27,WF,Brad Hoylman,13
-New York,67023,State Senate,SD27,WF,Brad Hoylman,13
-New York,67024,State Senate,SD27,WF,Brad Hoylman,14
-New York,67031,State Senate,SD27,WF,Brad Hoylman,29
-New York,67032,State Senate,SD27,WF,Brad Hoylman,20
-New York,67033,State Senate,SD27,WF,Brad Hoylman,19
-New York,67034,State Senate,SD27,WF,Brad Hoylman,3
-New York,67035,State Senate,SD27,WF,Brad Hoylman,18
-New York,67036,State Senate,SD27,WF,Brad Hoylman,10
-New York,67037,State Senate,SD27,WF,Brad Hoylman,26
-New York,67038,State Senate,SD27,WF,Brad Hoylman,10
-New York,67039,State Senate,SD27,WF,Brad Hoylman,9
-New York,67040,State Senate,SD27,WF,Brad Hoylman,20
-New York,67041,State Senate,SD27,WF,Brad Hoylman,21
-New York,67042,State Senate,SD27,WF,Brad Hoylman,30
-New York,67043,State Senate,SD27,WF,Brad Hoylman,25
-New York,67044,State Senate,SD27,WF,Brad Hoylman,25
-New York,67045,State Senate,SD27,WF,Brad Hoylman,19
-New York,67046,State Senate,SD27,WF,Brad Hoylman,33
-New York,67047,State Senate,SD27,WF,Brad Hoylman,16
-New York,67048,State Senate,SD27,WF,Brad Hoylman,33
-New York,67049,State Senate,SD27,WF,Brad Hoylman,27
-New York,67050,State Senate,SD27,WF,Brad Hoylman,36
-New York,73006,State Senate,SD27,WF,Brad Hoylman,19
-New York,73011,State Senate,SD27,WF,Brad Hoylman,19
-New York,73012,State Senate,SD27,WF,Brad Hoylman,5
-New York,73013,State Senate,SD27,WF,Brad Hoylman,0
-New York,73015,State Senate,SD27,WF,Brad Hoylman,13
-New York,73020,State Senate,SD27,WF,Brad Hoylman,3
-New York,73043,State Senate,SD27,WF,Brad Hoylman,2
-New York,74019,State Senate,SD27,WF,Brad Hoylman,57
-New York,74020,State Senate,SD27,WF,Brad Hoylman,46
-New York,74021,State Senate,SD27,WF,Brad Hoylman,52
-New York,74022,State Senate,SD27,WF,Brad Hoylman,27
-New York,74023,State Senate,SD27,WF,Brad Hoylman,42
-New York,74024,State Senate,SD27,WF,Brad Hoylman,45
-New York,74025,State Senate,SD27,WF,Brad Hoylman,31
-New York,74026,State Senate,SD27,WF,Brad Hoylman,9
-New York,74027,State Senate,SD27,WF,Brad Hoylman,7
-New York,74028,State Senate,SD27,WF,Brad Hoylman,5
-New York,74029,State Senate,SD27,WF,Brad Hoylman,9
-New York,74030,State Senate,SD27,WF,Brad Hoylman,3
-New York,74031,State Senate,SD27,WF,Brad Hoylman,30
-New York,74032,State Senate,SD27,WF,Brad Hoylman,41
-New York,74033,State Senate,SD27,WF,Brad Hoylman,49
-New York,74034,State Senate,SD27,WF,Brad Hoylman,36
-New York,74035,State Senate,SD27,WF,Brad Hoylman,9
-New York,74036,State Senate,SD27,WF,Brad Hoylman,46
-New York,74037,State Senate,SD27,WF,Brad Hoylman,49
-New York,74038,State Senate,SD27,WF,Brad Hoylman,20
-New York,74039,State Senate,SD27,WF,Brad Hoylman,60
-New York,74040,State Senate,SD27,WF,Brad Hoylman,42
-New York,74041,State Senate,SD27,WF,Brad Hoylman,54
-New York,74042,State Senate,SD27,WF,Brad Hoylman,44
-New York,74043,State Senate,SD27,WF,Brad Hoylman,35
-New York,74044,State Senate,SD27,WF,Brad Hoylman,48
-New York,74045,State Senate,SD27,WF,Brad Hoylman,44
-New York,74046,State Senate,SD27,WF,Brad Hoylman,51
-New York,74047,State Senate,SD27,WF,Brad Hoylman,47
-New York,74048,State Senate,SD27,WF,Brad Hoylman,38
-New York,74049,State Senate,SD27,WF,Brad Hoylman,28
-New York,74050,State Senate,SD27,WF,Brad Hoylman,30
-New York,74051,State Senate,SD27,WF,Brad Hoylman,19
-New York,74052,State Senate,SD27,WF,Brad Hoylman,18
-New York,74053,State Senate,SD27,WF,Brad Hoylman,49
-New York,74054,State Senate,SD27,WF,Brad Hoylman,21
-New York,74055,State Senate,SD27,WF,Brad Hoylman,6
-New York,74071,State Senate,SD27,WF,Brad Hoylman,22
-New York,74072,State Senate,SD27,WF,Brad Hoylman,14
-New York,74073,State Senate,SD27,WF,Brad Hoylman,15
-New York,74074,State Senate,SD27,WF,Brad Hoylman,20
-New York,74075,State Senate,SD27,WF,Brad Hoylman,18
-New York,74076,State Senate,SD27,WF,Brad Hoylman,12
-New York,74077,State Senate,SD27,WF,Brad Hoylman,18
-New York,74078,State Senate,SD27,WF,Brad Hoylman,11
-New York,74079,State Senate,SD27,WF,Brad Hoylman,18
-New York,74080,State Senate,SD27,WF,Brad Hoylman,9
-New York,74081,State Senate,SD27,WF,Brad Hoylman,5
-New York,74084,State Senate,SD27,WF,Brad Hoylman,12
-New York,75001,State Senate,SD27,WF,Brad Hoylman,36
-New York,75002,State Senate,SD27,WF,Brad Hoylman,23
-New York,75003,State Senate,SD27,WF,Brad Hoylman,19
-New York,75004,State Senate,SD27,WF,Brad Hoylman,35
-New York,75005,State Senate,SD27,WF,Brad Hoylman,38
-New York,75006,State Senate,SD27,WF,Brad Hoylman,29
-New York,75007,State Senate,SD27,WF,Brad Hoylman,13
-New York,75010,State Senate,SD27,WF,Brad Hoylman,26
-New York,75011,State Senate,SD27,WF,Brad Hoylman,27
-New York,75012,State Senate,SD27,WF,Brad Hoylman,20
-New York,75013,State Senate,SD27,WF,Brad Hoylman,8
-New York,75014,State Senate,SD27,WF,Brad Hoylman,22
-New York,75015,State Senate,SD27,WF,Brad Hoylman,38
-New York,75016,State Senate,SD27,WF,Brad Hoylman,46
-New York,75017,State Senate,SD27,WF,Brad Hoylman,23
-New York,75018,State Senate,SD27,WF,Brad Hoylman,24
-New York,75019,State Senate,SD27,WF,Brad Hoylman,29
-New York,75020,State Senate,SD27,WF,Brad Hoylman,48
-New York,75021,State Senate,SD27,WF,Brad Hoylman,17
-New York,75022,State Senate,SD27,WF,Brad Hoylman,15
-New York,75023,State Senate,SD27,WF,Brad Hoylman,25
-New York,75024,State Senate,SD27,WF,Brad Hoylman,23
-New York,75025,State Senate,SD27,WF,Brad Hoylman,41
-New York,75026,State Senate,SD27,WF,Brad Hoylman,43
-New York,75027,State Senate,SD27,WF,Brad Hoylman,47
-New York,75028,State Senate,SD27,WF,Brad Hoylman,38
-New York,75036,State Senate,SD27,WF,Brad Hoylman,30
-New York,75037,State Senate,SD27,WF,Brad Hoylman,20
-New York,75038,State Senate,SD27,WF,Brad Hoylman,80
-New York,75039,State Senate,SD27,WF,Brad Hoylman,19
-New York,75040,State Senate,SD27,WF,Brad Hoylman,10
-New York,75041,State Senate,SD27,WF,Brad Hoylman,41
-New York,75042,State Senate,SD27,WF,Brad Hoylman,39
-New York,75043,State Senate,SD27,WF,Brad Hoylman,76
-New York,75044,State Senate,SD27,WF,Brad Hoylman,69
-New York,75046,State Senate,SD27,WF,Brad Hoylman,12
-New York,75047,State Senate,SD27,WF,Brad Hoylman,10
-New York,75048,State Senate,SD27,WF,Brad Hoylman,9
-New York,75049,State Senate,SD27,WF,Brad Hoylman,13
-New York,75050,State Senate,SD27,WF,Brad Hoylman,11
-New York,75058,State Senate,SD27,WF,Brad Hoylman,15
-New York,75062,State Senate,SD27,WF,Brad Hoylman,21
-New York,75063,State Senate,SD27,WF,Brad Hoylman,29
-New York,75064,State Senate,SD27,WF,Brad Hoylman,29
-New York,75068,State Senate,SD27,WF,Brad Hoylman,8
-New York,75069,State Senate,SD27,WF,Brad Hoylman,18
-New York,75070,State Senate,SD27,WF,Brad Hoylman,29
-New York,75071,State Senate,SD27,WF,Brad Hoylman,48
-New York,75072,State Senate,SD27,WF,Brad Hoylman,60
-New York,75073,State Senate,SD27,WF,Brad Hoylman,16
-New York,75074,State Senate,SD27,WF,Brad Hoylman,16
-New York,75075,State Senate,SD27,WF,Brad Hoylman,14
-New York,75076,State Senate,SD27,WF,Brad Hoylman,10
-New York,75077,State Senate,SD27,WF,Brad Hoylman,36
-New York,75078,State Senate,SD27,WF,Brad Hoylman,24
-New York,75079,State Senate,SD27,WF,Brad Hoylman,13
-New York,75080,State Senate,SD27,WF,Brad Hoylman,39
-New York,75081,State Senate,SD27,WF,Brad Hoylman,17
-New York,75082,State Senate,SD27,WF,Brad Hoylman,19
-New York,75083,State Senate,SD27,WF,Brad Hoylman,32
-New York,75084,State Senate,SD27,WF,Brad Hoylman,19
-New York,75085,State Senate,SD27,WF,Brad Hoylman,17
-New York,75089,State Senate,SD27,WF,Brad Hoylman,5
-New York,75094,State Senate,SD27,WF,Brad Hoylman,26
-New York,75095,State Senate,SD27,WF,Brad Hoylman,16
-New York,75096,State Senate,SD27,WF,Brad Hoylman,14
-New York,75097,State Senate,SD27,WF,Brad Hoylman,12
-New York,75098,State Senate,SD27,WF,Brad Hoylman,24
-New York,75099,State Senate,SD27,WF,Brad Hoylman,20
-New York,65079,State Senate,SD27,Ind,writein,1
-New York,66028,State Senate,SD27,Ind,writein,0
-New York,66029,State Senate,SD27,Ind,writein,1
-New York,66030,State Senate,SD27,Ind,writein,0
-New York,66031,State Senate,SD27,Ind,writein,3
-New York,66032,State Senate,SD27,Ind,writein,1
-New York,66033,State Senate,SD27,Ind,writein,1
-New York,66034,State Senate,SD27,Ind,writein,0
-New York,66035,State Senate,SD27,Ind,writein,3
-New York,66036,State Senate,SD27,Ind,writein,1
-New York,66037,State Senate,SD27,Ind,writein,1
-New York,66038,State Senate,SD27,Ind,writein,0
-New York,66039,State Senate,SD27,Ind,writein,0
-New York,66045,State Senate,SD27,Ind,writein,1
-New York,66046,State Senate,SD27,Ind,writein,0
-New York,66047,State Senate,SD27,Ind,writein,1
-New York,66048,State Senate,SD27,Ind,writein,0
-New York,66049,State Senate,SD27,Ind,writein,0
-New York,66050,State Senate,SD27,Ind,writein,0
-New York,66051,State Senate,SD27,Ind,writein,2
-New York,66052,State Senate,SD27,Ind,writein,0
-New York,66053,State Senate,SD27,Ind,writein,0
-New York,66054,State Senate,SD27,Ind,writein,0
-New York,66057,State Senate,SD27,Ind,writein,0
-New York,66058,State Senate,SD27,Ind,writein,1
-New York,66059,State Senate,SD27,Ind,writein,1
-New York,66060,State Senate,SD27,Ind,writein,1
-New York,66061,State Senate,SD27,Ind,writein,0
-New York,66062,State Senate,SD27,Ind,writein,0
-New York,66063,State Senate,SD27,Ind,writein,4
-New York,66064,State Senate,SD27,Ind,writein,1
-New York,66065,State Senate,SD27,Ind,writein,0
-New York,66066,State Senate,SD27,Ind,writein,1
-New York,66067,State Senate,SD27,Ind,writein,0
-New York,66068,State Senate,SD27,Ind,writein,4
-New York,66069,State Senate,SD27,Ind,writein,0
-New York,66071,State Senate,SD27,Ind,writein,0
-New York,66072,State Senate,SD27,Ind,writein,1
-New York,66073,State Senate,SD27,Ind,writein,1
-New York,66074,State Senate,SD27,Ind,writein,0
-New York,66075,State Senate,SD27,Ind,writein,0
-New York,66076,State Senate,SD27,Ind,writein,4
-New York,66077,State Senate,SD27,Ind,writein,0
-New York,66078,State Senate,SD27,Ind,writein,2
-New York,66079,State Senate,SD27,Ind,writein,1
-New York,66080,State Senate,SD27,Ind,writein,1
-New York,66081,State Senate,SD27,Ind,writein,0
-New York,66082,State Senate,SD27,Ind,writein,2
-New York,66083,State Senate,SD27,Ind,writein,4
-New York,66084,State Senate,SD27,Ind,writein,1
-New York,66085,State Senate,SD27,Ind,writein,0
-New York,66086,State Senate,SD27,Ind,writein,0
-New York,66087,State Senate,SD27,Ind,writein,0
-New York,66088,State Senate,SD27,Ind,writein,2
-New York,66089,State Senate,SD27,Ind,writein,0
-New York,66090,State Senate,SD27,Ind,writein,0
-New York,67002,State Senate,SD27,Ind,writein,1
-New York,67004,State Senate,SD27,Ind,writein,1
-New York,67006,State Senate,SD27,Ind,writein,1
-New York,67008,State Senate,SD27,Ind,writein,0
-New York,67009,State Senate,SD27,Ind,writein,1
-New York,67010,State Senate,SD27,Ind,writein,3
-New York,67011,State Senate,SD27,Ind,writein,0
-New York,67012,State Senate,SD27,Ind,writein,1
-New York,67013,State Senate,SD27,Ind,writein,0
-New York,67014,State Senate,SD27,Ind,writein,2
-New York,67015,State Senate,SD27,Ind,writein,0
-New York,67016,State Senate,SD27,Ind,writein,0
-New York,67017,State Senate,SD27,Ind,writein,4
-New York,67018,State Senate,SD27,Ind,writein,2
-New York,67019,State Senate,SD27,Ind,writein,1
-New York,67020,State Senate,SD27,Ind,writein,1
-New York,67021,State Senate,SD27,Ind,writein,1
-New York,67022,State Senate,SD27,Ind,writein,1
-New York,67023,State Senate,SD27,Ind,writein,0
-New York,67024,State Senate,SD27,Ind,writein,0
-New York,67031,State Senate,SD27,Ind,writein,0
-New York,67032,State Senate,SD27,Ind,writein,1
-New York,67033,State Senate,SD27,Ind,writein,3
-New York,67034,State Senate,SD27,Ind,writein,0
-New York,67035,State Senate,SD27,Ind,writein,2
-New York,67036,State Senate,SD27,Ind,writein,1
-New York,67037,State Senate,SD27,Ind,writein,1
-New York,67038,State Senate,SD27,Ind,writein,1
-New York,67039,State Senate,SD27,Ind,writein,0
-New York,67040,State Senate,SD27,Ind,writein,1
-New York,67041,State Senate,SD27,Ind,writein,1
-New York,67042,State Senate,SD27,Ind,writein,0
-New York,67043,State Senate,SD27,Ind,writein,1
-New York,67044,State Senate,SD27,Ind,writein,0
-New York,67045,State Senate,SD27,Ind,writein,0
-New York,67046,State Senate,SD27,Ind,writein,4
-New York,67047,State Senate,SD27,Ind,writein,0
-New York,67048,State Senate,SD27,Ind,writein,1
-New York,67049,State Senate,SD27,Ind,writein,1
-New York,67050,State Senate,SD27,Ind,writein,0
-New York,73006,State Senate,SD27,Ind,writein,2
-New York,73011,State Senate,SD27,Ind,writein,1
-New York,73012,State Senate,SD27,Ind,writein,0
-New York,73013,State Senate,SD27,Ind,writein,0
-New York,73015,State Senate,SD27,Ind,writein,0
-New York,73020,State Senate,SD27,Ind,writein,0
-New York,73043,State Senate,SD27,Ind,writein,1
-New York,74019,State Senate,SD27,Ind,writein,0
-New York,74020,State Senate,SD27,Ind,writein,0
-New York,74021,State Senate,SD27,Ind,writein,0
-New York,74022,State Senate,SD27,Ind,writein,1
-New York,74023,State Senate,SD27,Ind,writein,0
-New York,74024,State Senate,SD27,Ind,writein,2
-New York,74025,State Senate,SD27,Ind,writein,0
-New York,74026,State Senate,SD27,Ind,writein,0
-New York,74027,State Senate,SD27,Ind,writein,0
-New York,74028,State Senate,SD27,Ind,writein,0
-New York,74029,State Senate,SD27,Ind,writein,0
-New York,74030,State Senate,SD27,Ind,writein,0
-New York,74031,State Senate,SD27,Ind,writein,0
-New York,74032,State Senate,SD27,Ind,writein,0
-New York,74033,State Senate,SD27,Ind,writein,0
-New York,74034,State Senate,SD27,Ind,writein,0
-New York,74035,State Senate,SD27,Ind,writein,0
-New York,74036,State Senate,SD27,Ind,writein,2
-New York,74037,State Senate,SD27,Ind,writein,0
-New York,74038,State Senate,SD27,Ind,writein,1
-New York,74039,State Senate,SD27,Ind,writein,0
-New York,74040,State Senate,SD27,Ind,writein,4
-New York,74041,State Senate,SD27,Ind,writein,1
-New York,74042,State Senate,SD27,Ind,writein,2
-New York,74043,State Senate,SD27,Ind,writein,0
-New York,74044,State Senate,SD27,Ind,writein,1
-New York,74045,State Senate,SD27,Ind,writein,0
-New York,74046,State Senate,SD27,Ind,writein,0
-New York,74047,State Senate,SD27,Ind,writein,3
-New York,74048,State Senate,SD27,Ind,writein,0
-New York,74049,State Senate,SD27,Ind,writein,4
-New York,74050,State Senate,SD27,Ind,writein,1
-New York,74051,State Senate,SD27,Ind,writein,0
-New York,74052,State Senate,SD27,Ind,writein,2
-New York,74053,State Senate,SD27,Ind,writein,2
-New York,74054,State Senate,SD27,Ind,writein,0
-New York,74055,State Senate,SD27,Ind,writein,2
-New York,74071,State Senate,SD27,Ind,writein,0
-New York,74072,State Senate,SD27,Ind,writein,1
-New York,74073,State Senate,SD27,Ind,writein,2
-New York,74074,State Senate,SD27,Ind,writein,2
-New York,74075,State Senate,SD27,Ind,writein,4
-New York,74076,State Senate,SD27,Ind,writein,2
-New York,74077,State Senate,SD27,Ind,writein,2
-New York,74078,State Senate,SD27,Ind,writein,1
-New York,74079,State Senate,SD27,Ind,writein,2
-New York,74080,State Senate,SD27,Ind,writein,0
-New York,74081,State Senate,SD27,Ind,writein,0
-New York,74084,State Senate,SD27,Ind,writein,0
-New York,75001,State Senate,SD27,Ind,writein,1
-New York,75002,State Senate,SD27,Ind,writein,1
-New York,75003,State Senate,SD27,Ind,writein,1
-New York,75004,State Senate,SD27,Ind,writein,1
-New York,75005,State Senate,SD27,Ind,writein,1
-New York,75006,State Senate,SD27,Ind,writein,2
-New York,75007,State Senate,SD27,Ind,writein,0
-New York,75010,State Senate,SD27,Ind,writein,2
-New York,75011,State Senate,SD27,Ind,writein,0
-New York,75012,State Senate,SD27,Ind,writein,3
-New York,75013,State Senate,SD27,Ind,writein,0
-New York,75014,State Senate,SD27,Ind,writein,1
-New York,75015,State Senate,SD27,Ind,writein,1
-New York,75016,State Senate,SD27,Ind,writein,0
-New York,75017,State Senate,SD27,Ind,writein,1
-New York,75018,State Senate,SD27,Ind,writein,0
-New York,75019,State Senate,SD27,Ind,writein,0
-New York,75020,State Senate,SD27,Ind,writein,2
-New York,75021,State Senate,SD27,Ind,writein,0
-New York,75022,State Senate,SD27,Ind,writein,1
-New York,75023,State Senate,SD27,Ind,writein,0
-New York,75024,State Senate,SD27,Ind,writein,0
-New York,75025,State Senate,SD27,Ind,writein,0
-New York,75026,State Senate,SD27,Ind,writein,2
-New York,75027,State Senate,SD27,Ind,writein,1
-New York,75028,State Senate,SD27,Ind,writein,0
-New York,75036,State Senate,SD27,Ind,writein,2
-New York,75037,State Senate,SD27,Ind,writein,0
-New York,75038,State Senate,SD27,Ind,writein,2
-New York,75039,State Senate,SD27,Ind,writein,1
-New York,75040,State Senate,SD27,Ind,writein,1
-New York,75041,State Senate,SD27,Ind,writein,0
-New York,75042,State Senate,SD27,Ind,writein,1
-New York,75043,State Senate,SD27,Ind,writein,2
-New York,75044,State Senate,SD27,Ind,writein,1
-New York,75046,State Senate,SD27,Ind,writein,0
-New York,75047,State Senate,SD27,Ind,writein,0
-New York,75048,State Senate,SD27,Ind,writein,1
-New York,75049,State Senate,SD27,Ind,writein,0
-New York,75050,State Senate,SD27,Ind,writein,1
-New York,75058,State Senate,SD27,Ind,writein,2
-New York,75062,State Senate,SD27,Ind,writein,2
-New York,75063,State Senate,SD27,Ind,writein,0
-New York,75064,State Senate,SD27,Ind,writein,3
-New York,75068,State Senate,SD27,Ind,writein,0
-New York,75069,State Senate,SD27,Ind,writein,1
-New York,75070,State Senate,SD27,Ind,writein,0
-New York,75071,State Senate,SD27,Ind,writein,1
-New York,75072,State Senate,SD27,Ind,writein,1
-New York,75073,State Senate,SD27,Ind,writein,3
-New York,75074,State Senate,SD27,Ind,writein,4
-New York,75075,State Senate,SD27,Ind,writein,0
-New York,75076,State Senate,SD27,Ind,writein,1
-New York,75077,State Senate,SD27,Ind,writein,0
-New York,75078,State Senate,SD27,Ind,writein,1
-New York,75079,State Senate,SD27,Ind,writein,0
-New York,75080,State Senate,SD27,Ind,writein,1
-New York,75081,State Senate,SD27,Ind,writein,1
-New York,75082,State Senate,SD27,Ind,writein,1
-New York,75083,State Senate,SD27,Ind,writein,3
-New York,75084,State Senate,SD27,Ind,writein,5
-New York,75085,State Senate,SD27,Ind,writein,0
-New York,75089,State Senate,SD27,Ind,writein,0
-New York,75094,State Senate,SD27,Ind,writein,1
-New York,75095,State Senate,SD27,Ind,writein,1
-New York,75096,State Senate,SD27,Ind,writein,1
-New York,75097,State Senate,SD27,Ind,writein,1
-New York,75098,State Senate,SD27,Ind,writein,2
-New York,75099,State Senate,SD27,Ind,writein,3
-New York,66055,State Senate,SD28,Rep,David Garland,99
-New York,66056,State Senate,SD28,Rep,David Garland,18
-New York,68001,State Senate,SD28,Rep,David Garland,52
-New York,68005,State Senate,SD28,Rep,David Garland,61
-New York,68006,State Senate,SD28,Rep,David Garland,7
-New York,68007,State Senate,SD28,Rep,David Garland,60
-New York,68008,State Senate,SD28,Rep,David Garland,54
-New York,73001,State Senate,SD28,Rep,David Garland,128
-New York,73002,State Senate,SD28,Rep,David Garland,156
-New York,73003,State Senate,SD28,Rep,David Garland,108
-New York,73004,State Senate,SD28,Rep,David Garland,92
-New York,73005,State Senate,SD28,Rep,David Garland,199
-New York,73007,State Senate,SD28,Rep,David Garland,67
-New York,73008,State Senate,SD28,Rep,David Garland,63
-New York,73009,State Senate,SD28,Rep,David Garland,172
-New York,73010,State Senate,SD28,Rep,David Garland,101
-New York,73014,State Senate,SD28,Rep,David Garland,45
-New York,73016,State Senate,SD28,Rep,David Garland,200
-New York,73017,State Senate,SD28,Rep,David Garland,70
-New York,73018,State Senate,SD28,Rep,David Garland,155
-New York,73019,State Senate,SD28,Rep,David Garland,61
-New York,73021,State Senate,SD28,Rep,David Garland,139
-New York,73022,State Senate,SD28,Rep,David Garland,97
-New York,73023,State Senate,SD28,Rep,David Garland,133
-New York,73024,State Senate,SD28,Rep,David Garland,107
-New York,73025,State Senate,SD28,Rep,David Garland,88
-New York,73026,State Senate,SD28,Rep,David Garland,88
-New York,73027,State Senate,SD28,Rep,David Garland,119
-New York,73028,State Senate,SD28,Rep,David Garland,87
-New York,73029,State Senate,SD28,Rep,David Garland,132
-New York,73030,State Senate,SD28,Rep,David Garland,74
-New York,73031,State Senate,SD28,Rep,David Garland,17
-New York,73032,State Senate,SD28,Rep,David Garland,216
-New York,73033,State Senate,SD28,Rep,David Garland,168
-New York,73034,State Senate,SD28,Rep,David Garland,199
-New York,73035,State Senate,SD28,Rep,David Garland,170
-New York,73036,State Senate,SD28,Rep,David Garland,185
-New York,73037,State Senate,SD28,Rep,David Garland,144
-New York,73038,State Senate,SD28,Rep,David Garland,209
-New York,73039,State Senate,SD28,Rep,David Garland,177
-New York,73040,State Senate,SD28,Rep,David Garland,139
-New York,73041,State Senate,SD28,Rep,David Garland,210
-New York,73042,State Senate,SD28,Rep,David Garland,106
-New York,73045,State Senate,SD28,Rep,David Garland,161
-New York,73046,State Senate,SD28,Rep,David Garland,87
-New York,73047,State Senate,SD28,Rep,David Garland,33
-New York,73048,State Senate,SD28,Rep,David Garland,121
-New York,73049,State Senate,SD28,Rep,David Garland,42
-New York,73050,State Senate,SD28,Rep,David Garland,168
-New York,73051,State Senate,SD28,Rep,David Garland,141
-New York,73052,State Senate,SD28,Rep,David Garland,179
-New York,73053,State Senate,SD28,Rep,David Garland,161
-New York,73054,State Senate,SD28,Rep,David Garland,57
-New York,73055,State Senate,SD28,Rep,David Garland,167
-New York,73056,State Senate,SD28,Rep,David Garland,193
-New York,73057,State Senate,SD28,Rep,David Garland,181
-New York,73058,State Senate,SD28,Rep,David Garland,223
-New York,73059,State Senate,SD28,Rep,David Garland,217
-New York,73060,State Senate,SD28,Rep,David Garland,255
-New York,73061,State Senate,SD28,Rep,David Garland,198
-New York,73062,State Senate,SD28,Rep,David Garland,154
-New York,73063,State Senate,SD28,Rep,David Garland,210
-New York,73064,State Senate,SD28,Rep,David Garland,180
-New York,73065,State Senate,SD28,Rep,David Garland,164
-New York,73066,State Senate,SD28,Rep,David Garland,166
-New York,73067,State Senate,SD28,Rep,David Garland,233
-New York,73068,State Senate,SD28,Rep,David Garland,145
-New York,73069,State Senate,SD28,Rep,David Garland,138
-New York,73070,State Senate,SD28,Rep,David Garland,144
-New York,73071,State Senate,SD28,Rep,David Garland,229
-New York,73072,State Senate,SD28,Rep,David Garland,291
-New York,73073,State Senate,SD28,Rep,David Garland,203
-New York,73074,State Senate,SD28,Rep,David Garland,152
-New York,73075,State Senate,SD28,Rep,David Garland,146
-New York,73076,State Senate,SD28,Rep,David Garland,168
-New York,73077,State Senate,SD28,Rep,David Garland,211
-New York,73078,State Senate,SD28,Rep,David Garland,167
-New York,73079,State Senate,SD28,Rep,David Garland,194
-New York,73080,State Senate,SD28,Rep,David Garland,205
-New York,73081,State Senate,SD28,Rep,David Garland,114
-New York,73082,State Senate,SD28,Rep,David Garland,249
-New York,73083,State Senate,SD28,Rep,David Garland,133
-New York,73084,State Senate,SD28,Rep,David Garland,95
-New York,73085,State Senate,SD28,Rep,David Garland,151
-New York,73086,State Senate,SD28,Rep,David Garland,215
-New York,73087,State Senate,SD28,Rep,David Garland,198
-New York,73088,State Senate,SD28,Rep,David Garland,138
-New York,73089,State Senate,SD28,Rep,David Garland,166
-New York,73090,State Senate,SD28,Rep,David Garland,150
-New York,73091,State Senate,SD28,Rep,David Garland,134
-New York,73092,State Senate,SD28,Rep,David Garland,46
-New York,73097,State Senate,SD28,Rep,David Garland,53
-New York,73099,State Senate,SD28,Rep,David Garland,143
-New York,73100,State Senate,SD28,Rep,David Garland,156
-New York,74056,State Senate,SD28,Rep,David Garland,117
-New York,74057,State Senate,SD28,Rep,David Garland,92
-New York,74058,State Senate,SD28,Rep,David Garland,72
-New York,74059,State Senate,SD28,Rep,David Garland,95
-New York,74060,State Senate,SD28,Rep,David Garland,111
-New York,74061,State Senate,SD28,Rep,David Garland,90
-New York,74062,State Senate,SD28,Rep,David Garland,99
-New York,74063,State Senate,SD28,Rep,David Garland,68
-New York,74064,State Senate,SD28,Rep,David Garland,98
-New York,74065,State Senate,SD28,Rep,David Garland,47
-New York,74066,State Senate,SD28,Rep,David Garland,56
-New York,74067,State Senate,SD28,Rep,David Garland,76
-New York,74068,State Senate,SD28,Rep,David Garland,78
-New York,74069,State Senate,SD28,Rep,David Garland,51
-New York,74070,State Senate,SD28,Rep,David Garland,111
-New York,74082,State Senate,SD28,Rep,David Garland,122
-New York,74083,State Senate,SD28,Rep,David Garland,110
-New York,74085,State Senate,SD28,Rep,David Garland,33
-New York,74086,State Senate,SD28,Rep,David Garland,168
-New York,74087,State Senate,SD28,Rep,David Garland,153
-New York,74088,State Senate,SD28,Rep,David Garland,164
-New York,74089,State Senate,SD28,Rep,David Garland,172
-New York,74090,State Senate,SD28,Rep,David Garland,111
-New York,74091,State Senate,SD28,Rep,David Garland,142
-New York,75008,State Senate,SD28,Rep,David Garland,158
-New York,75009,State Senate,SD28,Rep,David Garland,149
-New York,75029,State Senate,SD28,Rep,David Garland,80
-New York,75030,State Senate,SD28,Rep,David Garland,108
-New York,75031,State Senate,SD28,Rep,David Garland,78
-New York,75032,State Senate,SD28,Rep,David Garland,102
-New York,75033,State Senate,SD28,Rep,David Garland,122
-New York,75034,State Senate,SD28,Rep,David Garland,105
-New York,75035,State Senate,SD28,Rep,David Garland,57
-New York,75051,State Senate,SD28,Rep,David Garland,93
-New York,75052,State Senate,SD28,Rep,David Garland,99
-New York,75053,State Senate,SD28,Rep,David Garland,95
-New York,75054,State Senate,SD28,Rep,David Garland,142
-New York,75055,State Senate,SD28,Rep,David Garland,72
-New York,75056,State Senate,SD28,Rep,David Garland,180
-New York,75057,State Senate,SD28,Rep,David Garland,72
-New York,75086,State Senate,SD28,Rep,David Garland,53
-New York,75087,State Senate,SD28,Rep,David Garland,95
-New York,75088,State Senate,SD28,Rep,David Garland,105
-New York,75090,State Senate,SD28,Rep,David Garland,64
-New York,75091,State Senate,SD28,Rep,David Garland,140
-New York,75092,State Senate,SD28,Rep,David Garland,121
-New York,76001,State Senate,SD28,Rep,David Garland,96
-New York,76002,State Senate,SD28,Rep,David Garland,120
-New York,76003,State Senate,SD28,Rep,David Garland,170
-New York,76004,State Senate,SD28,Rep,David Garland,134
-New York,76005,State Senate,SD28,Rep,David Garland,137
-New York,76006,State Senate,SD28,Rep,David Garland,145
-New York,76007,State Senate,SD28,Rep,David Garland,66
-New York,76008,State Senate,SD28,Rep,David Garland,125
-New York,76009,State Senate,SD28,Rep,David Garland,158
-New York,76010,State Senate,SD28,Rep,David Garland,166
-New York,76011,State Senate,SD28,Rep,David Garland,117
-New York,76012,State Senate,SD28,Rep,David Garland,91
-New York,76013,State Senate,SD28,Rep,David Garland,203
-New York,76014,State Senate,SD28,Rep,David Garland,201
-New York,76015,State Senate,SD28,Rep,David Garland,79
-New York,76016,State Senate,SD28,Rep,David Garland,154
-New York,76017,State Senate,SD28,Rep,David Garland,100
-New York,76018,State Senate,SD28,Rep,David Garland,143
-New York,76019,State Senate,SD28,Rep,David Garland,186
-New York,76020,State Senate,SD28,Rep,David Garland,141
-New York,76021,State Senate,SD28,Rep,David Garland,167
-New York,76022,State Senate,SD28,Rep,David Garland,175
-New York,76023,State Senate,SD28,Rep,David Garland,150
-New York,76024,State Senate,SD28,Rep,David Garland,124
-New York,76025,State Senate,SD28,Rep,David Garland,143
-New York,76026,State Senate,SD28,Rep,David Garland,113
-New York,76027,State Senate,SD28,Rep,David Garland,92
-New York,76028,State Senate,SD28,Rep,David Garland,125
-New York,76029,State Senate,SD28,Rep,David Garland,98
-New York,76030,State Senate,SD28,Rep,David Garland,125
-New York,76031,State Senate,SD28,Rep,David Garland,141
-New York,76032,State Senate,SD28,Rep,David Garland,76
-New York,76033,State Senate,SD28,Rep,David Garland,133
-New York,76034,State Senate,SD28,Rep,David Garland,128
-New York,76035,State Senate,SD28,Rep,David Garland,208
-New York,76036,State Senate,SD28,Rep,David Garland,125
-New York,76037,State Senate,SD28,Rep,David Garland,136
-New York,76038,State Senate,SD28,Rep,David Garland,133
-New York,76039,State Senate,SD28,Rep,David Garland,122
-New York,76040,State Senate,SD28,Rep,David Garland,139
-New York,76041,State Senate,SD28,Rep,David Garland,84
-New York,76042,State Senate,SD28,Rep,David Garland,116
-New York,76043,State Senate,SD28,Rep,David Garland,107
-New York,76044,State Senate,SD28,Rep,David Garland,107
-New York,76045,State Senate,SD28,Rep,David Garland,98
-New York,76046,State Senate,SD28,Rep,David Garland,160
-New York,76047,State Senate,SD28,Rep,David Garland,104
-New York,76048,State Senate,SD28,Rep,David Garland,111
-New York,76049,State Senate,SD28,Rep,David Garland,117
-New York,76050,State Senate,SD28,Rep,David Garland,179
-New York,76051,State Senate,SD28,Rep,David Garland,101
-New York,76052,State Senate,SD28,Rep,David Garland,163
-New York,76053,State Senate,SD28,Rep,David Garland,155
-New York,76054,State Senate,SD28,Rep,David Garland,123
-New York,76055,State Senate,SD28,Rep,David Garland,133
-New York,76056,State Senate,SD28,Rep,David Garland,75
-New York,76057,State Senate,SD28,Rep,David Garland,122
-New York,76058,State Senate,SD28,Rep,David Garland,157
-New York,76059,State Senate,SD28,Rep,David Garland,93
-New York,76060,State Senate,SD28,Rep,David Garland,75
-New York,76061,State Senate,SD28,Rep,David Garland,121
-New York,76062,State Senate,SD28,Rep,David Garland,83
-New York,76063,State Senate,SD28,Rep,David Garland,101
-New York,76064,State Senate,SD28,Rep,David Garland,131
-New York,76065,State Senate,SD28,Rep,David Garland,167
-New York,76066,State Senate,SD28,Rep,David Garland,165
-New York,76067,State Senate,SD28,Rep,David Garland,190
-New York,76068,State Senate,SD28,Rep,David Garland,118
-New York,76069,State Senate,SD28,Rep,David Garland,127
-New York,76070,State Senate,SD28,Rep,David Garland,69
-New York,76071,State Senate,SD28,Rep,David Garland,154
-New York,76072,State Senate,SD28,Rep,David Garland,172
-New York,76073,State Senate,SD28,Rep,David Garland,150
-New York,76074,State Senate,SD28,Rep,David Garland,79
-New York,76075,State Senate,SD28,Rep,David Garland,118
-New York,76076,State Senate,SD28,Rep,David Garland,90
-New York,76077,State Senate,SD28,Rep,David Garland,124
-New York,76078,State Senate,SD28,Rep,David Garland,79
-New York,76079,State Senate,SD28,Rep,David Garland,169
-New York,76080,State Senate,SD28,Rep,David Garland,72
-New York,66055,State Senate,SD28,Ind,David Garland,8
-New York,66056,State Senate,SD28,Ind,David Garland,4
-New York,68001,State Senate,SD28,Ind,David Garland,2
-New York,68005,State Senate,SD28,Ind,David Garland,4
-New York,68006,State Senate,SD28,Ind,David Garland,2
-New York,68007,State Senate,SD28,Ind,David Garland,2
-New York,68008,State Senate,SD28,Ind,David Garland,6
-New York,73001,State Senate,SD28,Ind,David Garland,5
-New York,73002,State Senate,SD28,Ind,David Garland,8
-New York,73003,State Senate,SD28,Ind,David Garland,10
-New York,73004,State Senate,SD28,Ind,David Garland,4
-New York,73005,State Senate,SD28,Ind,David Garland,16
-New York,73007,State Senate,SD28,Ind,David Garland,4
-New York,73008,State Senate,SD28,Ind,David Garland,3
-New York,73009,State Senate,SD28,Ind,David Garland,3
-New York,73010,State Senate,SD28,Ind,David Garland,9
-New York,73014,State Senate,SD28,Ind,David Garland,4
-New York,73016,State Senate,SD28,Ind,David Garland,7
-New York,73017,State Senate,SD28,Ind,David Garland,2
-New York,73018,State Senate,SD28,Ind,David Garland,5
-New York,73019,State Senate,SD28,Ind,David Garland,1
-New York,73021,State Senate,SD28,Ind,David Garland,7
-New York,73022,State Senate,SD28,Ind,David Garland,2
-New York,73023,State Senate,SD28,Ind,David Garland,5
-New York,73024,State Senate,SD28,Ind,David Garland,8
-New York,73025,State Senate,SD28,Ind,David Garland,5
-New York,73026,State Senate,SD28,Ind,David Garland,2
-New York,73027,State Senate,SD28,Ind,David Garland,2
-New York,73028,State Senate,SD28,Ind,David Garland,5
-New York,73029,State Senate,SD28,Ind,David Garland,8
-New York,73030,State Senate,SD28,Ind,David Garland,4
-New York,73031,State Senate,SD28,Ind,David Garland,2
-New York,73032,State Senate,SD28,Ind,David Garland,10
-New York,73033,State Senate,SD28,Ind,David Garland,4
-New York,73034,State Senate,SD28,Ind,David Garland,5
-New York,73035,State Senate,SD28,Ind,David Garland,0
-New York,73036,State Senate,SD28,Ind,David Garland,11
-New York,73037,State Senate,SD28,Ind,David Garland,3
-New York,73038,State Senate,SD28,Ind,David Garland,7
-New York,73039,State Senate,SD28,Ind,David Garland,3
-New York,73040,State Senate,SD28,Ind,David Garland,5
-New York,73041,State Senate,SD28,Ind,David Garland,9
-New York,73042,State Senate,SD28,Ind,David Garland,7
-New York,73045,State Senate,SD28,Ind,David Garland,8
-New York,73046,State Senate,SD28,Ind,David Garland,2
-New York,73047,State Senate,SD28,Ind,David Garland,1
-New York,73048,State Senate,SD28,Ind,David Garland,0
-New York,73049,State Senate,SD28,Ind,David Garland,2
-New York,73050,State Senate,SD28,Ind,David Garland,5
-New York,73051,State Senate,SD28,Ind,David Garland,5
-New York,73052,State Senate,SD28,Ind,David Garland,1
-New York,73053,State Senate,SD28,Ind,David Garland,0
-New York,73054,State Senate,SD28,Ind,David Garland,4
-New York,73055,State Senate,SD28,Ind,David Garland,6
-New York,73056,State Senate,SD28,Ind,David Garland,5
-New York,73057,State Senate,SD28,Ind,David Garland,7
-New York,73058,State Senate,SD28,Ind,David Garland,4
-New York,73059,State Senate,SD28,Ind,David Garland,5
-New York,73060,State Senate,SD28,Ind,David Garland,5
-New York,73061,State Senate,SD28,Ind,David Garland,3
-New York,73062,State Senate,SD28,Ind,David Garland,2
-New York,73063,State Senate,SD28,Ind,David Garland,6
-New York,73064,State Senate,SD28,Ind,David Garland,5
-New York,73065,State Senate,SD28,Ind,David Garland,12
-New York,73066,State Senate,SD28,Ind,David Garland,1
-New York,73067,State Senate,SD28,Ind,David Garland,4
-New York,73068,State Senate,SD28,Ind,David Garland,0
-New York,73069,State Senate,SD28,Ind,David Garland,5
-New York,73070,State Senate,SD28,Ind,David Garland,2
-New York,73071,State Senate,SD28,Ind,David Garland,6
-New York,73072,State Senate,SD28,Ind,David Garland,7
-New York,73073,State Senate,SD28,Ind,David Garland,12
-New York,73074,State Senate,SD28,Ind,David Garland,11
-New York,73075,State Senate,SD28,Ind,David Garland,3
-New York,73076,State Senate,SD28,Ind,David Garland,7
-New York,73077,State Senate,SD28,Ind,David Garland,8
-New York,73078,State Senate,SD28,Ind,David Garland,8
-New York,73079,State Senate,SD28,Ind,David Garland,6
-New York,73080,State Senate,SD28,Ind,David Garland,8
-New York,73081,State Senate,SD28,Ind,David Garland,1
-New York,73082,State Senate,SD28,Ind,David Garland,4
-New York,73083,State Senate,SD28,Ind,David Garland,5
-New York,73084,State Senate,SD28,Ind,David Garland,6
-New York,73085,State Senate,SD28,Ind,David Garland,12
-New York,73086,State Senate,SD28,Ind,David Garland,8
-New York,73087,State Senate,SD28,Ind,David Garland,7
-New York,73088,State Senate,SD28,Ind,David Garland,6
-New York,73089,State Senate,SD28,Ind,David Garland,1
-New York,73090,State Senate,SD28,Ind,David Garland,8
-New York,73091,State Senate,SD28,Ind,David Garland,8
-New York,73092,State Senate,SD28,Ind,David Garland,6
-New York,73097,State Senate,SD28,Ind,David Garland,3
-New York,73099,State Senate,SD28,Ind,David Garland,2
-New York,73100,State Senate,SD28,Ind,David Garland,3
-New York,74056,State Senate,SD28,Ind,David Garland,7
-New York,74057,State Senate,SD28,Ind,David Garland,3
-New York,74058,State Senate,SD28,Ind,David Garland,5
-New York,74059,State Senate,SD28,Ind,David Garland,6
-New York,74060,State Senate,SD28,Ind,David Garland,10
-New York,74061,State Senate,SD28,Ind,David Garland,7
-New York,74062,State Senate,SD28,Ind,David Garland,9
-New York,74063,State Senate,SD28,Ind,David Garland,5
-New York,74064,State Senate,SD28,Ind,David Garland,5
-New York,74065,State Senate,SD28,Ind,David Garland,1
-New York,74066,State Senate,SD28,Ind,David Garland,4
-New York,74067,State Senate,SD28,Ind,David Garland,7
-New York,74068,State Senate,SD28,Ind,David Garland,13
-New York,74069,State Senate,SD28,Ind,David Garland,7
-New York,74070,State Senate,SD28,Ind,David Garland,8
-New York,74082,State Senate,SD28,Ind,David Garland,4
-New York,74083,State Senate,SD28,Ind,David Garland,6
-New York,74085,State Senate,SD28,Ind,David Garland,4
-New York,74086,State Senate,SD28,Ind,David Garland,7
-New York,74087,State Senate,SD28,Ind,David Garland,4
-New York,74088,State Senate,SD28,Ind,David Garland,10
-New York,74089,State Senate,SD28,Ind,David Garland,6
-New York,74090,State Senate,SD28,Ind,David Garland,5
-New York,74091,State Senate,SD28,Ind,David Garland,9
-New York,75008,State Senate,SD28,Ind,David Garland,5
-New York,75009,State Senate,SD28,Ind,David Garland,9
-New York,75029,State Senate,SD28,Ind,David Garland,6
-New York,75030,State Senate,SD28,Ind,David Garland,10
-New York,75031,State Senate,SD28,Ind,David Garland,5
-New York,75032,State Senate,SD28,Ind,David Garland,8
-New York,75033,State Senate,SD28,Ind,David Garland,8
-New York,75034,State Senate,SD28,Ind,David Garland,7
-New York,75035,State Senate,SD28,Ind,David Garland,2
-New York,75051,State Senate,SD28,Ind,David Garland,8
-New York,75052,State Senate,SD28,Ind,David Garland,4
-New York,75053,State Senate,SD28,Ind,David Garland,6
-New York,75054,State Senate,SD28,Ind,David Garland,2
-New York,75055,State Senate,SD28,Ind,David Garland,2
-New York,75056,State Senate,SD28,Ind,David Garland,3
-New York,75057,State Senate,SD28,Ind,David Garland,2
-New York,75086,State Senate,SD28,Ind,David Garland,0
-New York,75087,State Senate,SD28,Ind,David Garland,4
-New York,75088,State Senate,SD28,Ind,David Garland,6
-New York,75090,State Senate,SD28,Ind,David Garland,6
-New York,75091,State Senate,SD28,Ind,David Garland,5
-New York,75092,State Senate,SD28,Ind,David Garland,4
-New York,76001,State Senate,SD28,Ind,David Garland,5
-New York,76002,State Senate,SD28,Ind,David Garland,11
-New York,76003,State Senate,SD28,Ind,David Garland,6
-New York,76004,State Senate,SD28,Ind,David Garland,3
-New York,76005,State Senate,SD28,Ind,David Garland,3
-New York,76006,State Senate,SD28,Ind,David Garland,11
-New York,76007,State Senate,SD28,Ind,David Garland,6
-New York,76008,State Senate,SD28,Ind,David Garland,4
-New York,76009,State Senate,SD28,Ind,David Garland,4
-New York,76010,State Senate,SD28,Ind,David Garland,8
-New York,76011,State Senate,SD28,Ind,David Garland,8
-New York,76012,State Senate,SD28,Ind,David Garland,5
-New York,76013,State Senate,SD28,Ind,David Garland,5
-New York,76014,State Senate,SD28,Ind,David Garland,2
-New York,76015,State Senate,SD28,Ind,David Garland,3
-New York,76016,State Senate,SD28,Ind,David Garland,5
-New York,76017,State Senate,SD28,Ind,David Garland,2
-New York,76018,State Senate,SD28,Ind,David Garland,7
-New York,76019,State Senate,SD28,Ind,David Garland,6
-New York,76020,State Senate,SD28,Ind,David Garland,5
-New York,76021,State Senate,SD28,Ind,David Garland,5
-New York,76022,State Senate,SD28,Ind,David Garland,7
-New York,76023,State Senate,SD28,Ind,David Garland,6
-New York,76024,State Senate,SD28,Ind,David Garland,7
-New York,76025,State Senate,SD28,Ind,David Garland,6
-New York,76026,State Senate,SD28,Ind,David Garland,5
-New York,76027,State Senate,SD28,Ind,David Garland,2
-New York,76028,State Senate,SD28,Ind,David Garland,6
-New York,76029,State Senate,SD28,Ind,David Garland,5
-New York,76030,State Senate,SD28,Ind,David Garland,3
-New York,76031,State Senate,SD28,Ind,David Garland,5
-New York,76032,State Senate,SD28,Ind,David Garland,5
-New York,76033,State Senate,SD28,Ind,David Garland,7
-New York,76034,State Senate,SD28,Ind,David Garland,7
-New York,76035,State Senate,SD28,Ind,David Garland,13
-New York,76036,State Senate,SD28,Ind,David Garland,7
-New York,76037,State Senate,SD28,Ind,David Garland,12
-New York,76038,State Senate,SD28,Ind,David Garland,11
-New York,76039,State Senate,SD28,Ind,David Garland,5
-New York,76040,State Senate,SD28,Ind,David Garland,6
-New York,76041,State Senate,SD28,Ind,David Garland,11
-New York,76042,State Senate,SD28,Ind,David Garland,8
-New York,76043,State Senate,SD28,Ind,David Garland,0
-New York,76044,State Senate,SD28,Ind,David Garland,10
-New York,76045,State Senate,SD28,Ind,David Garland,6
-New York,76046,State Senate,SD28,Ind,David Garland,7
-New York,76047,State Senate,SD28,Ind,David Garland,5
-New York,76048,State Senate,SD28,Ind,David Garland,3
-New York,76049,State Senate,SD28,Ind,David Garland,12
-New York,76050,State Senate,SD28,Ind,David Garland,9
-New York,76051,State Senate,SD28,Ind,David Garland,3
-New York,76052,State Senate,SD28,Ind,David Garland,9
-New York,76053,State Senate,SD28,Ind,David Garland,10
-New York,76054,State Senate,SD28,Ind,David Garland,6
-New York,76055,State Senate,SD28,Ind,David Garland,6
-New York,76056,State Senate,SD28,Ind,David Garland,6
-New York,76057,State Senate,SD28,Ind,David Garland,1
-New York,76058,State Senate,SD28,Ind,David Garland,3
-New York,76059,State Senate,SD28,Ind,David Garland,8
-New York,76060,State Senate,SD28,Ind,David Garland,7
-New York,76061,State Senate,SD28,Ind,David Garland,5
-New York,76062,State Senate,SD28,Ind,David Garland,3
-New York,76063,State Senate,SD28,Ind,David Garland,7
-New York,76064,State Senate,SD28,Ind,David Garland,4
-New York,76065,State Senate,SD28,Ind,David Garland,11
-New York,76066,State Senate,SD28,Ind,David Garland,9
-New York,76067,State Senate,SD28,Ind,David Garland,10
-New York,76068,State Senate,SD28,Ind,David Garland,11
-New York,76069,State Senate,SD28,Ind,David Garland,13
-New York,76070,State Senate,SD28,Ind,David Garland,6
-New York,76071,State Senate,SD28,Ind,David Garland,13
-New York,76072,State Senate,SD28,Ind,David Garland,18
-New York,76073,State Senate,SD28,Ind,David Garland,13
-New York,76074,State Senate,SD28,Ind,David Garland,2
-New York,76075,State Senate,SD28,Ind,David Garland,13
-New York,76076,State Senate,SD28,Ind,David Garland,7
-New York,76077,State Senate,SD28,Ind,David Garland,3
-New York,76078,State Senate,SD28,Ind,David Garland,5
-New York,76079,State Senate,SD28,Ind,David Garland,8
-New York,76080,State Senate,SD28,Ind,David Garland,9
-New York,66055,State Senate,SD28,Dem,Liz Krueger,554
-New York,66056,State Senate,SD28,Dem,Liz Krueger,77
-New York,68001,State Senate,SD28,Dem,Liz Krueger,371
-New York,68005,State Senate,SD28,Dem,Liz Krueger,226
-New York,68006,State Senate,SD28,Dem,Liz Krueger,29
-New York,68007,State Senate,SD28,Dem,Liz Krueger,221
-New York,68008,State Senate,SD28,Dem,Liz Krueger,168
-New York,73001,State Senate,SD28,Dem,Liz Krueger,444
-New York,73002,State Senate,SD28,Dem,Liz Krueger,331
-New York,73003,State Senate,SD28,Dem,Liz Krueger,365
-New York,73004,State Senate,SD28,Dem,Liz Krueger,252
-New York,73005,State Senate,SD28,Dem,Liz Krueger,543
-New York,73007,State Senate,SD28,Dem,Liz Krueger,190
-New York,73008,State Senate,SD28,Dem,Liz Krueger,155
-New York,73009,State Senate,SD28,Dem,Liz Krueger,512
-New York,73010,State Senate,SD28,Dem,Liz Krueger,479
-New York,73014,State Senate,SD28,Dem,Liz Krueger,125
-New York,73016,State Senate,SD28,Dem,Liz Krueger,420
-New York,73017,State Senate,SD28,Dem,Liz Krueger,177
-New York,73018,State Senate,SD28,Dem,Liz Krueger,393
-New York,73019,State Senate,SD28,Dem,Liz Krueger,156
-New York,73021,State Senate,SD28,Dem,Liz Krueger,391
-New York,73022,State Senate,SD28,Dem,Liz Krueger,310
-New York,73023,State Senate,SD28,Dem,Liz Krueger,348
-New York,73024,State Senate,SD28,Dem,Liz Krueger,306
-New York,73025,State Senate,SD28,Dem,Liz Krueger,260
-New York,73026,State Senate,SD28,Dem,Liz Krueger,235
-New York,73027,State Senate,SD28,Dem,Liz Krueger,293
-New York,73028,State Senate,SD28,Dem,Liz Krueger,237
-New York,73029,State Senate,SD28,Dem,Liz Krueger,386
-New York,73030,State Senate,SD28,Dem,Liz Krueger,189
-New York,73031,State Senate,SD28,Dem,Liz Krueger,61
-New York,73032,State Senate,SD28,Dem,Liz Krueger,434
-New York,73033,State Senate,SD28,Dem,Liz Krueger,517
-New York,73034,State Senate,SD28,Dem,Liz Krueger,393
-New York,73035,State Senate,SD28,Dem,Liz Krueger,470
-New York,73036,State Senate,SD28,Dem,Liz Krueger,406
-New York,73037,State Senate,SD28,Dem,Liz Krueger,394
-New York,73038,State Senate,SD28,Dem,Liz Krueger,504
-New York,73039,State Senate,SD28,Dem,Liz Krueger,350
-New York,73040,State Senate,SD28,Dem,Liz Krueger,376
-New York,73041,State Senate,SD28,Dem,Liz Krueger,478
-New York,73042,State Senate,SD28,Dem,Liz Krueger,231
-New York,73045,State Senate,SD28,Dem,Liz Krueger,213
-New York,73046,State Senate,SD28,Dem,Liz Krueger,125
-New York,73047,State Senate,SD28,Dem,Liz Krueger,104
-New York,73048,State Senate,SD28,Dem,Liz Krueger,247
-New York,73049,State Senate,SD28,Dem,Liz Krueger,103
-New York,73050,State Senate,SD28,Dem,Liz Krueger,415
-New York,73051,State Senate,SD28,Dem,Liz Krueger,222
-New York,73052,State Senate,SD28,Dem,Liz Krueger,264
-New York,73053,State Senate,SD28,Dem,Liz Krueger,262
-New York,73054,State Senate,SD28,Dem,Liz Krueger,113
-New York,73055,State Senate,SD28,Dem,Liz Krueger,364
-New York,73056,State Senate,SD28,Dem,Liz Krueger,332
-New York,73057,State Senate,SD28,Dem,Liz Krueger,460
-New York,73058,State Senate,SD28,Dem,Liz Krueger,326
-New York,73059,State Senate,SD28,Dem,Liz Krueger,397
-New York,73060,State Senate,SD28,Dem,Liz Krueger,387
-New York,73061,State Senate,SD28,Dem,Liz Krueger,277
-New York,73062,State Senate,SD28,Dem,Liz Krueger,324
-New York,73063,State Senate,SD28,Dem,Liz Krueger,343
-New York,73064,State Senate,SD28,Dem,Liz Krueger,433
-New York,73065,State Senate,SD28,Dem,Liz Krueger,356
-New York,73066,State Senate,SD28,Dem,Liz Krueger,355
-New York,73067,State Senate,SD28,Dem,Liz Krueger,368
-New York,73068,State Senate,SD28,Dem,Liz Krueger,402
-New York,73069,State Senate,SD28,Dem,Liz Krueger,487
-New York,73070,State Senate,SD28,Dem,Liz Krueger,421
-New York,73071,State Senate,SD28,Dem,Liz Krueger,424
-New York,73072,State Senate,SD28,Dem,Liz Krueger,489
-New York,73073,State Senate,SD28,Dem,Liz Krueger,467
-New York,73074,State Senate,SD28,Dem,Liz Krueger,373
-New York,73075,State Senate,SD28,Dem,Liz Krueger,438
-New York,73076,State Senate,SD28,Dem,Liz Krueger,496
-New York,73077,State Senate,SD28,Dem,Liz Krueger,464
-New York,73078,State Senate,SD28,Dem,Liz Krueger,362
-New York,73079,State Senate,SD28,Dem,Liz Krueger,445
-New York,73080,State Senate,SD28,Dem,Liz Krueger,522
-New York,73081,State Senate,SD28,Dem,Liz Krueger,298
-New York,73082,State Senate,SD28,Dem,Liz Krueger,464
-New York,73083,State Senate,SD28,Dem,Liz Krueger,415
-New York,73084,State Senate,SD28,Dem,Liz Krueger,327
-New York,73085,State Senate,SD28,Dem,Liz Krueger,513
-New York,73086,State Senate,SD28,Dem,Liz Krueger,487
-New York,73087,State Senate,SD28,Dem,Liz Krueger,450
-New York,73088,State Senate,SD28,Dem,Liz Krueger,286
-New York,73089,State Senate,SD28,Dem,Liz Krueger,390
-New York,73090,State Senate,SD28,Dem,Liz Krueger,578
-New York,73091,State Senate,SD28,Dem,Liz Krueger,586
-New York,73092,State Senate,SD28,Dem,Liz Krueger,270
-New York,73097,State Senate,SD28,Dem,Liz Krueger,182
-New York,73099,State Senate,SD28,Dem,Liz Krueger,308
-New York,73100,State Senate,SD28,Dem,Liz Krueger,425
-New York,74056,State Senate,SD28,Dem,Liz Krueger,376
-New York,74057,State Senate,SD28,Dem,Liz Krueger,342
-New York,74058,State Senate,SD28,Dem,Liz Krueger,408
-New York,74059,State Senate,SD28,Dem,Liz Krueger,521
-New York,74060,State Senate,SD28,Dem,Liz Krueger,537
-New York,74061,State Senate,SD28,Dem,Liz Krueger,415
-New York,74062,State Senate,SD28,Dem,Liz Krueger,448
-New York,74063,State Senate,SD28,Dem,Liz Krueger,272
-New York,74064,State Senate,SD28,Dem,Liz Krueger,664
-New York,74065,State Senate,SD28,Dem,Liz Krueger,251
-New York,74066,State Senate,SD28,Dem,Liz Krueger,316
-New York,74067,State Senate,SD28,Dem,Liz Krueger,437
-New York,74068,State Senate,SD28,Dem,Liz Krueger,405
-New York,74069,State Senate,SD28,Dem,Liz Krueger,253
-New York,74070,State Senate,SD28,Dem,Liz Krueger,462
-New York,74082,State Senate,SD28,Dem,Liz Krueger,544
-New York,74083,State Senate,SD28,Dem,Liz Krueger,264
-New York,74085,State Senate,SD28,Dem,Liz Krueger,148
-New York,74086,State Senate,SD28,Dem,Liz Krueger,442
-New York,74087,State Senate,SD28,Dem,Liz Krueger,401
-New York,74088,State Senate,SD28,Dem,Liz Krueger,511
-New York,74089,State Senate,SD28,Dem,Liz Krueger,393
-New York,74090,State Senate,SD28,Dem,Liz Krueger,367
-New York,74091,State Senate,SD28,Dem,Liz Krueger,416
-New York,75008,State Senate,SD28,Dem,Liz Krueger,631
-New York,75009,State Senate,SD28,Dem,Liz Krueger,470
-New York,75029,State Senate,SD28,Dem,Liz Krueger,277
-New York,75030,State Senate,SD28,Dem,Liz Krueger,435
-New York,75031,State Senate,SD28,Dem,Liz Krueger,407
-New York,75032,State Senate,SD28,Dem,Liz Krueger,472
-New York,75033,State Senate,SD28,Dem,Liz Krueger,405
-New York,75034,State Senate,SD28,Dem,Liz Krueger,393
-New York,75035,State Senate,SD28,Dem,Liz Krueger,192
-New York,75051,State Senate,SD28,Dem,Liz Krueger,290
-New York,75052,State Senate,SD28,Dem,Liz Krueger,336
-New York,75053,State Senate,SD28,Dem,Liz Krueger,346
-New York,75054,State Senate,SD28,Dem,Liz Krueger,310
-New York,75055,State Senate,SD28,Dem,Liz Krueger,253
-New York,75056,State Senate,SD28,Dem,Liz Krueger,491
-New York,75057,State Senate,SD28,Dem,Liz Krueger,215
-New York,75086,State Senate,SD28,Dem,Liz Krueger,115
-New York,75087,State Senate,SD28,Dem,Liz Krueger,343
-New York,75088,State Senate,SD28,Dem,Liz Krueger,283
-New York,75090,State Senate,SD28,Dem,Liz Krueger,195
-New York,75091,State Senate,SD28,Dem,Liz Krueger,284
-New York,75092,State Senate,SD28,Dem,Liz Krueger,308
-New York,76001,State Senate,SD28,Dem,Liz Krueger,556
-New York,76002,State Senate,SD28,Dem,Liz Krueger,341
-New York,76003,State Senate,SD28,Dem,Liz Krueger,311
-New York,76004,State Senate,SD28,Dem,Liz Krueger,339
-New York,76005,State Senate,SD28,Dem,Liz Krueger,263
-New York,76006,State Senate,SD28,Dem,Liz Krueger,440
-New York,76007,State Senate,SD28,Dem,Liz Krueger,285
-New York,76008,State Senate,SD28,Dem,Liz Krueger,308
-New York,76009,State Senate,SD28,Dem,Liz Krueger,262
-New York,76010,State Senate,SD28,Dem,Liz Krueger,542
-New York,76011,State Senate,SD28,Dem,Liz Krueger,405
-New York,76012,State Senate,SD28,Dem,Liz Krueger,286
-New York,76013,State Senate,SD28,Dem,Liz Krueger,530
-New York,76014,State Senate,SD28,Dem,Liz Krueger,346
-New York,76015,State Senate,SD28,Dem,Liz Krueger,284
-New York,76016,State Senate,SD28,Dem,Liz Krueger,483
-New York,76017,State Senate,SD28,Dem,Liz Krueger,345
-New York,76018,State Senate,SD28,Dem,Liz Krueger,454
-New York,76019,State Senate,SD28,Dem,Liz Krueger,420
-New York,76020,State Senate,SD28,Dem,Liz Krueger,423
-New York,76021,State Senate,SD28,Dem,Liz Krueger,526
-New York,76022,State Senate,SD28,Dem,Liz Krueger,327
-New York,76023,State Senate,SD28,Dem,Liz Krueger,263
-New York,76024,State Senate,SD28,Dem,Liz Krueger,310
-New York,76025,State Senate,SD28,Dem,Liz Krueger,435
-New York,76026,State Senate,SD28,Dem,Liz Krueger,396
-New York,76027,State Senate,SD28,Dem,Liz Krueger,292
-New York,76028,State Senate,SD28,Dem,Liz Krueger,396
-New York,76029,State Senate,SD28,Dem,Liz Krueger,260
-New York,76030,State Senate,SD28,Dem,Liz Krueger,356
-New York,76031,State Senate,SD28,Dem,Liz Krueger,308
-New York,76032,State Senate,SD28,Dem,Liz Krueger,319
-New York,76033,State Senate,SD28,Dem,Liz Krueger,351
-New York,76034,State Senate,SD28,Dem,Liz Krueger,447
-New York,76035,State Senate,SD28,Dem,Liz Krueger,550
-New York,76036,State Senate,SD28,Dem,Liz Krueger,533
-New York,76037,State Senate,SD28,Dem,Liz Krueger,517
-New York,76038,State Senate,SD28,Dem,Liz Krueger,480
-New York,76039,State Senate,SD28,Dem,Liz Krueger,394
-New York,76040,State Senate,SD28,Dem,Liz Krueger,437
-New York,76041,State Senate,SD28,Dem,Liz Krueger,388
-New York,76042,State Senate,SD28,Dem,Liz Krueger,389
-New York,76043,State Senate,SD28,Dem,Liz Krueger,357
-New York,76044,State Senate,SD28,Dem,Liz Krueger,413
-New York,76045,State Senate,SD28,Dem,Liz Krueger,329
-New York,76046,State Senate,SD28,Dem,Liz Krueger,544
-New York,76047,State Senate,SD28,Dem,Liz Krueger,260
-New York,76048,State Senate,SD28,Dem,Liz Krueger,311
-New York,76049,State Senate,SD28,Dem,Liz Krueger,367
-New York,76050,State Senate,SD28,Dem,Liz Krueger,566
-New York,76051,State Senate,SD28,Dem,Liz Krueger,420
-New York,76052,State Senate,SD28,Dem,Liz Krueger,470
-New York,76053,State Senate,SD28,Dem,Liz Krueger,533
-New York,76054,State Senate,SD28,Dem,Liz Krueger,439
-New York,76055,State Senate,SD28,Dem,Liz Krueger,399
-New York,76056,State Senate,SD28,Dem,Liz Krueger,194
-New York,76057,State Senate,SD28,Dem,Liz Krueger,364
-New York,76058,State Senate,SD28,Dem,Liz Krueger,422
-New York,76059,State Senate,SD28,Dem,Liz Krueger,350
-New York,76060,State Senate,SD28,Dem,Liz Krueger,312
-New York,76061,State Senate,SD28,Dem,Liz Krueger,333
-New York,76062,State Senate,SD28,Dem,Liz Krueger,309
-New York,76063,State Senate,SD28,Dem,Liz Krueger,330
-New York,76064,State Senate,SD28,Dem,Liz Krueger,389
-New York,76065,State Senate,SD28,Dem,Liz Krueger,508
-New York,76066,State Senate,SD28,Dem,Liz Krueger,395
-New York,76067,State Senate,SD28,Dem,Liz Krueger,507
-New York,76068,State Senate,SD28,Dem,Liz Krueger,510
-New York,76069,State Senate,SD28,Dem,Liz Krueger,433
-New York,76070,State Senate,SD28,Dem,Liz Krueger,360
-New York,76071,State Senate,SD28,Dem,Liz Krueger,440
-New York,76072,State Senate,SD28,Dem,Liz Krueger,550
-New York,76073,State Senate,SD28,Dem,Liz Krueger,524
-New York,76074,State Senate,SD28,Dem,Liz Krueger,339
-New York,76075,State Senate,SD28,Dem,Liz Krueger,433
-New York,76076,State Senate,SD28,Dem,Liz Krueger,344
-New York,76077,State Senate,SD28,Dem,Liz Krueger,411
-New York,76078,State Senate,SD28,Dem,Liz Krueger,388
-New York,76079,State Senate,SD28,Dem,Liz Krueger,526
-New York,76080,State Senate,SD28,Dem,Liz Krueger,327
-New York,66055,State Senate,SD28,WF,Liz Krueger,22
-New York,66056,State Senate,SD28,WF,Liz Krueger,9
-New York,68001,State Senate,SD28,WF,Liz Krueger,6
-New York,68005,State Senate,SD28,WF,Liz Krueger,9
-New York,68006,State Senate,SD28,WF,Liz Krueger,1
-New York,68007,State Senate,SD28,WF,Liz Krueger,8
-New York,68008,State Senate,SD28,WF,Liz Krueger,6
-New York,73001,State Senate,SD28,WF,Liz Krueger,12
-New York,73002,State Senate,SD28,WF,Liz Krueger,8
-New York,73003,State Senate,SD28,WF,Liz Krueger,8
-New York,73004,State Senate,SD28,WF,Liz Krueger,5
-New York,73005,State Senate,SD28,WF,Liz Krueger,15
-New York,73007,State Senate,SD28,WF,Liz Krueger,8
-New York,73008,State Senate,SD28,WF,Liz Krueger,3
-New York,73009,State Senate,SD28,WF,Liz Krueger,15
-New York,73010,State Senate,SD28,WF,Liz Krueger,10
-New York,73014,State Senate,SD28,WF,Liz Krueger,3
-New York,73016,State Senate,SD28,WF,Liz Krueger,14
-New York,73017,State Senate,SD28,WF,Liz Krueger,1
-New York,73018,State Senate,SD28,WF,Liz Krueger,10
-New York,73019,State Senate,SD28,WF,Liz Krueger,2
-New York,73021,State Senate,SD28,WF,Liz Krueger,16
-New York,73022,State Senate,SD28,WF,Liz Krueger,8
-New York,73023,State Senate,SD28,WF,Liz Krueger,7
-New York,73024,State Senate,SD28,WF,Liz Krueger,8
-New York,73025,State Senate,SD28,WF,Liz Krueger,6
-New York,73026,State Senate,SD28,WF,Liz Krueger,8
-New York,73027,State Senate,SD28,WF,Liz Krueger,9
-New York,73028,State Senate,SD28,WF,Liz Krueger,4
-New York,73029,State Senate,SD28,WF,Liz Krueger,9
-New York,73030,State Senate,SD28,WF,Liz Krueger,6
-New York,73031,State Senate,SD28,WF,Liz Krueger,6
-New York,73032,State Senate,SD28,WF,Liz Krueger,22
-New York,73033,State Senate,SD28,WF,Liz Krueger,6
-New York,73034,State Senate,SD28,WF,Liz Krueger,11
-New York,73035,State Senate,SD28,WF,Liz Krueger,7
-New York,73036,State Senate,SD28,WF,Liz Krueger,5
-New York,73037,State Senate,SD28,WF,Liz Krueger,14
-New York,73038,State Senate,SD28,WF,Liz Krueger,10
-New York,73039,State Senate,SD28,WF,Liz Krueger,5
-New York,73040,State Senate,SD28,WF,Liz Krueger,8
-New York,73041,State Senate,SD28,WF,Liz Krueger,17
-New York,73042,State Senate,SD28,WF,Liz Krueger,5
-New York,73045,State Senate,SD28,WF,Liz Krueger,5
-New York,73046,State Senate,SD28,WF,Liz Krueger,1
-New York,73047,State Senate,SD28,WF,Liz Krueger,4
-New York,73048,State Senate,SD28,WF,Liz Krueger,4
-New York,73049,State Senate,SD28,WF,Liz Krueger,1
-New York,73050,State Senate,SD28,WF,Liz Krueger,9
-New York,73051,State Senate,SD28,WF,Liz Krueger,6
-New York,73052,State Senate,SD28,WF,Liz Krueger,2
-New York,73053,State Senate,SD28,WF,Liz Krueger,8
-New York,73054,State Senate,SD28,WF,Liz Krueger,1
-New York,73055,State Senate,SD28,WF,Liz Krueger,10
-New York,73056,State Senate,SD28,WF,Liz Krueger,7
-New York,73057,State Senate,SD28,WF,Liz Krueger,16
-New York,73058,State Senate,SD28,WF,Liz Krueger,3
-New York,73059,State Senate,SD28,WF,Liz Krueger,7
-New York,73060,State Senate,SD28,WF,Liz Krueger,8
-New York,73061,State Senate,SD28,WF,Liz Krueger,2
-New York,73062,State Senate,SD28,WF,Liz Krueger,0
-New York,73063,State Senate,SD28,WF,Liz Krueger,6
-New York,73064,State Senate,SD28,WF,Liz Krueger,7
-New York,73065,State Senate,SD28,WF,Liz Krueger,14
-New York,73066,State Senate,SD28,WF,Liz Krueger,6
-New York,73067,State Senate,SD28,WF,Liz Krueger,7
-New York,73068,State Senate,SD28,WF,Liz Krueger,11
-New York,73069,State Senate,SD28,WF,Liz Krueger,14
-New York,73070,State Senate,SD28,WF,Liz Krueger,16
-New York,73071,State Senate,SD28,WF,Liz Krueger,9
-New York,73072,State Senate,SD28,WF,Liz Krueger,11
-New York,73073,State Senate,SD28,WF,Liz Krueger,9
-New York,73074,State Senate,SD28,WF,Liz Krueger,8
-New York,73075,State Senate,SD28,WF,Liz Krueger,5
-New York,73076,State Senate,SD28,WF,Liz Krueger,9
-New York,73077,State Senate,SD28,WF,Liz Krueger,9
-New York,73078,State Senate,SD28,WF,Liz Krueger,12
-New York,73079,State Senate,SD28,WF,Liz Krueger,8
-New York,73080,State Senate,SD28,WF,Liz Krueger,11
-New York,73081,State Senate,SD28,WF,Liz Krueger,3
-New York,73082,State Senate,SD28,WF,Liz Krueger,9
-New York,73083,State Senate,SD28,WF,Liz Krueger,11
-New York,73084,State Senate,SD28,WF,Liz Krueger,15
-New York,73085,State Senate,SD28,WF,Liz Krueger,31
-New York,73086,State Senate,SD28,WF,Liz Krueger,6
-New York,73087,State Senate,SD28,WF,Liz Krueger,12
-New York,73088,State Senate,SD28,WF,Liz Krueger,4
-New York,73089,State Senate,SD28,WF,Liz Krueger,16
-New York,73090,State Senate,SD28,WF,Liz Krueger,21
-New York,73091,State Senate,SD28,WF,Liz Krueger,20
-New York,73092,State Senate,SD28,WF,Liz Krueger,8
-New York,73097,State Senate,SD28,WF,Liz Krueger,8
-New York,73099,State Senate,SD28,WF,Liz Krueger,5
-New York,73100,State Senate,SD28,WF,Liz Krueger,6
-New York,74056,State Senate,SD28,WF,Liz Krueger,20
-New York,74057,State Senate,SD28,WF,Liz Krueger,18
-New York,74058,State Senate,SD28,WF,Liz Krueger,18
-New York,74059,State Senate,SD28,WF,Liz Krueger,27
-New York,74060,State Senate,SD28,WF,Liz Krueger,17
-New York,74061,State Senate,SD28,WF,Liz Krueger,25
-New York,74062,State Senate,SD28,WF,Liz Krueger,12
-New York,74063,State Senate,SD28,WF,Liz Krueger,9
-New York,74064,State Senate,SD28,WF,Liz Krueger,24
-New York,74065,State Senate,SD28,WF,Liz Krueger,16
-New York,74066,State Senate,SD28,WF,Liz Krueger,19
-New York,74067,State Senate,SD28,WF,Liz Krueger,16
-New York,74068,State Senate,SD28,WF,Liz Krueger,18
-New York,74069,State Senate,SD28,WF,Liz Krueger,3
-New York,74070,State Senate,SD28,WF,Liz Krueger,13
-New York,74082,State Senate,SD28,WF,Liz Krueger,15
-New York,74083,State Senate,SD28,WF,Liz Krueger,10
-New York,74085,State Senate,SD28,WF,Liz Krueger,5
-New York,74086,State Senate,SD28,WF,Liz Krueger,9
-New York,74087,State Senate,SD28,WF,Liz Krueger,12
-New York,74088,State Senate,SD28,WF,Liz Krueger,17
-New York,74089,State Senate,SD28,WF,Liz Krueger,17
-New York,74090,State Senate,SD28,WF,Liz Krueger,13
-New York,74091,State Senate,SD28,WF,Liz Krueger,15
-New York,75008,State Senate,SD28,WF,Liz Krueger,34
-New York,75009,State Senate,SD28,WF,Liz Krueger,16
-New York,75029,State Senate,SD28,WF,Liz Krueger,8
-New York,75030,State Senate,SD28,WF,Liz Krueger,28
-New York,75031,State Senate,SD28,WF,Liz Krueger,12
-New York,75032,State Senate,SD28,WF,Liz Krueger,28
-New York,75033,State Senate,SD28,WF,Liz Krueger,14
-New York,75034,State Senate,SD28,WF,Liz Krueger,21
-New York,75035,State Senate,SD28,WF,Liz Krueger,7
-New York,75051,State Senate,SD28,WF,Liz Krueger,10
-New York,75052,State Senate,SD28,WF,Liz Krueger,15
-New York,75053,State Senate,SD28,WF,Liz Krueger,16
-New York,75054,State Senate,SD28,WF,Liz Krueger,10
-New York,75055,State Senate,SD28,WF,Liz Krueger,10
-New York,75056,State Senate,SD28,WF,Liz Krueger,10
-New York,75057,State Senate,SD28,WF,Liz Krueger,4
-New York,75086,State Senate,SD28,WF,Liz Krueger,5
-New York,75087,State Senate,SD28,WF,Liz Krueger,16
-New York,75088,State Senate,SD28,WF,Liz Krueger,7
-New York,75090,State Senate,SD28,WF,Liz Krueger,7
-New York,75091,State Senate,SD28,WF,Liz Krueger,5
-New York,75092,State Senate,SD28,WF,Liz Krueger,7
-New York,76001,State Senate,SD28,WF,Liz Krueger,21
-New York,76002,State Senate,SD28,WF,Liz Krueger,10
-New York,76003,State Senate,SD28,WF,Liz Krueger,7
-New York,76004,State Senate,SD28,WF,Liz Krueger,8
-New York,76005,State Senate,SD28,WF,Liz Krueger,6
-New York,76006,State Senate,SD28,WF,Liz Krueger,18
-New York,76007,State Senate,SD28,WF,Liz Krueger,21
-New York,76008,State Senate,SD28,WF,Liz Krueger,8
-New York,76009,State Senate,SD28,WF,Liz Krueger,11
-New York,76010,State Senate,SD28,WF,Liz Krueger,18
-New York,76011,State Senate,SD28,WF,Liz Krueger,18
-New York,76012,State Senate,SD28,WF,Liz Krueger,11
-New York,76013,State Senate,SD28,WF,Liz Krueger,11
-New York,76014,State Senate,SD28,WF,Liz Krueger,10
-New York,76015,State Senate,SD28,WF,Liz Krueger,7
-New York,76016,State Senate,SD28,WF,Liz Krueger,9
-New York,76017,State Senate,SD28,WF,Liz Krueger,8
-New York,76018,State Senate,SD28,WF,Liz Krueger,12
-New York,76019,State Senate,SD28,WF,Liz Krueger,7
-New York,76020,State Senate,SD28,WF,Liz Krueger,9
-New York,76021,State Senate,SD28,WF,Liz Krueger,14
-New York,76022,State Senate,SD28,WF,Liz Krueger,6
-New York,76023,State Senate,SD28,WF,Liz Krueger,3
-New York,76024,State Senate,SD28,WF,Liz Krueger,5
-New York,76025,State Senate,SD28,WF,Liz Krueger,8
-New York,76026,State Senate,SD28,WF,Liz Krueger,13
-New York,76027,State Senate,SD28,WF,Liz Krueger,13
-New York,76028,State Senate,SD28,WF,Liz Krueger,7
-New York,76029,State Senate,SD28,WF,Liz Krueger,4
-New York,76030,State Senate,SD28,WF,Liz Krueger,5
-New York,76031,State Senate,SD28,WF,Liz Krueger,8
-New York,76032,State Senate,SD28,WF,Liz Krueger,11
-New York,76033,State Senate,SD28,WF,Liz Krueger,17
-New York,76034,State Senate,SD28,WF,Liz Krueger,13
-New York,76035,State Senate,SD28,WF,Liz Krueger,15
-New York,76036,State Senate,SD28,WF,Liz Krueger,22
-New York,76037,State Senate,SD28,WF,Liz Krueger,19
-New York,76038,State Senate,SD28,WF,Liz Krueger,12
-New York,76039,State Senate,SD28,WF,Liz Krueger,8
-New York,76040,State Senate,SD28,WF,Liz Krueger,17
-New York,76041,State Senate,SD28,WF,Liz Krueger,20
-New York,76042,State Senate,SD28,WF,Liz Krueger,13
-New York,76043,State Senate,SD28,WF,Liz Krueger,12
-New York,76044,State Senate,SD28,WF,Liz Krueger,7
-New York,76045,State Senate,SD28,WF,Liz Krueger,12
-New York,76046,State Senate,SD28,WF,Liz Krueger,13
-New York,76047,State Senate,SD28,WF,Liz Krueger,9
-New York,76048,State Senate,SD28,WF,Liz Krueger,9
-New York,76049,State Senate,SD28,WF,Liz Krueger,17
-New York,76050,State Senate,SD28,WF,Liz Krueger,18
-New York,76051,State Senate,SD28,WF,Liz Krueger,10
-New York,76052,State Senate,SD28,WF,Liz Krueger,13
-New York,76053,State Senate,SD28,WF,Liz Krueger,17
-New York,76054,State Senate,SD28,WF,Liz Krueger,18
-New York,76055,State Senate,SD28,WF,Liz Krueger,11
-New York,76056,State Senate,SD28,WF,Liz Krueger,9
-New York,76057,State Senate,SD28,WF,Liz Krueger,23
-New York,76058,State Senate,SD28,WF,Liz Krueger,4
-New York,76059,State Senate,SD28,WF,Liz Krueger,18
-New York,76060,State Senate,SD28,WF,Liz Krueger,7
-New York,76061,State Senate,SD28,WF,Liz Krueger,14
-New York,76062,State Senate,SD28,WF,Liz Krueger,10
-New York,76063,State Senate,SD28,WF,Liz Krueger,9
-New York,76064,State Senate,SD28,WF,Liz Krueger,9
-New York,76065,State Senate,SD28,WF,Liz Krueger,16
-New York,76066,State Senate,SD28,WF,Liz Krueger,12
-New York,76067,State Senate,SD28,WF,Liz Krueger,16
-New York,76068,State Senate,SD28,WF,Liz Krueger,20
-New York,76069,State Senate,SD28,WF,Liz Krueger,14
-New York,76070,State Senate,SD28,WF,Liz Krueger,7
-New York,76071,State Senate,SD28,WF,Liz Krueger,24
-New York,76072,State Senate,SD28,WF,Liz Krueger,28
-New York,76073,State Senate,SD28,WF,Liz Krueger,18
-New York,76074,State Senate,SD28,WF,Liz Krueger,18
-New York,76075,State Senate,SD28,WF,Liz Krueger,10
-New York,76076,State Senate,SD28,WF,Liz Krueger,12
-New York,76077,State Senate,SD28,WF,Liz Krueger,10
-New York,76078,State Senate,SD28,WF,Liz Krueger,7
-New York,76079,State Senate,SD28,WF,Liz Krueger,12
-New York,76080,State Senate,SD28,WF,Liz Krueger,19
-New York,66055,State Senate,SD28,Ind,writein,1
-New York,66056,State Senate,SD28,Ind,writein,0
-New York,68001,State Senate,SD28,Ind,writein,0
-New York,68005,State Senate,SD28,Ind,writein,0
-New York,68006,State Senate,SD28,Ind,writein,0
-New York,68007,State Senate,SD28,Ind,writein,0
-New York,68008,State Senate,SD28,Ind,writein,0
-New York,73001,State Senate,SD28,Ind,writein,0
-New York,73002,State Senate,SD28,Ind,writein,0
-New York,73003,State Senate,SD28,Ind,writein,0
-New York,73004,State Senate,SD28,Ind,writein,0
-New York,73005,State Senate,SD28,Ind,writein,0
-New York,73007,State Senate,SD28,Ind,writein,0
-New York,73008,State Senate,SD28,Ind,writein,1
-New York,73009,State Senate,SD28,Ind,writein,0
-New York,73010,State Senate,SD28,Ind,writein,0
-New York,73014,State Senate,SD28,Ind,writein,0
-New York,73016,State Senate,SD28,Ind,writein,0
-New York,73017,State Senate,SD28,Ind,writein,0
-New York,73018,State Senate,SD28,Ind,writein,0
-New York,73019,State Senate,SD28,Ind,writein,0
-New York,73021,State Senate,SD28,Ind,writein,0
-New York,73022,State Senate,SD28,Ind,writein,0
-New York,73023,State Senate,SD28,Ind,writein,0
-New York,73024,State Senate,SD28,Ind,writein,0
-New York,73025,State Senate,SD28,Ind,writein,0
-New York,73026,State Senate,SD28,Ind,writein,0
-New York,73027,State Senate,SD28,Ind,writein,0
-New York,73028,State Senate,SD28,Ind,writein,0
-New York,73029,State Senate,SD28,Ind,writein,0
-New York,73030,State Senate,SD28,Ind,writein,0
-New York,73031,State Senate,SD28,Ind,writein,0
-New York,73032,State Senate,SD28,Ind,writein,0
-New York,73033,State Senate,SD28,Ind,writein,0
-New York,73034,State Senate,SD28,Ind,writein,0
-New York,73035,State Senate,SD28,Ind,writein,0
-New York,73036,State Senate,SD28,Ind,writein,0
-New York,73037,State Senate,SD28,Ind,writein,0
-New York,73038,State Senate,SD28,Ind,writein,1
-New York,73039,State Senate,SD28,Ind,writein,0
-New York,73040,State Senate,SD28,Ind,writein,0
-New York,73041,State Senate,SD28,Ind,writein,0
-New York,73042,State Senate,SD28,Ind,writein,0
-New York,73045,State Senate,SD28,Ind,writein,0
-New York,73046,State Senate,SD28,Ind,writein,0
-New York,73047,State Senate,SD28,Ind,writein,0
-New York,73048,State Senate,SD28,Ind,writein,0
-New York,73049,State Senate,SD28,Ind,writein,0
-New York,73050,State Senate,SD28,Ind,writein,0
-New York,73051,State Senate,SD28,Ind,writein,0
-New York,73052,State Senate,SD28,Ind,writein,0
-New York,73053,State Senate,SD28,Ind,writein,0
-New York,73054,State Senate,SD28,Ind,writein,0
-New York,73055,State Senate,SD28,Ind,writein,0
-New York,73056,State Senate,SD28,Ind,writein,1
-New York,73057,State Senate,SD28,Ind,writein,0
-New York,73058,State Senate,SD28,Ind,writein,0
-New York,73059,State Senate,SD28,Ind,writein,0
-New York,73060,State Senate,SD28,Ind,writein,0
-New York,73061,State Senate,SD28,Ind,writein,0
-New York,73062,State Senate,SD28,Ind,writein,0
-New York,73063,State Senate,SD28,Ind,writein,0
-New York,73064,State Senate,SD28,Ind,writein,0
-New York,73065,State Senate,SD28,Ind,writein,0
-New York,73066,State Senate,SD28,Ind,writein,0
-New York,73067,State Senate,SD28,Ind,writein,0
-New York,73068,State Senate,SD28,Ind,writein,0
-New York,73069,State Senate,SD28,Ind,writein,0
-New York,73070,State Senate,SD28,Ind,writein,0
-New York,73071,State Senate,SD28,Ind,writein,0
-New York,73072,State Senate,SD28,Ind,writein,0
-New York,73073,State Senate,SD28,Ind,writein,0
-New York,73074,State Senate,SD28,Ind,writein,0
-New York,73075,State Senate,SD28,Ind,writein,1
-New York,73076,State Senate,SD28,Ind,writein,1
-New York,73077,State Senate,SD28,Ind,writein,0
-New York,73078,State Senate,SD28,Ind,writein,0
-New York,73079,State Senate,SD28,Ind,writein,0
-New York,73080,State Senate,SD28,Ind,writein,0
-New York,73081,State Senate,SD28,Ind,writein,0
-New York,73082,State Senate,SD28,Ind,writein,0
-New York,73083,State Senate,SD28,Ind,writein,0
-New York,73084,State Senate,SD28,Ind,writein,0
-New York,73085,State Senate,SD28,Ind,writein,0
-New York,73086,State Senate,SD28,Ind,writein,0
-New York,73087,State Senate,SD28,Ind,writein,0
-New York,73088,State Senate,SD28,Ind,writein,0
-New York,73089,State Senate,SD28,Ind,writein,0
-New York,73090,State Senate,SD28,Ind,writein,0
-New York,73091,State Senate,SD28,Ind,writein,0
-New York,73092,State Senate,SD28,Ind,writein,0
-New York,73097,State Senate,SD28,Ind,writein,0
-New York,73099,State Senate,SD28,Ind,writein,0
-New York,73100,State Senate,SD28,Ind,writein,0
-New York,74056,State Senate,SD28,Ind,writein,0
-New York,74057,State Senate,SD28,Ind,writein,0
-New York,74058,State Senate,SD28,Ind,writein,1
-New York,74059,State Senate,SD28,Ind,writein,0
-New York,74060,State Senate,SD28,Ind,writein,0
-New York,74061,State Senate,SD28,Ind,writein,0
-New York,74062,State Senate,SD28,Ind,writein,0
-New York,74063,State Senate,SD28,Ind,writein,0
-New York,74064,State Senate,SD28,Ind,writein,0
-New York,74065,State Senate,SD28,Ind,writein,0
-New York,74066,State Senate,SD28,Ind,writein,0
-New York,74067,State Senate,SD28,Ind,writein,0
-New York,74068,State Senate,SD28,Ind,writein,0
-New York,74069,State Senate,SD28,Ind,writein,0
-New York,74070,State Senate,SD28,Ind,writein,0
-New York,74082,State Senate,SD28,Ind,writein,0
-New York,74083,State Senate,SD28,Ind,writein,1
-New York,74085,State Senate,SD28,Ind,writein,0
-New York,74086,State Senate,SD28,Ind,writein,0
-New York,74087,State Senate,SD28,Ind,writein,0
-New York,74088,State Senate,SD28,Ind,writein,0
-New York,74089,State Senate,SD28,Ind,writein,2
-New York,74090,State Senate,SD28,Ind,writein,0
-New York,74091,State Senate,SD28,Ind,writein,0
-New York,75008,State Senate,SD28,Ind,writein,0
-New York,75009,State Senate,SD28,Ind,writein,2
-New York,75029,State Senate,SD28,Ind,writein,1
-New York,75030,State Senate,SD28,Ind,writein,0
-New York,75031,State Senate,SD28,Ind,writein,0
-New York,75032,State Senate,SD28,Ind,writein,1
-New York,75033,State Senate,SD28,Ind,writein,2
-New York,75034,State Senate,SD28,Ind,writein,1
-New York,75035,State Senate,SD28,Ind,writein,0
-New York,75051,State Senate,SD28,Ind,writein,0
-New York,75052,State Senate,SD28,Ind,writein,0
-New York,75053,State Senate,SD28,Ind,writein,0
-New York,75054,State Senate,SD28,Ind,writein,0
-New York,75055,State Senate,SD28,Ind,writein,0
-New York,75056,State Senate,SD28,Ind,writein,0
-New York,75057,State Senate,SD28,Ind,writein,0
-New York,75086,State Senate,SD28,Ind,writein,0
-New York,75087,State Senate,SD28,Ind,writein,0
-New York,75088,State Senate,SD28,Ind,writein,0
-New York,75090,State Senate,SD28,Ind,writein,1
-New York,75091,State Senate,SD28,Ind,writein,0
-New York,75092,State Senate,SD28,Ind,writein,1
-New York,76001,State Senate,SD28,Ind,writein,0
-New York,76002,State Senate,SD28,Ind,writein,2
-New York,76003,State Senate,SD28,Ind,writein,0
-New York,76004,State Senate,SD28,Ind,writein,0
-New York,76005,State Senate,SD28,Ind,writein,0
-New York,76006,State Senate,SD28,Ind,writein,1
-New York,76007,State Senate,SD28,Ind,writein,0
-New York,76008,State Senate,SD28,Ind,writein,0
-New York,76009,State Senate,SD28,Ind,writein,0
-New York,76010,State Senate,SD28,Ind,writein,0
-New York,76011,State Senate,SD28,Ind,writein,0
-New York,76012,State Senate,SD28,Ind,writein,0
-New York,76013,State Senate,SD28,Ind,writein,0
-New York,76014,State Senate,SD28,Ind,writein,1
-New York,76015,State Senate,SD28,Ind,writein,0
-New York,76016,State Senate,SD28,Ind,writein,0
-New York,76017,State Senate,SD28,Ind,writein,0
-New York,76018,State Senate,SD28,Ind,writein,0
-New York,76019,State Senate,SD28,Ind,writein,0
-New York,76020,State Senate,SD28,Ind,writein,0
-New York,76021,State Senate,SD28,Ind,writein,0
-New York,76022,State Senate,SD28,Ind,writein,1
-New York,76023,State Senate,SD28,Ind,writein,0
-New York,76024,State Senate,SD28,Ind,writein,0
-New York,76025,State Senate,SD28,Ind,writein,0
-New York,76026,State Senate,SD28,Ind,writein,0
-New York,76027,State Senate,SD28,Ind,writein,0
-New York,76028,State Senate,SD28,Ind,writein,1
-New York,76029,State Senate,SD28,Ind,writein,0
-New York,76030,State Senate,SD28,Ind,writein,1
-New York,76031,State Senate,SD28,Ind,writein,0
-New York,76032,State Senate,SD28,Ind,writein,0
-New York,76033,State Senate,SD28,Ind,writein,0
-New York,76034,State Senate,SD28,Ind,writein,0
-New York,76035,State Senate,SD28,Ind,writein,0
-New York,76036,State Senate,SD28,Ind,writein,0
-New York,76037,State Senate,SD28,Ind,writein,0
-New York,76038,State Senate,SD28,Ind,writein,1
-New York,76039,State Senate,SD28,Ind,writein,0
-New York,76040,State Senate,SD28,Ind,writein,0
-New York,76041,State Senate,SD28,Ind,writein,0
-New York,76042,State Senate,SD28,Ind,writein,0
-New York,76043,State Senate,SD28,Ind,writein,0
-New York,76044,State Senate,SD28,Ind,writein,0
-New York,76045,State Senate,SD28,Ind,writein,0
-New York,76046,State Senate,SD28,Ind,writein,0
-New York,76047,State Senate,SD28,Ind,writein,0
-New York,76048,State Senate,SD28,Ind,writein,1
-New York,76049,State Senate,SD28,Ind,writein,1
-New York,76050,State Senate,SD28,Ind,writein,0
-New York,76051,State Senate,SD28,Ind,writein,1
-New York,76052,State Senate,SD28,Ind,writein,1
-New York,76053,State Senate,SD28,Ind,writein,0
-New York,76054,State Senate,SD28,Ind,writein,0
-New York,76055,State Senate,SD28,Ind,writein,0
-New York,76056,State Senate,SD28,Ind,writein,0
-New York,76057,State Senate,SD28,Ind,writein,1
-New York,76058,State Senate,SD28,Ind,writein,0
-New York,76059,State Senate,SD28,Ind,writein,0
-New York,76060,State Senate,SD28,Ind,writein,0
-New York,76061,State Senate,SD28,Ind,writein,0
-New York,76062,State Senate,SD28,Ind,writein,0
-New York,76063,State Senate,SD28,Ind,writein,1
-New York,76064,State Senate,SD28,Ind,writein,0
-New York,76065,State Senate,SD28,Ind,writein,1
-New York,76066,State Senate,SD28,Ind,writein,0
-New York,76067,State Senate,SD28,Ind,writein,1
-New York,76068,State Senate,SD28,Ind,writein,0
-New York,76069,State Senate,SD28,Ind,writein,0
-New York,76070,State Senate,SD28,Ind,writein,0
-New York,76071,State Senate,SD28,Ind,writein,0
-New York,76072,State Senate,SD28,Ind,writein,1
-New York,76073,State Senate,SD28,Ind,writein,1
-New York,76074,State Senate,SD28,Ind,writein,0
-New York,76075,State Senate,SD28,Ind,writein,0
-New York,76076,State Senate,SD28,Ind,writein,0
-New York,76077,State Senate,SD28,Ind,writein,0
-New York,76078,State Senate,SD28,Ind,writein,0
-New York,76079,State Senate,SD28,Ind,writein,0
-New York,76080,State Senate,SD28,Ind,writein,0
-New York,67052,State Senate,SD29,Dem,Jose Serrano,474
-New York,67053,State Senate,SD29,Dem,Jose Serrano,363
-New York,67054,State Senate,SD29,Dem,Jose Serrano,317
-New York,67055,State Senate,SD29,Dem,Jose Serrano,251
-New York,67056,State Senate,SD29,Dem,Jose Serrano,379
-New York,67057,State Senate,SD29,Dem,Jose Serrano,403
-New York,67058,State Senate,SD29,Dem,Jose Serrano,276
-New York,67059,State Senate,SD29,Dem,Jose Serrano,419
-New York,67060,State Senate,SD29,Dem,Jose Serrano,371
-New York,67061,State Senate,SD29,Dem,Jose Serrano,408
-New York,67062,State Senate,SD29,Dem,Jose Serrano,359
-New York,67063,State Senate,SD29,Dem,Jose Serrano,354
-New York,67064,State Senate,SD29,Dem,Jose Serrano,380
-New York,67065,State Senate,SD29,Dem,Jose Serrano,438
-New York,67066,State Senate,SD29,Dem,Jose Serrano,409
-New York,67068,State Senate,SD29,Dem,Jose Serrano,551
-New York,67069,State Senate,SD29,Dem,Jose Serrano,548
-New York,67070,State Senate,SD29,Dem,Jose Serrano,303
-New York,67071,State Senate,SD29,Dem,Jose Serrano,341
-New York,67072,State Senate,SD29,Dem,Jose Serrano,558
-New York,67073,State Senate,SD29,Dem,Jose Serrano,359
-New York,67074,State Senate,SD29,Dem,Jose Serrano,489
-New York,67075,State Senate,SD29,Dem,Jose Serrano,359
-New York,67076,State Senate,SD29,Dem,Jose Serrano,594
-New York,67077,State Senate,SD29,Dem,Jose Serrano,366
-New York,67078,State Senate,SD29,Dem,Jose Serrano,437
-New York,68002,State Senate,SD29,Dem,Jose Serrano,335
-New York,68003,State Senate,SD29,Dem,Jose Serrano,449
-New York,68004,State Senate,SD29,Dem,Jose Serrano,632
-New York,68009,State Senate,SD29,Dem,Jose Serrano,136
-New York,68010,State Senate,SD29,Dem,Jose Serrano,246
-New York,68011,State Senate,SD29,Dem,Jose Serrano,391
-New York,68012,State Senate,SD29,Dem,Jose Serrano,292
-New York,68014,State Senate,SD29,Dem,Jose Serrano,551
-New York,68015,State Senate,SD29,Dem,Jose Serrano,181
-New York,68016,State Senate,SD29,Dem,Jose Serrano,228
-New York,68017,State Senate,SD29,Dem,Jose Serrano,279
-New York,68018,State Senate,SD29,Dem,Jose Serrano,358
-New York,68019,State Senate,SD29,Dem,Jose Serrano,354
-New York,68020,State Senate,SD29,Dem,Jose Serrano,175
-New York,68021,State Senate,SD29,Dem,Jose Serrano,258
-New York,68022,State Senate,SD29,Dem,Jose Serrano,257
-New York,68023,State Senate,SD29,Dem,Jose Serrano,384
-New York,68037,State Senate,SD29,Dem,Jose Serrano,460
-New York,68038,State Senate,SD29,Dem,Jose Serrano,113
-New York,68039,State Senate,SD29,Dem,Jose Serrano,228
-New York,68040,State Senate,SD29,Dem,Jose Serrano,491
-New York,68041,State Senate,SD29,Dem,Jose Serrano,480
-New York,68042,State Senate,SD29,Dem,Jose Serrano,253
-New York,68043,State Senate,SD29,Dem,Jose Serrano,315
-New York,68044,State Senate,SD29,Dem,Jose Serrano,320
-New York,68045,State Senate,SD29,Dem,Jose Serrano,251
-New York,68046,State Senate,SD29,Dem,Jose Serrano,253
-New York,68054,State Senate,SD29,Dem,Jose Serrano,364
-New York,68055,State Senate,SD29,Dem,Jose Serrano,209
-New York,68071,State Senate,SD29,Dem,Jose Serrano,350
-New York,68072,State Senate,SD29,Dem,Jose Serrano,156
-New York,68075,State Senate,SD29,Dem,Jose Serrano,411
-New York,68076,State Senate,SD29,Dem,Jose Serrano,313
-New York,68077,State Senate,SD29,Dem,Jose Serrano,199
-New York,68094,State Senate,SD29,Dem,Jose Serrano,50
-New York,69001,State Senate,SD29,Dem,Jose Serrano,352
-New York,69002,State Senate,SD29,Dem,Jose Serrano,280
-New York,69003,State Senate,SD29,Dem,Jose Serrano,482
-New York,69004,State Senate,SD29,Dem,Jose Serrano,382
-New York,69005,State Senate,SD29,Dem,Jose Serrano,382
-New York,69006,State Senate,SD29,Dem,Jose Serrano,482
-New York,69007,State Senate,SD29,Dem,Jose Serrano,404
-New York,69009,State Senate,SD29,Dem,Jose Serrano,466
-New York,69010,State Senate,SD29,Dem,Jose Serrano,479
-New York,69011,State Senate,SD29,Dem,Jose Serrano,494
-New York,69012,State Senate,SD29,Dem,Jose Serrano,536
-New York,73093,State Senate,SD29,Dem,Jose Serrano,443
-New York,73094,State Senate,SD29,Dem,Jose Serrano,309
-New York,73095,State Senate,SD29,Dem,Jose Serrano,427
-New York,73096,State Senate,SD29,Dem,Jose Serrano,335
-New York,73098,State Senate,SD29,Dem,Jose Serrano,251
-New York,76081,State Senate,SD29,Dem,Jose Serrano,265
-New York,76082,State Senate,SD29,Dem,Jose Serrano,273
-New York,76083,State Senate,SD29,Dem,Jose Serrano,578
-New York,76084,State Senate,SD29,Dem,Jose Serrano,441
-New York,76085,State Senate,SD29,Dem,Jose Serrano,345
-New York,76086,State Senate,SD29,Dem,Jose Serrano,336
-New York,76087,State Senate,SD29,Dem,Jose Serrano,161
-New York,67052,State Senate,SD29,WF,Jose Serrano,13
-New York,67053,State Senate,SD29,WF,Jose Serrano,15
-New York,67054,State Senate,SD29,WF,Jose Serrano,6
-New York,67055,State Senate,SD29,WF,Jose Serrano,8
-New York,67056,State Senate,SD29,WF,Jose Serrano,20
-New York,67057,State Senate,SD29,WF,Jose Serrano,19
-New York,67058,State Senate,SD29,WF,Jose Serrano,7
-New York,67059,State Senate,SD29,WF,Jose Serrano,16
-New York,67060,State Senate,SD29,WF,Jose Serrano,14
-New York,67061,State Senate,SD29,WF,Jose Serrano,23
-New York,67062,State Senate,SD29,WF,Jose Serrano,10
-New York,67063,State Senate,SD29,WF,Jose Serrano,5
-New York,67064,State Senate,SD29,WF,Jose Serrano,20
-New York,67065,State Senate,SD29,WF,Jose Serrano,15
-New York,67066,State Senate,SD29,WF,Jose Serrano,11
-New York,67068,State Senate,SD29,WF,Jose Serrano,34
-New York,67069,State Senate,SD29,WF,Jose Serrano,37
-New York,67070,State Senate,SD29,WF,Jose Serrano,17
-New York,67071,State Senate,SD29,WF,Jose Serrano,13
-New York,67072,State Senate,SD29,WF,Jose Serrano,15
-New York,67073,State Senate,SD29,WF,Jose Serrano,26
-New York,67074,State Senate,SD29,WF,Jose Serrano,21
-New York,67075,State Senate,SD29,WF,Jose Serrano,24
-New York,67076,State Senate,SD29,WF,Jose Serrano,41
-New York,67077,State Senate,SD29,WF,Jose Serrano,12
-New York,67078,State Senate,SD29,WF,Jose Serrano,24
-New York,68002,State Senate,SD29,WF,Jose Serrano,10
-New York,68003,State Senate,SD29,WF,Jose Serrano,22
-New York,68004,State Senate,SD29,WF,Jose Serrano,17
-New York,68009,State Senate,SD29,WF,Jose Serrano,2
-New York,68010,State Senate,SD29,WF,Jose Serrano,8
-New York,68011,State Senate,SD29,WF,Jose Serrano,14
-New York,68012,State Senate,SD29,WF,Jose Serrano,12
-New York,68014,State Senate,SD29,WF,Jose Serrano,17
-New York,68015,State Senate,SD29,WF,Jose Serrano,4
-New York,68016,State Senate,SD29,WF,Jose Serrano,1
-New York,68017,State Senate,SD29,WF,Jose Serrano,8
-New York,68018,State Senate,SD29,WF,Jose Serrano,10
-New York,68019,State Senate,SD29,WF,Jose Serrano,7
-New York,68020,State Senate,SD29,WF,Jose Serrano,7
-New York,68021,State Senate,SD29,WF,Jose Serrano,3
-New York,68022,State Senate,SD29,WF,Jose Serrano,6
-New York,68023,State Senate,SD29,WF,Jose Serrano,11
-New York,68037,State Senate,SD29,WF,Jose Serrano,13
-New York,68038,State Senate,SD29,WF,Jose Serrano,8
-New York,68039,State Senate,SD29,WF,Jose Serrano,9
-New York,68040,State Senate,SD29,WF,Jose Serrano,19
-New York,68041,State Senate,SD29,WF,Jose Serrano,12
-New York,68042,State Senate,SD29,WF,Jose Serrano,7
-New York,68043,State Senate,SD29,WF,Jose Serrano,14
-New York,68044,State Senate,SD29,WF,Jose Serrano,1
-New York,68045,State Senate,SD29,WF,Jose Serrano,2
-New York,68046,State Senate,SD29,WF,Jose Serrano,3
-New York,68054,State Senate,SD29,WF,Jose Serrano,11
-New York,68055,State Senate,SD29,WF,Jose Serrano,11
-New York,68071,State Senate,SD29,WF,Jose Serrano,24
-New York,68072,State Senate,SD29,WF,Jose Serrano,7
-New York,68075,State Senate,SD29,WF,Jose Serrano,21
-New York,68076,State Senate,SD29,WF,Jose Serrano,21
-New York,68077,State Senate,SD29,WF,Jose Serrano,12
-New York,68094,State Senate,SD29,WF,Jose Serrano,1
-New York,69001,State Senate,SD29,WF,Jose Serrano,24
-New York,69002,State Senate,SD29,WF,Jose Serrano,13
-New York,69003,State Senate,SD29,WF,Jose Serrano,14
-New York,69004,State Senate,SD29,WF,Jose Serrano,24
-New York,69005,State Senate,SD29,WF,Jose Serrano,18
-New York,69006,State Senate,SD29,WF,Jose Serrano,15
-New York,69007,State Senate,SD29,WF,Jose Serrano,15
-New York,69009,State Senate,SD29,WF,Jose Serrano,13
-New York,69010,State Senate,SD29,WF,Jose Serrano,34
-New York,69011,State Senate,SD29,WF,Jose Serrano,27
-New York,69012,State Senate,SD29,WF,Jose Serrano,20
-New York,73093,State Senate,SD29,WF,Jose Serrano,20
-New York,73094,State Senate,SD29,WF,Jose Serrano,10
-New York,73095,State Senate,SD29,WF,Jose Serrano,17
-New York,73096,State Senate,SD29,WF,Jose Serrano,3
-New York,73098,State Senate,SD29,WF,Jose Serrano,7
-New York,76081,State Senate,SD29,WF,Jose Serrano,11
-New York,76082,State Senate,SD29,WF,Jose Serrano,6
-New York,76083,State Senate,SD29,WF,Jose Serrano,38
-New York,76084,State Senate,SD29,WF,Jose Serrano,16
-New York,76085,State Senate,SD29,WF,Jose Serrano,10
-New York,76086,State Senate,SD29,WF,Jose Serrano,24
-New York,76087,State Senate,SD29,WF,Jose Serrano,4
-New York,67052,State Senate,SD29,Rep,Robert Goodman,50
-New York,67053,State Senate,SD29,Rep,Robert Goodman,47
-New York,67054,State Senate,SD29,Rep,Robert Goodman,35
-New York,67055,State Senate,SD29,Rep,Robert Goodman,52
-New York,67056,State Senate,SD29,Rep,Robert Goodman,40
-New York,67057,State Senate,SD29,Rep,Robert Goodman,58
-New York,67058,State Senate,SD29,Rep,Robert Goodman,29
-New York,67059,State Senate,SD29,Rep,Robert Goodman,29
-New York,67060,State Senate,SD29,Rep,Robert Goodman,57
-New York,67061,State Senate,SD29,Rep,Robert Goodman,49
-New York,67062,State Senate,SD29,Rep,Robert Goodman,43
-New York,67063,State Senate,SD29,Rep,Robert Goodman,44
-New York,67064,State Senate,SD29,Rep,Robert Goodman,51
-New York,67065,State Senate,SD29,Rep,Robert Goodman,58
-New York,67066,State Senate,SD29,Rep,Robert Goodman,40
-New York,67068,State Senate,SD29,Rep,Robert Goodman,60
-New York,67069,State Senate,SD29,Rep,Robert Goodman,71
-New York,67070,State Senate,SD29,Rep,Robert Goodman,46
-New York,67071,State Senate,SD29,Rep,Robert Goodman,60
-New York,67072,State Senate,SD29,Rep,Robert Goodman,57
-New York,67073,State Senate,SD29,Rep,Robert Goodman,39
-New York,67074,State Senate,SD29,Rep,Robert Goodman,58
-New York,67075,State Senate,SD29,Rep,Robert Goodman,36
-New York,67076,State Senate,SD29,Rep,Robert Goodman,59
-New York,67077,State Senate,SD29,Rep,Robert Goodman,36
-New York,67078,State Senate,SD29,Rep,Robert Goodman,44
-New York,68002,State Senate,SD29,Rep,Robert Goodman,14
-New York,68003,State Senate,SD29,Rep,Robert Goodman,54
-New York,68004,State Senate,SD29,Rep,Robert Goodman,79
-New York,68009,State Senate,SD29,Rep,Robert Goodman,27
-New York,68010,State Senate,SD29,Rep,Robert Goodman,58
-New York,68011,State Senate,SD29,Rep,Robert Goodman,85
-New York,68012,State Senate,SD29,Rep,Robert Goodman,45
-New York,68014,State Senate,SD29,Rep,Robert Goodman,85
-New York,68015,State Senate,SD29,Rep,Robert Goodman,26
-New York,68016,State Senate,SD29,Rep,Robert Goodman,7
-New York,68017,State Senate,SD29,Rep,Robert Goodman,5
-New York,68018,State Senate,SD29,Rep,Robert Goodman,8
-New York,68019,State Senate,SD29,Rep,Robert Goodman,8
-New York,68020,State Senate,SD29,Rep,Robert Goodman,9
-New York,68021,State Senate,SD29,Rep,Robert Goodman,3
-New York,68022,State Senate,SD29,Rep,Robert Goodman,15
-New York,68023,State Senate,SD29,Rep,Robert Goodman,18
-New York,68037,State Senate,SD29,Rep,Robert Goodman,17
-New York,68038,State Senate,SD29,Rep,Robert Goodman,8
-New York,68039,State Senate,SD29,Rep,Robert Goodman,5
-New York,68040,State Senate,SD29,Rep,Robert Goodman,15
-New York,68041,State Senate,SD29,Rep,Robert Goodman,12
-New York,68042,State Senate,SD29,Rep,Robert Goodman,7
-New York,68043,State Senate,SD29,Rep,Robert Goodman,8
-New York,68044,State Senate,SD29,Rep,Robert Goodman,4
-New York,68045,State Senate,SD29,Rep,Robert Goodman,2
-New York,68046,State Senate,SD29,Rep,Robert Goodman,15
-New York,68054,State Senate,SD29,Rep,Robert Goodman,11
-New York,68055,State Senate,SD29,Rep,Robert Goodman,15
-New York,68071,State Senate,SD29,Rep,Robert Goodman,10
-New York,68072,State Senate,SD29,Rep,Robert Goodman,4
-New York,68075,State Senate,SD29,Rep,Robert Goodman,13
-New York,68076,State Senate,SD29,Rep,Robert Goodman,9
-New York,68077,State Senate,SD29,Rep,Robert Goodman,4
-New York,68094,State Senate,SD29,Rep,Robert Goodman,4
-New York,69001,State Senate,SD29,Rep,Robert Goodman,22
-New York,69002,State Senate,SD29,Rep,Robert Goodman,32
-New York,69003,State Senate,SD29,Rep,Robert Goodman,38
-New York,69004,State Senate,SD29,Rep,Robert Goodman,43
-New York,69005,State Senate,SD29,Rep,Robert Goodman,48
-New York,69006,State Senate,SD29,Rep,Robert Goodman,41
-New York,69007,State Senate,SD29,Rep,Robert Goodman,45
-New York,69009,State Senate,SD29,Rep,Robert Goodman,56
-New York,69010,State Senate,SD29,Rep,Robert Goodman,42
-New York,69011,State Senate,SD29,Rep,Robert Goodman,46
-New York,69012,State Senate,SD29,Rep,Robert Goodman,48
-New York,73093,State Senate,SD29,Rep,Robert Goodman,67
-New York,73094,State Senate,SD29,Rep,Robert Goodman,41
-New York,73095,State Senate,SD29,Rep,Robert Goodman,37
-New York,73096,State Senate,SD29,Rep,Robert Goodman,75
-New York,73098,State Senate,SD29,Rep,Robert Goodman,31
-New York,76081,State Senate,SD29,Rep,Robert Goodman,45
-New York,76082,State Senate,SD29,Rep,Robert Goodman,40
-New York,76083,State Senate,SD29,Rep,Robert Goodman,38
-New York,76084,State Senate,SD29,Rep,Robert Goodman,26
-New York,76085,State Senate,SD29,Rep,Robert Goodman,16
-New York,76086,State Senate,SD29,Rep,Robert Goodman,25
-New York,76087,State Senate,SD29,Rep,Robert Goodman,10
-New York,67052,State Senate,SD29,Green,Thomas Siracuse,21
-New York,67053,State Senate,SD29,Green,Thomas Siracuse,5
-New York,67054,State Senate,SD29,Green,Thomas Siracuse,14
-New York,67055,State Senate,SD29,Green,Thomas Siracuse,7
-New York,67056,State Senate,SD29,Green,Thomas Siracuse,26
-New York,67057,State Senate,SD29,Green,Thomas Siracuse,21
-New York,67058,State Senate,SD29,Green,Thomas Siracuse,7
-New York,67059,State Senate,SD29,Green,Thomas Siracuse,4
-New York,67060,State Senate,SD29,Green,Thomas Siracuse,35
-New York,67061,State Senate,SD29,Green,Thomas Siracuse,25
-New York,67062,State Senate,SD29,Green,Thomas Siracuse,18
-New York,67063,State Senate,SD29,Green,Thomas Siracuse,14
-New York,67064,State Senate,SD29,Green,Thomas Siracuse,23
-New York,67065,State Senate,SD29,Green,Thomas Siracuse,14
-New York,67066,State Senate,SD29,Green,Thomas Siracuse,14
-New York,67068,State Senate,SD29,Green,Thomas Siracuse,23
-New York,67069,State Senate,SD29,Green,Thomas Siracuse,30
-New York,67070,State Senate,SD29,Green,Thomas Siracuse,9
-New York,67071,State Senate,SD29,Green,Thomas Siracuse,7
-New York,67072,State Senate,SD29,Green,Thomas Siracuse,22
-New York,67073,State Senate,SD29,Green,Thomas Siracuse,17
-New York,67074,State Senate,SD29,Green,Thomas Siracuse,24
-New York,67075,State Senate,SD29,Green,Thomas Siracuse,13
-New York,67076,State Senate,SD29,Green,Thomas Siracuse,21
-New York,67077,State Senate,SD29,Green,Thomas Siracuse,13
-New York,67078,State Senate,SD29,Green,Thomas Siracuse,10
-New York,68002,State Senate,SD29,Green,Thomas Siracuse,3
-New York,68003,State Senate,SD29,Green,Thomas Siracuse,21
-New York,68004,State Senate,SD29,Green,Thomas Siracuse,20
-New York,68009,State Senate,SD29,Green,Thomas Siracuse,8
-New York,68010,State Senate,SD29,Green,Thomas Siracuse,9
-New York,68011,State Senate,SD29,Green,Thomas Siracuse,14
-New York,68012,State Senate,SD29,Green,Thomas Siracuse,15
-New York,68014,State Senate,SD29,Green,Thomas Siracuse,16
-New York,68015,State Senate,SD29,Green,Thomas Siracuse,5
-New York,68016,State Senate,SD29,Green,Thomas Siracuse,0
-New York,68017,State Senate,SD29,Green,Thomas Siracuse,0
-New York,68018,State Senate,SD29,Green,Thomas Siracuse,7
-New York,68019,State Senate,SD29,Green,Thomas Siracuse,2
-New York,68020,State Senate,SD29,Green,Thomas Siracuse,10
-New York,68021,State Senate,SD29,Green,Thomas Siracuse,4
-New York,68022,State Senate,SD29,Green,Thomas Siracuse,11
-New York,68023,State Senate,SD29,Green,Thomas Siracuse,18
-New York,68037,State Senate,SD29,Green,Thomas Siracuse,14
-New York,68038,State Senate,SD29,Green,Thomas Siracuse,5
-New York,68039,State Senate,SD29,Green,Thomas Siracuse,3
-New York,68040,State Senate,SD29,Green,Thomas Siracuse,3
-New York,68041,State Senate,SD29,Green,Thomas Siracuse,7
-New York,68042,State Senate,SD29,Green,Thomas Siracuse,4
-New York,68043,State Senate,SD29,Green,Thomas Siracuse,10
-New York,68044,State Senate,SD29,Green,Thomas Siracuse,0
-New York,68045,State Senate,SD29,Green,Thomas Siracuse,4
-New York,68046,State Senate,SD29,Green,Thomas Siracuse,3
-New York,68054,State Senate,SD29,Green,Thomas Siracuse,11
-New York,68055,State Senate,SD29,Green,Thomas Siracuse,13
-New York,68071,State Senate,SD29,Green,Thomas Siracuse,7
-New York,68072,State Senate,SD29,Green,Thomas Siracuse,6
-New York,68075,State Senate,SD29,Green,Thomas Siracuse,17
-New York,68076,State Senate,SD29,Green,Thomas Siracuse,8
-New York,68077,State Senate,SD29,Green,Thomas Siracuse,6
-New York,68094,State Senate,SD29,Green,Thomas Siracuse,0
-New York,69001,State Senate,SD29,Green,Thomas Siracuse,14
-New York,69002,State Senate,SD29,Green,Thomas Siracuse,11
-New York,69003,State Senate,SD29,Green,Thomas Siracuse,15
-New York,69004,State Senate,SD29,Green,Thomas Siracuse,15
-New York,69005,State Senate,SD29,Green,Thomas Siracuse,14
-New York,69006,State Senate,SD29,Green,Thomas Siracuse,16
-New York,69007,State Senate,SD29,Green,Thomas Siracuse,18
-New York,69009,State Senate,SD29,Green,Thomas Siracuse,15
-New York,69010,State Senate,SD29,Green,Thomas Siracuse,19
-New York,69011,State Senate,SD29,Green,Thomas Siracuse,26
-New York,69012,State Senate,SD29,Green,Thomas Siracuse,8
-New York,73093,State Senate,SD29,Green,Thomas Siracuse,27
-New York,73094,State Senate,SD29,Green,Thomas Siracuse,17
-New York,73095,State Senate,SD29,Green,Thomas Siracuse,9
-New York,73096,State Senate,SD29,Green,Thomas Siracuse,11
-New York,73098,State Senate,SD29,Green,Thomas Siracuse,7
-New York,76081,State Senate,SD29,Green,Thomas Siracuse,14
-New York,76082,State Senate,SD29,Green,Thomas Siracuse,13
-New York,76083,State Senate,SD29,Green,Thomas Siracuse,31
-New York,76084,State Senate,SD29,Green,Thomas Siracuse,12
-New York,76085,State Senate,SD29,Green,Thomas Siracuse,5
-New York,76086,State Senate,SD29,Green,Thomas Siracuse,22
-New York,76087,State Senate,SD29,Green,Thomas Siracuse,5
-New York,67052,State Senate,SD29,Ind,writein,0
-New York,67053,State Senate,SD29,Ind,writein,0
-New York,67054,State Senate,SD29,Ind,writein,0
-New York,67055,State Senate,SD29,Ind,writein,0
-New York,67056,State Senate,SD29,Ind,writein,1
-New York,67057,State Senate,SD29,Ind,writein,0
-New York,67058,State Senate,SD29,Ind,writein,1
-New York,67059,State Senate,SD29,Ind,writein,0
-New York,67060,State Senate,SD29,Ind,writein,0
-New York,67061,State Senate,SD29,Ind,writein,1
-New York,67062,State Senate,SD29,Ind,writein,0
-New York,67063,State Senate,SD29,Ind,writein,1
-New York,67064,State Senate,SD29,Ind,writein,1
-New York,67065,State Senate,SD29,Ind,writein,0
-New York,67066,State Senate,SD29,Ind,writein,1
-New York,67068,State Senate,SD29,Ind,writein,1
-New York,67069,State Senate,SD29,Ind,writein,0
-New York,67070,State Senate,SD29,Ind,writein,0
-New York,67071,State Senate,SD29,Ind,writein,1
-New York,67072,State Senate,SD29,Ind,writein,0
-New York,67073,State Senate,SD29,Ind,writein,1
-New York,67074,State Senate,SD29,Ind,writein,1
-New York,67075,State Senate,SD29,Ind,writein,2
-New York,67076,State Senate,SD29,Ind,writein,1
-New York,67077,State Senate,SD29,Ind,writein,0
-New York,67078,State Senate,SD29,Ind,writein,0
-New York,68002,State Senate,SD29,Ind,writein,0
-New York,68003,State Senate,SD29,Ind,writein,0
-New York,68004,State Senate,SD29,Ind,writein,0
-New York,68009,State Senate,SD29,Ind,writein,0
-New York,68010,State Senate,SD29,Ind,writein,1
-New York,68011,State Senate,SD29,Ind,writein,0
-New York,68012,State Senate,SD29,Ind,writein,0
-New York,68014,State Senate,SD29,Ind,writein,1
-New York,68015,State Senate,SD29,Ind,writein,0
-New York,68016,State Senate,SD29,Ind,writein,0
-New York,68017,State Senate,SD29,Ind,writein,1
-New York,68018,State Senate,SD29,Ind,writein,0
-New York,68019,State Senate,SD29,Ind,writein,0
-New York,68020,State Senate,SD29,Ind,writein,0
-New York,68021,State Senate,SD29,Ind,writein,0
-New York,68022,State Senate,SD29,Ind,writein,0
-New York,68023,State Senate,SD29,Ind,writein,0
-New York,68037,State Senate,SD29,Ind,writein,0
-New York,68038,State Senate,SD29,Ind,writein,1
-New York,68039,State Senate,SD29,Ind,writein,0
-New York,68040,State Senate,SD29,Ind,writein,0
-New York,68041,State Senate,SD29,Ind,writein,1
-New York,68042,State Senate,SD29,Ind,writein,0
-New York,68043,State Senate,SD29,Ind,writein,0
-New York,68044,State Senate,SD29,Ind,writein,0
-New York,68045,State Senate,SD29,Ind,writein,0
-New York,68046,State Senate,SD29,Ind,writein,0
-New York,68054,State Senate,SD29,Ind,writein,0
-New York,68055,State Senate,SD29,Ind,writein,1
-New York,68071,State Senate,SD29,Ind,writein,0
-New York,68072,State Senate,SD29,Ind,writein,0
-New York,68075,State Senate,SD29,Ind,writein,0
-New York,68076,State Senate,SD29,Ind,writein,0
-New York,68077,State Senate,SD29,Ind,writein,0
-New York,68094,State Senate,SD29,Ind,writein,0
-New York,69001,State Senate,SD29,Ind,writein,0
-New York,69002,State Senate,SD29,Ind,writein,0
-New York,69003,State Senate,SD29,Ind,writein,1
-New York,69004,State Senate,SD29,Ind,writein,0
-New York,69005,State Senate,SD29,Ind,writein,0
-New York,69006,State Senate,SD29,Ind,writein,0
-New York,69007,State Senate,SD29,Ind,writein,1
-New York,69009,State Senate,SD29,Ind,writein,0
-New York,69010,State Senate,SD29,Ind,writein,1
-New York,69011,State Senate,SD29,Ind,writein,0
-New York,69012,State Senate,SD29,Ind,writein,1
-New York,73093,State Senate,SD29,Ind,writein,0
-New York,73094,State Senate,SD29,Ind,writein,1
-New York,73095,State Senate,SD29,Ind,writein,0
-New York,73096,State Senate,SD29,Ind,writein,0
-New York,73098,State Senate,SD29,Ind,writein,0
-New York,76081,State Senate,SD29,Ind,writein,0
-New York,76082,State Senate,SD29,Ind,writein,0
-New York,76083,State Senate,SD29,Ind,writein,0
-New York,76084,State Senate,SD29,Ind,writein,0
-New York,76085,State Senate,SD29,Ind,writein,0
-New York,76086,State Senate,SD29,Ind,writein,0
-New York,76087,State Senate,SD29,Ind,writein,0
-New York,67086,State Senate,SD30,Dem,Bill Perkins,626
-New York,68013,State Senate,SD30,Dem,Bill Perkins,144
-New York,68024,State Senate,SD30,Dem,Bill Perkins,215
-New York,68025,State Senate,SD30,Dem,Bill Perkins,266
-New York,68026,State Senate,SD30,Dem,Bill Perkins,273
-New York,68027,State Senate,SD30,Dem,Bill Perkins,217
-New York,68028,State Senate,SD30,Dem,Bill Perkins,266
-New York,68029,State Senate,SD30,Dem,Bill Perkins,149
-New York,68030,State Senate,SD30,Dem,Bill Perkins,305
-New York,68031,State Senate,SD30,Dem,Bill Perkins,490
-New York,68032,State Senate,SD30,Dem,Bill Perkins,433
-New York,68033,State Senate,SD30,Dem,Bill Perkins,399
-New York,68034,State Senate,SD30,Dem,Bill Perkins,541
-New York,68035,State Senate,SD30,Dem,Bill Perkins,180
-New York,68036,State Senate,SD30,Dem,Bill Perkins,352
-New York,68047,State Senate,SD30,Dem,Bill Perkins,218
-New York,68048,State Senate,SD30,Dem,Bill Perkins,315
-New York,68049,State Senate,SD30,Dem,Bill Perkins,343
-New York,68050,State Senate,SD30,Dem,Bill Perkins,341
-New York,68051,State Senate,SD30,Dem,Bill Perkins,308
-New York,68052,State Senate,SD30,Dem,Bill Perkins,301
-New York,68053,State Senate,SD30,Dem,Bill Perkins,264
-New York,68056,State Senate,SD30,Dem,Bill Perkins,452
-New York,68057,State Senate,SD30,Dem,Bill Perkins,519
-New York,68058,State Senate,SD30,Dem,Bill Perkins,346
-New York,68059,State Senate,SD30,Dem,Bill Perkins,456
-New York,68060,State Senate,SD30,Dem,Bill Perkins,467
-New York,68061,State Senate,SD30,Dem,Bill Perkins,326
-New York,68062,State Senate,SD30,Dem,Bill Perkins,249
-New York,68063,State Senate,SD30,Dem,Bill Perkins,372
-New York,68064,State Senate,SD30,Dem,Bill Perkins,224
-New York,68065,State Senate,SD30,Dem,Bill Perkins,224
-New York,68066,State Senate,SD30,Dem,Bill Perkins,370
-New York,68067,State Senate,SD30,Dem,Bill Perkins,196
-New York,68068,State Senate,SD30,Dem,Bill Perkins,234
-New York,68069,State Senate,SD30,Dem,Bill Perkins,265
-New York,68070,State Senate,SD30,Dem,Bill Perkins,237
-New York,68073,State Senate,SD30,Dem,Bill Perkins,436
-New York,68074,State Senate,SD30,Dem,Bill Perkins,410
-New York,68078,State Senate,SD30,Dem,Bill Perkins,472
-New York,68079,State Senate,SD30,Dem,Bill Perkins,386
-New York,68080,State Senate,SD30,Dem,Bill Perkins,533
-New York,68081,State Senate,SD30,Dem,Bill Perkins,33
-New York,68082,State Senate,SD30,Dem,Bill Perkins,431
-New York,68083,State Senate,SD30,Dem,Bill Perkins,551
-New York,68084,State Senate,SD30,Dem,Bill Perkins,479
-New York,68085,State Senate,SD30,Dem,Bill Perkins,419
-New York,68086,State Senate,SD30,Dem,Bill Perkins,200
-New York,68087,State Senate,SD30,Dem,Bill Perkins,428
-New York,68088,State Senate,SD30,Dem,Bill Perkins,409
-New York,68089,State Senate,SD30,Dem,Bill Perkins,436
-New York,68090,State Senate,SD30,Dem,Bill Perkins,376
-New York,68091,State Senate,SD30,Dem,Bill Perkins,284
-New York,68092,State Senate,SD30,Dem,Bill Perkins,308
-New York,68093,State Senate,SD30,Dem,Bill Perkins,354
-New York,69013,State Senate,SD30,Dem,Bill Perkins,350
-New York,69014,State Senate,SD30,Dem,Bill Perkins,286
-New York,69015,State Senate,SD30,Dem,Bill Perkins,487
-New York,69016,State Senate,SD30,Dem,Bill Perkins,404
-New York,69017,State Senate,SD30,Dem,Bill Perkins,550
-New York,69018,State Senate,SD30,Dem,Bill Perkins,550
-New York,69019,State Senate,SD30,Dem,Bill Perkins,347
-New York,69020,State Senate,SD30,Dem,Bill Perkins,545
-New York,69021,State Senate,SD30,Dem,Bill Perkins,343
-New York,69028,State Senate,SD30,Dem,Bill Perkins,251
-New York,69029,State Senate,SD30,Dem,Bill Perkins,558
-New York,69030,State Senate,SD30,Dem,Bill Perkins,468
-New York,69031,State Senate,SD30,Dem,Bill Perkins,490
-New York,69032,State Senate,SD30,Dem,Bill Perkins,487
-New York,69033,State Senate,SD30,Dem,Bill Perkins,599
-New York,69034,State Senate,SD30,Dem,Bill Perkins,564
-New York,69035,State Senate,SD30,Dem,Bill Perkins,223
-New York,69037,State Senate,SD30,Dem,Bill Perkins,271
-New York,69038,State Senate,SD30,Dem,Bill Perkins,407
-New York,69039,State Senate,SD30,Dem,Bill Perkins,494
-New York,69040,State Senate,SD30,Dem,Bill Perkins,509
-New York,69041,State Senate,SD30,Dem,Bill Perkins,451
-New York,69042,State Senate,SD30,Dem,Bill Perkins,574
-New York,69043,State Senate,SD30,Dem,Bill Perkins,498
-New York,69044,State Senate,SD30,Dem,Bill Perkins,452
-New York,69052,State Senate,SD30,Dem,Bill Perkins,391
-New York,69053,State Senate,SD30,Dem,Bill Perkins,333
-New York,69054,State Senate,SD30,Dem,Bill Perkins,432
-New York,69055,State Senate,SD30,Dem,Bill Perkins,473
-New York,69056,State Senate,SD30,Dem,Bill Perkins,256
-New York,69057,State Senate,SD30,Dem,Bill Perkins,607
-New York,69058,State Senate,SD30,Dem,Bill Perkins,370
-New York,69059,State Senate,SD30,Dem,Bill Perkins,226
-New York,69067,State Senate,SD30,Dem,Bill Perkins,244
-New York,69068,State Senate,SD30,Dem,Bill Perkins,469
-New York,69069,State Senate,SD30,Dem,Bill Perkins,562
-New York,69070,State Senate,SD30,Dem,Bill Perkins,247
-New York,69071,State Senate,SD30,Dem,Bill Perkins,354
-New York,69074,State Senate,SD30,Dem,Bill Perkins,527
-New York,69075,State Senate,SD30,Dem,Bill Perkins,488
-New York,69076,State Senate,SD30,Dem,Bill Perkins,271
-New York,69080,State Senate,SD30,Dem,Bill Perkins,442
-New York,69081,State Senate,SD30,Dem,Bill Perkins,494
-New York,69082,State Senate,SD30,Dem,Bill Perkins,232
-New York,69083,State Senate,SD30,Dem,Bill Perkins,575
-New York,69087,State Senate,SD30,Dem,Bill Perkins,500
-New York,69089,State Senate,SD30,Dem,Bill Perkins,113
-New York,69090,State Senate,SD30,Dem,Bill Perkins,374
-New York,69091,State Senate,SD30,Dem,Bill Perkins,353
-New York,69093,State Senate,SD30,Dem,Bill Perkins,597
-New York,69094,State Senate,SD30,Dem,Bill Perkins,325
-New York,69095,State Senate,SD30,Dem,Bill Perkins,484
-New York,69097,State Senate,SD30,Dem,Bill Perkins,397
-New York,69098,State Senate,SD30,Dem,Bill Perkins,454
-New York,69099,State Senate,SD30,Dem,Bill Perkins,601
-New York,69100,State Senate,SD30,Dem,Bill Perkins,457
-New York,69101,State Senate,SD30,Dem,Bill Perkins,631
-New York,69102,State Senate,SD30,Dem,Bill Perkins,670
-New York,69103,State Senate,SD30,Dem,Bill Perkins,223
-New York,70001,State Senate,SD30,Dem,Bill Perkins,561
-New York,70002,State Senate,SD30,Dem,Bill Perkins,329
-New York,70003,State Senate,SD30,Dem,Bill Perkins,547
-New York,70004,State Senate,SD30,Dem,Bill Perkins,617
-New York,70005,State Senate,SD30,Dem,Bill Perkins,593
-New York,70006,State Senate,SD30,Dem,Bill Perkins,634
-New York,70007,State Senate,SD30,Dem,Bill Perkins,519
-New York,70008,State Senate,SD30,Dem,Bill Perkins,483
-New York,70009,State Senate,SD30,Dem,Bill Perkins,635
-New York,70010,State Senate,SD30,Dem,Bill Perkins,617
-New York,70011,State Senate,SD30,Dem,Bill Perkins,481
-New York,70012,State Senate,SD30,Dem,Bill Perkins,448
-New York,70013,State Senate,SD30,Dem,Bill Perkins,376
-New York,70014,State Senate,SD30,Dem,Bill Perkins,385
-New York,70015,State Senate,SD30,Dem,Bill Perkins,376
-New York,70016,State Senate,SD30,Dem,Bill Perkins,585
-New York,70017,State Senate,SD30,Dem,Bill Perkins,154
-New York,70018,State Senate,SD30,Dem,Bill Perkins,320
-New York,70019,State Senate,SD30,Dem,Bill Perkins,646
-New York,70020,State Senate,SD30,Dem,Bill Perkins,580
-New York,70021,State Senate,SD30,Dem,Bill Perkins,483
-New York,70022,State Senate,SD30,Dem,Bill Perkins,434
-New York,70023,State Senate,SD30,Dem,Bill Perkins,443
-New York,70024,State Senate,SD30,Dem,Bill Perkins,512
-New York,70025,State Senate,SD30,Dem,Bill Perkins,677
-New York,70026,State Senate,SD30,Dem,Bill Perkins,665
-New York,70027,State Senate,SD30,Dem,Bill Perkins,434
-New York,70028,State Senate,SD30,Dem,Bill Perkins,482
-New York,70029,State Senate,SD30,Dem,Bill Perkins,368
-New York,70030,State Senate,SD30,Dem,Bill Perkins,378
-New York,70031,State Senate,SD30,Dem,Bill Perkins,421
-New York,70032,State Senate,SD30,Dem,Bill Perkins,370
-New York,70033,State Senate,SD30,Dem,Bill Perkins,479
-New York,70034,State Senate,SD30,Dem,Bill Perkins,461
-New York,70035,State Senate,SD30,Dem,Bill Perkins,390
-New York,70036,State Senate,SD30,Dem,Bill Perkins,502
-New York,70037,State Senate,SD30,Dem,Bill Perkins,536
-New York,70038,State Senate,SD30,Dem,Bill Perkins,332
-New York,70039,State Senate,SD30,Dem,Bill Perkins,344
-New York,70040,State Senate,SD30,Dem,Bill Perkins,641
-New York,70041,State Senate,SD30,Dem,Bill Perkins,587
-New York,70042,State Senate,SD30,Dem,Bill Perkins,443
-New York,70043,State Senate,SD30,Dem,Bill Perkins,636
-New York,70044,State Senate,SD30,Dem,Bill Perkins,531
-New York,70045,State Senate,SD30,Dem,Bill Perkins,487
-New York,70046,State Senate,SD30,Dem,Bill Perkins,694
-New York,70047,State Senate,SD30,Dem,Bill Perkins,590
-New York,70048,State Senate,SD30,Dem,Bill Perkins,577
-New York,70049,State Senate,SD30,Dem,Bill Perkins,525
-New York,70050,State Senate,SD30,Dem,Bill Perkins,551
-New York,70051,State Senate,SD30,Dem,Bill Perkins,288
-New York,70052,State Senate,SD30,Dem,Bill Perkins,486
-New York,70053,State Senate,SD30,Dem,Bill Perkins,598
-New York,70054,State Senate,SD30,Dem,Bill Perkins,343
-New York,70055,State Senate,SD30,Dem,Bill Perkins,289
-New York,70056,State Senate,SD30,Dem,Bill Perkins,484
-New York,70057,State Senate,SD30,Dem,Bill Perkins,383
-New York,70058,State Senate,SD30,Dem,Bill Perkins,462
-New York,70059,State Senate,SD30,Dem,Bill Perkins,367
-New York,70060,State Senate,SD30,Dem,Bill Perkins,476
-New York,70061,State Senate,SD30,Dem,Bill Perkins,534
-New York,70062,State Senate,SD30,Dem,Bill Perkins,586
-New York,70063,State Senate,SD30,Dem,Bill Perkins,486
-New York,70064,State Senate,SD30,Dem,Bill Perkins,16
-New York,70065,State Senate,SD30,Dem,Bill Perkins,475
-New York,70067,State Senate,SD30,Dem,Bill Perkins,523
-New York,70073,State Senate,SD30,Dem,Bill Perkins,255
-New York,70074,State Senate,SD30,Dem,Bill Perkins,612
-New York,70075,State Senate,SD30,Dem,Bill Perkins,508
-New York,70076,State Senate,SD30,Dem,Bill Perkins,432
-New York,70088,State Senate,SD30,Dem,Bill Perkins,338
-New York,70089,State Senate,SD30,Dem,Bill Perkins,534
-New York,71004,State Senate,SD30,Dem,Bill Perkins,361
-New York,71008,State Senate,SD30,Dem,Bill Perkins,458
-New York,71009,State Senate,SD30,Dem,Bill Perkins,413
-New York,71010,State Senate,SD30,Dem,Bill Perkins,141
-New York,71011,State Senate,SD30,Dem,Bill Perkins,535
-New York,71012,State Senate,SD30,Dem,Bill Perkins,594
-New York,71013,State Senate,SD30,Dem,Bill Perkins,339
-New York,71014,State Senate,SD30,Dem,Bill Perkins,420
-New York,71015,State Senate,SD30,Dem,Bill Perkins,300
-New York,71016,State Senate,SD30,Dem,Bill Perkins,673
-New York,71017,State Senate,SD30,Dem,Bill Perkins,304
-New York,71018,State Senate,SD30,Dem,Bill Perkins,660
-New York,71019,State Senate,SD30,Dem,Bill Perkins,679
-New York,71020,State Senate,SD30,Dem,Bill Perkins,701
-New York,71021,State Senate,SD30,Dem,Bill Perkins,576
-New York,71022,State Senate,SD30,Dem,Bill Perkins,631
-New York,71023,State Senate,SD30,Dem,Bill Perkins,525
-New York,71024,State Senate,SD30,Dem,Bill Perkins,596
-New York,71025,State Senate,SD30,Dem,Bill Perkins,297
-New York,71026,State Senate,SD30,Dem,Bill Perkins,540
-New York,71027,State Senate,SD30,Dem,Bill Perkins,344
-New York,71028,State Senate,SD30,Dem,Bill Perkins,326
-New York,71031,State Senate,SD30,Dem,Bill Perkins,303
-New York,71032,State Senate,SD30,Dem,Bill Perkins,452
-New York,71033,State Senate,SD30,Dem,Bill Perkins,495
-New York,71034,State Senate,SD30,Dem,Bill Perkins,528
-New York,71035,State Senate,SD30,Dem,Bill Perkins,320
-New York,71038,State Senate,SD30,Dem,Bill Perkins,466
-New York,71044,State Senate,SD30,Dem,Bill Perkins,517
-New York,71087,State Senate,SD30,Dem,Bill Perkins,179
-New York,71088,State Senate,SD30,Dem,Bill Perkins,807
-New York,71089,State Senate,SD30,Dem,Bill Perkins,379
-New York,71090,State Senate,SD30,Dem,Bill Perkins,440
-New York,71091,State Senate,SD30,Dem,Bill Perkins,413
-New York,72001,State Senate,SD30,Dem,Bill Perkins,285
-New York,67086,State Senate,SD30,WF,Bill Perkins,39
-New York,68013,State Senate,SD30,WF,Bill Perkins,7
-New York,68024,State Senate,SD30,WF,Bill Perkins,6
-New York,68025,State Senate,SD30,WF,Bill Perkins,5
-New York,68026,State Senate,SD30,WF,Bill Perkins,5
-New York,68027,State Senate,SD30,WF,Bill Perkins,4
-New York,68028,State Senate,SD30,WF,Bill Perkins,5
-New York,68029,State Senate,SD30,WF,Bill Perkins,4
-New York,68030,State Senate,SD30,WF,Bill Perkins,11
-New York,68031,State Senate,SD30,WF,Bill Perkins,16
-New York,68032,State Senate,SD30,WF,Bill Perkins,7
-New York,68033,State Senate,SD30,WF,Bill Perkins,23
-New York,68034,State Senate,SD30,WF,Bill Perkins,18
-New York,68035,State Senate,SD30,WF,Bill Perkins,5
-New York,68036,State Senate,SD30,WF,Bill Perkins,13
-New York,68047,State Senate,SD30,WF,Bill Perkins,9
-New York,68048,State Senate,SD30,WF,Bill Perkins,4
-New York,68049,State Senate,SD30,WF,Bill Perkins,6
-New York,68050,State Senate,SD30,WF,Bill Perkins,5
-New York,68051,State Senate,SD30,WF,Bill Perkins,7
-New York,68052,State Senate,SD30,WF,Bill Perkins,6
-New York,68053,State Senate,SD30,WF,Bill Perkins,3
-New York,68056,State Senate,SD30,WF,Bill Perkins,12
-New York,68057,State Senate,SD30,WF,Bill Perkins,10
-New York,68058,State Senate,SD30,WF,Bill Perkins,3
-New York,68059,State Senate,SD30,WF,Bill Perkins,2
-New York,68060,State Senate,SD30,WF,Bill Perkins,6
-New York,68061,State Senate,SD30,WF,Bill Perkins,5
-New York,68062,State Senate,SD30,WF,Bill Perkins,7
-New York,68063,State Senate,SD30,WF,Bill Perkins,11
-New York,68064,State Senate,SD30,WF,Bill Perkins,6
-New York,68065,State Senate,SD30,WF,Bill Perkins,2
-New York,68066,State Senate,SD30,WF,Bill Perkins,6
-New York,68067,State Senate,SD30,WF,Bill Perkins,2
-New York,68068,State Senate,SD30,WF,Bill Perkins,11
-New York,68069,State Senate,SD30,WF,Bill Perkins,4
-New York,68070,State Senate,SD30,WF,Bill Perkins,7
-New York,68073,State Senate,SD30,WF,Bill Perkins,26
-New York,68074,State Senate,SD30,WF,Bill Perkins,15
-New York,68078,State Senate,SD30,WF,Bill Perkins,23
-New York,68079,State Senate,SD30,WF,Bill Perkins,7
-New York,68080,State Senate,SD30,WF,Bill Perkins,34
-New York,68081,State Senate,SD30,WF,Bill Perkins,2
-New York,68082,State Senate,SD30,WF,Bill Perkins,16
-New York,68083,State Senate,SD30,WF,Bill Perkins,18
-New York,68084,State Senate,SD30,WF,Bill Perkins,10
-New York,68085,State Senate,SD30,WF,Bill Perkins,4
-New York,68086,State Senate,SD30,WF,Bill Perkins,8
-New York,68087,State Senate,SD30,WF,Bill Perkins,14
-New York,68088,State Senate,SD30,WF,Bill Perkins,14
-New York,68089,State Senate,SD30,WF,Bill Perkins,9
-New York,68090,State Senate,SD30,WF,Bill Perkins,13
-New York,68091,State Senate,SD30,WF,Bill Perkins,0
-New York,68092,State Senate,SD30,WF,Bill Perkins,6
-New York,68093,State Senate,SD30,WF,Bill Perkins,7
-New York,69013,State Senate,SD30,WF,Bill Perkins,23
-New York,69014,State Senate,SD30,WF,Bill Perkins,17
-New York,69015,State Senate,SD30,WF,Bill Perkins,28
-New York,69016,State Senate,SD30,WF,Bill Perkins,12
-New York,69017,State Senate,SD30,WF,Bill Perkins,18
-New York,69018,State Senate,SD30,WF,Bill Perkins,29
-New York,69019,State Senate,SD30,WF,Bill Perkins,11
-New York,69020,State Senate,SD30,WF,Bill Perkins,20
-New York,69021,State Senate,SD30,WF,Bill Perkins,21
-New York,69028,State Senate,SD30,WF,Bill Perkins,2
-New York,69029,State Senate,SD30,WF,Bill Perkins,42
-New York,69030,State Senate,SD30,WF,Bill Perkins,48
-New York,69031,State Senate,SD30,WF,Bill Perkins,32
-New York,69032,State Senate,SD30,WF,Bill Perkins,64
-New York,69033,State Senate,SD30,WF,Bill Perkins,45
-New York,69034,State Senate,SD30,WF,Bill Perkins,36
-New York,69035,State Senate,SD30,WF,Bill Perkins,10
-New York,69037,State Senate,SD30,WF,Bill Perkins,19
-New York,69038,State Senate,SD30,WF,Bill Perkins,21
-New York,69039,State Senate,SD30,WF,Bill Perkins,40
-New York,69040,State Senate,SD30,WF,Bill Perkins,35
-New York,69041,State Senate,SD30,WF,Bill Perkins,37
-New York,69042,State Senate,SD30,WF,Bill Perkins,33
-New York,69043,State Senate,SD30,WF,Bill Perkins,39
-New York,69044,State Senate,SD30,WF,Bill Perkins,35
-New York,69052,State Senate,SD30,WF,Bill Perkins,25
-New York,69053,State Senate,SD30,WF,Bill Perkins,2
-New York,69054,State Senate,SD30,WF,Bill Perkins,14
-New York,69055,State Senate,SD30,WF,Bill Perkins,23
-New York,69056,State Senate,SD30,WF,Bill Perkins,3
-New York,69057,State Senate,SD30,WF,Bill Perkins,17
-New York,69058,State Senate,SD30,WF,Bill Perkins,24
-New York,69059,State Senate,SD30,WF,Bill Perkins,17
-New York,69067,State Senate,SD30,WF,Bill Perkins,10
-New York,69068,State Senate,SD30,WF,Bill Perkins,21
-New York,69069,State Senate,SD30,WF,Bill Perkins,45
-New York,69070,State Senate,SD30,WF,Bill Perkins,14
-New York,69071,State Senate,SD30,WF,Bill Perkins,29
-New York,69074,State Senate,SD30,WF,Bill Perkins,26
-New York,69075,State Senate,SD30,WF,Bill Perkins,20
-New York,69076,State Senate,SD30,WF,Bill Perkins,18
-New York,69080,State Senate,SD30,WF,Bill Perkins,19
-New York,69081,State Senate,SD30,WF,Bill Perkins,20
-New York,69082,State Senate,SD30,WF,Bill Perkins,15
-New York,69083,State Senate,SD30,WF,Bill Perkins,16
-New York,69087,State Senate,SD30,WF,Bill Perkins,50
-New York,69089,State Senate,SD30,WF,Bill Perkins,2
-New York,69090,State Senate,SD30,WF,Bill Perkins,36
-New York,69091,State Senate,SD30,WF,Bill Perkins,29
-New York,69093,State Senate,SD30,WF,Bill Perkins,68
-New York,69094,State Senate,SD30,WF,Bill Perkins,26
-New York,69095,State Senate,SD30,WF,Bill Perkins,57
-New York,69097,State Senate,SD30,WF,Bill Perkins,43
-New York,69098,State Senate,SD30,WF,Bill Perkins,41
-New York,69099,State Senate,SD30,WF,Bill Perkins,78
-New York,69100,State Senate,SD30,WF,Bill Perkins,22
-New York,69101,State Senate,SD30,WF,Bill Perkins,10
-New York,69102,State Senate,SD30,WF,Bill Perkins,5
-New York,69103,State Senate,SD30,WF,Bill Perkins,3
-New York,70001,State Senate,SD30,WF,Bill Perkins,17
-New York,70002,State Senate,SD30,WF,Bill Perkins,9
-New York,70003,State Senate,SD30,WF,Bill Perkins,19
-New York,70004,State Senate,SD30,WF,Bill Perkins,20
-New York,70005,State Senate,SD30,WF,Bill Perkins,21
-New York,70006,State Senate,SD30,WF,Bill Perkins,27
-New York,70007,State Senate,SD30,WF,Bill Perkins,20
-New York,70008,State Senate,SD30,WF,Bill Perkins,28
-New York,70009,State Senate,SD30,WF,Bill Perkins,30
-New York,70010,State Senate,SD30,WF,Bill Perkins,21
-New York,70011,State Senate,SD30,WF,Bill Perkins,23
-New York,70012,State Senate,SD30,WF,Bill Perkins,21
-New York,70013,State Senate,SD30,WF,Bill Perkins,4
-New York,70014,State Senate,SD30,WF,Bill Perkins,22
-New York,70015,State Senate,SD30,WF,Bill Perkins,9
-New York,70016,State Senate,SD30,WF,Bill Perkins,22
-New York,70017,State Senate,SD30,WF,Bill Perkins,6
-New York,70018,State Senate,SD30,WF,Bill Perkins,18
-New York,70019,State Senate,SD30,WF,Bill Perkins,37
-New York,70020,State Senate,SD30,WF,Bill Perkins,15
-New York,70021,State Senate,SD30,WF,Bill Perkins,23
-New York,70022,State Senate,SD30,WF,Bill Perkins,23
-New York,70023,State Senate,SD30,WF,Bill Perkins,18
-New York,70024,State Senate,SD30,WF,Bill Perkins,15
-New York,70025,State Senate,SD30,WF,Bill Perkins,15
-New York,70026,State Senate,SD30,WF,Bill Perkins,21
-New York,70027,State Senate,SD30,WF,Bill Perkins,18
-New York,70028,State Senate,SD30,WF,Bill Perkins,17
-New York,70029,State Senate,SD30,WF,Bill Perkins,7
-New York,70030,State Senate,SD30,WF,Bill Perkins,7
-New York,70031,State Senate,SD30,WF,Bill Perkins,9
-New York,70032,State Senate,SD30,WF,Bill Perkins,6
-New York,70033,State Senate,SD30,WF,Bill Perkins,13
-New York,70034,State Senate,SD30,WF,Bill Perkins,17
-New York,70035,State Senate,SD30,WF,Bill Perkins,15
-New York,70036,State Senate,SD30,WF,Bill Perkins,17
-New York,70037,State Senate,SD30,WF,Bill Perkins,8
-New York,70038,State Senate,SD30,WF,Bill Perkins,4
-New York,70039,State Senate,SD30,WF,Bill Perkins,5
-New York,70040,State Senate,SD30,WF,Bill Perkins,17
-New York,70041,State Senate,SD30,WF,Bill Perkins,17
-New York,70042,State Senate,SD30,WF,Bill Perkins,11
-New York,70043,State Senate,SD30,WF,Bill Perkins,41
-New York,70044,State Senate,SD30,WF,Bill Perkins,23
-New York,70045,State Senate,SD30,WF,Bill Perkins,18
-New York,70046,State Senate,SD30,WF,Bill Perkins,9
-New York,70047,State Senate,SD30,WF,Bill Perkins,18
-New York,70048,State Senate,SD30,WF,Bill Perkins,14
-New York,70049,State Senate,SD30,WF,Bill Perkins,8
-New York,70050,State Senate,SD30,WF,Bill Perkins,18
-New York,70051,State Senate,SD30,WF,Bill Perkins,8
-New York,70052,State Senate,SD30,WF,Bill Perkins,11
-New York,70053,State Senate,SD30,WF,Bill Perkins,13
-New York,70054,State Senate,SD30,WF,Bill Perkins,1
-New York,70055,State Senate,SD30,WF,Bill Perkins,7
-New York,70056,State Senate,SD30,WF,Bill Perkins,8
-New York,70057,State Senate,SD30,WF,Bill Perkins,6
-New York,70058,State Senate,SD30,WF,Bill Perkins,10
-New York,70059,State Senate,SD30,WF,Bill Perkins,8
-New York,70060,State Senate,SD30,WF,Bill Perkins,5
-New York,70061,State Senate,SD30,WF,Bill Perkins,5
-New York,70062,State Senate,SD30,WF,Bill Perkins,14
-New York,70063,State Senate,SD30,WF,Bill Perkins,9
-New York,70064,State Senate,SD30,WF,Bill Perkins,6
-New York,70065,State Senate,SD30,WF,Bill Perkins,40
-New York,70067,State Senate,SD30,WF,Bill Perkins,43
-New York,70073,State Senate,SD30,WF,Bill Perkins,5
-New York,70074,State Senate,SD30,WF,Bill Perkins,30
-New York,70075,State Senate,SD30,WF,Bill Perkins,14
-New York,70076,State Senate,SD30,WF,Bill Perkins,6
-New York,70088,State Senate,SD30,WF,Bill Perkins,16
-New York,70089,State Senate,SD30,WF,Bill Perkins,23
-New York,71004,State Senate,SD30,WF,Bill Perkins,9
-New York,71008,State Senate,SD30,WF,Bill Perkins,19
-New York,71009,State Senate,SD30,WF,Bill Perkins,17
-New York,71010,State Senate,SD30,WF,Bill Perkins,4
-New York,71011,State Senate,SD30,WF,Bill Perkins,23
-New York,71012,State Senate,SD30,WF,Bill Perkins,23
-New York,71013,State Senate,SD30,WF,Bill Perkins,10
-New York,71014,State Senate,SD30,WF,Bill Perkins,3
-New York,71015,State Senate,SD30,WF,Bill Perkins,5
-New York,71016,State Senate,SD30,WF,Bill Perkins,16
-New York,71017,State Senate,SD30,WF,Bill Perkins,7
-New York,71018,State Senate,SD30,WF,Bill Perkins,8
-New York,71019,State Senate,SD30,WF,Bill Perkins,10
-New York,71020,State Senate,SD30,WF,Bill Perkins,7
-New York,71021,State Senate,SD30,WF,Bill Perkins,10
-New York,71022,State Senate,SD30,WF,Bill Perkins,5
-New York,71023,State Senate,SD30,WF,Bill Perkins,14
-New York,71024,State Senate,SD30,WF,Bill Perkins,16
-New York,71025,State Senate,SD30,WF,Bill Perkins,7
-New York,71026,State Senate,SD30,WF,Bill Perkins,28
-New York,71027,State Senate,SD30,WF,Bill Perkins,22
-New York,71028,State Senate,SD30,WF,Bill Perkins,12
-New York,71031,State Senate,SD30,WF,Bill Perkins,14
-New York,71032,State Senate,SD30,WF,Bill Perkins,19
-New York,71033,State Senate,SD30,WF,Bill Perkins,19
-New York,71034,State Senate,SD30,WF,Bill Perkins,16
-New York,71035,State Senate,SD30,WF,Bill Perkins,7
-New York,71038,State Senate,SD30,WF,Bill Perkins,11
-New York,71044,State Senate,SD30,WF,Bill Perkins,16
-New York,71087,State Senate,SD30,WF,Bill Perkins,7
-New York,71088,State Senate,SD30,WF,Bill Perkins,9
-New York,71089,State Senate,SD30,WF,Bill Perkins,6
-New York,71090,State Senate,SD30,WF,Bill Perkins,11
-New York,71091,State Senate,SD30,WF,Bill Perkins,6
-New York,72001,State Senate,SD30,WF,Bill Perkins,13
-New York,67086,State Senate,SD30,Ind,writein,2
-New York,68013,State Senate,SD30,Ind,writein,1
-New York,68024,State Senate,SD30,Ind,writein,0
-New York,68025,State Senate,SD30,Ind,writein,0
-New York,68026,State Senate,SD30,Ind,writein,0
-New York,68027,State Senate,SD30,Ind,writein,0
-New York,68028,State Senate,SD30,Ind,writein,0
-New York,68029,State Senate,SD30,Ind,writein,0
-New York,68030,State Senate,SD30,Ind,writein,0
-New York,68031,State Senate,SD30,Ind,writein,0
-New York,68032,State Senate,SD30,Ind,writein,1
-New York,68033,State Senate,SD30,Ind,writein,0
-New York,68034,State Senate,SD30,Ind,writein,2
-New York,68035,State Senate,SD30,Ind,writein,0
-New York,68036,State Senate,SD30,Ind,writein,0
-New York,68047,State Senate,SD30,Ind,writein,1
-New York,68048,State Senate,SD30,Ind,writein,0
-New York,68049,State Senate,SD30,Ind,writein,0
-New York,68050,State Senate,SD30,Ind,writein,0
-New York,68051,State Senate,SD30,Ind,writein,0
-New York,68052,State Senate,SD30,Ind,writein,0
-New York,68053,State Senate,SD30,Ind,writein,0
-New York,68056,State Senate,SD30,Ind,writein,1
-New York,68057,State Senate,SD30,Ind,writein,2
-New York,68058,State Senate,SD30,Ind,writein,0
-New York,68059,State Senate,SD30,Ind,writein,0
-New York,68060,State Senate,SD30,Ind,writein,0
-New York,68061,State Senate,SD30,Ind,writein,0
-New York,68062,State Senate,SD30,Ind,writein,0
-New York,68063,State Senate,SD30,Ind,writein,0
-New York,68064,State Senate,SD30,Ind,writein,0
-New York,68065,State Senate,SD30,Ind,writein,0
-New York,68066,State Senate,SD30,Ind,writein,0
-New York,68067,State Senate,SD30,Ind,writein,1
-New York,68068,State Senate,SD30,Ind,writein,0
-New York,68069,State Senate,SD30,Ind,writein,0
-New York,68070,State Senate,SD30,Ind,writein,0
-New York,68073,State Senate,SD30,Ind,writein,0
-New York,68074,State Senate,SD30,Ind,writein,0
-New York,68078,State Senate,SD30,Ind,writein,0
-New York,68079,State Senate,SD30,Ind,writein,0
-New York,68080,State Senate,SD30,Ind,writein,2
-New York,68081,State Senate,SD30,Ind,writein,0
-New York,68082,State Senate,SD30,Ind,writein,1
-New York,68083,State Senate,SD30,Ind,writein,0
-New York,68084,State Senate,SD30,Ind,writein,0
-New York,68085,State Senate,SD30,Ind,writein,0
-New York,68086,State Senate,SD30,Ind,writein,1
-New York,68087,State Senate,SD30,Ind,writein,0
-New York,68088,State Senate,SD30,Ind,writein,0
-New York,68089,State Senate,SD30,Ind,writein,0
-New York,68090,State Senate,SD30,Ind,writein,0
-New York,68091,State Senate,SD30,Ind,writein,0
-New York,68092,State Senate,SD30,Ind,writein,0
-New York,68093,State Senate,SD30,Ind,writein,0
-New York,69013,State Senate,SD30,Ind,writein,2
-New York,69014,State Senate,SD30,Ind,writein,0
-New York,69015,State Senate,SD30,Ind,writein,0
-New York,69016,State Senate,SD30,Ind,writein,1
-New York,69017,State Senate,SD30,Ind,writein,1
-New York,69018,State Senate,SD30,Ind,writein,0
-New York,69019,State Senate,SD30,Ind,writein,0
-New York,69020,State Senate,SD30,Ind,writein,1
-New York,69021,State Senate,SD30,Ind,writein,2
-New York,69028,State Senate,SD30,Ind,writein,0
-New York,69029,State Senate,SD30,Ind,writein,1
-New York,69030,State Senate,SD30,Ind,writein,1
-New York,69031,State Senate,SD30,Ind,writein,0
-New York,69032,State Senate,SD30,Ind,writein,0
-New York,69033,State Senate,SD30,Ind,writein,3
-New York,69034,State Senate,SD30,Ind,writein,1
-New York,69035,State Senate,SD30,Ind,writein,2
-New York,69037,State Senate,SD30,Ind,writein,1
-New York,69038,State Senate,SD30,Ind,writein,0
-New York,69039,State Senate,SD30,Ind,writein,2
-New York,69040,State Senate,SD30,Ind,writein,0
-New York,69041,State Senate,SD30,Ind,writein,2
-New York,69042,State Senate,SD30,Ind,writein,3
-New York,69043,State Senate,SD30,Ind,writein,0
-New York,69044,State Senate,SD30,Ind,writein,1
-New York,69052,State Senate,SD30,Ind,writein,2
-New York,69053,State Senate,SD30,Ind,writein,0
-New York,69054,State Senate,SD30,Ind,writein,0
-New York,69055,State Senate,SD30,Ind,writein,1
-New York,69056,State Senate,SD30,Ind,writein,0
-New York,69057,State Senate,SD30,Ind,writein,1
-New York,69058,State Senate,SD30,Ind,writein,0
-New York,69059,State Senate,SD30,Ind,writein,0
-New York,69067,State Senate,SD30,Ind,writein,0
-New York,69068,State Senate,SD30,Ind,writein,1
-New York,69069,State Senate,SD30,Ind,writein,2
-New York,69070,State Senate,SD30,Ind,writein,0
-New York,69071,State Senate,SD30,Ind,writein,0
-New York,69074,State Senate,SD30,Ind,writein,2
-New York,69075,State Senate,SD30,Ind,writein,2
-New York,69076,State Senate,SD30,Ind,writein,0
-New York,69080,State Senate,SD30,Ind,writein,2
-New York,69081,State Senate,SD30,Ind,writein,0
-New York,69082,State Senate,SD30,Ind,writein,0
-New York,69083,State Senate,SD30,Ind,writein,0
-New York,69087,State Senate,SD30,Ind,writein,1
-New York,69089,State Senate,SD30,Ind,writein,0
-New York,69090,State Senate,SD30,Ind,writein,1
-New York,69091,State Senate,SD30,Ind,writein,5
-New York,69093,State Senate,SD30,Ind,writein,2
-New York,69094,State Senate,SD30,Ind,writein,1
-New York,69095,State Senate,SD30,Ind,writein,4
-New York,69097,State Senate,SD30,Ind,writein,1
-New York,69098,State Senate,SD30,Ind,writein,4
-New York,69099,State Senate,SD30,Ind,writein,0
-New York,69100,State Senate,SD30,Ind,writein,0
-New York,69101,State Senate,SD30,Ind,writein,0
-New York,69102,State Senate,SD30,Ind,writein,1
-New York,69103,State Senate,SD30,Ind,writein,0
-New York,70001,State Senate,SD30,Ind,writein,1
-New York,70002,State Senate,SD30,Ind,writein,0
-New York,70003,State Senate,SD30,Ind,writein,3
-New York,70004,State Senate,SD30,Ind,writein,0
-New York,70005,State Senate,SD30,Ind,writein,0
-New York,70006,State Senate,SD30,Ind,writein,4
-New York,70007,State Senate,SD30,Ind,writein,3
-New York,70008,State Senate,SD30,Ind,writein,0
-New York,70009,State Senate,SD30,Ind,writein,2
-New York,70010,State Senate,SD30,Ind,writein,0
-New York,70011,State Senate,SD30,Ind,writein,1
-New York,70012,State Senate,SD30,Ind,writein,1
-New York,70013,State Senate,SD30,Ind,writein,0
-New York,70014,State Senate,SD30,Ind,writein,1
-New York,70015,State Senate,SD30,Ind,writein,0
-New York,70016,State Senate,SD30,Ind,writein,1
-New York,70017,State Senate,SD30,Ind,writein,0
-New York,70018,State Senate,SD30,Ind,writein,1
-New York,70019,State Senate,SD30,Ind,writein,0
-New York,70020,State Senate,SD30,Ind,writein,2
-New York,70021,State Senate,SD30,Ind,writein,0
-New York,70022,State Senate,SD30,Ind,writein,0
-New York,70023,State Senate,SD30,Ind,writein,1
-New York,70024,State Senate,SD30,Ind,writein,1
-New York,70025,State Senate,SD30,Ind,writein,2
-New York,70026,State Senate,SD30,Ind,writein,1
-New York,70027,State Senate,SD30,Ind,writein,1
-New York,70028,State Senate,SD30,Ind,writein,1
-New York,70029,State Senate,SD30,Ind,writein,1
-New York,70030,State Senate,SD30,Ind,writein,0
-New York,70031,State Senate,SD30,Ind,writein,0
-New York,70032,State Senate,SD30,Ind,writein,0
-New York,70033,State Senate,SD30,Ind,writein,2
-New York,70034,State Senate,SD30,Ind,writein,0
-New York,70035,State Senate,SD30,Ind,writein,1
-New York,70036,State Senate,SD30,Ind,writein,0
-New York,70037,State Senate,SD30,Ind,writein,0
-New York,70038,State Senate,SD30,Ind,writein,0
-New York,70039,State Senate,SD30,Ind,writein,1
-New York,70040,State Senate,SD30,Ind,writein,0
-New York,70041,State Senate,SD30,Ind,writein,1
-New York,70042,State Senate,SD30,Ind,writein,0
-New York,70043,State Senate,SD30,Ind,writein,3
-New York,70044,State Senate,SD30,Ind,writein,0
-New York,70045,State Senate,SD30,Ind,writein,0
-New York,70046,State Senate,SD30,Ind,writein,0
-New York,70047,State Senate,SD30,Ind,writein,0
-New York,70048,State Senate,SD30,Ind,writein,1
-New York,70049,State Senate,SD30,Ind,writein,1
-New York,70050,State Senate,SD30,Ind,writein,0
-New York,70051,State Senate,SD30,Ind,writein,0
-New York,70052,State Senate,SD30,Ind,writein,0
-New York,70053,State Senate,SD30,Ind,writein,0
-New York,70054,State Senate,SD30,Ind,writein,0
-New York,70055,State Senate,SD30,Ind,writein,0
-New York,70056,State Senate,SD30,Ind,writein,1
-New York,70057,State Senate,SD30,Ind,writein,0
-New York,70058,State Senate,SD30,Ind,writein,0
-New York,70059,State Senate,SD30,Ind,writein,0
-New York,70060,State Senate,SD30,Ind,writein,0
-New York,70061,State Senate,SD30,Ind,writein,0
-New York,70062,State Senate,SD30,Ind,writein,0
-New York,70063,State Senate,SD30,Ind,writein,1
-New York,70064,State Senate,SD30,Ind,writein,0
-New York,70065,State Senate,SD30,Ind,writein,4
-New York,70067,State Senate,SD30,Ind,writein,1
-New York,70073,State Senate,SD30,Ind,writein,1
-New York,70074,State Senate,SD30,Ind,writein,0
-New York,70075,State Senate,SD30,Ind,writein,1
-New York,70076,State Senate,SD30,Ind,writein,0
-New York,70088,State Senate,SD30,Ind,writein,0
-New York,70089,State Senate,SD30,Ind,writein,1
-New York,71004,State Senate,SD30,Ind,writein,0
-New York,71008,State Senate,SD30,Ind,writein,0
-New York,71009,State Senate,SD30,Ind,writein,2
-New York,71010,State Senate,SD30,Ind,writein,2
-New York,71011,State Senate,SD30,Ind,writein,0
-New York,71012,State Senate,SD30,Ind,writein,2
-New York,71013,State Senate,SD30,Ind,writein,2
-New York,71014,State Senate,SD30,Ind,writein,0
-New York,71015,State Senate,SD30,Ind,writein,0
-New York,71016,State Senate,SD30,Ind,writein,0
-New York,71017,State Senate,SD30,Ind,writein,0
-New York,71018,State Senate,SD30,Ind,writein,0
-New York,71019,State Senate,SD30,Ind,writein,0
-New York,71020,State Senate,SD30,Ind,writein,0
-New York,71021,State Senate,SD30,Ind,writein,1
-New York,71022,State Senate,SD30,Ind,writein,0
-New York,71023,State Senate,SD30,Ind,writein,0
-New York,71024,State Senate,SD30,Ind,writein,1
-New York,71025,State Senate,SD30,Ind,writein,0
-New York,71026,State Senate,SD30,Ind,writein,0
-New York,71027,State Senate,SD30,Ind,writein,0
-New York,71028,State Senate,SD30,Ind,writein,1
-New York,71031,State Senate,SD30,Ind,writein,1
-New York,71032,State Senate,SD30,Ind,writein,1
-New York,71033,State Senate,SD30,Ind,writein,2
-New York,71034,State Senate,SD30,Ind,writein,1
-New York,71035,State Senate,SD30,Ind,writein,0
-New York,71038,State Senate,SD30,Ind,writein,2
-New York,71044,State Senate,SD30,Ind,writein,1
-New York,71087,State Senate,SD30,Ind,writein,0
-New York,71088,State Senate,SD30,Ind,writein,0
-New York,71089,State Senate,SD30,Ind,writein,0
-New York,71090,State Senate,SD30,Ind,writein,0
-New York,71091,State Senate,SD30,Ind,writein,0
-New York,72001,State Senate,SD30,Ind,writein,2
-New York,67001,State Senate,SD31,Dem,Adriano Espillait,383
-New York,67003,State Senate,SD31,Dem,Adriano Espillait,535
-New York,67005,State Senate,SD31,Dem,Adriano Espillait,453
-New York,67007,State Senate,SD31,Dem,Adriano Espillait,286
-New York,67025,State Senate,SD31,Dem,Adriano Espillait,313
-New York,67026,State Senate,SD31,Dem,Adriano Espillait,391
-New York,67027,State Senate,SD31,Dem,Adriano Espillait,449
-New York,67028,State Senate,SD31,Dem,Adriano Espillait,655
-New York,67029,State Senate,SD31,Dem,Adriano Espillait,78
-New York,67030,State Senate,SD31,Dem,Adriano Espillait,138
-New York,67051,State Senate,SD31,Dem,Adriano Espillait,52
-New York,67067,State Senate,SD31,Dem,Adriano Espillait,502
-New York,67079,State Senate,SD31,Dem,Adriano Espillait,324
-New York,67080,State Senate,SD31,Dem,Adriano Espillait,555
-New York,67081,State Senate,SD31,Dem,Adriano Espillait,385
-New York,67082,State Senate,SD31,Dem,Adriano Espillait,430
-New York,67083,State Senate,SD31,Dem,Adriano Espillait,552
-New York,67084,State Senate,SD31,Dem,Adriano Espillait,328
-New York,67085,State Senate,SD31,Dem,Adriano Espillait,585
-New York,67087,State Senate,SD31,Dem,Adriano Espillait,514
-New York,67088,State Senate,SD31,Dem,Adriano Espillait,589
-New York,67089,State Senate,SD31,Dem,Adriano Espillait,577
-New York,67090,State Senate,SD31,Dem,Adriano Espillait,572
-New York,67091,State Senate,SD31,Dem,Adriano Espillait,422
-New York,67092,State Senate,SD31,Dem,Adriano Espillait,383
-New York,67093,State Senate,SD31,Dem,Adriano Espillait,378
-New York,67094,State Senate,SD31,Dem,Adriano Espillait,481
-New York,67095,State Senate,SD31,Dem,Adriano Espillait,331
-New York,67096,State Senate,SD31,Dem,Adriano Espillait,324
-New York,67097,State Senate,SD31,Dem,Adriano Espillait,385
-New York,67098,State Senate,SD31,Dem,Adriano Espillait,415
-New York,67099,State Senate,SD31,Dem,Adriano Espillait,359
-New York,67100,State Senate,SD31,Dem,Adriano Espillait,0
-New York,67101,State Senate,SD31,Dem,Adriano Espillait,0
-New York,69022,State Senate,SD31,Dem,Adriano Espillait,452
-New York,69023,State Senate,SD31,Dem,Adriano Espillait,304
-New York,69024,State Senate,SD31,Dem,Adriano Espillait,416
-New York,69025,State Senate,SD31,Dem,Adriano Espillait,489
-New York,69026,State Senate,SD31,Dem,Adriano Espillait,595
-New York,69027,State Senate,SD31,Dem,Adriano Espillait,212
-New York,69036,State Senate,SD31,Dem,Adriano Espillait,70
-New York,69045,State Senate,SD31,Dem,Adriano Espillait,340
-New York,69046,State Senate,SD31,Dem,Adriano Espillait,550
-New York,69047,State Senate,SD31,Dem,Adriano Espillait,543
-New York,69048,State Senate,SD31,Dem,Adriano Espillait,437
-New York,69049,State Senate,SD31,Dem,Adriano Espillait,444
-New York,69050,State Senate,SD31,Dem,Adriano Espillait,390
-New York,69051,State Senate,SD31,Dem,Adriano Espillait,382
-New York,69060,State Senate,SD31,Dem,Adriano Espillait,475
-New York,69061,State Senate,SD31,Dem,Adriano Espillait,414
-New York,69062,State Senate,SD31,Dem,Adriano Espillait,413
-New York,69063,State Senate,SD31,Dem,Adriano Espillait,271
-New York,69064,State Senate,SD31,Dem,Adriano Espillait,429
-New York,69065,State Senate,SD31,Dem,Adriano Espillait,399
-New York,69066,State Senate,SD31,Dem,Adriano Espillait,531
-New York,69072,State Senate,SD31,Dem,Adriano Espillait,633
-New York,69073,State Senate,SD31,Dem,Adriano Espillait,632
-New York,69077,State Senate,SD31,Dem,Adriano Espillait,510
-New York,69078,State Senate,SD31,Dem,Adriano Espillait,430
-New York,69079,State Senate,SD31,Dem,Adriano Espillait,384
-New York,69084,State Senate,SD31,Dem,Adriano Espillait,399
-New York,69085,State Senate,SD31,Dem,Adriano Espillait,268
-New York,69086,State Senate,SD31,Dem,Adriano Espillait,587
-New York,69088,State Senate,SD31,Dem,Adriano Espillait,44
-New York,69092,State Senate,SD31,Dem,Adriano Espillait,429
-New York,69096,State Senate,SD31,Dem,Adriano Espillait,34
-New York,69105,State Senate,SD31,Dem,Adriano Espillait,0
-New York,69106,State Senate,SD31,Dem,Adriano Espillait,0
-New York,69107,State Senate,SD31,Dem,Adriano Espillait,0
-New York,70068,State Senate,SD31,Dem,Adriano Espillait,380
-New York,70070,State Senate,SD31,Dem,Adriano Espillait,269
-New York,70071,State Senate,SD31,Dem,Adriano Espillait,525
-New York,70072,State Senate,SD31,Dem,Adriano Espillait,594
-New York,70077,State Senate,SD31,Dem,Adriano Espillait,391
-New York,70078,State Senate,SD31,Dem,Adriano Espillait,282
-New York,70079,State Senate,SD31,Dem,Adriano Espillait,296
-New York,70080,State Senate,SD31,Dem,Adriano Espillait,396
-New York,70081,State Senate,SD31,Dem,Adriano Espillait,366
-New York,70082,State Senate,SD31,Dem,Adriano Espillait,347
-New York,70083,State Senate,SD31,Dem,Adriano Espillait,264
-New York,70084,State Senate,SD31,Dem,Adriano Espillait,319
-New York,70085,State Senate,SD31,Dem,Adriano Espillait,451
-New York,70086,State Senate,SD31,Dem,Adriano Espillait,407
-New York,70087,State Senate,SD31,Dem,Adriano Espillait,475
-New York,70090,State Senate,SD31,Dem,Adriano Espillait,0
-New York,71001,State Senate,SD31,Dem,Adriano Espillait,499
-New York,71002,State Senate,SD31,Dem,Adriano Espillait,406
-New York,71003,State Senate,SD31,Dem,Adriano Espillait,249
-New York,71005,State Senate,SD31,Dem,Adriano Espillait,514
-New York,71006,State Senate,SD31,Dem,Adriano Espillait,418
-New York,71007,State Senate,SD31,Dem,Adriano Espillait,293
-New York,71029,State Senate,SD31,Dem,Adriano Espillait,303
-New York,71030,State Senate,SD31,Dem,Adriano Espillait,326
-New York,71036,State Senate,SD31,Dem,Adriano Espillait,302
-New York,71037,State Senate,SD31,Dem,Adriano Espillait,462
-New York,71039,State Senate,SD31,Dem,Adriano Espillait,360
-New York,71040,State Senate,SD31,Dem,Adriano Espillait,436
-New York,71041,State Senate,SD31,Dem,Adriano Espillait,524
-New York,71042,State Senate,SD31,Dem,Adriano Espillait,401
-New York,71043,State Senate,SD31,Dem,Adriano Espillait,501
-New York,71045,State Senate,SD31,Dem,Adriano Espillait,306
-New York,71046,State Senate,SD31,Dem,Adriano Espillait,451
-New York,71047,State Senate,SD31,Dem,Adriano Espillait,373
-New York,71048,State Senate,SD31,Dem,Adriano Espillait,361
-New York,71049,State Senate,SD31,Dem,Adriano Espillait,457
-New York,71050,State Senate,SD31,Dem,Adriano Espillait,434
-New York,71051,State Senate,SD31,Dem,Adriano Espillait,111
-New York,71052,State Senate,SD31,Dem,Adriano Espillait,427
-New York,71053,State Senate,SD31,Dem,Adriano Espillait,341
-New York,71054,State Senate,SD31,Dem,Adriano Espillait,389
-New York,71055,State Senate,SD31,Dem,Adriano Espillait,282
-New York,71056,State Senate,SD31,Dem,Adriano Espillait,504
-New York,71057,State Senate,SD31,Dem,Adriano Espillait,298
-New York,71058,State Senate,SD31,Dem,Adriano Espillait,311
-New York,71059,State Senate,SD31,Dem,Adriano Espillait,267
-New York,71060,State Senate,SD31,Dem,Adriano Espillait,337
-New York,71061,State Senate,SD31,Dem,Adriano Espillait,417
-New York,71062,State Senate,SD31,Dem,Adriano Espillait,302
-New York,71063,State Senate,SD31,Dem,Adriano Espillait,467
-New York,71064,State Senate,SD31,Dem,Adriano Espillait,437
-New York,71065,State Senate,SD31,Dem,Adriano Espillait,554
-New York,71066,State Senate,SD31,Dem,Adriano Espillait,498
-New York,71067,State Senate,SD31,Dem,Adriano Espillait,71
-New York,71068,State Senate,SD31,Dem,Adriano Espillait,96
-New York,71069,State Senate,SD31,Dem,Adriano Espillait,428
-New York,71070,State Senate,SD31,Dem,Adriano Espillait,483
-New York,71071,State Senate,SD31,Dem,Adriano Espillait,79
-New York,71072,State Senate,SD31,Dem,Adriano Espillait,424
-New York,71073,State Senate,SD31,Dem,Adriano Espillait,353
-New York,71074,State Senate,SD31,Dem,Adriano Espillait,373
-New York,71075,State Senate,SD31,Dem,Adriano Espillait,399
-New York,71076,State Senate,SD31,Dem,Adriano Espillait,575
-New York,71077,State Senate,SD31,Dem,Adriano Espillait,474
-New York,71078,State Senate,SD31,Dem,Adriano Espillait,484
-New York,71079,State Senate,SD31,Dem,Adriano Espillait,416
-New York,71080,State Senate,SD31,Dem,Adriano Espillait,291
-New York,71081,State Senate,SD31,Dem,Adriano Espillait,364
-New York,71082,State Senate,SD31,Dem,Adriano Espillait,321
-New York,71083,State Senate,SD31,Dem,Adriano Espillait,630
-New York,71084,State Senate,SD31,Dem,Adriano Espillait,584
-New York,71085,State Senate,SD31,Dem,Adriano Espillait,343
-New York,71086,State Senate,SD31,Dem,Adriano Espillait,65
-New York,71092,State Senate,SD31,Dem,Adriano Espillait,0
-New York,72002,State Senate,SD31,Dem,Adriano Espillait,483
-New York,72003,State Senate,SD31,Dem,Adriano Espillait,349
-New York,72004,State Senate,SD31,Dem,Adriano Espillait,537
-New York,72005,State Senate,SD31,Dem,Adriano Espillait,477
-New York,72006,State Senate,SD31,Dem,Adriano Espillait,467
-New York,72007,State Senate,SD31,Dem,Adriano Espillait,453
-New York,72008,State Senate,SD31,Dem,Adriano Espillait,500
-New York,72009,State Senate,SD31,Dem,Adriano Espillait,557
-New York,72010,State Senate,SD31,Dem,Adriano Espillait,426
-New York,72011,State Senate,SD31,Dem,Adriano Espillait,446
-New York,72012,State Senate,SD31,Dem,Adriano Espillait,477
-New York,72013,State Senate,SD31,Dem,Adriano Espillait,320
-New York,72014,State Senate,SD31,Dem,Adriano Espillait,496
-New York,72015,State Senate,SD31,Dem,Adriano Espillait,436
-New York,72016,State Senate,SD31,Dem,Adriano Espillait,469
-New York,72017,State Senate,SD31,Dem,Adriano Espillait,476
-New York,72018,State Senate,SD31,Dem,Adriano Espillait,279
-New York,72019,State Senate,SD31,Dem,Adriano Espillait,305
-New York,72020,State Senate,SD31,Dem,Adriano Espillait,480
-New York,72021,State Senate,SD31,Dem,Adriano Espillait,383
-New York,72022,State Senate,SD31,Dem,Adriano Espillait,395
-New York,72023,State Senate,SD31,Dem,Adriano Espillait,518
-New York,72024,State Senate,SD31,Dem,Adriano Espillait,485
-New York,72025,State Senate,SD31,Dem,Adriano Espillait,393
-New York,72026,State Senate,SD31,Dem,Adriano Espillait,267
-New York,72027,State Senate,SD31,Dem,Adriano Espillait,301
-New York,72028,State Senate,SD31,Dem,Adriano Espillait,210
-New York,72029,State Senate,SD31,Dem,Adriano Espillait,388
-New York,72030,State Senate,SD31,Dem,Adriano Espillait,465
-New York,72031,State Senate,SD31,Dem,Adriano Espillait,515
-New York,72032,State Senate,SD31,Dem,Adriano Espillait,457
-New York,72033,State Senate,SD31,Dem,Adriano Espillait,239
-New York,72034,State Senate,SD31,Dem,Adriano Espillait,453
-New York,72035,State Senate,SD31,Dem,Adriano Espillait,453
-New York,72036,State Senate,SD31,Dem,Adriano Espillait,360
-New York,72037,State Senate,SD31,Dem,Adriano Espillait,228
-New York,72038,State Senate,SD31,Dem,Adriano Espillait,399
-New York,72039,State Senate,SD31,Dem,Adriano Espillait,527
-New York,72040,State Senate,SD31,Dem,Adriano Espillait,265
-New York,72041,State Senate,SD31,Dem,Adriano Espillait,529
-New York,72042,State Senate,SD31,Dem,Adriano Espillait,604
-New York,72043,State Senate,SD31,Dem,Adriano Espillait,460
-New York,72044,State Senate,SD31,Dem,Adriano Espillait,591
-New York,72045,State Senate,SD31,Dem,Adriano Espillait,546
-New York,72046,State Senate,SD31,Dem,Adriano Espillait,439
-New York,72047,State Senate,SD31,Dem,Adriano Espillait,389
-New York,72048,State Senate,SD31,Dem,Adriano Espillait,377
-New York,72049,State Senate,SD31,Dem,Adriano Espillait,502
-New York,72050,State Senate,SD31,Dem,Adriano Espillait,388
-New York,72051,State Senate,SD31,Dem,Adriano Espillait,322
-New York,72052,State Senate,SD31,Dem,Adriano Espillait,425
-New York,72053,State Senate,SD31,Dem,Adriano Espillait,516
-New York,72054,State Senate,SD31,Dem,Adriano Espillait,371
-New York,72055,State Senate,SD31,Dem,Adriano Espillait,292
-New York,72056,State Senate,SD31,Dem,Adriano Espillait,383
-New York,72057,State Senate,SD31,Dem,Adriano Espillait,565
-New York,72058,State Senate,SD31,Dem,Adriano Espillait,476
-New York,72059,State Senate,SD31,Dem,Adriano Espillait,231
-New York,72060,State Senate,SD31,Dem,Adriano Espillait,574
-New York,72061,State Senate,SD31,Dem,Adriano Espillait,337
-New York,72062,State Senate,SD31,Dem,Adriano Espillait,337
-New York,72063,State Senate,SD31,Dem,Adriano Espillait,467
-New York,72064,State Senate,SD31,Dem,Adriano Espillait,534
-New York,72065,State Senate,SD31,Dem,Adriano Espillait,280
-New York,72066,State Senate,SD31,Dem,Adriano Espillait,515
-New York,72067,State Senate,SD31,Dem,Adriano Espillait,509
-New York,72068,State Senate,SD31,Dem,Adriano Espillait,588
-New York,72069,State Senate,SD31,Dem,Adriano Espillait,368
-New York,72070,State Senate,SD31,Dem,Adriano Espillait,328
-New York,72071,State Senate,SD31,Dem,Adriano Espillait,389
-New York,72072,State Senate,SD31,Dem,Adriano Espillait,427
-New York,72073,State Senate,SD31,Dem,Adriano Espillait,114
-New York,72074,State Senate,SD31,Dem,Adriano Espillait,502
-New York,72075,State Senate,SD31,Dem,Adriano Espillait,557
-New York,72077,State Senate,SD31,Dem,Adriano Espillait,1
-New York,75045,State Senate,SD31,Dem,Adriano Espillait,234
-New York,75060,State Senate,SD31,Dem,Adriano Espillait,3
-New York,75061,State Senate,SD31,Dem,Adriano Espillait,13
-New York,75067,State Senate,SD31,Dem,Adriano Espillait,183
-New York,67001,State Senate,SD31,Rep,Martin Chicon,59
-New York,67003,State Senate,SD31,Rep,Martin Chicon,141
-New York,67005,State Senate,SD31,Rep,Martin Chicon,50
-New York,67007,State Senate,SD31,Rep,Martin Chicon,43
-New York,67025,State Senate,SD31,Rep,Martin Chicon,14
-New York,67026,State Senate,SD31,Rep,Martin Chicon,26
-New York,67027,State Senate,SD31,Rep,Martin Chicon,31
-New York,67028,State Senate,SD31,Rep,Martin Chicon,213
-New York,67029,State Senate,SD31,Rep,Martin Chicon,31
-New York,67030,State Senate,SD31,Rep,Martin Chicon,70
-New York,67051,State Senate,SD31,Rep,Martin Chicon,32
-New York,67067,State Senate,SD31,Rep,Martin Chicon,113
-New York,67079,State Senate,SD31,Rep,Martin Chicon,66
-New York,67080,State Senate,SD31,Rep,Martin Chicon,108
-New York,67081,State Senate,SD31,Rep,Martin Chicon,74
-New York,67082,State Senate,SD31,Rep,Martin Chicon,95
-New York,67083,State Senate,SD31,Rep,Martin Chicon,95
-New York,67084,State Senate,SD31,Rep,Martin Chicon,92
-New York,67085,State Senate,SD31,Rep,Martin Chicon,91
-New York,67087,State Senate,SD31,Rep,Martin Chicon,117
-New York,67088,State Senate,SD31,Rep,Martin Chicon,120
-New York,67089,State Senate,SD31,Rep,Martin Chicon,135
-New York,67090,State Senate,SD31,Rep,Martin Chicon,116
-New York,67091,State Senate,SD31,Rep,Martin Chicon,77
-New York,67092,State Senate,SD31,Rep,Martin Chicon,72
-New York,67093,State Senate,SD31,Rep,Martin Chicon,78
-New York,67094,State Senate,SD31,Rep,Martin Chicon,70
-New York,67095,State Senate,SD31,Rep,Martin Chicon,69
-New York,67096,State Senate,SD31,Rep,Martin Chicon,51
-New York,67097,State Senate,SD31,Rep,Martin Chicon,74
-New York,67098,State Senate,SD31,Rep,Martin Chicon,68
-New York,67099,State Senate,SD31,Rep,Martin Chicon,64
-New York,67100,State Senate,SD31,Rep,Martin Chicon,0
-New York,67101,State Senate,SD31,Rep,Martin Chicon,0
-New York,69022,State Senate,SD31,Rep,Martin Chicon,84
-New York,69023,State Senate,SD31,Rep,Martin Chicon,50
-New York,69024,State Senate,SD31,Rep,Martin Chicon,52
-New York,69025,State Senate,SD31,Rep,Martin Chicon,70
-New York,69026,State Senate,SD31,Rep,Martin Chicon,60
-New York,69027,State Senate,SD31,Rep,Martin Chicon,49
-New York,69036,State Senate,SD31,Rep,Martin Chicon,9
-New York,69045,State Senate,SD31,Rep,Martin Chicon,80
-New York,69046,State Senate,SD31,Rep,Martin Chicon,68
-New York,69047,State Senate,SD31,Rep,Martin Chicon,60
-New York,69048,State Senate,SD31,Rep,Martin Chicon,45
-New York,69049,State Senate,SD31,Rep,Martin Chicon,61
-New York,69050,State Senate,SD31,Rep,Martin Chicon,53
-New York,69051,State Senate,SD31,Rep,Martin Chicon,64
-New York,69060,State Senate,SD31,Rep,Martin Chicon,48
-New York,69061,State Senate,SD31,Rep,Martin Chicon,50
-New York,69062,State Senate,SD31,Rep,Martin Chicon,43
-New York,69063,State Senate,SD31,Rep,Martin Chicon,22
-New York,69064,State Senate,SD31,Rep,Martin Chicon,53
-New York,69065,State Senate,SD31,Rep,Martin Chicon,58
-New York,69066,State Senate,SD31,Rep,Martin Chicon,41
-New York,69072,State Senate,SD31,Rep,Martin Chicon,73
-New York,69073,State Senate,SD31,Rep,Martin Chicon,78
-New York,69077,State Senate,SD31,Rep,Martin Chicon,38
-New York,69078,State Senate,SD31,Rep,Martin Chicon,44
-New York,69079,State Senate,SD31,Rep,Martin Chicon,22
-New York,69084,State Senate,SD31,Rep,Martin Chicon,46
-New York,69085,State Senate,SD31,Rep,Martin Chicon,31
-New York,69086,State Senate,SD31,Rep,Martin Chicon,58
-New York,69088,State Senate,SD31,Rep,Martin Chicon,8
-New York,69092,State Senate,SD31,Rep,Martin Chicon,39
-New York,69096,State Senate,SD31,Rep,Martin Chicon,1
-New York,69105,State Senate,SD31,Rep,Martin Chicon,0
-New York,69106,State Senate,SD31,Rep,Martin Chicon,0
-New York,69107,State Senate,SD31,Rep,Martin Chicon,0
-New York,70068,State Senate,SD31,Rep,Martin Chicon,37
-New York,70070,State Senate,SD31,Rep,Martin Chicon,5
-New York,70071,State Senate,SD31,Rep,Martin Chicon,15
-New York,70072,State Senate,SD31,Rep,Martin Chicon,12
-New York,70077,State Senate,SD31,Rep,Martin Chicon,5
-New York,70078,State Senate,SD31,Rep,Martin Chicon,3
-New York,70079,State Senate,SD31,Rep,Martin Chicon,9
-New York,70080,State Senate,SD31,Rep,Martin Chicon,11
-New York,70081,State Senate,SD31,Rep,Martin Chicon,22
-New York,70082,State Senate,SD31,Rep,Martin Chicon,26
-New York,70083,State Senate,SD31,Rep,Martin Chicon,16
-New York,70084,State Senate,SD31,Rep,Martin Chicon,21
-New York,70085,State Senate,SD31,Rep,Martin Chicon,17
-New York,70086,State Senate,SD31,Rep,Martin Chicon,15
-New York,70087,State Senate,SD31,Rep,Martin Chicon,20
-New York,70090,State Senate,SD31,Rep,Martin Chicon,0
-New York,71001,State Senate,SD31,Rep,Martin Chicon,19
-New York,71002,State Senate,SD31,Rep,Martin Chicon,13
-New York,71003,State Senate,SD31,Rep,Martin Chicon,10
-New York,71005,State Senate,SD31,Rep,Martin Chicon,18
-New York,71006,State Senate,SD31,Rep,Martin Chicon,21
-New York,71007,State Senate,SD31,Rep,Martin Chicon,9
-New York,71029,State Senate,SD31,Rep,Martin Chicon,15
-New York,71030,State Senate,SD31,Rep,Martin Chicon,19
-New York,71036,State Senate,SD31,Rep,Martin Chicon,14
-New York,71037,State Senate,SD31,Rep,Martin Chicon,14
-New York,71039,State Senate,SD31,Rep,Martin Chicon,13
-New York,71040,State Senate,SD31,Rep,Martin Chicon,32
-New York,71041,State Senate,SD31,Rep,Martin Chicon,32
-New York,71042,State Senate,SD31,Rep,Martin Chicon,25
-New York,71043,State Senate,SD31,Rep,Martin Chicon,10
-New York,71045,State Senate,SD31,Rep,Martin Chicon,11
-New York,71046,State Senate,SD31,Rep,Martin Chicon,21
-New York,71047,State Senate,SD31,Rep,Martin Chicon,13
-New York,71048,State Senate,SD31,Rep,Martin Chicon,23
-New York,71049,State Senate,SD31,Rep,Martin Chicon,11
-New York,71050,State Senate,SD31,Rep,Martin Chicon,13
-New York,71051,State Senate,SD31,Rep,Martin Chicon,3
-New York,71052,State Senate,SD31,Rep,Martin Chicon,11
-New York,71053,State Senate,SD31,Rep,Martin Chicon,11
-New York,71054,State Senate,SD31,Rep,Martin Chicon,11
-New York,71055,State Senate,SD31,Rep,Martin Chicon,12
-New York,71056,State Senate,SD31,Rep,Martin Chicon,16
-New York,71057,State Senate,SD31,Rep,Martin Chicon,9
-New York,71058,State Senate,SD31,Rep,Martin Chicon,11
-New York,71059,State Senate,SD31,Rep,Martin Chicon,14
-New York,71060,State Senate,SD31,Rep,Martin Chicon,21
-New York,71061,State Senate,SD31,Rep,Martin Chicon,40
-New York,71062,State Senate,SD31,Rep,Martin Chicon,21
-New York,71063,State Senate,SD31,Rep,Martin Chicon,49
-New York,71064,State Senate,SD31,Rep,Martin Chicon,33
-New York,71065,State Senate,SD31,Rep,Martin Chicon,28
-New York,71066,State Senate,SD31,Rep,Martin Chicon,22
-New York,71067,State Senate,SD31,Rep,Martin Chicon,24
-New York,71068,State Senate,SD31,Rep,Martin Chicon,15
-New York,71069,State Senate,SD31,Rep,Martin Chicon,35
-New York,71070,State Senate,SD31,Rep,Martin Chicon,48
-New York,71071,State Senate,SD31,Rep,Martin Chicon,2
-New York,71072,State Senate,SD31,Rep,Martin Chicon,49
-New York,71073,State Senate,SD31,Rep,Martin Chicon,44
-New York,71074,State Senate,SD31,Rep,Martin Chicon,43
-New York,71075,State Senate,SD31,Rep,Martin Chicon,31
-New York,71076,State Senate,SD31,Rep,Martin Chicon,58
-New York,71077,State Senate,SD31,Rep,Martin Chicon,55
-New York,71078,State Senate,SD31,Rep,Martin Chicon,54
-New York,71079,State Senate,SD31,Rep,Martin Chicon,48
-New York,71080,State Senate,SD31,Rep,Martin Chicon,37
-New York,71081,State Senate,SD31,Rep,Martin Chicon,61
-New York,71082,State Senate,SD31,Rep,Martin Chicon,130
-New York,71083,State Senate,SD31,Rep,Martin Chicon,103
-New York,71084,State Senate,SD31,Rep,Martin Chicon,120
-New York,71085,State Senate,SD31,Rep,Martin Chicon,51
-New York,71086,State Senate,SD31,Rep,Martin Chicon,6
-New York,71092,State Senate,SD31,Rep,Martin Chicon,0
-New York,72002,State Senate,SD31,Rep,Martin Chicon,9
-New York,72003,State Senate,SD31,Rep,Martin Chicon,12
-New York,72004,State Senate,SD31,Rep,Martin Chicon,20
-New York,72005,State Senate,SD31,Rep,Martin Chicon,5
-New York,72006,State Senate,SD31,Rep,Martin Chicon,9
-New York,72007,State Senate,SD31,Rep,Martin Chicon,18
-New York,72008,State Senate,SD31,Rep,Martin Chicon,28
-New York,72009,State Senate,SD31,Rep,Martin Chicon,15
-New York,72010,State Senate,SD31,Rep,Martin Chicon,16
-New York,72011,State Senate,SD31,Rep,Martin Chicon,15
-New York,72012,State Senate,SD31,Rep,Martin Chicon,15
-New York,72013,State Senate,SD31,Rep,Martin Chicon,17
-New York,72014,State Senate,SD31,Rep,Martin Chicon,8
-New York,72015,State Senate,SD31,Rep,Martin Chicon,9
-New York,72016,State Senate,SD31,Rep,Martin Chicon,25
-New York,72017,State Senate,SD31,Rep,Martin Chicon,24
-New York,72018,State Senate,SD31,Rep,Martin Chicon,91
-New York,72019,State Senate,SD31,Rep,Martin Chicon,62
-New York,72020,State Senate,SD31,Rep,Martin Chicon,26
-New York,72021,State Senate,SD31,Rep,Martin Chicon,29
-New York,72022,State Senate,SD31,Rep,Martin Chicon,39
-New York,72023,State Senate,SD31,Rep,Martin Chicon,50
-New York,72024,State Senate,SD31,Rep,Martin Chicon,36
-New York,72025,State Senate,SD31,Rep,Martin Chicon,25
-New York,72026,State Senate,SD31,Rep,Martin Chicon,37
-New York,72027,State Senate,SD31,Rep,Martin Chicon,12
-New York,72028,State Senate,SD31,Rep,Martin Chicon,19
-New York,72029,State Senate,SD31,Rep,Martin Chicon,14
-New York,72030,State Senate,SD31,Rep,Martin Chicon,23
-New York,72031,State Senate,SD31,Rep,Martin Chicon,14
-New York,72032,State Senate,SD31,Rep,Martin Chicon,10
-New York,72033,State Senate,SD31,Rep,Martin Chicon,61
-New York,72034,State Senate,SD31,Rep,Martin Chicon,15
-New York,72035,State Senate,SD31,Rep,Martin Chicon,17
-New York,72036,State Senate,SD31,Rep,Martin Chicon,47
-New York,72037,State Senate,SD31,Rep,Martin Chicon,66
-New York,72038,State Senate,SD31,Rep,Martin Chicon,51
-New York,72039,State Senate,SD31,Rep,Martin Chicon,43
-New York,72040,State Senate,SD31,Rep,Martin Chicon,22
-New York,72041,State Senate,SD31,Rep,Martin Chicon,52
-New York,72042,State Senate,SD31,Rep,Martin Chicon,60
-New York,72043,State Senate,SD31,Rep,Martin Chicon,19
-New York,72044,State Senate,SD31,Rep,Martin Chicon,32
-New York,72045,State Senate,SD31,Rep,Martin Chicon,22
-New York,72046,State Senate,SD31,Rep,Martin Chicon,31
-New York,72047,State Senate,SD31,Rep,Martin Chicon,17
-New York,72048,State Senate,SD31,Rep,Martin Chicon,4
-New York,72049,State Senate,SD31,Rep,Martin Chicon,20
-New York,72050,State Senate,SD31,Rep,Martin Chicon,8
-New York,72051,State Senate,SD31,Rep,Martin Chicon,11
-New York,72052,State Senate,SD31,Rep,Martin Chicon,20
-New York,72053,State Senate,SD31,Rep,Martin Chicon,34
-New York,72054,State Senate,SD31,Rep,Martin Chicon,11
-New York,72055,State Senate,SD31,Rep,Martin Chicon,19
-New York,72056,State Senate,SD31,Rep,Martin Chicon,14
-New York,72057,State Senate,SD31,Rep,Martin Chicon,73
-New York,72058,State Senate,SD31,Rep,Martin Chicon,50
-New York,72059,State Senate,SD31,Rep,Martin Chicon,29
-New York,72060,State Senate,SD31,Rep,Martin Chicon,42
-New York,72061,State Senate,SD31,Rep,Martin Chicon,19
-New York,72062,State Senate,SD31,Rep,Martin Chicon,19
-New York,72063,State Senate,SD31,Rep,Martin Chicon,21
-New York,72064,State Senate,SD31,Rep,Martin Chicon,68
-New York,72065,State Senate,SD31,Rep,Martin Chicon,16
-New York,72066,State Senate,SD31,Rep,Martin Chicon,63
-New York,72067,State Senate,SD31,Rep,Martin Chicon,69
-New York,72068,State Senate,SD31,Rep,Martin Chicon,66
-New York,72069,State Senate,SD31,Rep,Martin Chicon,56
-New York,72070,State Senate,SD31,Rep,Martin Chicon,21
-New York,72071,State Senate,SD31,Rep,Martin Chicon,10
-New York,72072,State Senate,SD31,Rep,Martin Chicon,12
-New York,72073,State Senate,SD31,Rep,Martin Chicon,4
-New York,72074,State Senate,SD31,Rep,Martin Chicon,35
-New York,72075,State Senate,SD31,Rep,Martin Chicon,24
-New York,72077,State Senate,SD31,Rep,Martin Chicon,0
-New York,75045,State Senate,SD31,Rep,Martin Chicon,15
-New York,75060,State Senate,SD31,Rep,Martin Chicon,0
-New York,75061,State Senate,SD31,Rep,Martin Chicon,4
-New York,75067,State Senate,SD31,Rep,Martin Chicon,17
-New York,67001,State Senate,SD31,Ind,writein,1
-New York,67003,State Senate,SD31,Ind,writein,1
-New York,67005,State Senate,SD31,Ind,writein,0
-New York,67007,State Senate,SD31,Ind,writein,0
-New York,67025,State Senate,SD31,Ind,writein,1
-New York,67026,State Senate,SD31,Ind,writein,1
-New York,67027,State Senate,SD31,Ind,writein,1
-New York,67028,State Senate,SD31,Ind,writein,0
-New York,67029,State Senate,SD31,Ind,writein,0
-New York,67030,State Senate,SD31,Ind,writein,0
-New York,67051,State Senate,SD31,Ind,writein,0
-New York,67067,State Senate,SD31,Ind,writein,0
-New York,67079,State Senate,SD31,Ind,writein,1
-New York,67080,State Senate,SD31,Ind,writein,0
-New York,67081,State Senate,SD31,Ind,writein,0
-New York,67082,State Senate,SD31,Ind,writein,1
-New York,67083,State Senate,SD31,Ind,writein,1
-New York,67084,State Senate,SD31,Ind,writein,0
-New York,67085,State Senate,SD31,Ind,writein,1
-New York,67087,State Senate,SD31,Ind,writein,0
-New York,67088,State Senate,SD31,Ind,writein,0
-New York,67089,State Senate,SD31,Ind,writein,1
-New York,67090,State Senate,SD31,Ind,writein,3
-New York,67091,State Senate,SD31,Ind,writein,0
-New York,67092,State Senate,SD31,Ind,writein,1
-New York,67093,State Senate,SD31,Ind,writein,3
-New York,67094,State Senate,SD31,Ind,writein,2
-New York,67095,State Senate,SD31,Ind,writein,0
-New York,67096,State Senate,SD31,Ind,writein,0
-New York,67097,State Senate,SD31,Ind,writein,0
-New York,67098,State Senate,SD31,Ind,writein,0
-New York,67099,State Senate,SD31,Ind,writein,0
-New York,67100,State Senate,SD31,Ind,writein,0
-New York,67101,State Senate,SD31,Ind,writein,0
-New York,69022,State Senate,SD31,Ind,writein,1
-New York,69023,State Senate,SD31,Ind,writein,0
-New York,69024,State Senate,SD31,Ind,writein,0
-New York,69025,State Senate,SD31,Ind,writein,1
-New York,69026,State Senate,SD31,Ind,writein,0
-New York,69027,State Senate,SD31,Ind,writein,0
-New York,69036,State Senate,SD31,Ind,writein,0
-New York,69045,State Senate,SD31,Ind,writein,2
-New York,69046,State Senate,SD31,Ind,writein,0
-New York,69047,State Senate,SD31,Ind,writein,0
-New York,69048,State Senate,SD31,Ind,writein,1
-New York,69049,State Senate,SD31,Ind,writein,2
-New York,69050,State Senate,SD31,Ind,writein,1
-New York,69051,State Senate,SD31,Ind,writein,1
-New York,69060,State Senate,SD31,Ind,writein,0
-New York,69061,State Senate,SD31,Ind,writein,0
-New York,69062,State Senate,SD31,Ind,writein,0
-New York,69063,State Senate,SD31,Ind,writein,0
-New York,69064,State Senate,SD31,Ind,writein,0
-New York,69065,State Senate,SD31,Ind,writein,0
-New York,69066,State Senate,SD31,Ind,writein,0
-New York,69072,State Senate,SD31,Ind,writein,1
-New York,69073,State Senate,SD31,Ind,writein,1
-New York,69077,State Senate,SD31,Ind,writein,1
-New York,69078,State Senate,SD31,Ind,writein,0
-New York,69079,State Senate,SD31,Ind,writein,1
-New York,69084,State Senate,SD31,Ind,writein,1
-New York,69085,State Senate,SD31,Ind,writein,0
-New York,69086,State Senate,SD31,Ind,writein,2
-New York,69088,State Senate,SD31,Ind,writein,0
-New York,69092,State Senate,SD31,Ind,writein,1
-New York,69096,State Senate,SD31,Ind,writein,0
-New York,69105,State Senate,SD31,Ind,writein,0
-New York,69106,State Senate,SD31,Ind,writein,0
-New York,69107,State Senate,SD31,Ind,writein,0
-New York,70068,State Senate,SD31,Ind,writein,1
-New York,70070,State Senate,SD31,Ind,writein,0
-New York,70071,State Senate,SD31,Ind,writein,1
-New York,70072,State Senate,SD31,Ind,writein,1
-New York,70077,State Senate,SD31,Ind,writein,0
-New York,70078,State Senate,SD31,Ind,writein,0
-New York,70079,State Senate,SD31,Ind,writein,0
-New York,70080,State Senate,SD31,Ind,writein,0
-New York,70081,State Senate,SD31,Ind,writein,1
-New York,70082,State Senate,SD31,Ind,writein,0
-New York,70083,State Senate,SD31,Ind,writein,1
-New York,70084,State Senate,SD31,Ind,writein,0
-New York,70085,State Senate,SD31,Ind,writein,1
-New York,70086,State Senate,SD31,Ind,writein,0
-New York,70087,State Senate,SD31,Ind,writein,1
-New York,70090,State Senate,SD31,Ind,writein,0
-New York,71001,State Senate,SD31,Ind,writein,1
-New York,71002,State Senate,SD31,Ind,writein,1
-New York,71003,State Senate,SD31,Ind,writein,1
-New York,71005,State Senate,SD31,Ind,writein,1
-New York,71006,State Senate,SD31,Ind,writein,1
-New York,71007,State Senate,SD31,Ind,writein,1
-New York,71029,State Senate,SD31,Ind,writein,0
-New York,71030,State Senate,SD31,Ind,writein,0
-New York,71036,State Senate,SD31,Ind,writein,0
-New York,71037,State Senate,SD31,Ind,writein,1
-New York,71039,State Senate,SD31,Ind,writein,0
-New York,71040,State Senate,SD31,Ind,writein,3
-New York,71041,State Senate,SD31,Ind,writein,0
-New York,71042,State Senate,SD31,Ind,writein,1
-New York,71043,State Senate,SD31,Ind,writein,0
-New York,71045,State Senate,SD31,Ind,writein,0
-New York,71046,State Senate,SD31,Ind,writein,0
-New York,71047,State Senate,SD31,Ind,writein,2
-New York,71048,State Senate,SD31,Ind,writein,3
-New York,71049,State Senate,SD31,Ind,writein,0
-New York,71050,State Senate,SD31,Ind,writein,0
-New York,71051,State Senate,SD31,Ind,writein,1
-New York,71052,State Senate,SD31,Ind,writein,0
-New York,71053,State Senate,SD31,Ind,writein,1
-New York,71054,State Senate,SD31,Ind,writein,0
-New York,71055,State Senate,SD31,Ind,writein,0
-New York,71056,State Senate,SD31,Ind,writein,0
-New York,71057,State Senate,SD31,Ind,writein,0
-New York,71058,State Senate,SD31,Ind,writein,0
-New York,71059,State Senate,SD31,Ind,writein,0
-New York,71060,State Senate,SD31,Ind,writein,0
-New York,71061,State Senate,SD31,Ind,writein,0
-New York,71062,State Senate,SD31,Ind,writein,0
-New York,71063,State Senate,SD31,Ind,writein,2
-New York,71064,State Senate,SD31,Ind,writein,0
-New York,71065,State Senate,SD31,Ind,writein,0
-New York,71066,State Senate,SD31,Ind,writein,1
-New York,71067,State Senate,SD31,Ind,writein,0
-New York,71068,State Senate,SD31,Ind,writein,1
-New York,71069,State Senate,SD31,Ind,writein,0
-New York,71070,State Senate,SD31,Ind,writein,0
-New York,71071,State Senate,SD31,Ind,writein,0
-New York,71072,State Senate,SD31,Ind,writein,1
-New York,71073,State Senate,SD31,Ind,writein,1
-New York,71074,State Senate,SD31,Ind,writein,0
-New York,71075,State Senate,SD31,Ind,writein,1
-New York,71076,State Senate,SD31,Ind,writein,1
-New York,71077,State Senate,SD31,Ind,writein,0
-New York,71078,State Senate,SD31,Ind,writein,0
-New York,71079,State Senate,SD31,Ind,writein,0
-New York,71080,State Senate,SD31,Ind,writein,1
-New York,71081,State Senate,SD31,Ind,writein,0
-New York,71082,State Senate,SD31,Ind,writein,2
-New York,71083,State Senate,SD31,Ind,writein,1
-New York,71084,State Senate,SD31,Ind,writein,0
-New York,71085,State Senate,SD31,Ind,writein,0
-New York,71086,State Senate,SD31,Ind,writein,0
-New York,71092,State Senate,SD31,Ind,writein,0
-New York,72002,State Senate,SD31,Ind,writein,0
-New York,72003,State Senate,SD31,Ind,writein,0
-New York,72004,State Senate,SD31,Ind,writein,0
-New York,72005,State Senate,SD31,Ind,writein,0
-New York,72006,State Senate,SD31,Ind,writein,0
-New York,72007,State Senate,SD31,Ind,writein,0
-New York,72008,State Senate,SD31,Ind,writein,0
-New York,72009,State Senate,SD31,Ind,writein,0
-New York,72010,State Senate,SD31,Ind,writein,0
-New York,72011,State Senate,SD31,Ind,writein,0
-New York,72012,State Senate,SD31,Ind,writein,0
-New York,72013,State Senate,SD31,Ind,writein,0
-New York,72014,State Senate,SD31,Ind,writein,0
-New York,72015,State Senate,SD31,Ind,writein,2
-New York,72016,State Senate,SD31,Ind,writein,0
-New York,72017,State Senate,SD31,Ind,writein,1
-New York,72018,State Senate,SD31,Ind,writein,0
-New York,72019,State Senate,SD31,Ind,writein,0
-New York,72020,State Senate,SD31,Ind,writein,0
-New York,72021,State Senate,SD31,Ind,writein,2
-New York,72022,State Senate,SD31,Ind,writein,2
-New York,72023,State Senate,SD31,Ind,writein,0
-New York,72024,State Senate,SD31,Ind,writein,0
-New York,72025,State Senate,SD31,Ind,writein,0
-New York,72026,State Senate,SD31,Ind,writein,1
-New York,72027,State Senate,SD31,Ind,writein,0
-New York,72028,State Senate,SD31,Ind,writein,0
-New York,72029,State Senate,SD31,Ind,writein,0
-New York,72030,State Senate,SD31,Ind,writein,0
-New York,72031,State Senate,SD31,Ind,writein,0
-New York,72032,State Senate,SD31,Ind,writein,0
-New York,72033,State Senate,SD31,Ind,writein,0
-New York,72034,State Senate,SD31,Ind,writein,0
-New York,72035,State Senate,SD31,Ind,writein,0
-New York,72036,State Senate,SD31,Ind,writein,1
-New York,72037,State Senate,SD31,Ind,writein,0
-New York,72038,State Senate,SD31,Ind,writein,1
-New York,72039,State Senate,SD31,Ind,writein,1
-New York,72040,State Senate,SD31,Ind,writein,1
-New York,72041,State Senate,SD31,Ind,writein,0
-New York,72042,State Senate,SD31,Ind,writein,0
-New York,72043,State Senate,SD31,Ind,writein,0
-New York,72044,State Senate,SD31,Ind,writein,0
-New York,72045,State Senate,SD31,Ind,writein,0
-New York,72046,State Senate,SD31,Ind,writein,1
-New York,72047,State Senate,SD31,Ind,writein,1
-New York,72048,State Senate,SD31,Ind,writein,0
-New York,72049,State Senate,SD31,Ind,writein,0
-New York,72050,State Senate,SD31,Ind,writein,1
-New York,72051,State Senate,SD31,Ind,writein,0
-New York,72052,State Senate,SD31,Ind,writein,1
-New York,72053,State Senate,SD31,Ind,writein,0
-New York,72054,State Senate,SD31,Ind,writein,1
-New York,72055,State Senate,SD31,Ind,writein,0
-New York,72056,State Senate,SD31,Ind,writein,0
-New York,72057,State Senate,SD31,Ind,writein,3
-New York,72058,State Senate,SD31,Ind,writein,2
-New York,72059,State Senate,SD31,Ind,writein,1
-New York,72060,State Senate,SD31,Ind,writein,3
-New York,72061,State Senate,SD31,Ind,writein,0
-New York,72062,State Senate,SD31,Ind,writein,0
-New York,72063,State Senate,SD31,Ind,writein,0
-New York,72064,State Senate,SD31,Ind,writein,0
-New York,72065,State Senate,SD31,Ind,writein,1
-New York,72066,State Senate,SD31,Ind,writein,2
-New York,72067,State Senate,SD31,Ind,writein,2
-New York,72068,State Senate,SD31,Ind,writein,3
-New York,72069,State Senate,SD31,Ind,writein,2
-New York,72070,State Senate,SD31,Ind,writein,2
-New York,72071,State Senate,SD31,Ind,writein,0
-New York,72072,State Senate,SD31,Ind,writein,0
-New York,72073,State Senate,SD31,Ind,writein,0
-New York,72074,State Senate,SD31,Ind,writein,1
-New York,72075,State Senate,SD31,Ind,writein,0
-New York,72077,State Senate,SD31,Ind,writein,0
-New York,75045,State Senate,SD31,Ind,writein,0
-New York,75060,State Senate,SD31,Ind,writein,0
-New York,75061,State Senate,SD31,Ind,writein,0
-New York,75067,State Senate,SD31,Ind,writein,0
+New York,65001,State Senate,26,Dem,Daniel Squadron,413
+New York,65002,State Senate,26,Dem,Daniel Squadron,429
+New York,65003,State Senate,26,Dem,Daniel Squadron,296
+New York,65004,State Senate,26,Dem,Daniel Squadron,358
+New York,65005,State Senate,26,Dem,Daniel Squadron,278
+New York,65006,State Senate,26,Dem,Daniel Squadron,407
+New York,65007,State Senate,26,Dem,Daniel Squadron,237
+New York,65008,State Senate,26,Dem,Daniel Squadron,406
+New York,65009,State Senate,26,Dem,Daniel Squadron,432
+New York,65010,State Senate,26,Dem,Daniel Squadron,286
+New York,65011,State Senate,26,Dem,Daniel Squadron,375
+New York,65012,State Senate,26,Dem,Daniel Squadron,393
+New York,65013,State Senate,26,Dem,Daniel Squadron,557
+New York,65014,State Senate,26,Dem,Daniel Squadron,390
+New York,65015,State Senate,26,Dem,Daniel Squadron,235
+New York,65016,State Senate,26,Dem,Daniel Squadron,440
+New York,65017,State Senate,26,Dem,Daniel Squadron,5
+New York,65018,State Senate,26,Dem,Daniel Squadron,271
+New York,65019,State Senate,26,Dem,Daniel Squadron,247
+New York,65020,State Senate,26,Dem,Daniel Squadron,255
+New York,65021,State Senate,26,Dem,Daniel Squadron,284
+New York,65022,State Senate,26,Dem,Daniel Squadron,272
+New York,65023,State Senate,26,Dem,Daniel Squadron,172
+New York,65024,State Senate,26,Dem,Daniel Squadron,271
+New York,65025,State Senate,26,Dem,Daniel Squadron,81
+New York,65026,State Senate,26,Dem,Daniel Squadron,99
+New York,65027,State Senate,26,Dem,Daniel Squadron,194
+New York,65028,State Senate,26,Dem,Daniel Squadron,41
+New York,65029,State Senate,26,Dem,Daniel Squadron,227
+New York,65030,State Senate,26,Dem,Daniel Squadron,266
+New York,65031,State Senate,26,Dem,Daniel Squadron,296
+New York,65032,State Senate,26,Dem,Daniel Squadron,280
+New York,65033,State Senate,26,Dem,Daniel Squadron,283
+New York,65034,State Senate,26,Dem,Daniel Squadron,298
+New York,65035,State Senate,26,Dem,Daniel Squadron,222
+New York,65036,State Senate,26,Dem,Daniel Squadron,255
+New York,65037,State Senate,26,Dem,Daniel Squadron,315
+New York,65038,State Senate,26,Dem,Daniel Squadron,325
+New York,65039,State Senate,26,Dem,Daniel Squadron,190
+New York,65040,State Senate,26,Dem,Daniel Squadron,319
+New York,65041,State Senate,26,Dem,Daniel Squadron,283
+New York,65042,State Senate,26,Dem,Daniel Squadron,370
+New York,65043,State Senate,26,Dem,Daniel Squadron,400
+New York,65044,State Senate,26,Dem,Daniel Squadron,375
+New York,65045,State Senate,26,Dem,Daniel Squadron,396
+New York,65046,State Senate,26,Dem,Daniel Squadron,286
+New York,65047,State Senate,26,Dem,Daniel Squadron,243
+New York,65048,State Senate,26,Dem,Daniel Squadron,354
+New York,65049,State Senate,26,Dem,Daniel Squadron,18
+New York,65050,State Senate,26,Dem,Daniel Squadron,663
+New York,65051,State Senate,26,Dem,Daniel Squadron,322
+New York,65052,State Senate,26,Dem,Daniel Squadron,255
+New York,65053,State Senate,26,Dem,Daniel Squadron,288
+New York,65054,State Senate,26,Dem,Daniel Squadron,268
+New York,65055,State Senate,26,Dem,Daniel Squadron,292
+New York,65056,State Senate,26,Dem,Daniel Squadron,332
+New York,65057,State Senate,26,Dem,Daniel Squadron,225
+New York,65058,State Senate,26,Dem,Daniel Squadron,218
+New York,65059,State Senate,26,Dem,Daniel Squadron,381
+New York,65060,State Senate,26,Dem,Daniel Squadron,199
+New York,65061,State Senate,26,Dem,Daniel Squadron,285
+New York,65062,State Senate,26,Dem,Daniel Squadron,252
+New York,65063,State Senate,26,Dem,Daniel Squadron,273
+New York,65064,State Senate,26,Dem,Daniel Squadron,208
+New York,65065,State Senate,26,Dem,Daniel Squadron,130
+New York,65066,State Senate,26,Dem,Daniel Squadron,180
+New York,65067,State Senate,26,Dem,Daniel Squadron,94
+New York,65068,State Senate,26,Dem,Daniel Squadron,416
+New York,65069,State Senate,26,Dem,Daniel Squadron,263
+New York,65070,State Senate,26,Dem,Daniel Squadron,36
+New York,65071,State Senate,26,Dem,Daniel Squadron,308
+New York,65072,State Senate,26,Dem,Daniel Squadron,352
+New York,65073,State Senate,26,Dem,Daniel Squadron,396
+New York,65074,State Senate,26,Dem,Daniel Squadron,418
+New York,65075,State Senate,26,Dem,Daniel Squadron,352
+New York,65076,State Senate,26,Dem,Daniel Squadron,350
+New York,65077,State Senate,26,Dem,Daniel Squadron,431
+New York,65078,State Senate,26,Dem,Daniel Squadron,278
+New York,65080,State Senate,26,Dem,Daniel Squadron,345
+New York,65081,State Senate,26,Dem,Daniel Squadron,345
+New York,65082,State Senate,26,Dem,Daniel Squadron,1
+New York,66001,State Senate,26,Dem,Daniel Squadron,465
+New York,66002,State Senate,26,Dem,Daniel Squadron,490
+New York,66003,State Senate,26,Dem,Daniel Squadron,460
+New York,66004,State Senate,26,Dem,Daniel Squadron,358
+New York,66005,State Senate,26,Dem,Daniel Squadron,566
+New York,66006,State Senate,26,Dem,Daniel Squadron,550
+New York,66007,State Senate,26,Dem,Daniel Squadron,472
+New York,66008,State Senate,26,Dem,Daniel Squadron,546
+New York,66009,State Senate,26,Dem,Daniel Squadron,542
+New York,66010,State Senate,26,Dem,Daniel Squadron,550
+New York,66011,State Senate,26,Dem,Daniel Squadron,459
+New York,66012,State Senate,26,Dem,Daniel Squadron,397
+New York,66013,State Senate,26,Dem,Daniel Squadron,203
+New York,66014,State Senate,26,Dem,Daniel Squadron,262
+New York,66015,State Senate,26,Dem,Daniel Squadron,213
+New York,66016,State Senate,26,Dem,Daniel Squadron,8
+New York,66017,State Senate,26,Dem,Daniel Squadron,17
+New York,66018,State Senate,26,Dem,Daniel Squadron,520
+New York,66019,State Senate,26,Dem,Daniel Squadron,484
+New York,66020,State Senate,26,Dem,Daniel Squadron,331
+New York,66021,State Senate,26,Dem,Daniel Squadron,337
+New York,66022,State Senate,26,Dem,Daniel Squadron,548
+New York,66023,State Senate,26,Dem,Daniel Squadron,265
+New York,66024,State Senate,26,Dem,Daniel Squadron,318
+New York,66025,State Senate,26,Dem,Daniel Squadron,317
+New York,66026,State Senate,26,Dem,Daniel Squadron,65
+New York,66027,State Senate,26,Dem,Daniel Squadron,454
+New York,66040,State Senate,26,Dem,Daniel Squadron,96
+New York,66041,State Senate,26,Dem,Daniel Squadron,397
+New York,66042,State Senate,26,Dem,Daniel Squadron,76
+New York,66043,State Senate,26,Dem,Daniel Squadron,229
+New York,66044,State Senate,26,Dem,Daniel Squadron,330
+New York,66070,State Senate,26,Dem,Daniel Squadron,80
+New York,74001,State Senate,26,Dem,Daniel Squadron,282
+New York,74002,State Senate,26,Dem,Daniel Squadron,293
+New York,74003,State Senate,26,Dem,Daniel Squadron,296
+New York,74004,State Senate,26,Dem,Daniel Squadron,333
+New York,74005,State Senate,26,Dem,Daniel Squadron,121
+New York,74006,State Senate,26,Dem,Daniel Squadron,265
+New York,74007,State Senate,26,Dem,Daniel Squadron,248
+New York,74008,State Senate,26,Dem,Daniel Squadron,317
+New York,74009,State Senate,26,Dem,Daniel Squadron,118
+New York,74010,State Senate,26,Dem,Daniel Squadron,447
+New York,74011,State Senate,26,Dem,Daniel Squadron,356
+New York,74012,State Senate,26,Dem,Daniel Squadron,221
+New York,74013,State Senate,26,Dem,Daniel Squadron,277
+New York,74014,State Senate,26,Dem,Daniel Squadron,250
+New York,74015,State Senate,26,Dem,Daniel Squadron,392
+New York,74016,State Senate,26,Dem,Daniel Squadron,227
+New York,74017,State Senate,26,Dem,Daniel Squadron,181
+New York,74018,State Senate,26,Dem,Daniel Squadron,121
+New York,65001,State Senate,26,WF,Daniel Squadron,16
+New York,65002,State Senate,26,WF,Daniel Squadron,12
+New York,65003,State Senate,26,WF,Daniel Squadron,12
+New York,65004,State Senate,26,WF,Daniel Squadron,15
+New York,65005,State Senate,26,WF,Daniel Squadron,11
+New York,65006,State Senate,26,WF,Daniel Squadron,30
+New York,65007,State Senate,26,WF,Daniel Squadron,19
+New York,65008,State Senate,26,WF,Daniel Squadron,24
+New York,65009,State Senate,26,WF,Daniel Squadron,26
+New York,65010,State Senate,26,WF,Daniel Squadron,16
+New York,65011,State Senate,26,WF,Daniel Squadron,17
+New York,65012,State Senate,26,WF,Daniel Squadron,15
+New York,65013,State Senate,26,WF,Daniel Squadron,31
+New York,65014,State Senate,26,WF,Daniel Squadron,14
+New York,65015,State Senate,26,WF,Daniel Squadron,18
+New York,65016,State Senate,26,WF,Daniel Squadron,12
+New York,65017,State Senate,26,WF,Daniel Squadron,1
+New York,65018,State Senate,26,WF,Daniel Squadron,9
+New York,65019,State Senate,26,WF,Daniel Squadron,12
+New York,65020,State Senate,26,WF,Daniel Squadron,9
+New York,65021,State Senate,26,WF,Daniel Squadron,14
+New York,65022,State Senate,26,WF,Daniel Squadron,19
+New York,65023,State Senate,26,WF,Daniel Squadron,9
+New York,65024,State Senate,26,WF,Daniel Squadron,17
+New York,65025,State Senate,26,WF,Daniel Squadron,4
+New York,65026,State Senate,26,WF,Daniel Squadron,8
+New York,65027,State Senate,26,WF,Daniel Squadron,5
+New York,65028,State Senate,26,WF,Daniel Squadron,3
+New York,65029,State Senate,26,WF,Daniel Squadron,8
+New York,65030,State Senate,26,WF,Daniel Squadron,7
+New York,65031,State Senate,26,WF,Daniel Squadron,11
+New York,65032,State Senate,26,WF,Daniel Squadron,16
+New York,65033,State Senate,26,WF,Daniel Squadron,10
+New York,65034,State Senate,26,WF,Daniel Squadron,5
+New York,65035,State Senate,26,WF,Daniel Squadron,7
+New York,65036,State Senate,26,WF,Daniel Squadron,9
+New York,65037,State Senate,26,WF,Daniel Squadron,4
+New York,65038,State Senate,26,WF,Daniel Squadron,15
+New York,65039,State Senate,26,WF,Daniel Squadron,16
+New York,65040,State Senate,26,WF,Daniel Squadron,2
+New York,65041,State Senate,26,WF,Daniel Squadron,10
+New York,65042,State Senate,26,WF,Daniel Squadron,12
+New York,65043,State Senate,26,WF,Daniel Squadron,10
+New York,65044,State Senate,26,WF,Daniel Squadron,31
+New York,65045,State Senate,26,WF,Daniel Squadron,23
+New York,65046,State Senate,26,WF,Daniel Squadron,20
+New York,65047,State Senate,26,WF,Daniel Squadron,24
+New York,65048,State Senate,26,WF,Daniel Squadron,35
+New York,65049,State Senate,26,WF,Daniel Squadron,1
+New York,65050,State Senate,26,WF,Daniel Squadron,19
+New York,65051,State Senate,26,WF,Daniel Squadron,21
+New York,65052,State Senate,26,WF,Daniel Squadron,29
+New York,65053,State Senate,26,WF,Daniel Squadron,12
+New York,65054,State Senate,26,WF,Daniel Squadron,22
+New York,65055,State Senate,26,WF,Daniel Squadron,16
+New York,65056,State Senate,26,WF,Daniel Squadron,12
+New York,65057,State Senate,26,WF,Daniel Squadron,5
+New York,65058,State Senate,26,WF,Daniel Squadron,14
+New York,65059,State Senate,26,WF,Daniel Squadron,34
+New York,65060,State Senate,26,WF,Daniel Squadron,8
+New York,65061,State Senate,26,WF,Daniel Squadron,10
+New York,65062,State Senate,26,WF,Daniel Squadron,11
+New York,65063,State Senate,26,WF,Daniel Squadron,19
+New York,65064,State Senate,26,WF,Daniel Squadron,14
+New York,65065,State Senate,26,WF,Daniel Squadron,6
+New York,65066,State Senate,26,WF,Daniel Squadron,13
+New York,65067,State Senate,26,WF,Daniel Squadron,13
+New York,65068,State Senate,26,WF,Daniel Squadron,18
+New York,65069,State Senate,26,WF,Daniel Squadron,16
+New York,65070,State Senate,26,WF,Daniel Squadron,5
+New York,65071,State Senate,26,WF,Daniel Squadron,15
+New York,65072,State Senate,26,WF,Daniel Squadron,27
+New York,65073,State Senate,26,WF,Daniel Squadron,28
+New York,65074,State Senate,26,WF,Daniel Squadron,30
+New York,65075,State Senate,26,WF,Daniel Squadron,15
+New York,65076,State Senate,26,WF,Daniel Squadron,27
+New York,65077,State Senate,26,WF,Daniel Squadron,35
+New York,65078,State Senate,26,WF,Daniel Squadron,24
+New York,65080,State Senate,26,WF,Daniel Squadron,26
+New York,65081,State Senate,26,WF,Daniel Squadron,35
+New York,65082,State Senate,26,WF,Daniel Squadron,0
+New York,66001,State Senate,26,WF,Daniel Squadron,23
+New York,66002,State Senate,26,WF,Daniel Squadron,14
+New York,66003,State Senate,26,WF,Daniel Squadron,24
+New York,66004,State Senate,26,WF,Daniel Squadron,12
+New York,66005,State Senate,26,WF,Daniel Squadron,24
+New York,66006,State Senate,26,WF,Daniel Squadron,27
+New York,66007,State Senate,26,WF,Daniel Squadron,22
+New York,66008,State Senate,26,WF,Daniel Squadron,56
+New York,66009,State Senate,26,WF,Daniel Squadron,38
+New York,66010,State Senate,26,WF,Daniel Squadron,30
+New York,66011,State Senate,26,WF,Daniel Squadron,44
+New York,66012,State Senate,26,WF,Daniel Squadron,18
+New York,66013,State Senate,26,WF,Daniel Squadron,17
+New York,66014,State Senate,26,WF,Daniel Squadron,8
+New York,66015,State Senate,26,WF,Daniel Squadron,21
+New York,66016,State Senate,26,WF,Daniel Squadron,0
+New York,66017,State Senate,26,WF,Daniel Squadron,0
+New York,66018,State Senate,26,WF,Daniel Squadron,37
+New York,66019,State Senate,26,WF,Daniel Squadron,35
+New York,66020,State Senate,26,WF,Daniel Squadron,27
+New York,66021,State Senate,26,WF,Daniel Squadron,24
+New York,66022,State Senate,26,WF,Daniel Squadron,52
+New York,66023,State Senate,26,WF,Daniel Squadron,26
+New York,66024,State Senate,26,WF,Daniel Squadron,17
+New York,66025,State Senate,26,WF,Daniel Squadron,28
+New York,66026,State Senate,26,WF,Daniel Squadron,8
+New York,66027,State Senate,26,WF,Daniel Squadron,54
+New York,66040,State Senate,26,WF,Daniel Squadron,7
+New York,66041,State Senate,26,WF,Daniel Squadron,33
+New York,66042,State Senate,26,WF,Daniel Squadron,7
+New York,66043,State Senate,26,WF,Daniel Squadron,18
+New York,66044,State Senate,26,WF,Daniel Squadron,24
+New York,66070,State Senate,26,WF,Daniel Squadron,3
+New York,74001,State Senate,26,WF,Daniel Squadron,4
+New York,74002,State Senate,26,WF,Daniel Squadron,8
+New York,74003,State Senate,26,WF,Daniel Squadron,5
+New York,74004,State Senate,26,WF,Daniel Squadron,4
+New York,74005,State Senate,26,WF,Daniel Squadron,0
+New York,74006,State Senate,26,WF,Daniel Squadron,9
+New York,74007,State Senate,26,WF,Daniel Squadron,30
+New York,74008,State Senate,26,WF,Daniel Squadron,24
+New York,74009,State Senate,26,WF,Daniel Squadron,6
+New York,74010,State Senate,26,WF,Daniel Squadron,44
+New York,74011,State Senate,26,WF,Daniel Squadron,8
+New York,74012,State Senate,26,WF,Daniel Squadron,4
+New York,74013,State Senate,26,WF,Daniel Squadron,10
+New York,74014,State Senate,26,WF,Daniel Squadron,3
+New York,74015,State Senate,26,WF,Daniel Squadron,34
+New York,74016,State Senate,26,WF,Daniel Squadron,15
+New York,74017,State Senate,26,WF,Daniel Squadron,18
+New York,74018,State Senate,26,WF,Daniel Squadron,5
+New York,65001,State Senate,26,Rep,Jacqueline Haro,147
+New York,65002,State Senate,26,Rep,Jacqueline Haro,190
+New York,65003,State Senate,26,Rep,Jacqueline Haro,112
+New York,65004,State Senate,26,Rep,Jacqueline Haro,121
+New York,65005,State Senate,26,Rep,Jacqueline Haro,90
+New York,65006,State Senate,26,Rep,Jacqueline Haro,104
+New York,65007,State Senate,26,Rep,Jacqueline Haro,85
+New York,65008,State Senate,26,Rep,Jacqueline Haro,119
+New York,65009,State Senate,26,Rep,Jacqueline Haro,97
+New York,65010,State Senate,26,Rep,Jacqueline Haro,73
+New York,65011,State Senate,26,Rep,Jacqueline Haro,122
+New York,65012,State Senate,26,Rep,Jacqueline Haro,206
+New York,65013,State Senate,26,Rep,Jacqueline Haro,213
+New York,65014,State Senate,26,Rep,Jacqueline Haro,175
+New York,65015,State Senate,26,Rep,Jacqueline Haro,55
+New York,65016,State Senate,26,Rep,Jacqueline Haro,134
+New York,65017,State Senate,26,Rep,Jacqueline Haro,2
+New York,65018,State Senate,26,Rep,Jacqueline Haro,11
+New York,65019,State Senate,26,Rep,Jacqueline Haro,14
+New York,65020,State Senate,26,Rep,Jacqueline Haro,18
+New York,65021,State Senate,26,Rep,Jacqueline Haro,12
+New York,65022,State Senate,26,Rep,Jacqueline Haro,82
+New York,65023,State Senate,26,Rep,Jacqueline Haro,29
+New York,65024,State Senate,26,Rep,Jacqueline Haro,29
+New York,65025,State Senate,26,Rep,Jacqueline Haro,35
+New York,65026,State Senate,26,Rep,Jacqueline Haro,22
+New York,65027,State Senate,26,Rep,Jacqueline Haro,39
+New York,65028,State Senate,26,Rep,Jacqueline Haro,8
+New York,65029,State Senate,26,Rep,Jacqueline Haro,29
+New York,65030,State Senate,26,Rep,Jacqueline Haro,39
+New York,65031,State Senate,26,Rep,Jacqueline Haro,68
+New York,65032,State Senate,26,Rep,Jacqueline Haro,31
+New York,65033,State Senate,26,Rep,Jacqueline Haro,18
+New York,65034,State Senate,26,Rep,Jacqueline Haro,22
+New York,65035,State Senate,26,Rep,Jacqueline Haro,18
+New York,65036,State Senate,26,Rep,Jacqueline Haro,11
+New York,65037,State Senate,26,Rep,Jacqueline Haro,14
+New York,65038,State Senate,26,Rep,Jacqueline Haro,25
+New York,65039,State Senate,26,Rep,Jacqueline Haro,27
+New York,65040,State Senate,26,Rep,Jacqueline Haro,19
+New York,65041,State Senate,26,Rep,Jacqueline Haro,37
+New York,65042,State Senate,26,Rep,Jacqueline Haro,27
+New York,65043,State Senate,26,Rep,Jacqueline Haro,17
+New York,65044,State Senate,26,Rep,Jacqueline Haro,66
+New York,65045,State Senate,26,Rep,Jacqueline Haro,48
+New York,65046,State Senate,26,Rep,Jacqueline Haro,47
+New York,65047,State Senate,26,Rep,Jacqueline Haro,37
+New York,65048,State Senate,26,Rep,Jacqueline Haro,36
+New York,65049,State Senate,26,Rep,Jacqueline Haro,1
+New York,65050,State Senate,26,Rep,Jacqueline Haro,37
+New York,65051,State Senate,26,Rep,Jacqueline Haro,47
+New York,65052,State Senate,26,Rep,Jacqueline Haro,31
+New York,65053,State Senate,26,Rep,Jacqueline Haro,32
+New York,65054,State Senate,26,Rep,Jacqueline Haro,48
+New York,65055,State Senate,26,Rep,Jacqueline Haro,34
+New York,65056,State Senate,26,Rep,Jacqueline Haro,20
+New York,65057,State Senate,26,Rep,Jacqueline Haro,8
+New York,65058,State Senate,26,Rep,Jacqueline Haro,16
+New York,65059,State Senate,26,Rep,Jacqueline Haro,46
+New York,65060,State Senate,26,Rep,Jacqueline Haro,17
+New York,65061,State Senate,26,Rep,Jacqueline Haro,20
+New York,65062,State Senate,26,Rep,Jacqueline Haro,27
+New York,65063,State Senate,26,Rep,Jacqueline Haro,36
+New York,65064,State Senate,26,Rep,Jacqueline Haro,38
+New York,65065,State Senate,26,Rep,Jacqueline Haro,25
+New York,65066,State Senate,26,Rep,Jacqueline Haro,43
+New York,65067,State Senate,26,Rep,Jacqueline Haro,3
+New York,65068,State Senate,26,Rep,Jacqueline Haro,74
+New York,65069,State Senate,26,Rep,Jacqueline Haro,53
+New York,65070,State Senate,26,Rep,Jacqueline Haro,24
+New York,65071,State Senate,26,Rep,Jacqueline Haro,57
+New York,65072,State Senate,26,Rep,Jacqueline Haro,26
+New York,65073,State Senate,26,Rep,Jacqueline Haro,25
+New York,65074,State Senate,26,Rep,Jacqueline Haro,35
+New York,65075,State Senate,26,Rep,Jacqueline Haro,39
+New York,65076,State Senate,26,Rep,Jacqueline Haro,39
+New York,65077,State Senate,26,Rep,Jacqueline Haro,45
+New York,65078,State Senate,26,Rep,Jacqueline Haro,23
+New York,65080,State Senate,26,Rep,Jacqueline Haro,27
+New York,65081,State Senate,26,Rep,Jacqueline Haro,26
+New York,65082,State Senate,26,Rep,Jacqueline Haro,1
+New York,66001,State Senate,26,Rep,Jacqueline Haro,264
+New York,66002,State Senate,26,Rep,Jacqueline Haro,188
+New York,66003,State Senate,26,Rep,Jacqueline Haro,168
+New York,66004,State Senate,26,Rep,Jacqueline Haro,143
+New York,66005,State Senate,26,Rep,Jacqueline Haro,153
+New York,66006,State Senate,26,Rep,Jacqueline Haro,164
+New York,66007,State Senate,26,Rep,Jacqueline Haro,215
+New York,66008,State Senate,26,Rep,Jacqueline Haro,98
+New York,66009,State Senate,26,Rep,Jacqueline Haro,131
+New York,66010,State Senate,26,Rep,Jacqueline Haro,100
+New York,66011,State Senate,26,Rep,Jacqueline Haro,58
+New York,66012,State Senate,26,Rep,Jacqueline Haro,129
+New York,66013,State Senate,26,Rep,Jacqueline Haro,62
+New York,66014,State Senate,26,Rep,Jacqueline Haro,34
+New York,66015,State Senate,26,Rep,Jacqueline Haro,29
+New York,66016,State Senate,26,Rep,Jacqueline Haro,6
+New York,66017,State Senate,26,Rep,Jacqueline Haro,0
+New York,66018,State Senate,26,Rep,Jacqueline Haro,101
+New York,66019,State Senate,26,Rep,Jacqueline Haro,75
+New York,66020,State Senate,26,Rep,Jacqueline Haro,67
+New York,66021,State Senate,26,Rep,Jacqueline Haro,63
+New York,66022,State Senate,26,Rep,Jacqueline Haro,97
+New York,66023,State Senate,26,Rep,Jacqueline Haro,28
+New York,66024,State Senate,26,Rep,Jacqueline Haro,45
+New York,66025,State Senate,26,Rep,Jacqueline Haro,47
+New York,66026,State Senate,26,Rep,Jacqueline Haro,1
+New York,66027,State Senate,26,Rep,Jacqueline Haro,31
+New York,66040,State Senate,26,Rep,Jacqueline Haro,15
+New York,66041,State Senate,26,Rep,Jacqueline Haro,99
+New York,66042,State Senate,26,Rep,Jacqueline Haro,13
+New York,66043,State Senate,26,Rep,Jacqueline Haro,71
+New York,66044,State Senate,26,Rep,Jacqueline Haro,49
+New York,66070,State Senate,26,Rep,Jacqueline Haro,42
+New York,74001,State Senate,26,Rep,Jacqueline Haro,6
+New York,74002,State Senate,26,Rep,Jacqueline Haro,6
+New York,74003,State Senate,26,Rep,Jacqueline Haro,9
+New York,74004,State Senate,26,Rep,Jacqueline Haro,10
+New York,74005,State Senate,26,Rep,Jacqueline Haro,3
+New York,74006,State Senate,26,Rep,Jacqueline Haro,7
+New York,74007,State Senate,26,Rep,Jacqueline Haro,32
+New York,74008,State Senate,26,Rep,Jacqueline Haro,22
+New York,74009,State Senate,26,Rep,Jacqueline Haro,8
+New York,74010,State Senate,26,Rep,Jacqueline Haro,44
+New York,74011,State Senate,26,Rep,Jacqueline Haro,16
+New York,74012,State Senate,26,Rep,Jacqueline Haro,6
+New York,74013,State Senate,26,Rep,Jacqueline Haro,10
+New York,74014,State Senate,26,Rep,Jacqueline Haro,5
+New York,74015,State Senate,26,Rep,Jacqueline Haro,29
+New York,74016,State Senate,26,Rep,Jacqueline Haro,8
+New York,74017,State Senate,26,Rep,Jacqueline Haro,11
+New York,74018,State Senate,26,Rep,Jacqueline Haro,24
+New York,65001,State Senate,26,Ind,writein,0
+New York,65002,State Senate,26,Ind,writein,0
+New York,65003,State Senate,26,Ind,writein,0
+New York,65004,State Senate,26,Ind,writein,1
+New York,65005,State Senate,26,Ind,writein,0
+New York,65006,State Senate,26,Ind,writein,0
+New York,65007,State Senate,26,Ind,writein,0
+New York,65008,State Senate,26,Ind,writein,0
+New York,65009,State Senate,26,Ind,writein,2
+New York,65010,State Senate,26,Ind,writein,0
+New York,65011,State Senate,26,Ind,writein,0
+New York,65012,State Senate,26,Ind,writein,0
+New York,65013,State Senate,26,Ind,writein,0
+New York,65014,State Senate,26,Ind,writein,0
+New York,65015,State Senate,26,Ind,writein,0
+New York,65016,State Senate,26,Ind,writein,0
+New York,65017,State Senate,26,Ind,writein,0
+New York,65018,State Senate,26,Ind,writein,0
+New York,65019,State Senate,26,Ind,writein,0
+New York,65020,State Senate,26,Ind,writein,0
+New York,65021,State Senate,26,Ind,writein,0
+New York,65022,State Senate,26,Ind,writein,0
+New York,65023,State Senate,26,Ind,writein,0
+New York,65024,State Senate,26,Ind,writein,1
+New York,65025,State Senate,26,Ind,writein,0
+New York,65026,State Senate,26,Ind,writein,0
+New York,65027,State Senate,26,Ind,writein,0
+New York,65028,State Senate,26,Ind,writein,0
+New York,65029,State Senate,26,Ind,writein,0
+New York,65030,State Senate,26,Ind,writein,0
+New York,65031,State Senate,26,Ind,writein,0
+New York,65032,State Senate,26,Ind,writein,0
+New York,65033,State Senate,26,Ind,writein,0
+New York,65034,State Senate,26,Ind,writein,0
+New York,65035,State Senate,26,Ind,writein,0
+New York,65036,State Senate,26,Ind,writein,0
+New York,65037,State Senate,26,Ind,writein,0
+New York,65038,State Senate,26,Ind,writein,0
+New York,65039,State Senate,26,Ind,writein,0
+New York,65040,State Senate,26,Ind,writein,0
+New York,65041,State Senate,26,Ind,writein,1
+New York,65042,State Senate,26,Ind,writein,0
+New York,65043,State Senate,26,Ind,writein,0
+New York,65044,State Senate,26,Ind,writein,3
+New York,65045,State Senate,26,Ind,writein,1
+New York,65046,State Senate,26,Ind,writein,0
+New York,65047,State Senate,26,Ind,writein,0
+New York,65048,State Senate,26,Ind,writein,0
+New York,65049,State Senate,26,Ind,writein,0
+New York,65050,State Senate,26,Ind,writein,0
+New York,65051,State Senate,26,Ind,writein,0
+New York,65052,State Senate,26,Ind,writein,0
+New York,65053,State Senate,26,Ind,writein,0
+New York,65054,State Senate,26,Ind,writein,0
+New York,65055,State Senate,26,Ind,writein,0
+New York,65056,State Senate,26,Ind,writein,0
+New York,65057,State Senate,26,Ind,writein,0
+New York,65058,State Senate,26,Ind,writein,0
+New York,65059,State Senate,26,Ind,writein,0
+New York,65060,State Senate,26,Ind,writein,0
+New York,65061,State Senate,26,Ind,writein,0
+New York,65062,State Senate,26,Ind,writein,0
+New York,65063,State Senate,26,Ind,writein,0
+New York,65064,State Senate,26,Ind,writein,0
+New York,65065,State Senate,26,Ind,writein,0
+New York,65066,State Senate,26,Ind,writein,0
+New York,65067,State Senate,26,Ind,writein,0
+New York,65068,State Senate,26,Ind,writein,0
+New York,65069,State Senate,26,Ind,writein,0
+New York,65070,State Senate,26,Ind,writein,0
+New York,65071,State Senate,26,Ind,writein,1
+New York,65072,State Senate,26,Ind,writein,1
+New York,65073,State Senate,26,Ind,writein,0
+New York,65074,State Senate,26,Ind,writein,3
+New York,65075,State Senate,26,Ind,writein,1
+New York,65076,State Senate,26,Ind,writein,1
+New York,65077,State Senate,26,Ind,writein,0
+New York,65078,State Senate,26,Ind,writein,0
+New York,65080,State Senate,26,Ind,writein,0
+New York,65081,State Senate,26,Ind,writein,0
+New York,65082,State Senate,26,Ind,writein,0
+New York,66001,State Senate,26,Ind,writein,0
+New York,66002,State Senate,26,Ind,writein,0
+New York,66003,State Senate,26,Ind,writein,0
+New York,66004,State Senate,26,Ind,writein,1
+New York,66005,State Senate,26,Ind,writein,0
+New York,66006,State Senate,26,Ind,writein,0
+New York,66007,State Senate,26,Ind,writein,0
+New York,66008,State Senate,26,Ind,writein,0
+New York,66009,State Senate,26,Ind,writein,0
+New York,66010,State Senate,26,Ind,writein,0
+New York,66011,State Senate,26,Ind,writein,2
+New York,66012,State Senate,26,Ind,writein,1
+New York,66013,State Senate,26,Ind,writein,0
+New York,66014,State Senate,26,Ind,writein,0
+New York,66015,State Senate,26,Ind,writein,0
+New York,66016,State Senate,26,Ind,writein,0
+New York,66017,State Senate,26,Ind,writein,0
+New York,66018,State Senate,26,Ind,writein,0
+New York,66019,State Senate,26,Ind,writein,0
+New York,66020,State Senate,26,Ind,writein,1
+New York,66021,State Senate,26,Ind,writein,0
+New York,66022,State Senate,26,Ind,writein,1
+New York,66023,State Senate,26,Ind,writein,0
+New York,66024,State Senate,26,Ind,writein,0
+New York,66025,State Senate,26,Ind,writein,1
+New York,66026,State Senate,26,Ind,writein,0
+New York,66027,State Senate,26,Ind,writein,2
+New York,66040,State Senate,26,Ind,writein,0
+New York,66041,State Senate,26,Ind,writein,1
+New York,66042,State Senate,26,Ind,writein,0
+New York,66043,State Senate,26,Ind,writein,0
+New York,66044,State Senate,26,Ind,writein,0
+New York,66070,State Senate,26,Ind,writein,0
+New York,74001,State Senate,26,Ind,writein,0
+New York,74002,State Senate,26,Ind,writein,0
+New York,74003,State Senate,26,Ind,writein,0
+New York,74004,State Senate,26,Ind,writein,0
+New York,74005,State Senate,26,Ind,writein,0
+New York,74006,State Senate,26,Ind,writein,1
+New York,74007,State Senate,26,Ind,writein,0
+New York,74008,State Senate,26,Ind,writein,1
+New York,74009,State Senate,26,Ind,writein,0
+New York,74010,State Senate,26,Ind,writein,0
+New York,74011,State Senate,26,Ind,writein,0
+New York,74012,State Senate,26,Ind,writein,0
+New York,74013,State Senate,26,Ind,writein,0
+New York,74014,State Senate,26,Ind,writein,0
+New York,74015,State Senate,26,Ind,writein,1
+New York,74016,State Senate,26,Ind,writein,0
+New York,74017,State Senate,26,Ind,writein,0
+New York,74018,State Senate,26,Ind,writein,1
+New York,65079,State Senate,27,Dem,Brad Hoylman,425
+New York,66028,State Senate,27,Dem,Brad Hoylman,507
+New York,66029,State Senate,27,Dem,Brad Hoylman,475
+New York,66030,State Senate,27,Dem,Brad Hoylman,445
+New York,66031,State Senate,27,Dem,Brad Hoylman,424
+New York,66032,State Senate,27,Dem,Brad Hoylman,387
+New York,66033,State Senate,27,Dem,Brad Hoylman,265
+New York,66034,State Senate,27,Dem,Brad Hoylman,471
+New York,66035,State Senate,27,Dem,Brad Hoylman,462
+New York,66036,State Senate,27,Dem,Brad Hoylman,526
+New York,66037,State Senate,27,Dem,Brad Hoylman,475
+New York,66038,State Senate,27,Dem,Brad Hoylman,475
+New York,66039,State Senate,27,Dem,Brad Hoylman,554
+New York,66045,State Senate,27,Dem,Brad Hoylman,610
+New York,66046,State Senate,27,Dem,Brad Hoylman,378
+New York,66047,State Senate,27,Dem,Brad Hoylman,406
+New York,66048,State Senate,27,Dem,Brad Hoylman,546
+New York,66049,State Senate,27,Dem,Brad Hoylman,499
+New York,66050,State Senate,27,Dem,Brad Hoylman,345
+New York,66051,State Senate,27,Dem,Brad Hoylman,610
+New York,66052,State Senate,27,Dem,Brad Hoylman,432
+New York,66053,State Senate,27,Dem,Brad Hoylman,503
+New York,66054,State Senate,27,Dem,Brad Hoylman,474
+New York,66057,State Senate,27,Dem,Brad Hoylman,477
+New York,66058,State Senate,27,Dem,Brad Hoylman,221
+New York,66059,State Senate,27,Dem,Brad Hoylman,476
+New York,66060,State Senate,27,Dem,Brad Hoylman,461
+New York,66061,State Senate,27,Dem,Brad Hoylman,506
+New York,66062,State Senate,27,Dem,Brad Hoylman,304
+New York,66063,State Senate,27,Dem,Brad Hoylman,482
+New York,66064,State Senate,27,Dem,Brad Hoylman,509
+New York,66065,State Senate,27,Dem,Brad Hoylman,141
+New York,66066,State Senate,27,Dem,Brad Hoylman,435
+New York,66067,State Senate,27,Dem,Brad Hoylman,439
+New York,66068,State Senate,27,Dem,Brad Hoylman,373
+New York,66069,State Senate,27,Dem,Brad Hoylman,520
+New York,66071,State Senate,27,Dem,Brad Hoylman,250
+New York,66072,State Senate,27,Dem,Brad Hoylman,417
+New York,66073,State Senate,27,Dem,Brad Hoylman,519
+New York,66074,State Senate,27,Dem,Brad Hoylman,410
+New York,66075,State Senate,27,Dem,Brad Hoylman,443
+New York,66076,State Senate,27,Dem,Brad Hoylman,542
+New York,66077,State Senate,27,Dem,Brad Hoylman,562
+New York,66078,State Senate,27,Dem,Brad Hoylman,551
+New York,66079,State Senate,27,Dem,Brad Hoylman,566
+New York,66080,State Senate,27,Dem,Brad Hoylman,492
+New York,66081,State Senate,27,Dem,Brad Hoylman,598
+New York,66082,State Senate,27,Dem,Brad Hoylman,431
+New York,66083,State Senate,27,Dem,Brad Hoylman,386
+New York,66084,State Senate,27,Dem,Brad Hoylman,577
+New York,66085,State Senate,27,Dem,Brad Hoylman,519
+New York,66086,State Senate,27,Dem,Brad Hoylman,491
+New York,66087,State Senate,27,Dem,Brad Hoylman,463
+New York,66088,State Senate,27,Dem,Brad Hoylman,301
+New York,66089,State Senate,27,Dem,Brad Hoylman,355
+New York,66090,State Senate,27,Dem,Brad Hoylman,270
+New York,67002,State Senate,27,Dem,Brad Hoylman,329
+New York,67004,State Senate,27,Dem,Brad Hoylman,345
+New York,67006,State Senate,27,Dem,Brad Hoylman,589
+New York,67008,State Senate,27,Dem,Brad Hoylman,418
+New York,67009,State Senate,27,Dem,Brad Hoylman,438
+New York,67010,State Senate,27,Dem,Brad Hoylman,598
+New York,67011,State Senate,27,Dem,Brad Hoylman,223
+New York,67012,State Senate,27,Dem,Brad Hoylman,79
+New York,67013,State Senate,27,Dem,Brad Hoylman,335
+New York,67014,State Senate,27,Dem,Brad Hoylman,455
+New York,67015,State Senate,27,Dem,Brad Hoylman,423
+New York,67016,State Senate,27,Dem,Brad Hoylman,333
+New York,67017,State Senate,27,Dem,Brad Hoylman,370
+New York,67018,State Senate,27,Dem,Brad Hoylman,488
+New York,67019,State Senate,27,Dem,Brad Hoylman,352
+New York,67020,State Senate,27,Dem,Brad Hoylman,180
+New York,67021,State Senate,27,Dem,Brad Hoylman,424
+New York,67022,State Senate,27,Dem,Brad Hoylman,403
+New York,67023,State Senate,27,Dem,Brad Hoylman,166
+New York,67024,State Senate,27,Dem,Brad Hoylman,247
+New York,67031,State Senate,27,Dem,Brad Hoylman,466
+New York,67032,State Senate,27,Dem,Brad Hoylman,470
+New York,67033,State Senate,27,Dem,Brad Hoylman,352
+New York,67034,State Senate,27,Dem,Brad Hoylman,112
+New York,67035,State Senate,27,Dem,Brad Hoylman,295
+New York,67036,State Senate,27,Dem,Brad Hoylman,263
+New York,67037,State Senate,27,Dem,Brad Hoylman,441
+New York,67038,State Senate,27,Dem,Brad Hoylman,267
+New York,67039,State Senate,27,Dem,Brad Hoylman,288
+New York,67040,State Senate,27,Dem,Brad Hoylman,306
+New York,67041,State Senate,27,Dem,Brad Hoylman,420
+New York,67042,State Senate,27,Dem,Brad Hoylman,618
+New York,67043,State Senate,27,Dem,Brad Hoylman,635
+New York,67044,State Senate,27,Dem,Brad Hoylman,316
+New York,67045,State Senate,27,Dem,Brad Hoylman,488
+New York,67046,State Senate,27,Dem,Brad Hoylman,530
+New York,67047,State Senate,27,Dem,Brad Hoylman,355
+New York,67048,State Senate,27,Dem,Brad Hoylman,631
+New York,67049,State Senate,27,Dem,Brad Hoylman,334
+New York,67050,State Senate,27,Dem,Brad Hoylman,539
+New York,73006,State Senate,27,Dem,Brad Hoylman,331
+New York,73011,State Senate,27,Dem,Brad Hoylman,420
+New York,73012,State Senate,27,Dem,Brad Hoylman,67
+New York,73013,State Senate,27,Dem,Brad Hoylman,5
+New York,73015,State Senate,27,Dem,Brad Hoylman,123
+New York,73020,State Senate,27,Dem,Brad Hoylman,20
+New York,73043,State Senate,27,Dem,Brad Hoylman,54
+New York,74019,State Senate,27,Dem,Brad Hoylman,425
+New York,74020,State Senate,27,Dem,Brad Hoylman,329
+New York,74021,State Senate,27,Dem,Brad Hoylman,446
+New York,74022,State Senate,27,Dem,Brad Hoylman,371
+New York,74023,State Senate,27,Dem,Brad Hoylman,417
+New York,74024,State Senate,27,Dem,Brad Hoylman,414
+New York,74025,State Senate,27,Dem,Brad Hoylman,381
+New York,74026,State Senate,27,Dem,Brad Hoylman,298
+New York,74027,State Senate,27,Dem,Brad Hoylman,216
+New York,74028,State Senate,27,Dem,Brad Hoylman,154
+New York,74029,State Senate,27,Dem,Brad Hoylman,225
+New York,74030,State Senate,27,Dem,Brad Hoylman,135
+New York,74031,State Senate,27,Dem,Brad Hoylman,307
+New York,74032,State Senate,27,Dem,Brad Hoylman,380
+New York,74033,State Senate,27,Dem,Brad Hoylman,419
+New York,74034,State Senate,27,Dem,Brad Hoylman,424
+New York,74035,State Senate,27,Dem,Brad Hoylman,221
+New York,74036,State Senate,27,Dem,Brad Hoylman,467
+New York,74037,State Senate,27,Dem,Brad Hoylman,427
+New York,74038,State Senate,27,Dem,Brad Hoylman,236
+New York,74039,State Senate,27,Dem,Brad Hoylman,636
+New York,74040,State Senate,27,Dem,Brad Hoylman,422
+New York,74041,State Senate,27,Dem,Brad Hoylman,530
+New York,74042,State Senate,27,Dem,Brad Hoylman,440
+New York,74043,State Senate,27,Dem,Brad Hoylman,501
+New York,74044,State Senate,27,Dem,Brad Hoylman,423
+New York,74045,State Senate,27,Dem,Brad Hoylman,569
+New York,74046,State Senate,27,Dem,Brad Hoylman,582
+New York,74047,State Senate,27,Dem,Brad Hoylman,508
+New York,74048,State Senate,27,Dem,Brad Hoylman,370
+New York,74049,State Senate,27,Dem,Brad Hoylman,314
+New York,74050,State Senate,27,Dem,Brad Hoylman,446
+New York,74051,State Senate,27,Dem,Brad Hoylman,383
+New York,74052,State Senate,27,Dem,Brad Hoylman,318
+New York,74053,State Senate,27,Dem,Brad Hoylman,423
+New York,74054,State Senate,27,Dem,Brad Hoylman,403
+New York,74055,State Senate,27,Dem,Brad Hoylman,218
+New York,74071,State Senate,27,Dem,Brad Hoylman,309
+New York,74072,State Senate,27,Dem,Brad Hoylman,255
+New York,74073,State Senate,27,Dem,Brad Hoylman,445
+New York,74074,State Senate,27,Dem,Brad Hoylman,344
+New York,74075,State Senate,27,Dem,Brad Hoylman,412
+New York,74076,State Senate,27,Dem,Brad Hoylman,391
+New York,74077,State Senate,27,Dem,Brad Hoylman,332
+New York,74078,State Senate,27,Dem,Brad Hoylman,373
+New York,74079,State Senate,27,Dem,Brad Hoylman,304
+New York,74080,State Senate,27,Dem,Brad Hoylman,231
+New York,74081,State Senate,27,Dem,Brad Hoylman,108
+New York,74084,State Senate,27,Dem,Brad Hoylman,234
+New York,75001,State Senate,27,Dem,Brad Hoylman,613
+New York,75002,State Senate,27,Dem,Brad Hoylman,483
+New York,75003,State Senate,27,Dem,Brad Hoylman,301
+New York,75004,State Senate,27,Dem,Brad Hoylman,407
+New York,75005,State Senate,27,Dem,Brad Hoylman,545
+New York,75006,State Senate,27,Dem,Brad Hoylman,450
+New York,75007,State Senate,27,Dem,Brad Hoylman,155
+New York,75010,State Senate,27,Dem,Brad Hoylman,452
+New York,75011,State Senate,27,Dem,Brad Hoylman,538
+New York,75012,State Senate,27,Dem,Brad Hoylman,492
+New York,75013,State Senate,27,Dem,Brad Hoylman,302
+New York,75014,State Senate,27,Dem,Brad Hoylman,412
+New York,75015,State Senate,27,Dem,Brad Hoylman,390
+New York,75016,State Senate,27,Dem,Brad Hoylman,650
+New York,75017,State Senate,27,Dem,Brad Hoylman,449
+New York,75018,State Senate,27,Dem,Brad Hoylman,275
+New York,75019,State Senate,27,Dem,Brad Hoylman,367
+New York,75020,State Senate,27,Dem,Brad Hoylman,626
+New York,75021,State Senate,27,Dem,Brad Hoylman,288
+New York,75022,State Senate,27,Dem,Brad Hoylman,555
+New York,75023,State Senate,27,Dem,Brad Hoylman,309
+New York,75024,State Senate,27,Dem,Brad Hoylman,377
+New York,75025,State Senate,27,Dem,Brad Hoylman,449
+New York,75026,State Senate,27,Dem,Brad Hoylman,552
+New York,75027,State Senate,27,Dem,Brad Hoylman,575
+New York,75028,State Senate,27,Dem,Brad Hoylman,514
+New York,75036,State Senate,27,Dem,Brad Hoylman,517
+New York,75037,State Senate,27,Dem,Brad Hoylman,315
+New York,75038,State Senate,27,Dem,Brad Hoylman,433
+New York,75039,State Senate,27,Dem,Brad Hoylman,295
+New York,75040,State Senate,27,Dem,Brad Hoylman,307
+New York,75041,State Senate,27,Dem,Brad Hoylman,400
+New York,75042,State Senate,27,Dem,Brad Hoylman,500
+New York,75043,State Senate,27,Dem,Brad Hoylman,471
+New York,75044,State Senate,27,Dem,Brad Hoylman,496
+New York,75046,State Senate,27,Dem,Brad Hoylman,208
+New York,75047,State Senate,27,Dem,Brad Hoylman,312
+New York,75048,State Senate,27,Dem,Brad Hoylman,174
+New York,75049,State Senate,27,Dem,Brad Hoylman,272
+New York,75050,State Senate,27,Dem,Brad Hoylman,314
+New York,75058,State Senate,27,Dem,Brad Hoylman,266
+New York,75062,State Senate,27,Dem,Brad Hoylman,469
+New York,75063,State Senate,27,Dem,Brad Hoylman,350
+New York,75064,State Senate,27,Dem,Brad Hoylman,568
+New York,75068,State Senate,27,Dem,Brad Hoylman,114
+New York,75069,State Senate,27,Dem,Brad Hoylman,433
+New York,75070,State Senate,27,Dem,Brad Hoylman,384
+New York,75071,State Senate,27,Dem,Brad Hoylman,674
+New York,75072,State Senate,27,Dem,Brad Hoylman,695
+New York,75073,State Senate,27,Dem,Brad Hoylman,399
+New York,75074,State Senate,27,Dem,Brad Hoylman,297
+New York,75075,State Senate,27,Dem,Brad Hoylman,178
+New York,75076,State Senate,27,Dem,Brad Hoylman,280
+New York,75077,State Senate,27,Dem,Brad Hoylman,381
+New York,75078,State Senate,27,Dem,Brad Hoylman,257
+New York,75079,State Senate,27,Dem,Brad Hoylman,321
+New York,75080,State Senate,27,Dem,Brad Hoylman,536
+New York,75081,State Senate,27,Dem,Brad Hoylman,382
+New York,75082,State Senate,27,Dem,Brad Hoylman,396
+New York,75083,State Senate,27,Dem,Brad Hoylman,509
+New York,75084,State Senate,27,Dem,Brad Hoylman,465
+New York,75085,State Senate,27,Dem,Brad Hoylman,303
+New York,75089,State Senate,27,Dem,Brad Hoylman,148
+New York,75094,State Senate,27,Dem,Brad Hoylman,494
+New York,75095,State Senate,27,Dem,Brad Hoylman,363
+New York,75096,State Senate,27,Dem,Brad Hoylman,353
+New York,75097,State Senate,27,Dem,Brad Hoylman,461
+New York,75098,State Senate,27,Dem,Brad Hoylman,337
+New York,75099,State Senate,27,Dem,Brad Hoylman,378
+New York,65079,State Senate,27,WF,Brad Hoylman,44
+New York,66028,State Senate,27,WF,Brad Hoylman,56
+New York,66029,State Senate,27,WF,Brad Hoylman,49
+New York,66030,State Senate,27,WF,Brad Hoylman,43
+New York,66031,State Senate,27,WF,Brad Hoylman,67
+New York,66032,State Senate,27,WF,Brad Hoylman,44
+New York,66033,State Senate,27,WF,Brad Hoylman,11
+New York,66034,State Senate,27,WF,Brad Hoylman,45
+New York,66035,State Senate,27,WF,Brad Hoylman,59
+New York,66036,State Senate,27,WF,Brad Hoylman,39
+New York,66037,State Senate,27,WF,Brad Hoylman,38
+New York,66038,State Senate,27,WF,Brad Hoylman,29
+New York,66039,State Senate,27,WF,Brad Hoylman,22
+New York,66045,State Senate,27,WF,Brad Hoylman,59
+New York,66046,State Senate,27,WF,Brad Hoylman,41
+New York,66047,State Senate,27,WF,Brad Hoylman,27
+New York,66048,State Senate,27,WF,Brad Hoylman,22
+New York,66049,State Senate,27,WF,Brad Hoylman,27
+New York,66050,State Senate,27,WF,Brad Hoylman,31
+New York,66051,State Senate,27,WF,Brad Hoylman,35
+New York,66052,State Senate,27,WF,Brad Hoylman,14
+New York,66053,State Senate,27,WF,Brad Hoylman,38
+New York,66054,State Senate,27,WF,Brad Hoylman,22
+New York,66057,State Senate,27,WF,Brad Hoylman,20
+New York,66058,State Senate,27,WF,Brad Hoylman,8
+New York,66059,State Senate,27,WF,Brad Hoylman,26
+New York,66060,State Senate,27,WF,Brad Hoylman,31
+New York,66061,State Senate,27,WF,Brad Hoylman,29
+New York,66062,State Senate,27,WF,Brad Hoylman,16
+New York,66063,State Senate,27,WF,Brad Hoylman,29
+New York,66064,State Senate,27,WF,Brad Hoylman,28
+New York,66065,State Senate,27,WF,Brad Hoylman,12
+New York,66066,State Senate,27,WF,Brad Hoylman,21
+New York,66067,State Senate,27,WF,Brad Hoylman,42
+New York,66068,State Senate,27,WF,Brad Hoylman,28
+New York,66069,State Senate,27,WF,Brad Hoylman,37
+New York,66071,State Senate,27,WF,Brad Hoylman,26
+New York,66072,State Senate,27,WF,Brad Hoylman,22
+New York,66073,State Senate,27,WF,Brad Hoylman,46
+New York,66074,State Senate,27,WF,Brad Hoylman,25
+New York,66075,State Senate,27,WF,Brad Hoylman,39
+New York,66076,State Senate,27,WF,Brad Hoylman,44
+New York,66077,State Senate,27,WF,Brad Hoylman,32
+New York,66078,State Senate,27,WF,Brad Hoylman,44
+New York,66079,State Senate,27,WF,Brad Hoylman,48
+New York,66080,State Senate,27,WF,Brad Hoylman,33
+New York,66081,State Senate,27,WF,Brad Hoylman,40
+New York,66082,State Senate,27,WF,Brad Hoylman,29
+New York,66083,State Senate,27,WF,Brad Hoylman,29
+New York,66084,State Senate,27,WF,Brad Hoylman,37
+New York,66085,State Senate,27,WF,Brad Hoylman,44
+New York,66086,State Senate,27,WF,Brad Hoylman,44
+New York,66087,State Senate,27,WF,Brad Hoylman,20
+New York,66088,State Senate,27,WF,Brad Hoylman,24
+New York,66089,State Senate,27,WF,Brad Hoylman,30
+New York,66090,State Senate,27,WF,Brad Hoylman,17
+New York,67002,State Senate,27,WF,Brad Hoylman,27
+New York,67004,State Senate,27,WF,Brad Hoylman,27
+New York,67006,State Senate,27,WF,Brad Hoylman,44
+New York,67008,State Senate,27,WF,Brad Hoylman,20
+New York,67009,State Senate,27,WF,Brad Hoylman,20
+New York,67010,State Senate,27,WF,Brad Hoylman,43
+New York,67011,State Senate,27,WF,Brad Hoylman,17
+New York,67012,State Senate,27,WF,Brad Hoylman,1
+New York,67013,State Senate,27,WF,Brad Hoylman,23
+New York,67014,State Senate,27,WF,Brad Hoylman,25
+New York,67015,State Senate,27,WF,Brad Hoylman,37
+New York,67016,State Senate,27,WF,Brad Hoylman,16
+New York,67017,State Senate,27,WF,Brad Hoylman,24
+New York,67018,State Senate,27,WF,Brad Hoylman,33
+New York,67019,State Senate,27,WF,Brad Hoylman,14
+New York,67020,State Senate,27,WF,Brad Hoylman,8
+New York,67021,State Senate,27,WF,Brad Hoylman,15
+New York,67022,State Senate,27,WF,Brad Hoylman,13
+New York,67023,State Senate,27,WF,Brad Hoylman,13
+New York,67024,State Senate,27,WF,Brad Hoylman,14
+New York,67031,State Senate,27,WF,Brad Hoylman,29
+New York,67032,State Senate,27,WF,Brad Hoylman,20
+New York,67033,State Senate,27,WF,Brad Hoylman,19
+New York,67034,State Senate,27,WF,Brad Hoylman,3
+New York,67035,State Senate,27,WF,Brad Hoylman,18
+New York,67036,State Senate,27,WF,Brad Hoylman,10
+New York,67037,State Senate,27,WF,Brad Hoylman,26
+New York,67038,State Senate,27,WF,Brad Hoylman,10
+New York,67039,State Senate,27,WF,Brad Hoylman,9
+New York,67040,State Senate,27,WF,Brad Hoylman,20
+New York,67041,State Senate,27,WF,Brad Hoylman,21
+New York,67042,State Senate,27,WF,Brad Hoylman,30
+New York,67043,State Senate,27,WF,Brad Hoylman,25
+New York,67044,State Senate,27,WF,Brad Hoylman,25
+New York,67045,State Senate,27,WF,Brad Hoylman,19
+New York,67046,State Senate,27,WF,Brad Hoylman,33
+New York,67047,State Senate,27,WF,Brad Hoylman,16
+New York,67048,State Senate,27,WF,Brad Hoylman,33
+New York,67049,State Senate,27,WF,Brad Hoylman,27
+New York,67050,State Senate,27,WF,Brad Hoylman,36
+New York,73006,State Senate,27,WF,Brad Hoylman,19
+New York,73011,State Senate,27,WF,Brad Hoylman,19
+New York,73012,State Senate,27,WF,Brad Hoylman,5
+New York,73013,State Senate,27,WF,Brad Hoylman,0
+New York,73015,State Senate,27,WF,Brad Hoylman,13
+New York,73020,State Senate,27,WF,Brad Hoylman,3
+New York,73043,State Senate,27,WF,Brad Hoylman,2
+New York,74019,State Senate,27,WF,Brad Hoylman,57
+New York,74020,State Senate,27,WF,Brad Hoylman,46
+New York,74021,State Senate,27,WF,Brad Hoylman,52
+New York,74022,State Senate,27,WF,Brad Hoylman,27
+New York,74023,State Senate,27,WF,Brad Hoylman,42
+New York,74024,State Senate,27,WF,Brad Hoylman,45
+New York,74025,State Senate,27,WF,Brad Hoylman,31
+New York,74026,State Senate,27,WF,Brad Hoylman,9
+New York,74027,State Senate,27,WF,Brad Hoylman,7
+New York,74028,State Senate,27,WF,Brad Hoylman,5
+New York,74029,State Senate,27,WF,Brad Hoylman,9
+New York,74030,State Senate,27,WF,Brad Hoylman,3
+New York,74031,State Senate,27,WF,Brad Hoylman,30
+New York,74032,State Senate,27,WF,Brad Hoylman,41
+New York,74033,State Senate,27,WF,Brad Hoylman,49
+New York,74034,State Senate,27,WF,Brad Hoylman,36
+New York,74035,State Senate,27,WF,Brad Hoylman,9
+New York,74036,State Senate,27,WF,Brad Hoylman,46
+New York,74037,State Senate,27,WF,Brad Hoylman,49
+New York,74038,State Senate,27,WF,Brad Hoylman,20
+New York,74039,State Senate,27,WF,Brad Hoylman,60
+New York,74040,State Senate,27,WF,Brad Hoylman,42
+New York,74041,State Senate,27,WF,Brad Hoylman,54
+New York,74042,State Senate,27,WF,Brad Hoylman,44
+New York,74043,State Senate,27,WF,Brad Hoylman,35
+New York,74044,State Senate,27,WF,Brad Hoylman,48
+New York,74045,State Senate,27,WF,Brad Hoylman,44
+New York,74046,State Senate,27,WF,Brad Hoylman,51
+New York,74047,State Senate,27,WF,Brad Hoylman,47
+New York,74048,State Senate,27,WF,Brad Hoylman,38
+New York,74049,State Senate,27,WF,Brad Hoylman,28
+New York,74050,State Senate,27,WF,Brad Hoylman,30
+New York,74051,State Senate,27,WF,Brad Hoylman,19
+New York,74052,State Senate,27,WF,Brad Hoylman,18
+New York,74053,State Senate,27,WF,Brad Hoylman,49
+New York,74054,State Senate,27,WF,Brad Hoylman,21
+New York,74055,State Senate,27,WF,Brad Hoylman,6
+New York,74071,State Senate,27,WF,Brad Hoylman,22
+New York,74072,State Senate,27,WF,Brad Hoylman,14
+New York,74073,State Senate,27,WF,Brad Hoylman,15
+New York,74074,State Senate,27,WF,Brad Hoylman,20
+New York,74075,State Senate,27,WF,Brad Hoylman,18
+New York,74076,State Senate,27,WF,Brad Hoylman,12
+New York,74077,State Senate,27,WF,Brad Hoylman,18
+New York,74078,State Senate,27,WF,Brad Hoylman,11
+New York,74079,State Senate,27,WF,Brad Hoylman,18
+New York,74080,State Senate,27,WF,Brad Hoylman,9
+New York,74081,State Senate,27,WF,Brad Hoylman,5
+New York,74084,State Senate,27,WF,Brad Hoylman,12
+New York,75001,State Senate,27,WF,Brad Hoylman,36
+New York,75002,State Senate,27,WF,Brad Hoylman,23
+New York,75003,State Senate,27,WF,Brad Hoylman,19
+New York,75004,State Senate,27,WF,Brad Hoylman,35
+New York,75005,State Senate,27,WF,Brad Hoylman,38
+New York,75006,State Senate,27,WF,Brad Hoylman,29
+New York,75007,State Senate,27,WF,Brad Hoylman,13
+New York,75010,State Senate,27,WF,Brad Hoylman,26
+New York,75011,State Senate,27,WF,Brad Hoylman,27
+New York,75012,State Senate,27,WF,Brad Hoylman,20
+New York,75013,State Senate,27,WF,Brad Hoylman,8
+New York,75014,State Senate,27,WF,Brad Hoylman,22
+New York,75015,State Senate,27,WF,Brad Hoylman,38
+New York,75016,State Senate,27,WF,Brad Hoylman,46
+New York,75017,State Senate,27,WF,Brad Hoylman,23
+New York,75018,State Senate,27,WF,Brad Hoylman,24
+New York,75019,State Senate,27,WF,Brad Hoylman,29
+New York,75020,State Senate,27,WF,Brad Hoylman,48
+New York,75021,State Senate,27,WF,Brad Hoylman,17
+New York,75022,State Senate,27,WF,Brad Hoylman,15
+New York,75023,State Senate,27,WF,Brad Hoylman,25
+New York,75024,State Senate,27,WF,Brad Hoylman,23
+New York,75025,State Senate,27,WF,Brad Hoylman,41
+New York,75026,State Senate,27,WF,Brad Hoylman,43
+New York,75027,State Senate,27,WF,Brad Hoylman,47
+New York,75028,State Senate,27,WF,Brad Hoylman,38
+New York,75036,State Senate,27,WF,Brad Hoylman,30
+New York,75037,State Senate,27,WF,Brad Hoylman,20
+New York,75038,State Senate,27,WF,Brad Hoylman,80
+New York,75039,State Senate,27,WF,Brad Hoylman,19
+New York,75040,State Senate,27,WF,Brad Hoylman,10
+New York,75041,State Senate,27,WF,Brad Hoylman,41
+New York,75042,State Senate,27,WF,Brad Hoylman,39
+New York,75043,State Senate,27,WF,Brad Hoylman,76
+New York,75044,State Senate,27,WF,Brad Hoylman,69
+New York,75046,State Senate,27,WF,Brad Hoylman,12
+New York,75047,State Senate,27,WF,Brad Hoylman,10
+New York,75048,State Senate,27,WF,Brad Hoylman,9
+New York,75049,State Senate,27,WF,Brad Hoylman,13
+New York,75050,State Senate,27,WF,Brad Hoylman,11
+New York,75058,State Senate,27,WF,Brad Hoylman,15
+New York,75062,State Senate,27,WF,Brad Hoylman,21
+New York,75063,State Senate,27,WF,Brad Hoylman,29
+New York,75064,State Senate,27,WF,Brad Hoylman,29
+New York,75068,State Senate,27,WF,Brad Hoylman,8
+New York,75069,State Senate,27,WF,Brad Hoylman,18
+New York,75070,State Senate,27,WF,Brad Hoylman,29
+New York,75071,State Senate,27,WF,Brad Hoylman,48
+New York,75072,State Senate,27,WF,Brad Hoylman,60
+New York,75073,State Senate,27,WF,Brad Hoylman,16
+New York,75074,State Senate,27,WF,Brad Hoylman,16
+New York,75075,State Senate,27,WF,Brad Hoylman,14
+New York,75076,State Senate,27,WF,Brad Hoylman,10
+New York,75077,State Senate,27,WF,Brad Hoylman,36
+New York,75078,State Senate,27,WF,Brad Hoylman,24
+New York,75079,State Senate,27,WF,Brad Hoylman,13
+New York,75080,State Senate,27,WF,Brad Hoylman,39
+New York,75081,State Senate,27,WF,Brad Hoylman,17
+New York,75082,State Senate,27,WF,Brad Hoylman,19
+New York,75083,State Senate,27,WF,Brad Hoylman,32
+New York,75084,State Senate,27,WF,Brad Hoylman,19
+New York,75085,State Senate,27,WF,Brad Hoylman,17
+New York,75089,State Senate,27,WF,Brad Hoylman,5
+New York,75094,State Senate,27,WF,Brad Hoylman,26
+New York,75095,State Senate,27,WF,Brad Hoylman,16
+New York,75096,State Senate,27,WF,Brad Hoylman,14
+New York,75097,State Senate,27,WF,Brad Hoylman,12
+New York,75098,State Senate,27,WF,Brad Hoylman,24
+New York,75099,State Senate,27,WF,Brad Hoylman,20
+New York,65079,State Senate,27,Ind,writein,1
+New York,66028,State Senate,27,Ind,writein,0
+New York,66029,State Senate,27,Ind,writein,1
+New York,66030,State Senate,27,Ind,writein,0
+New York,66031,State Senate,27,Ind,writein,3
+New York,66032,State Senate,27,Ind,writein,1
+New York,66033,State Senate,27,Ind,writein,1
+New York,66034,State Senate,27,Ind,writein,0
+New York,66035,State Senate,27,Ind,writein,3
+New York,66036,State Senate,27,Ind,writein,1
+New York,66037,State Senate,27,Ind,writein,1
+New York,66038,State Senate,27,Ind,writein,0
+New York,66039,State Senate,27,Ind,writein,0
+New York,66045,State Senate,27,Ind,writein,1
+New York,66046,State Senate,27,Ind,writein,0
+New York,66047,State Senate,27,Ind,writein,1
+New York,66048,State Senate,27,Ind,writein,0
+New York,66049,State Senate,27,Ind,writein,0
+New York,66050,State Senate,27,Ind,writein,0
+New York,66051,State Senate,27,Ind,writein,2
+New York,66052,State Senate,27,Ind,writein,0
+New York,66053,State Senate,27,Ind,writein,0
+New York,66054,State Senate,27,Ind,writein,0
+New York,66057,State Senate,27,Ind,writein,0
+New York,66058,State Senate,27,Ind,writein,1
+New York,66059,State Senate,27,Ind,writein,1
+New York,66060,State Senate,27,Ind,writein,1
+New York,66061,State Senate,27,Ind,writein,0
+New York,66062,State Senate,27,Ind,writein,0
+New York,66063,State Senate,27,Ind,writein,4
+New York,66064,State Senate,27,Ind,writein,1
+New York,66065,State Senate,27,Ind,writein,0
+New York,66066,State Senate,27,Ind,writein,1
+New York,66067,State Senate,27,Ind,writein,0
+New York,66068,State Senate,27,Ind,writein,4
+New York,66069,State Senate,27,Ind,writein,0
+New York,66071,State Senate,27,Ind,writein,0
+New York,66072,State Senate,27,Ind,writein,1
+New York,66073,State Senate,27,Ind,writein,1
+New York,66074,State Senate,27,Ind,writein,0
+New York,66075,State Senate,27,Ind,writein,0
+New York,66076,State Senate,27,Ind,writein,4
+New York,66077,State Senate,27,Ind,writein,0
+New York,66078,State Senate,27,Ind,writein,2
+New York,66079,State Senate,27,Ind,writein,1
+New York,66080,State Senate,27,Ind,writein,1
+New York,66081,State Senate,27,Ind,writein,0
+New York,66082,State Senate,27,Ind,writein,2
+New York,66083,State Senate,27,Ind,writein,4
+New York,66084,State Senate,27,Ind,writein,1
+New York,66085,State Senate,27,Ind,writein,0
+New York,66086,State Senate,27,Ind,writein,0
+New York,66087,State Senate,27,Ind,writein,0
+New York,66088,State Senate,27,Ind,writein,2
+New York,66089,State Senate,27,Ind,writein,0
+New York,66090,State Senate,27,Ind,writein,0
+New York,67002,State Senate,27,Ind,writein,1
+New York,67004,State Senate,27,Ind,writein,1
+New York,67006,State Senate,27,Ind,writein,1
+New York,67008,State Senate,27,Ind,writein,0
+New York,67009,State Senate,27,Ind,writein,1
+New York,67010,State Senate,27,Ind,writein,3
+New York,67011,State Senate,27,Ind,writein,0
+New York,67012,State Senate,27,Ind,writein,1
+New York,67013,State Senate,27,Ind,writein,0
+New York,67014,State Senate,27,Ind,writein,2
+New York,67015,State Senate,27,Ind,writein,0
+New York,67016,State Senate,27,Ind,writein,0
+New York,67017,State Senate,27,Ind,writein,4
+New York,67018,State Senate,27,Ind,writein,2
+New York,67019,State Senate,27,Ind,writein,1
+New York,67020,State Senate,27,Ind,writein,1
+New York,67021,State Senate,27,Ind,writein,1
+New York,67022,State Senate,27,Ind,writein,1
+New York,67023,State Senate,27,Ind,writein,0
+New York,67024,State Senate,27,Ind,writein,0
+New York,67031,State Senate,27,Ind,writein,0
+New York,67032,State Senate,27,Ind,writein,1
+New York,67033,State Senate,27,Ind,writein,3
+New York,67034,State Senate,27,Ind,writein,0
+New York,67035,State Senate,27,Ind,writein,2
+New York,67036,State Senate,27,Ind,writein,1
+New York,67037,State Senate,27,Ind,writein,1
+New York,67038,State Senate,27,Ind,writein,1
+New York,67039,State Senate,27,Ind,writein,0
+New York,67040,State Senate,27,Ind,writein,1
+New York,67041,State Senate,27,Ind,writein,1
+New York,67042,State Senate,27,Ind,writein,0
+New York,67043,State Senate,27,Ind,writein,1
+New York,67044,State Senate,27,Ind,writein,0
+New York,67045,State Senate,27,Ind,writein,0
+New York,67046,State Senate,27,Ind,writein,4
+New York,67047,State Senate,27,Ind,writein,0
+New York,67048,State Senate,27,Ind,writein,1
+New York,67049,State Senate,27,Ind,writein,1
+New York,67050,State Senate,27,Ind,writein,0
+New York,73006,State Senate,27,Ind,writein,2
+New York,73011,State Senate,27,Ind,writein,1
+New York,73012,State Senate,27,Ind,writein,0
+New York,73013,State Senate,27,Ind,writein,0
+New York,73015,State Senate,27,Ind,writein,0
+New York,73020,State Senate,27,Ind,writein,0
+New York,73043,State Senate,27,Ind,writein,1
+New York,74019,State Senate,27,Ind,writein,0
+New York,74020,State Senate,27,Ind,writein,0
+New York,74021,State Senate,27,Ind,writein,0
+New York,74022,State Senate,27,Ind,writein,1
+New York,74023,State Senate,27,Ind,writein,0
+New York,74024,State Senate,27,Ind,writein,2
+New York,74025,State Senate,27,Ind,writein,0
+New York,74026,State Senate,27,Ind,writein,0
+New York,74027,State Senate,27,Ind,writein,0
+New York,74028,State Senate,27,Ind,writein,0
+New York,74029,State Senate,27,Ind,writein,0
+New York,74030,State Senate,27,Ind,writein,0
+New York,74031,State Senate,27,Ind,writein,0
+New York,74032,State Senate,27,Ind,writein,0
+New York,74033,State Senate,27,Ind,writein,0
+New York,74034,State Senate,27,Ind,writein,0
+New York,74035,State Senate,27,Ind,writein,0
+New York,74036,State Senate,27,Ind,writein,2
+New York,74037,State Senate,27,Ind,writein,0
+New York,74038,State Senate,27,Ind,writein,1
+New York,74039,State Senate,27,Ind,writein,0
+New York,74040,State Senate,27,Ind,writein,4
+New York,74041,State Senate,27,Ind,writein,1
+New York,74042,State Senate,27,Ind,writein,2
+New York,74043,State Senate,27,Ind,writein,0
+New York,74044,State Senate,27,Ind,writein,1
+New York,74045,State Senate,27,Ind,writein,0
+New York,74046,State Senate,27,Ind,writein,0
+New York,74047,State Senate,27,Ind,writein,3
+New York,74048,State Senate,27,Ind,writein,0
+New York,74049,State Senate,27,Ind,writein,4
+New York,74050,State Senate,27,Ind,writein,1
+New York,74051,State Senate,27,Ind,writein,0
+New York,74052,State Senate,27,Ind,writein,2
+New York,74053,State Senate,27,Ind,writein,2
+New York,74054,State Senate,27,Ind,writein,0
+New York,74055,State Senate,27,Ind,writein,2
+New York,74071,State Senate,27,Ind,writein,0
+New York,74072,State Senate,27,Ind,writein,1
+New York,74073,State Senate,27,Ind,writein,2
+New York,74074,State Senate,27,Ind,writein,2
+New York,74075,State Senate,27,Ind,writein,4
+New York,74076,State Senate,27,Ind,writein,2
+New York,74077,State Senate,27,Ind,writein,2
+New York,74078,State Senate,27,Ind,writein,1
+New York,74079,State Senate,27,Ind,writein,2
+New York,74080,State Senate,27,Ind,writein,0
+New York,74081,State Senate,27,Ind,writein,0
+New York,74084,State Senate,27,Ind,writein,0
+New York,75001,State Senate,27,Ind,writein,1
+New York,75002,State Senate,27,Ind,writein,1
+New York,75003,State Senate,27,Ind,writein,1
+New York,75004,State Senate,27,Ind,writein,1
+New York,75005,State Senate,27,Ind,writein,1
+New York,75006,State Senate,27,Ind,writein,2
+New York,75007,State Senate,27,Ind,writein,0
+New York,75010,State Senate,27,Ind,writein,2
+New York,75011,State Senate,27,Ind,writein,0
+New York,75012,State Senate,27,Ind,writein,3
+New York,75013,State Senate,27,Ind,writein,0
+New York,75014,State Senate,27,Ind,writein,1
+New York,75015,State Senate,27,Ind,writein,1
+New York,75016,State Senate,27,Ind,writein,0
+New York,75017,State Senate,27,Ind,writein,1
+New York,75018,State Senate,27,Ind,writein,0
+New York,75019,State Senate,27,Ind,writein,0
+New York,75020,State Senate,27,Ind,writein,2
+New York,75021,State Senate,27,Ind,writein,0
+New York,75022,State Senate,27,Ind,writein,1
+New York,75023,State Senate,27,Ind,writein,0
+New York,75024,State Senate,27,Ind,writein,0
+New York,75025,State Senate,27,Ind,writein,0
+New York,75026,State Senate,27,Ind,writein,2
+New York,75027,State Senate,27,Ind,writein,1
+New York,75028,State Senate,27,Ind,writein,0
+New York,75036,State Senate,27,Ind,writein,2
+New York,75037,State Senate,27,Ind,writein,0
+New York,75038,State Senate,27,Ind,writein,2
+New York,75039,State Senate,27,Ind,writein,1
+New York,75040,State Senate,27,Ind,writein,1
+New York,75041,State Senate,27,Ind,writein,0
+New York,75042,State Senate,27,Ind,writein,1
+New York,75043,State Senate,27,Ind,writein,2
+New York,75044,State Senate,27,Ind,writein,1
+New York,75046,State Senate,27,Ind,writein,0
+New York,75047,State Senate,27,Ind,writein,0
+New York,75048,State Senate,27,Ind,writein,1
+New York,75049,State Senate,27,Ind,writein,0
+New York,75050,State Senate,27,Ind,writein,1
+New York,75058,State Senate,27,Ind,writein,2
+New York,75062,State Senate,27,Ind,writein,2
+New York,75063,State Senate,27,Ind,writein,0
+New York,75064,State Senate,27,Ind,writein,3
+New York,75068,State Senate,27,Ind,writein,0
+New York,75069,State Senate,27,Ind,writein,1
+New York,75070,State Senate,27,Ind,writein,0
+New York,75071,State Senate,27,Ind,writein,1
+New York,75072,State Senate,27,Ind,writein,1
+New York,75073,State Senate,27,Ind,writein,3
+New York,75074,State Senate,27,Ind,writein,4
+New York,75075,State Senate,27,Ind,writein,0
+New York,75076,State Senate,27,Ind,writein,1
+New York,75077,State Senate,27,Ind,writein,0
+New York,75078,State Senate,27,Ind,writein,1
+New York,75079,State Senate,27,Ind,writein,0
+New York,75080,State Senate,27,Ind,writein,1
+New York,75081,State Senate,27,Ind,writein,1
+New York,75082,State Senate,27,Ind,writein,1
+New York,75083,State Senate,27,Ind,writein,3
+New York,75084,State Senate,27,Ind,writein,5
+New York,75085,State Senate,27,Ind,writein,0
+New York,75089,State Senate,27,Ind,writein,0
+New York,75094,State Senate,27,Ind,writein,1
+New York,75095,State Senate,27,Ind,writein,1
+New York,75096,State Senate,27,Ind,writein,1
+New York,75097,State Senate,27,Ind,writein,1
+New York,75098,State Senate,27,Ind,writein,2
+New York,75099,State Senate,27,Ind,writein,3
+New York,66055,State Senate,28,Rep,David Garland,99
+New York,66056,State Senate,28,Rep,David Garland,18
+New York,68001,State Senate,28,Rep,David Garland,52
+New York,68005,State Senate,28,Rep,David Garland,61
+New York,68006,State Senate,28,Rep,David Garland,7
+New York,68007,State Senate,28,Rep,David Garland,60
+New York,68008,State Senate,28,Rep,David Garland,54
+New York,73001,State Senate,28,Rep,David Garland,128
+New York,73002,State Senate,28,Rep,David Garland,156
+New York,73003,State Senate,28,Rep,David Garland,108
+New York,73004,State Senate,28,Rep,David Garland,92
+New York,73005,State Senate,28,Rep,David Garland,199
+New York,73007,State Senate,28,Rep,David Garland,67
+New York,73008,State Senate,28,Rep,David Garland,63
+New York,73009,State Senate,28,Rep,David Garland,172
+New York,73010,State Senate,28,Rep,David Garland,101
+New York,73014,State Senate,28,Rep,David Garland,45
+New York,73016,State Senate,28,Rep,David Garland,200
+New York,73017,State Senate,28,Rep,David Garland,70
+New York,73018,State Senate,28,Rep,David Garland,155
+New York,73019,State Senate,28,Rep,David Garland,61
+New York,73021,State Senate,28,Rep,David Garland,139
+New York,73022,State Senate,28,Rep,David Garland,97
+New York,73023,State Senate,28,Rep,David Garland,133
+New York,73024,State Senate,28,Rep,David Garland,107
+New York,73025,State Senate,28,Rep,David Garland,88
+New York,73026,State Senate,28,Rep,David Garland,88
+New York,73027,State Senate,28,Rep,David Garland,119
+New York,73028,State Senate,28,Rep,David Garland,87
+New York,73029,State Senate,28,Rep,David Garland,132
+New York,73030,State Senate,28,Rep,David Garland,74
+New York,73031,State Senate,28,Rep,David Garland,17
+New York,73032,State Senate,28,Rep,David Garland,216
+New York,73033,State Senate,28,Rep,David Garland,168
+New York,73034,State Senate,28,Rep,David Garland,199
+New York,73035,State Senate,28,Rep,David Garland,170
+New York,73036,State Senate,28,Rep,David Garland,185
+New York,73037,State Senate,28,Rep,David Garland,144
+New York,73038,State Senate,28,Rep,David Garland,209
+New York,73039,State Senate,28,Rep,David Garland,177
+New York,73040,State Senate,28,Rep,David Garland,139
+New York,73041,State Senate,28,Rep,David Garland,210
+New York,73042,State Senate,28,Rep,David Garland,106
+New York,73045,State Senate,28,Rep,David Garland,161
+New York,73046,State Senate,28,Rep,David Garland,87
+New York,73047,State Senate,28,Rep,David Garland,33
+New York,73048,State Senate,28,Rep,David Garland,121
+New York,73049,State Senate,28,Rep,David Garland,42
+New York,73050,State Senate,28,Rep,David Garland,168
+New York,73051,State Senate,28,Rep,David Garland,141
+New York,73052,State Senate,28,Rep,David Garland,179
+New York,73053,State Senate,28,Rep,David Garland,161
+New York,73054,State Senate,28,Rep,David Garland,57
+New York,73055,State Senate,28,Rep,David Garland,167
+New York,73056,State Senate,28,Rep,David Garland,193
+New York,73057,State Senate,28,Rep,David Garland,181
+New York,73058,State Senate,28,Rep,David Garland,223
+New York,73059,State Senate,28,Rep,David Garland,217
+New York,73060,State Senate,28,Rep,David Garland,255
+New York,73061,State Senate,28,Rep,David Garland,198
+New York,73062,State Senate,28,Rep,David Garland,154
+New York,73063,State Senate,28,Rep,David Garland,210
+New York,73064,State Senate,28,Rep,David Garland,180
+New York,73065,State Senate,28,Rep,David Garland,164
+New York,73066,State Senate,28,Rep,David Garland,166
+New York,73067,State Senate,28,Rep,David Garland,233
+New York,73068,State Senate,28,Rep,David Garland,145
+New York,73069,State Senate,28,Rep,David Garland,138
+New York,73070,State Senate,28,Rep,David Garland,144
+New York,73071,State Senate,28,Rep,David Garland,229
+New York,73072,State Senate,28,Rep,David Garland,291
+New York,73073,State Senate,28,Rep,David Garland,203
+New York,73074,State Senate,28,Rep,David Garland,152
+New York,73075,State Senate,28,Rep,David Garland,146
+New York,73076,State Senate,28,Rep,David Garland,168
+New York,73077,State Senate,28,Rep,David Garland,211
+New York,73078,State Senate,28,Rep,David Garland,167
+New York,73079,State Senate,28,Rep,David Garland,194
+New York,73080,State Senate,28,Rep,David Garland,205
+New York,73081,State Senate,28,Rep,David Garland,114
+New York,73082,State Senate,28,Rep,David Garland,249
+New York,73083,State Senate,28,Rep,David Garland,133
+New York,73084,State Senate,28,Rep,David Garland,95
+New York,73085,State Senate,28,Rep,David Garland,151
+New York,73086,State Senate,28,Rep,David Garland,215
+New York,73087,State Senate,28,Rep,David Garland,198
+New York,73088,State Senate,28,Rep,David Garland,138
+New York,73089,State Senate,28,Rep,David Garland,166
+New York,73090,State Senate,28,Rep,David Garland,150
+New York,73091,State Senate,28,Rep,David Garland,134
+New York,73092,State Senate,28,Rep,David Garland,46
+New York,73097,State Senate,28,Rep,David Garland,53
+New York,73099,State Senate,28,Rep,David Garland,143
+New York,73100,State Senate,28,Rep,David Garland,156
+New York,74056,State Senate,28,Rep,David Garland,117
+New York,74057,State Senate,28,Rep,David Garland,92
+New York,74058,State Senate,28,Rep,David Garland,72
+New York,74059,State Senate,28,Rep,David Garland,95
+New York,74060,State Senate,28,Rep,David Garland,111
+New York,74061,State Senate,28,Rep,David Garland,90
+New York,74062,State Senate,28,Rep,David Garland,99
+New York,74063,State Senate,28,Rep,David Garland,68
+New York,74064,State Senate,28,Rep,David Garland,98
+New York,74065,State Senate,28,Rep,David Garland,47
+New York,74066,State Senate,28,Rep,David Garland,56
+New York,74067,State Senate,28,Rep,David Garland,76
+New York,74068,State Senate,28,Rep,David Garland,78
+New York,74069,State Senate,28,Rep,David Garland,51
+New York,74070,State Senate,28,Rep,David Garland,111
+New York,74082,State Senate,28,Rep,David Garland,122
+New York,74083,State Senate,28,Rep,David Garland,110
+New York,74085,State Senate,28,Rep,David Garland,33
+New York,74086,State Senate,28,Rep,David Garland,168
+New York,74087,State Senate,28,Rep,David Garland,153
+New York,74088,State Senate,28,Rep,David Garland,164
+New York,74089,State Senate,28,Rep,David Garland,172
+New York,74090,State Senate,28,Rep,David Garland,111
+New York,74091,State Senate,28,Rep,David Garland,142
+New York,75008,State Senate,28,Rep,David Garland,158
+New York,75009,State Senate,28,Rep,David Garland,149
+New York,75029,State Senate,28,Rep,David Garland,80
+New York,75030,State Senate,28,Rep,David Garland,108
+New York,75031,State Senate,28,Rep,David Garland,78
+New York,75032,State Senate,28,Rep,David Garland,102
+New York,75033,State Senate,28,Rep,David Garland,122
+New York,75034,State Senate,28,Rep,David Garland,105
+New York,75035,State Senate,28,Rep,David Garland,57
+New York,75051,State Senate,28,Rep,David Garland,93
+New York,75052,State Senate,28,Rep,David Garland,99
+New York,75053,State Senate,28,Rep,David Garland,95
+New York,75054,State Senate,28,Rep,David Garland,142
+New York,75055,State Senate,28,Rep,David Garland,72
+New York,75056,State Senate,28,Rep,David Garland,180
+New York,75057,State Senate,28,Rep,David Garland,72
+New York,75086,State Senate,28,Rep,David Garland,53
+New York,75087,State Senate,28,Rep,David Garland,95
+New York,75088,State Senate,28,Rep,David Garland,105
+New York,75090,State Senate,28,Rep,David Garland,64
+New York,75091,State Senate,28,Rep,David Garland,140
+New York,75092,State Senate,28,Rep,David Garland,121
+New York,76001,State Senate,28,Rep,David Garland,96
+New York,76002,State Senate,28,Rep,David Garland,120
+New York,76003,State Senate,28,Rep,David Garland,170
+New York,76004,State Senate,28,Rep,David Garland,134
+New York,76005,State Senate,28,Rep,David Garland,137
+New York,76006,State Senate,28,Rep,David Garland,145
+New York,76007,State Senate,28,Rep,David Garland,66
+New York,76008,State Senate,28,Rep,David Garland,125
+New York,76009,State Senate,28,Rep,David Garland,158
+New York,76010,State Senate,28,Rep,David Garland,166
+New York,76011,State Senate,28,Rep,David Garland,117
+New York,76012,State Senate,28,Rep,David Garland,91
+New York,76013,State Senate,28,Rep,David Garland,203
+New York,76014,State Senate,28,Rep,David Garland,201
+New York,76015,State Senate,28,Rep,David Garland,79
+New York,76016,State Senate,28,Rep,David Garland,154
+New York,76017,State Senate,28,Rep,David Garland,100
+New York,76018,State Senate,28,Rep,David Garland,143
+New York,76019,State Senate,28,Rep,David Garland,186
+New York,76020,State Senate,28,Rep,David Garland,141
+New York,76021,State Senate,28,Rep,David Garland,167
+New York,76022,State Senate,28,Rep,David Garland,175
+New York,76023,State Senate,28,Rep,David Garland,150
+New York,76024,State Senate,28,Rep,David Garland,124
+New York,76025,State Senate,28,Rep,David Garland,143
+New York,76026,State Senate,28,Rep,David Garland,113
+New York,76027,State Senate,28,Rep,David Garland,92
+New York,76028,State Senate,28,Rep,David Garland,125
+New York,76029,State Senate,28,Rep,David Garland,98
+New York,76030,State Senate,28,Rep,David Garland,125
+New York,76031,State Senate,28,Rep,David Garland,141
+New York,76032,State Senate,28,Rep,David Garland,76
+New York,76033,State Senate,28,Rep,David Garland,133
+New York,76034,State Senate,28,Rep,David Garland,128
+New York,76035,State Senate,28,Rep,David Garland,208
+New York,76036,State Senate,28,Rep,David Garland,125
+New York,76037,State Senate,28,Rep,David Garland,136
+New York,76038,State Senate,28,Rep,David Garland,133
+New York,76039,State Senate,28,Rep,David Garland,122
+New York,76040,State Senate,28,Rep,David Garland,139
+New York,76041,State Senate,28,Rep,David Garland,84
+New York,76042,State Senate,28,Rep,David Garland,116
+New York,76043,State Senate,28,Rep,David Garland,107
+New York,76044,State Senate,28,Rep,David Garland,107
+New York,76045,State Senate,28,Rep,David Garland,98
+New York,76046,State Senate,28,Rep,David Garland,160
+New York,76047,State Senate,28,Rep,David Garland,104
+New York,76048,State Senate,28,Rep,David Garland,111
+New York,76049,State Senate,28,Rep,David Garland,117
+New York,76050,State Senate,28,Rep,David Garland,179
+New York,76051,State Senate,28,Rep,David Garland,101
+New York,76052,State Senate,28,Rep,David Garland,163
+New York,76053,State Senate,28,Rep,David Garland,155
+New York,76054,State Senate,28,Rep,David Garland,123
+New York,76055,State Senate,28,Rep,David Garland,133
+New York,76056,State Senate,28,Rep,David Garland,75
+New York,76057,State Senate,28,Rep,David Garland,122
+New York,76058,State Senate,28,Rep,David Garland,157
+New York,76059,State Senate,28,Rep,David Garland,93
+New York,76060,State Senate,28,Rep,David Garland,75
+New York,76061,State Senate,28,Rep,David Garland,121
+New York,76062,State Senate,28,Rep,David Garland,83
+New York,76063,State Senate,28,Rep,David Garland,101
+New York,76064,State Senate,28,Rep,David Garland,131
+New York,76065,State Senate,28,Rep,David Garland,167
+New York,76066,State Senate,28,Rep,David Garland,165
+New York,76067,State Senate,28,Rep,David Garland,190
+New York,76068,State Senate,28,Rep,David Garland,118
+New York,76069,State Senate,28,Rep,David Garland,127
+New York,76070,State Senate,28,Rep,David Garland,69
+New York,76071,State Senate,28,Rep,David Garland,154
+New York,76072,State Senate,28,Rep,David Garland,172
+New York,76073,State Senate,28,Rep,David Garland,150
+New York,76074,State Senate,28,Rep,David Garland,79
+New York,76075,State Senate,28,Rep,David Garland,118
+New York,76076,State Senate,28,Rep,David Garland,90
+New York,76077,State Senate,28,Rep,David Garland,124
+New York,76078,State Senate,28,Rep,David Garland,79
+New York,76079,State Senate,28,Rep,David Garland,169
+New York,76080,State Senate,28,Rep,David Garland,72
+New York,66055,State Senate,28,Ind,David Garland,8
+New York,66056,State Senate,28,Ind,David Garland,4
+New York,68001,State Senate,28,Ind,David Garland,2
+New York,68005,State Senate,28,Ind,David Garland,4
+New York,68006,State Senate,28,Ind,David Garland,2
+New York,68007,State Senate,28,Ind,David Garland,2
+New York,68008,State Senate,28,Ind,David Garland,6
+New York,73001,State Senate,28,Ind,David Garland,5
+New York,73002,State Senate,28,Ind,David Garland,8
+New York,73003,State Senate,28,Ind,David Garland,10
+New York,73004,State Senate,28,Ind,David Garland,4
+New York,73005,State Senate,28,Ind,David Garland,16
+New York,73007,State Senate,28,Ind,David Garland,4
+New York,73008,State Senate,28,Ind,David Garland,3
+New York,73009,State Senate,28,Ind,David Garland,3
+New York,73010,State Senate,28,Ind,David Garland,9
+New York,73014,State Senate,28,Ind,David Garland,4
+New York,73016,State Senate,28,Ind,David Garland,7
+New York,73017,State Senate,28,Ind,David Garland,2
+New York,73018,State Senate,28,Ind,David Garland,5
+New York,73019,State Senate,28,Ind,David Garland,1
+New York,73021,State Senate,28,Ind,David Garland,7
+New York,73022,State Senate,28,Ind,David Garland,2
+New York,73023,State Senate,28,Ind,David Garland,5
+New York,73024,State Senate,28,Ind,David Garland,8
+New York,73025,State Senate,28,Ind,David Garland,5
+New York,73026,State Senate,28,Ind,David Garland,2
+New York,73027,State Senate,28,Ind,David Garland,2
+New York,73028,State Senate,28,Ind,David Garland,5
+New York,73029,State Senate,28,Ind,David Garland,8
+New York,73030,State Senate,28,Ind,David Garland,4
+New York,73031,State Senate,28,Ind,David Garland,2
+New York,73032,State Senate,28,Ind,David Garland,10
+New York,73033,State Senate,28,Ind,David Garland,4
+New York,73034,State Senate,28,Ind,David Garland,5
+New York,73035,State Senate,28,Ind,David Garland,0
+New York,73036,State Senate,28,Ind,David Garland,11
+New York,73037,State Senate,28,Ind,David Garland,3
+New York,73038,State Senate,28,Ind,David Garland,7
+New York,73039,State Senate,28,Ind,David Garland,3
+New York,73040,State Senate,28,Ind,David Garland,5
+New York,73041,State Senate,28,Ind,David Garland,9
+New York,73042,State Senate,28,Ind,David Garland,7
+New York,73045,State Senate,28,Ind,David Garland,8
+New York,73046,State Senate,28,Ind,David Garland,2
+New York,73047,State Senate,28,Ind,David Garland,1
+New York,73048,State Senate,28,Ind,David Garland,0
+New York,73049,State Senate,28,Ind,David Garland,2
+New York,73050,State Senate,28,Ind,David Garland,5
+New York,73051,State Senate,28,Ind,David Garland,5
+New York,73052,State Senate,28,Ind,David Garland,1
+New York,73053,State Senate,28,Ind,David Garland,0
+New York,73054,State Senate,28,Ind,David Garland,4
+New York,73055,State Senate,28,Ind,David Garland,6
+New York,73056,State Senate,28,Ind,David Garland,5
+New York,73057,State Senate,28,Ind,David Garland,7
+New York,73058,State Senate,28,Ind,David Garland,4
+New York,73059,State Senate,28,Ind,David Garland,5
+New York,73060,State Senate,28,Ind,David Garland,5
+New York,73061,State Senate,28,Ind,David Garland,3
+New York,73062,State Senate,28,Ind,David Garland,2
+New York,73063,State Senate,28,Ind,David Garland,6
+New York,73064,State Senate,28,Ind,David Garland,5
+New York,73065,State Senate,28,Ind,David Garland,12
+New York,73066,State Senate,28,Ind,David Garland,1
+New York,73067,State Senate,28,Ind,David Garland,4
+New York,73068,State Senate,28,Ind,David Garland,0
+New York,73069,State Senate,28,Ind,David Garland,5
+New York,73070,State Senate,28,Ind,David Garland,2
+New York,73071,State Senate,28,Ind,David Garland,6
+New York,73072,State Senate,28,Ind,David Garland,7
+New York,73073,State Senate,28,Ind,David Garland,12
+New York,73074,State Senate,28,Ind,David Garland,11
+New York,73075,State Senate,28,Ind,David Garland,3
+New York,73076,State Senate,28,Ind,David Garland,7
+New York,73077,State Senate,28,Ind,David Garland,8
+New York,73078,State Senate,28,Ind,David Garland,8
+New York,73079,State Senate,28,Ind,David Garland,6
+New York,73080,State Senate,28,Ind,David Garland,8
+New York,73081,State Senate,28,Ind,David Garland,1
+New York,73082,State Senate,28,Ind,David Garland,4
+New York,73083,State Senate,28,Ind,David Garland,5
+New York,73084,State Senate,28,Ind,David Garland,6
+New York,73085,State Senate,28,Ind,David Garland,12
+New York,73086,State Senate,28,Ind,David Garland,8
+New York,73087,State Senate,28,Ind,David Garland,7
+New York,73088,State Senate,28,Ind,David Garland,6
+New York,73089,State Senate,28,Ind,David Garland,1
+New York,73090,State Senate,28,Ind,David Garland,8
+New York,73091,State Senate,28,Ind,David Garland,8
+New York,73092,State Senate,28,Ind,David Garland,6
+New York,73097,State Senate,28,Ind,David Garland,3
+New York,73099,State Senate,28,Ind,David Garland,2
+New York,73100,State Senate,28,Ind,David Garland,3
+New York,74056,State Senate,28,Ind,David Garland,7
+New York,74057,State Senate,28,Ind,David Garland,3
+New York,74058,State Senate,28,Ind,David Garland,5
+New York,74059,State Senate,28,Ind,David Garland,6
+New York,74060,State Senate,28,Ind,David Garland,10
+New York,74061,State Senate,28,Ind,David Garland,7
+New York,74062,State Senate,28,Ind,David Garland,9
+New York,74063,State Senate,28,Ind,David Garland,5
+New York,74064,State Senate,28,Ind,David Garland,5
+New York,74065,State Senate,28,Ind,David Garland,1
+New York,74066,State Senate,28,Ind,David Garland,4
+New York,74067,State Senate,28,Ind,David Garland,7
+New York,74068,State Senate,28,Ind,David Garland,13
+New York,74069,State Senate,28,Ind,David Garland,7
+New York,74070,State Senate,28,Ind,David Garland,8
+New York,74082,State Senate,28,Ind,David Garland,4
+New York,74083,State Senate,28,Ind,David Garland,6
+New York,74085,State Senate,28,Ind,David Garland,4
+New York,74086,State Senate,28,Ind,David Garland,7
+New York,74087,State Senate,28,Ind,David Garland,4
+New York,74088,State Senate,28,Ind,David Garland,10
+New York,74089,State Senate,28,Ind,David Garland,6
+New York,74090,State Senate,28,Ind,David Garland,5
+New York,74091,State Senate,28,Ind,David Garland,9
+New York,75008,State Senate,28,Ind,David Garland,5
+New York,75009,State Senate,28,Ind,David Garland,9
+New York,75029,State Senate,28,Ind,David Garland,6
+New York,75030,State Senate,28,Ind,David Garland,10
+New York,75031,State Senate,28,Ind,David Garland,5
+New York,75032,State Senate,28,Ind,David Garland,8
+New York,75033,State Senate,28,Ind,David Garland,8
+New York,75034,State Senate,28,Ind,David Garland,7
+New York,75035,State Senate,28,Ind,David Garland,2
+New York,75051,State Senate,28,Ind,David Garland,8
+New York,75052,State Senate,28,Ind,David Garland,4
+New York,75053,State Senate,28,Ind,David Garland,6
+New York,75054,State Senate,28,Ind,David Garland,2
+New York,75055,State Senate,28,Ind,David Garland,2
+New York,75056,State Senate,28,Ind,David Garland,3
+New York,75057,State Senate,28,Ind,David Garland,2
+New York,75086,State Senate,28,Ind,David Garland,0
+New York,75087,State Senate,28,Ind,David Garland,4
+New York,75088,State Senate,28,Ind,David Garland,6
+New York,75090,State Senate,28,Ind,David Garland,6
+New York,75091,State Senate,28,Ind,David Garland,5
+New York,75092,State Senate,28,Ind,David Garland,4
+New York,76001,State Senate,28,Ind,David Garland,5
+New York,76002,State Senate,28,Ind,David Garland,11
+New York,76003,State Senate,28,Ind,David Garland,6
+New York,76004,State Senate,28,Ind,David Garland,3
+New York,76005,State Senate,28,Ind,David Garland,3
+New York,76006,State Senate,28,Ind,David Garland,11
+New York,76007,State Senate,28,Ind,David Garland,6
+New York,76008,State Senate,28,Ind,David Garland,4
+New York,76009,State Senate,28,Ind,David Garland,4
+New York,76010,State Senate,28,Ind,David Garland,8
+New York,76011,State Senate,28,Ind,David Garland,8
+New York,76012,State Senate,28,Ind,David Garland,5
+New York,76013,State Senate,28,Ind,David Garland,5
+New York,76014,State Senate,28,Ind,David Garland,2
+New York,76015,State Senate,28,Ind,David Garland,3
+New York,76016,State Senate,28,Ind,David Garland,5
+New York,76017,State Senate,28,Ind,David Garland,2
+New York,76018,State Senate,28,Ind,David Garland,7
+New York,76019,State Senate,28,Ind,David Garland,6
+New York,76020,State Senate,28,Ind,David Garland,5
+New York,76021,State Senate,28,Ind,David Garland,5
+New York,76022,State Senate,28,Ind,David Garland,7
+New York,76023,State Senate,28,Ind,David Garland,6
+New York,76024,State Senate,28,Ind,David Garland,7
+New York,76025,State Senate,28,Ind,David Garland,6
+New York,76026,State Senate,28,Ind,David Garland,5
+New York,76027,State Senate,28,Ind,David Garland,2
+New York,76028,State Senate,28,Ind,David Garland,6
+New York,76029,State Senate,28,Ind,David Garland,5
+New York,76030,State Senate,28,Ind,David Garland,3
+New York,76031,State Senate,28,Ind,David Garland,5
+New York,76032,State Senate,28,Ind,David Garland,5
+New York,76033,State Senate,28,Ind,David Garland,7
+New York,76034,State Senate,28,Ind,David Garland,7
+New York,76035,State Senate,28,Ind,David Garland,13
+New York,76036,State Senate,28,Ind,David Garland,7
+New York,76037,State Senate,28,Ind,David Garland,12
+New York,76038,State Senate,28,Ind,David Garland,11
+New York,76039,State Senate,28,Ind,David Garland,5
+New York,76040,State Senate,28,Ind,David Garland,6
+New York,76041,State Senate,28,Ind,David Garland,11
+New York,76042,State Senate,28,Ind,David Garland,8
+New York,76043,State Senate,28,Ind,David Garland,0
+New York,76044,State Senate,28,Ind,David Garland,10
+New York,76045,State Senate,28,Ind,David Garland,6
+New York,76046,State Senate,28,Ind,David Garland,7
+New York,76047,State Senate,28,Ind,David Garland,5
+New York,76048,State Senate,28,Ind,David Garland,3
+New York,76049,State Senate,28,Ind,David Garland,12
+New York,76050,State Senate,28,Ind,David Garland,9
+New York,76051,State Senate,28,Ind,David Garland,3
+New York,76052,State Senate,28,Ind,David Garland,9
+New York,76053,State Senate,28,Ind,David Garland,10
+New York,76054,State Senate,28,Ind,David Garland,6
+New York,76055,State Senate,28,Ind,David Garland,6
+New York,76056,State Senate,28,Ind,David Garland,6
+New York,76057,State Senate,28,Ind,David Garland,1
+New York,76058,State Senate,28,Ind,David Garland,3
+New York,76059,State Senate,28,Ind,David Garland,8
+New York,76060,State Senate,28,Ind,David Garland,7
+New York,76061,State Senate,28,Ind,David Garland,5
+New York,76062,State Senate,28,Ind,David Garland,3
+New York,76063,State Senate,28,Ind,David Garland,7
+New York,76064,State Senate,28,Ind,David Garland,4
+New York,76065,State Senate,28,Ind,David Garland,11
+New York,76066,State Senate,28,Ind,David Garland,9
+New York,76067,State Senate,28,Ind,David Garland,10
+New York,76068,State Senate,28,Ind,David Garland,11
+New York,76069,State Senate,28,Ind,David Garland,13
+New York,76070,State Senate,28,Ind,David Garland,6
+New York,76071,State Senate,28,Ind,David Garland,13
+New York,76072,State Senate,28,Ind,David Garland,18
+New York,76073,State Senate,28,Ind,David Garland,13
+New York,76074,State Senate,28,Ind,David Garland,2
+New York,76075,State Senate,28,Ind,David Garland,13
+New York,76076,State Senate,28,Ind,David Garland,7
+New York,76077,State Senate,28,Ind,David Garland,3
+New York,76078,State Senate,28,Ind,David Garland,5
+New York,76079,State Senate,28,Ind,David Garland,8
+New York,76080,State Senate,28,Ind,David Garland,9
+New York,66055,State Senate,28,Dem,Liz Krueger,554
+New York,66056,State Senate,28,Dem,Liz Krueger,77
+New York,68001,State Senate,28,Dem,Liz Krueger,371
+New York,68005,State Senate,28,Dem,Liz Krueger,226
+New York,68006,State Senate,28,Dem,Liz Krueger,29
+New York,68007,State Senate,28,Dem,Liz Krueger,221
+New York,68008,State Senate,28,Dem,Liz Krueger,168
+New York,73001,State Senate,28,Dem,Liz Krueger,444
+New York,73002,State Senate,28,Dem,Liz Krueger,331
+New York,73003,State Senate,28,Dem,Liz Krueger,365
+New York,73004,State Senate,28,Dem,Liz Krueger,252
+New York,73005,State Senate,28,Dem,Liz Krueger,543
+New York,73007,State Senate,28,Dem,Liz Krueger,190
+New York,73008,State Senate,28,Dem,Liz Krueger,155
+New York,73009,State Senate,28,Dem,Liz Krueger,512
+New York,73010,State Senate,28,Dem,Liz Krueger,479
+New York,73014,State Senate,28,Dem,Liz Krueger,125
+New York,73016,State Senate,28,Dem,Liz Krueger,420
+New York,73017,State Senate,28,Dem,Liz Krueger,177
+New York,73018,State Senate,28,Dem,Liz Krueger,393
+New York,73019,State Senate,28,Dem,Liz Krueger,156
+New York,73021,State Senate,28,Dem,Liz Krueger,391
+New York,73022,State Senate,28,Dem,Liz Krueger,310
+New York,73023,State Senate,28,Dem,Liz Krueger,348
+New York,73024,State Senate,28,Dem,Liz Krueger,306
+New York,73025,State Senate,28,Dem,Liz Krueger,260
+New York,73026,State Senate,28,Dem,Liz Krueger,235
+New York,73027,State Senate,28,Dem,Liz Krueger,293
+New York,73028,State Senate,28,Dem,Liz Krueger,237
+New York,73029,State Senate,28,Dem,Liz Krueger,386
+New York,73030,State Senate,28,Dem,Liz Krueger,189
+New York,73031,State Senate,28,Dem,Liz Krueger,61
+New York,73032,State Senate,28,Dem,Liz Krueger,434
+New York,73033,State Senate,28,Dem,Liz Krueger,517
+New York,73034,State Senate,28,Dem,Liz Krueger,393
+New York,73035,State Senate,28,Dem,Liz Krueger,470
+New York,73036,State Senate,28,Dem,Liz Krueger,406
+New York,73037,State Senate,28,Dem,Liz Krueger,394
+New York,73038,State Senate,28,Dem,Liz Krueger,504
+New York,73039,State Senate,28,Dem,Liz Krueger,350
+New York,73040,State Senate,28,Dem,Liz Krueger,376
+New York,73041,State Senate,28,Dem,Liz Krueger,478
+New York,73042,State Senate,28,Dem,Liz Krueger,231
+New York,73045,State Senate,28,Dem,Liz Krueger,213
+New York,73046,State Senate,28,Dem,Liz Krueger,125
+New York,73047,State Senate,28,Dem,Liz Krueger,104
+New York,73048,State Senate,28,Dem,Liz Krueger,247
+New York,73049,State Senate,28,Dem,Liz Krueger,103
+New York,73050,State Senate,28,Dem,Liz Krueger,415
+New York,73051,State Senate,28,Dem,Liz Krueger,222
+New York,73052,State Senate,28,Dem,Liz Krueger,264
+New York,73053,State Senate,28,Dem,Liz Krueger,262
+New York,73054,State Senate,28,Dem,Liz Krueger,113
+New York,73055,State Senate,28,Dem,Liz Krueger,364
+New York,73056,State Senate,28,Dem,Liz Krueger,332
+New York,73057,State Senate,28,Dem,Liz Krueger,460
+New York,73058,State Senate,28,Dem,Liz Krueger,326
+New York,73059,State Senate,28,Dem,Liz Krueger,397
+New York,73060,State Senate,28,Dem,Liz Krueger,387
+New York,73061,State Senate,28,Dem,Liz Krueger,277
+New York,73062,State Senate,28,Dem,Liz Krueger,324
+New York,73063,State Senate,28,Dem,Liz Krueger,343
+New York,73064,State Senate,28,Dem,Liz Krueger,433
+New York,73065,State Senate,28,Dem,Liz Krueger,356
+New York,73066,State Senate,28,Dem,Liz Krueger,355
+New York,73067,State Senate,28,Dem,Liz Krueger,368
+New York,73068,State Senate,28,Dem,Liz Krueger,402
+New York,73069,State Senate,28,Dem,Liz Krueger,487
+New York,73070,State Senate,28,Dem,Liz Krueger,421
+New York,73071,State Senate,28,Dem,Liz Krueger,424
+New York,73072,State Senate,28,Dem,Liz Krueger,489
+New York,73073,State Senate,28,Dem,Liz Krueger,467
+New York,73074,State Senate,28,Dem,Liz Krueger,373
+New York,73075,State Senate,28,Dem,Liz Krueger,438
+New York,73076,State Senate,28,Dem,Liz Krueger,496
+New York,73077,State Senate,28,Dem,Liz Krueger,464
+New York,73078,State Senate,28,Dem,Liz Krueger,362
+New York,73079,State Senate,28,Dem,Liz Krueger,445
+New York,73080,State Senate,28,Dem,Liz Krueger,522
+New York,73081,State Senate,28,Dem,Liz Krueger,298
+New York,73082,State Senate,28,Dem,Liz Krueger,464
+New York,73083,State Senate,28,Dem,Liz Krueger,415
+New York,73084,State Senate,28,Dem,Liz Krueger,327
+New York,73085,State Senate,28,Dem,Liz Krueger,513
+New York,73086,State Senate,28,Dem,Liz Krueger,487
+New York,73087,State Senate,28,Dem,Liz Krueger,450
+New York,73088,State Senate,28,Dem,Liz Krueger,286
+New York,73089,State Senate,28,Dem,Liz Krueger,390
+New York,73090,State Senate,28,Dem,Liz Krueger,578
+New York,73091,State Senate,28,Dem,Liz Krueger,586
+New York,73092,State Senate,28,Dem,Liz Krueger,270
+New York,73097,State Senate,28,Dem,Liz Krueger,182
+New York,73099,State Senate,28,Dem,Liz Krueger,308
+New York,73100,State Senate,28,Dem,Liz Krueger,425
+New York,74056,State Senate,28,Dem,Liz Krueger,376
+New York,74057,State Senate,28,Dem,Liz Krueger,342
+New York,74058,State Senate,28,Dem,Liz Krueger,408
+New York,74059,State Senate,28,Dem,Liz Krueger,521
+New York,74060,State Senate,28,Dem,Liz Krueger,537
+New York,74061,State Senate,28,Dem,Liz Krueger,415
+New York,74062,State Senate,28,Dem,Liz Krueger,448
+New York,74063,State Senate,28,Dem,Liz Krueger,272
+New York,74064,State Senate,28,Dem,Liz Krueger,664
+New York,74065,State Senate,28,Dem,Liz Krueger,251
+New York,74066,State Senate,28,Dem,Liz Krueger,316
+New York,74067,State Senate,28,Dem,Liz Krueger,437
+New York,74068,State Senate,28,Dem,Liz Krueger,405
+New York,74069,State Senate,28,Dem,Liz Krueger,253
+New York,74070,State Senate,28,Dem,Liz Krueger,462
+New York,74082,State Senate,28,Dem,Liz Krueger,544
+New York,74083,State Senate,28,Dem,Liz Krueger,264
+New York,74085,State Senate,28,Dem,Liz Krueger,148
+New York,74086,State Senate,28,Dem,Liz Krueger,442
+New York,74087,State Senate,28,Dem,Liz Krueger,401
+New York,74088,State Senate,28,Dem,Liz Krueger,511
+New York,74089,State Senate,28,Dem,Liz Krueger,393
+New York,74090,State Senate,28,Dem,Liz Krueger,367
+New York,74091,State Senate,28,Dem,Liz Krueger,416
+New York,75008,State Senate,28,Dem,Liz Krueger,631
+New York,75009,State Senate,28,Dem,Liz Krueger,470
+New York,75029,State Senate,28,Dem,Liz Krueger,277
+New York,75030,State Senate,28,Dem,Liz Krueger,435
+New York,75031,State Senate,28,Dem,Liz Krueger,407
+New York,75032,State Senate,28,Dem,Liz Krueger,472
+New York,75033,State Senate,28,Dem,Liz Krueger,405
+New York,75034,State Senate,28,Dem,Liz Krueger,393
+New York,75035,State Senate,28,Dem,Liz Krueger,192
+New York,75051,State Senate,28,Dem,Liz Krueger,290
+New York,75052,State Senate,28,Dem,Liz Krueger,336
+New York,75053,State Senate,28,Dem,Liz Krueger,346
+New York,75054,State Senate,28,Dem,Liz Krueger,310
+New York,75055,State Senate,28,Dem,Liz Krueger,253
+New York,75056,State Senate,28,Dem,Liz Krueger,491
+New York,75057,State Senate,28,Dem,Liz Krueger,215
+New York,75086,State Senate,28,Dem,Liz Krueger,115
+New York,75087,State Senate,28,Dem,Liz Krueger,343
+New York,75088,State Senate,28,Dem,Liz Krueger,283
+New York,75090,State Senate,28,Dem,Liz Krueger,195
+New York,75091,State Senate,28,Dem,Liz Krueger,284
+New York,75092,State Senate,28,Dem,Liz Krueger,308
+New York,76001,State Senate,28,Dem,Liz Krueger,556
+New York,76002,State Senate,28,Dem,Liz Krueger,341
+New York,76003,State Senate,28,Dem,Liz Krueger,311
+New York,76004,State Senate,28,Dem,Liz Krueger,339
+New York,76005,State Senate,28,Dem,Liz Krueger,263
+New York,76006,State Senate,28,Dem,Liz Krueger,440
+New York,76007,State Senate,28,Dem,Liz Krueger,285
+New York,76008,State Senate,28,Dem,Liz Krueger,308
+New York,76009,State Senate,28,Dem,Liz Krueger,262
+New York,76010,State Senate,28,Dem,Liz Krueger,542
+New York,76011,State Senate,28,Dem,Liz Krueger,405
+New York,76012,State Senate,28,Dem,Liz Krueger,286
+New York,76013,State Senate,28,Dem,Liz Krueger,530
+New York,76014,State Senate,28,Dem,Liz Krueger,346
+New York,76015,State Senate,28,Dem,Liz Krueger,284
+New York,76016,State Senate,28,Dem,Liz Krueger,483
+New York,76017,State Senate,28,Dem,Liz Krueger,345
+New York,76018,State Senate,28,Dem,Liz Krueger,454
+New York,76019,State Senate,28,Dem,Liz Krueger,420
+New York,76020,State Senate,28,Dem,Liz Krueger,423
+New York,76021,State Senate,28,Dem,Liz Krueger,526
+New York,76022,State Senate,28,Dem,Liz Krueger,327
+New York,76023,State Senate,28,Dem,Liz Krueger,263
+New York,76024,State Senate,28,Dem,Liz Krueger,310
+New York,76025,State Senate,28,Dem,Liz Krueger,435
+New York,76026,State Senate,28,Dem,Liz Krueger,396
+New York,76027,State Senate,28,Dem,Liz Krueger,292
+New York,76028,State Senate,28,Dem,Liz Krueger,396
+New York,76029,State Senate,28,Dem,Liz Krueger,260
+New York,76030,State Senate,28,Dem,Liz Krueger,356
+New York,76031,State Senate,28,Dem,Liz Krueger,308
+New York,76032,State Senate,28,Dem,Liz Krueger,319
+New York,76033,State Senate,28,Dem,Liz Krueger,351
+New York,76034,State Senate,28,Dem,Liz Krueger,447
+New York,76035,State Senate,28,Dem,Liz Krueger,550
+New York,76036,State Senate,28,Dem,Liz Krueger,533
+New York,76037,State Senate,28,Dem,Liz Krueger,517
+New York,76038,State Senate,28,Dem,Liz Krueger,480
+New York,76039,State Senate,28,Dem,Liz Krueger,394
+New York,76040,State Senate,28,Dem,Liz Krueger,437
+New York,76041,State Senate,28,Dem,Liz Krueger,388
+New York,76042,State Senate,28,Dem,Liz Krueger,389
+New York,76043,State Senate,28,Dem,Liz Krueger,357
+New York,76044,State Senate,28,Dem,Liz Krueger,413
+New York,76045,State Senate,28,Dem,Liz Krueger,329
+New York,76046,State Senate,28,Dem,Liz Krueger,544
+New York,76047,State Senate,28,Dem,Liz Krueger,260
+New York,76048,State Senate,28,Dem,Liz Krueger,311
+New York,76049,State Senate,28,Dem,Liz Krueger,367
+New York,76050,State Senate,28,Dem,Liz Krueger,566
+New York,76051,State Senate,28,Dem,Liz Krueger,420
+New York,76052,State Senate,28,Dem,Liz Krueger,470
+New York,76053,State Senate,28,Dem,Liz Krueger,533
+New York,76054,State Senate,28,Dem,Liz Krueger,439
+New York,76055,State Senate,28,Dem,Liz Krueger,399
+New York,76056,State Senate,28,Dem,Liz Krueger,194
+New York,76057,State Senate,28,Dem,Liz Krueger,364
+New York,76058,State Senate,28,Dem,Liz Krueger,422
+New York,76059,State Senate,28,Dem,Liz Krueger,350
+New York,76060,State Senate,28,Dem,Liz Krueger,312
+New York,76061,State Senate,28,Dem,Liz Krueger,333
+New York,76062,State Senate,28,Dem,Liz Krueger,309
+New York,76063,State Senate,28,Dem,Liz Krueger,330
+New York,76064,State Senate,28,Dem,Liz Krueger,389
+New York,76065,State Senate,28,Dem,Liz Krueger,508
+New York,76066,State Senate,28,Dem,Liz Krueger,395
+New York,76067,State Senate,28,Dem,Liz Krueger,507
+New York,76068,State Senate,28,Dem,Liz Krueger,510
+New York,76069,State Senate,28,Dem,Liz Krueger,433
+New York,76070,State Senate,28,Dem,Liz Krueger,360
+New York,76071,State Senate,28,Dem,Liz Krueger,440
+New York,76072,State Senate,28,Dem,Liz Krueger,550
+New York,76073,State Senate,28,Dem,Liz Krueger,524
+New York,76074,State Senate,28,Dem,Liz Krueger,339
+New York,76075,State Senate,28,Dem,Liz Krueger,433
+New York,76076,State Senate,28,Dem,Liz Krueger,344
+New York,76077,State Senate,28,Dem,Liz Krueger,411
+New York,76078,State Senate,28,Dem,Liz Krueger,388
+New York,76079,State Senate,28,Dem,Liz Krueger,526
+New York,76080,State Senate,28,Dem,Liz Krueger,327
+New York,66055,State Senate,28,WF,Liz Krueger,22
+New York,66056,State Senate,28,WF,Liz Krueger,9
+New York,68001,State Senate,28,WF,Liz Krueger,6
+New York,68005,State Senate,28,WF,Liz Krueger,9
+New York,68006,State Senate,28,WF,Liz Krueger,1
+New York,68007,State Senate,28,WF,Liz Krueger,8
+New York,68008,State Senate,28,WF,Liz Krueger,6
+New York,73001,State Senate,28,WF,Liz Krueger,12
+New York,73002,State Senate,28,WF,Liz Krueger,8
+New York,73003,State Senate,28,WF,Liz Krueger,8
+New York,73004,State Senate,28,WF,Liz Krueger,5
+New York,73005,State Senate,28,WF,Liz Krueger,15
+New York,73007,State Senate,28,WF,Liz Krueger,8
+New York,73008,State Senate,28,WF,Liz Krueger,3
+New York,73009,State Senate,28,WF,Liz Krueger,15
+New York,73010,State Senate,28,WF,Liz Krueger,10
+New York,73014,State Senate,28,WF,Liz Krueger,3
+New York,73016,State Senate,28,WF,Liz Krueger,14
+New York,73017,State Senate,28,WF,Liz Krueger,1
+New York,73018,State Senate,28,WF,Liz Krueger,10
+New York,73019,State Senate,28,WF,Liz Krueger,2
+New York,73021,State Senate,28,WF,Liz Krueger,16
+New York,73022,State Senate,28,WF,Liz Krueger,8
+New York,73023,State Senate,28,WF,Liz Krueger,7
+New York,73024,State Senate,28,WF,Liz Krueger,8
+New York,73025,State Senate,28,WF,Liz Krueger,6
+New York,73026,State Senate,28,WF,Liz Krueger,8
+New York,73027,State Senate,28,WF,Liz Krueger,9
+New York,73028,State Senate,28,WF,Liz Krueger,4
+New York,73029,State Senate,28,WF,Liz Krueger,9
+New York,73030,State Senate,28,WF,Liz Krueger,6
+New York,73031,State Senate,28,WF,Liz Krueger,6
+New York,73032,State Senate,28,WF,Liz Krueger,22
+New York,73033,State Senate,28,WF,Liz Krueger,6
+New York,73034,State Senate,28,WF,Liz Krueger,11
+New York,73035,State Senate,28,WF,Liz Krueger,7
+New York,73036,State Senate,28,WF,Liz Krueger,5
+New York,73037,State Senate,28,WF,Liz Krueger,14
+New York,73038,State Senate,28,WF,Liz Krueger,10
+New York,73039,State Senate,28,WF,Liz Krueger,5
+New York,73040,State Senate,28,WF,Liz Krueger,8
+New York,73041,State Senate,28,WF,Liz Krueger,17
+New York,73042,State Senate,28,WF,Liz Krueger,5
+New York,73045,State Senate,28,WF,Liz Krueger,5
+New York,73046,State Senate,28,WF,Liz Krueger,1
+New York,73047,State Senate,28,WF,Liz Krueger,4
+New York,73048,State Senate,28,WF,Liz Krueger,4
+New York,73049,State Senate,28,WF,Liz Krueger,1
+New York,73050,State Senate,28,WF,Liz Krueger,9
+New York,73051,State Senate,28,WF,Liz Krueger,6
+New York,73052,State Senate,28,WF,Liz Krueger,2
+New York,73053,State Senate,28,WF,Liz Krueger,8
+New York,73054,State Senate,28,WF,Liz Krueger,1
+New York,73055,State Senate,28,WF,Liz Krueger,10
+New York,73056,State Senate,28,WF,Liz Krueger,7
+New York,73057,State Senate,28,WF,Liz Krueger,16
+New York,73058,State Senate,28,WF,Liz Krueger,3
+New York,73059,State Senate,28,WF,Liz Krueger,7
+New York,73060,State Senate,28,WF,Liz Krueger,8
+New York,73061,State Senate,28,WF,Liz Krueger,2
+New York,73062,State Senate,28,WF,Liz Krueger,0
+New York,73063,State Senate,28,WF,Liz Krueger,6
+New York,73064,State Senate,28,WF,Liz Krueger,7
+New York,73065,State Senate,28,WF,Liz Krueger,14
+New York,73066,State Senate,28,WF,Liz Krueger,6
+New York,73067,State Senate,28,WF,Liz Krueger,7
+New York,73068,State Senate,28,WF,Liz Krueger,11
+New York,73069,State Senate,28,WF,Liz Krueger,14
+New York,73070,State Senate,28,WF,Liz Krueger,16
+New York,73071,State Senate,28,WF,Liz Krueger,9
+New York,73072,State Senate,28,WF,Liz Krueger,11
+New York,73073,State Senate,28,WF,Liz Krueger,9
+New York,73074,State Senate,28,WF,Liz Krueger,8
+New York,73075,State Senate,28,WF,Liz Krueger,5
+New York,73076,State Senate,28,WF,Liz Krueger,9
+New York,73077,State Senate,28,WF,Liz Krueger,9
+New York,73078,State Senate,28,WF,Liz Krueger,12
+New York,73079,State Senate,28,WF,Liz Krueger,8
+New York,73080,State Senate,28,WF,Liz Krueger,11
+New York,73081,State Senate,28,WF,Liz Krueger,3
+New York,73082,State Senate,28,WF,Liz Krueger,9
+New York,73083,State Senate,28,WF,Liz Krueger,11
+New York,73084,State Senate,28,WF,Liz Krueger,15
+New York,73085,State Senate,28,WF,Liz Krueger,31
+New York,73086,State Senate,28,WF,Liz Krueger,6
+New York,73087,State Senate,28,WF,Liz Krueger,12
+New York,73088,State Senate,28,WF,Liz Krueger,4
+New York,73089,State Senate,28,WF,Liz Krueger,16
+New York,73090,State Senate,28,WF,Liz Krueger,21
+New York,73091,State Senate,28,WF,Liz Krueger,20
+New York,73092,State Senate,28,WF,Liz Krueger,8
+New York,73097,State Senate,28,WF,Liz Krueger,8
+New York,73099,State Senate,28,WF,Liz Krueger,5
+New York,73100,State Senate,28,WF,Liz Krueger,6
+New York,74056,State Senate,28,WF,Liz Krueger,20
+New York,74057,State Senate,28,WF,Liz Krueger,18
+New York,74058,State Senate,28,WF,Liz Krueger,18
+New York,74059,State Senate,28,WF,Liz Krueger,27
+New York,74060,State Senate,28,WF,Liz Krueger,17
+New York,74061,State Senate,28,WF,Liz Krueger,25
+New York,74062,State Senate,28,WF,Liz Krueger,12
+New York,74063,State Senate,28,WF,Liz Krueger,9
+New York,74064,State Senate,28,WF,Liz Krueger,24
+New York,74065,State Senate,28,WF,Liz Krueger,16
+New York,74066,State Senate,28,WF,Liz Krueger,19
+New York,74067,State Senate,28,WF,Liz Krueger,16
+New York,74068,State Senate,28,WF,Liz Krueger,18
+New York,74069,State Senate,28,WF,Liz Krueger,3
+New York,74070,State Senate,28,WF,Liz Krueger,13
+New York,74082,State Senate,28,WF,Liz Krueger,15
+New York,74083,State Senate,28,WF,Liz Krueger,10
+New York,74085,State Senate,28,WF,Liz Krueger,5
+New York,74086,State Senate,28,WF,Liz Krueger,9
+New York,74087,State Senate,28,WF,Liz Krueger,12
+New York,74088,State Senate,28,WF,Liz Krueger,17
+New York,74089,State Senate,28,WF,Liz Krueger,17
+New York,74090,State Senate,28,WF,Liz Krueger,13
+New York,74091,State Senate,28,WF,Liz Krueger,15
+New York,75008,State Senate,28,WF,Liz Krueger,34
+New York,75009,State Senate,28,WF,Liz Krueger,16
+New York,75029,State Senate,28,WF,Liz Krueger,8
+New York,75030,State Senate,28,WF,Liz Krueger,28
+New York,75031,State Senate,28,WF,Liz Krueger,12
+New York,75032,State Senate,28,WF,Liz Krueger,28
+New York,75033,State Senate,28,WF,Liz Krueger,14
+New York,75034,State Senate,28,WF,Liz Krueger,21
+New York,75035,State Senate,28,WF,Liz Krueger,7
+New York,75051,State Senate,28,WF,Liz Krueger,10
+New York,75052,State Senate,28,WF,Liz Krueger,15
+New York,75053,State Senate,28,WF,Liz Krueger,16
+New York,75054,State Senate,28,WF,Liz Krueger,10
+New York,75055,State Senate,28,WF,Liz Krueger,10
+New York,75056,State Senate,28,WF,Liz Krueger,10
+New York,75057,State Senate,28,WF,Liz Krueger,4
+New York,75086,State Senate,28,WF,Liz Krueger,5
+New York,75087,State Senate,28,WF,Liz Krueger,16
+New York,75088,State Senate,28,WF,Liz Krueger,7
+New York,75090,State Senate,28,WF,Liz Krueger,7
+New York,75091,State Senate,28,WF,Liz Krueger,5
+New York,75092,State Senate,28,WF,Liz Krueger,7
+New York,76001,State Senate,28,WF,Liz Krueger,21
+New York,76002,State Senate,28,WF,Liz Krueger,10
+New York,76003,State Senate,28,WF,Liz Krueger,7
+New York,76004,State Senate,28,WF,Liz Krueger,8
+New York,76005,State Senate,28,WF,Liz Krueger,6
+New York,76006,State Senate,28,WF,Liz Krueger,18
+New York,76007,State Senate,28,WF,Liz Krueger,21
+New York,76008,State Senate,28,WF,Liz Krueger,8
+New York,76009,State Senate,28,WF,Liz Krueger,11
+New York,76010,State Senate,28,WF,Liz Krueger,18
+New York,76011,State Senate,28,WF,Liz Krueger,18
+New York,76012,State Senate,28,WF,Liz Krueger,11
+New York,76013,State Senate,28,WF,Liz Krueger,11
+New York,76014,State Senate,28,WF,Liz Krueger,10
+New York,76015,State Senate,28,WF,Liz Krueger,7
+New York,76016,State Senate,28,WF,Liz Krueger,9
+New York,76017,State Senate,28,WF,Liz Krueger,8
+New York,76018,State Senate,28,WF,Liz Krueger,12
+New York,76019,State Senate,28,WF,Liz Krueger,7
+New York,76020,State Senate,28,WF,Liz Krueger,9
+New York,76021,State Senate,28,WF,Liz Krueger,14
+New York,76022,State Senate,28,WF,Liz Krueger,6
+New York,76023,State Senate,28,WF,Liz Krueger,3
+New York,76024,State Senate,28,WF,Liz Krueger,5
+New York,76025,State Senate,28,WF,Liz Krueger,8
+New York,76026,State Senate,28,WF,Liz Krueger,13
+New York,76027,State Senate,28,WF,Liz Krueger,13
+New York,76028,State Senate,28,WF,Liz Krueger,7
+New York,76029,State Senate,28,WF,Liz Krueger,4
+New York,76030,State Senate,28,WF,Liz Krueger,5
+New York,76031,State Senate,28,WF,Liz Krueger,8
+New York,76032,State Senate,28,WF,Liz Krueger,11
+New York,76033,State Senate,28,WF,Liz Krueger,17
+New York,76034,State Senate,28,WF,Liz Krueger,13
+New York,76035,State Senate,28,WF,Liz Krueger,15
+New York,76036,State Senate,28,WF,Liz Krueger,22
+New York,76037,State Senate,28,WF,Liz Krueger,19
+New York,76038,State Senate,28,WF,Liz Krueger,12
+New York,76039,State Senate,28,WF,Liz Krueger,8
+New York,76040,State Senate,28,WF,Liz Krueger,17
+New York,76041,State Senate,28,WF,Liz Krueger,20
+New York,76042,State Senate,28,WF,Liz Krueger,13
+New York,76043,State Senate,28,WF,Liz Krueger,12
+New York,76044,State Senate,28,WF,Liz Krueger,7
+New York,76045,State Senate,28,WF,Liz Krueger,12
+New York,76046,State Senate,28,WF,Liz Krueger,13
+New York,76047,State Senate,28,WF,Liz Krueger,9
+New York,76048,State Senate,28,WF,Liz Krueger,9
+New York,76049,State Senate,28,WF,Liz Krueger,17
+New York,76050,State Senate,28,WF,Liz Krueger,18
+New York,76051,State Senate,28,WF,Liz Krueger,10
+New York,76052,State Senate,28,WF,Liz Krueger,13
+New York,76053,State Senate,28,WF,Liz Krueger,17
+New York,76054,State Senate,28,WF,Liz Krueger,18
+New York,76055,State Senate,28,WF,Liz Krueger,11
+New York,76056,State Senate,28,WF,Liz Krueger,9
+New York,76057,State Senate,28,WF,Liz Krueger,23
+New York,76058,State Senate,28,WF,Liz Krueger,4
+New York,76059,State Senate,28,WF,Liz Krueger,18
+New York,76060,State Senate,28,WF,Liz Krueger,7
+New York,76061,State Senate,28,WF,Liz Krueger,14
+New York,76062,State Senate,28,WF,Liz Krueger,10
+New York,76063,State Senate,28,WF,Liz Krueger,9
+New York,76064,State Senate,28,WF,Liz Krueger,9
+New York,76065,State Senate,28,WF,Liz Krueger,16
+New York,76066,State Senate,28,WF,Liz Krueger,12
+New York,76067,State Senate,28,WF,Liz Krueger,16
+New York,76068,State Senate,28,WF,Liz Krueger,20
+New York,76069,State Senate,28,WF,Liz Krueger,14
+New York,76070,State Senate,28,WF,Liz Krueger,7
+New York,76071,State Senate,28,WF,Liz Krueger,24
+New York,76072,State Senate,28,WF,Liz Krueger,28
+New York,76073,State Senate,28,WF,Liz Krueger,18
+New York,76074,State Senate,28,WF,Liz Krueger,18
+New York,76075,State Senate,28,WF,Liz Krueger,10
+New York,76076,State Senate,28,WF,Liz Krueger,12
+New York,76077,State Senate,28,WF,Liz Krueger,10
+New York,76078,State Senate,28,WF,Liz Krueger,7
+New York,76079,State Senate,28,WF,Liz Krueger,12
+New York,76080,State Senate,28,WF,Liz Krueger,19
+New York,66055,State Senate,28,Ind,writein,1
+New York,66056,State Senate,28,Ind,writein,0
+New York,68001,State Senate,28,Ind,writein,0
+New York,68005,State Senate,28,Ind,writein,0
+New York,68006,State Senate,28,Ind,writein,0
+New York,68007,State Senate,28,Ind,writein,0
+New York,68008,State Senate,28,Ind,writein,0
+New York,73001,State Senate,28,Ind,writein,0
+New York,73002,State Senate,28,Ind,writein,0
+New York,73003,State Senate,28,Ind,writein,0
+New York,73004,State Senate,28,Ind,writein,0
+New York,73005,State Senate,28,Ind,writein,0
+New York,73007,State Senate,28,Ind,writein,0
+New York,73008,State Senate,28,Ind,writein,1
+New York,73009,State Senate,28,Ind,writein,0
+New York,73010,State Senate,28,Ind,writein,0
+New York,73014,State Senate,28,Ind,writein,0
+New York,73016,State Senate,28,Ind,writein,0
+New York,73017,State Senate,28,Ind,writein,0
+New York,73018,State Senate,28,Ind,writein,0
+New York,73019,State Senate,28,Ind,writein,0
+New York,73021,State Senate,28,Ind,writein,0
+New York,73022,State Senate,28,Ind,writein,0
+New York,73023,State Senate,28,Ind,writein,0
+New York,73024,State Senate,28,Ind,writein,0
+New York,73025,State Senate,28,Ind,writein,0
+New York,73026,State Senate,28,Ind,writein,0
+New York,73027,State Senate,28,Ind,writein,0
+New York,73028,State Senate,28,Ind,writein,0
+New York,73029,State Senate,28,Ind,writein,0
+New York,73030,State Senate,28,Ind,writein,0
+New York,73031,State Senate,28,Ind,writein,0
+New York,73032,State Senate,28,Ind,writein,0
+New York,73033,State Senate,28,Ind,writein,0
+New York,73034,State Senate,28,Ind,writein,0
+New York,73035,State Senate,28,Ind,writein,0
+New York,73036,State Senate,28,Ind,writein,0
+New York,73037,State Senate,28,Ind,writein,0
+New York,73038,State Senate,28,Ind,writein,1
+New York,73039,State Senate,28,Ind,writein,0
+New York,73040,State Senate,28,Ind,writein,0
+New York,73041,State Senate,28,Ind,writein,0
+New York,73042,State Senate,28,Ind,writein,0
+New York,73045,State Senate,28,Ind,writein,0
+New York,73046,State Senate,28,Ind,writein,0
+New York,73047,State Senate,28,Ind,writein,0
+New York,73048,State Senate,28,Ind,writein,0
+New York,73049,State Senate,28,Ind,writein,0
+New York,73050,State Senate,28,Ind,writein,0
+New York,73051,State Senate,28,Ind,writein,0
+New York,73052,State Senate,28,Ind,writein,0
+New York,73053,State Senate,28,Ind,writein,0
+New York,73054,State Senate,28,Ind,writein,0
+New York,73055,State Senate,28,Ind,writein,0
+New York,73056,State Senate,28,Ind,writein,1
+New York,73057,State Senate,28,Ind,writein,0
+New York,73058,State Senate,28,Ind,writein,0
+New York,73059,State Senate,28,Ind,writein,0
+New York,73060,State Senate,28,Ind,writein,0
+New York,73061,State Senate,28,Ind,writein,0
+New York,73062,State Senate,28,Ind,writein,0
+New York,73063,State Senate,28,Ind,writein,0
+New York,73064,State Senate,28,Ind,writein,0
+New York,73065,State Senate,28,Ind,writein,0
+New York,73066,State Senate,28,Ind,writein,0
+New York,73067,State Senate,28,Ind,writein,0
+New York,73068,State Senate,28,Ind,writein,0
+New York,73069,State Senate,28,Ind,writein,0
+New York,73070,State Senate,28,Ind,writein,0
+New York,73071,State Senate,28,Ind,writein,0
+New York,73072,State Senate,28,Ind,writein,0
+New York,73073,State Senate,28,Ind,writein,0
+New York,73074,State Senate,28,Ind,writein,0
+New York,73075,State Senate,28,Ind,writein,1
+New York,73076,State Senate,28,Ind,writein,1
+New York,73077,State Senate,28,Ind,writein,0
+New York,73078,State Senate,28,Ind,writein,0
+New York,73079,State Senate,28,Ind,writein,0
+New York,73080,State Senate,28,Ind,writein,0
+New York,73081,State Senate,28,Ind,writein,0
+New York,73082,State Senate,28,Ind,writein,0
+New York,73083,State Senate,28,Ind,writein,0
+New York,73084,State Senate,28,Ind,writein,0
+New York,73085,State Senate,28,Ind,writein,0
+New York,73086,State Senate,28,Ind,writein,0
+New York,73087,State Senate,28,Ind,writein,0
+New York,73088,State Senate,28,Ind,writein,0
+New York,73089,State Senate,28,Ind,writein,0
+New York,73090,State Senate,28,Ind,writein,0
+New York,73091,State Senate,28,Ind,writein,0
+New York,73092,State Senate,28,Ind,writein,0
+New York,73097,State Senate,28,Ind,writein,0
+New York,73099,State Senate,28,Ind,writein,0
+New York,73100,State Senate,28,Ind,writein,0
+New York,74056,State Senate,28,Ind,writein,0
+New York,74057,State Senate,28,Ind,writein,0
+New York,74058,State Senate,28,Ind,writein,1
+New York,74059,State Senate,28,Ind,writein,0
+New York,74060,State Senate,28,Ind,writein,0
+New York,74061,State Senate,28,Ind,writein,0
+New York,74062,State Senate,28,Ind,writein,0
+New York,74063,State Senate,28,Ind,writein,0
+New York,74064,State Senate,28,Ind,writein,0
+New York,74065,State Senate,28,Ind,writein,0
+New York,74066,State Senate,28,Ind,writein,0
+New York,74067,State Senate,28,Ind,writein,0
+New York,74068,State Senate,28,Ind,writein,0
+New York,74069,State Senate,28,Ind,writein,0
+New York,74070,State Senate,28,Ind,writein,0
+New York,74082,State Senate,28,Ind,writein,0
+New York,74083,State Senate,28,Ind,writein,1
+New York,74085,State Senate,28,Ind,writein,0
+New York,74086,State Senate,28,Ind,writein,0
+New York,74087,State Senate,28,Ind,writein,0
+New York,74088,State Senate,28,Ind,writein,0
+New York,74089,State Senate,28,Ind,writein,2
+New York,74090,State Senate,28,Ind,writein,0
+New York,74091,State Senate,28,Ind,writein,0
+New York,75008,State Senate,28,Ind,writein,0
+New York,75009,State Senate,28,Ind,writein,2
+New York,75029,State Senate,28,Ind,writein,1
+New York,75030,State Senate,28,Ind,writein,0
+New York,75031,State Senate,28,Ind,writein,0
+New York,75032,State Senate,28,Ind,writein,1
+New York,75033,State Senate,28,Ind,writein,2
+New York,75034,State Senate,28,Ind,writein,1
+New York,75035,State Senate,28,Ind,writein,0
+New York,75051,State Senate,28,Ind,writein,0
+New York,75052,State Senate,28,Ind,writein,0
+New York,75053,State Senate,28,Ind,writein,0
+New York,75054,State Senate,28,Ind,writein,0
+New York,75055,State Senate,28,Ind,writein,0
+New York,75056,State Senate,28,Ind,writein,0
+New York,75057,State Senate,28,Ind,writein,0
+New York,75086,State Senate,28,Ind,writein,0
+New York,75087,State Senate,28,Ind,writein,0
+New York,75088,State Senate,28,Ind,writein,0
+New York,75090,State Senate,28,Ind,writein,1
+New York,75091,State Senate,28,Ind,writein,0
+New York,75092,State Senate,28,Ind,writein,1
+New York,76001,State Senate,28,Ind,writein,0
+New York,76002,State Senate,28,Ind,writein,2
+New York,76003,State Senate,28,Ind,writein,0
+New York,76004,State Senate,28,Ind,writein,0
+New York,76005,State Senate,28,Ind,writein,0
+New York,76006,State Senate,28,Ind,writein,1
+New York,76007,State Senate,28,Ind,writein,0
+New York,76008,State Senate,28,Ind,writein,0
+New York,76009,State Senate,28,Ind,writein,0
+New York,76010,State Senate,28,Ind,writein,0
+New York,76011,State Senate,28,Ind,writein,0
+New York,76012,State Senate,28,Ind,writein,0
+New York,76013,State Senate,28,Ind,writein,0
+New York,76014,State Senate,28,Ind,writein,1
+New York,76015,State Senate,28,Ind,writein,0
+New York,76016,State Senate,28,Ind,writein,0
+New York,76017,State Senate,28,Ind,writein,0
+New York,76018,State Senate,28,Ind,writein,0
+New York,76019,State Senate,28,Ind,writein,0
+New York,76020,State Senate,28,Ind,writein,0
+New York,76021,State Senate,28,Ind,writein,0
+New York,76022,State Senate,28,Ind,writein,1
+New York,76023,State Senate,28,Ind,writein,0
+New York,76024,State Senate,28,Ind,writein,0
+New York,76025,State Senate,28,Ind,writein,0
+New York,76026,State Senate,28,Ind,writein,0
+New York,76027,State Senate,28,Ind,writein,0
+New York,76028,State Senate,28,Ind,writein,1
+New York,76029,State Senate,28,Ind,writein,0
+New York,76030,State Senate,28,Ind,writein,1
+New York,76031,State Senate,28,Ind,writein,0
+New York,76032,State Senate,28,Ind,writein,0
+New York,76033,State Senate,28,Ind,writein,0
+New York,76034,State Senate,28,Ind,writein,0
+New York,76035,State Senate,28,Ind,writein,0
+New York,76036,State Senate,28,Ind,writein,0
+New York,76037,State Senate,28,Ind,writein,0
+New York,76038,State Senate,28,Ind,writein,1
+New York,76039,State Senate,28,Ind,writein,0
+New York,76040,State Senate,28,Ind,writein,0
+New York,76041,State Senate,28,Ind,writein,0
+New York,76042,State Senate,28,Ind,writein,0
+New York,76043,State Senate,28,Ind,writein,0
+New York,76044,State Senate,28,Ind,writein,0
+New York,76045,State Senate,28,Ind,writein,0
+New York,76046,State Senate,28,Ind,writein,0
+New York,76047,State Senate,28,Ind,writein,0
+New York,76048,State Senate,28,Ind,writein,1
+New York,76049,State Senate,28,Ind,writein,1
+New York,76050,State Senate,28,Ind,writein,0
+New York,76051,State Senate,28,Ind,writein,1
+New York,76052,State Senate,28,Ind,writein,1
+New York,76053,State Senate,28,Ind,writein,0
+New York,76054,State Senate,28,Ind,writein,0
+New York,76055,State Senate,28,Ind,writein,0
+New York,76056,State Senate,28,Ind,writein,0
+New York,76057,State Senate,28,Ind,writein,1
+New York,76058,State Senate,28,Ind,writein,0
+New York,76059,State Senate,28,Ind,writein,0
+New York,76060,State Senate,28,Ind,writein,0
+New York,76061,State Senate,28,Ind,writein,0
+New York,76062,State Senate,28,Ind,writein,0
+New York,76063,State Senate,28,Ind,writein,1
+New York,76064,State Senate,28,Ind,writein,0
+New York,76065,State Senate,28,Ind,writein,1
+New York,76066,State Senate,28,Ind,writein,0
+New York,76067,State Senate,28,Ind,writein,1
+New York,76068,State Senate,28,Ind,writein,0
+New York,76069,State Senate,28,Ind,writein,0
+New York,76070,State Senate,28,Ind,writein,0
+New York,76071,State Senate,28,Ind,writein,0
+New York,76072,State Senate,28,Ind,writein,1
+New York,76073,State Senate,28,Ind,writein,1
+New York,76074,State Senate,28,Ind,writein,0
+New York,76075,State Senate,28,Ind,writein,0
+New York,76076,State Senate,28,Ind,writein,0
+New York,76077,State Senate,28,Ind,writein,0
+New York,76078,State Senate,28,Ind,writein,0
+New York,76079,State Senate,28,Ind,writein,0
+New York,76080,State Senate,28,Ind,writein,0
+New York,67052,State Senate,29,Dem,Jose Serrano,474
+New York,67053,State Senate,29,Dem,Jose Serrano,363
+New York,67054,State Senate,29,Dem,Jose Serrano,317
+New York,67055,State Senate,29,Dem,Jose Serrano,251
+New York,67056,State Senate,29,Dem,Jose Serrano,379
+New York,67057,State Senate,29,Dem,Jose Serrano,403
+New York,67058,State Senate,29,Dem,Jose Serrano,276
+New York,67059,State Senate,29,Dem,Jose Serrano,419
+New York,67060,State Senate,29,Dem,Jose Serrano,371
+New York,67061,State Senate,29,Dem,Jose Serrano,408
+New York,67062,State Senate,29,Dem,Jose Serrano,359
+New York,67063,State Senate,29,Dem,Jose Serrano,354
+New York,67064,State Senate,29,Dem,Jose Serrano,380
+New York,67065,State Senate,29,Dem,Jose Serrano,438
+New York,67066,State Senate,29,Dem,Jose Serrano,409
+New York,67068,State Senate,29,Dem,Jose Serrano,551
+New York,67069,State Senate,29,Dem,Jose Serrano,548
+New York,67070,State Senate,29,Dem,Jose Serrano,303
+New York,67071,State Senate,29,Dem,Jose Serrano,341
+New York,67072,State Senate,29,Dem,Jose Serrano,558
+New York,67073,State Senate,29,Dem,Jose Serrano,359
+New York,67074,State Senate,29,Dem,Jose Serrano,489
+New York,67075,State Senate,29,Dem,Jose Serrano,359
+New York,67076,State Senate,29,Dem,Jose Serrano,594
+New York,67077,State Senate,29,Dem,Jose Serrano,366
+New York,67078,State Senate,29,Dem,Jose Serrano,437
+New York,68002,State Senate,29,Dem,Jose Serrano,335
+New York,68003,State Senate,29,Dem,Jose Serrano,449
+New York,68004,State Senate,29,Dem,Jose Serrano,632
+New York,68009,State Senate,29,Dem,Jose Serrano,136
+New York,68010,State Senate,29,Dem,Jose Serrano,246
+New York,68011,State Senate,29,Dem,Jose Serrano,391
+New York,68012,State Senate,29,Dem,Jose Serrano,292
+New York,68014,State Senate,29,Dem,Jose Serrano,551
+New York,68015,State Senate,29,Dem,Jose Serrano,181
+New York,68016,State Senate,29,Dem,Jose Serrano,228
+New York,68017,State Senate,29,Dem,Jose Serrano,279
+New York,68018,State Senate,29,Dem,Jose Serrano,358
+New York,68019,State Senate,29,Dem,Jose Serrano,354
+New York,68020,State Senate,29,Dem,Jose Serrano,175
+New York,68021,State Senate,29,Dem,Jose Serrano,258
+New York,68022,State Senate,29,Dem,Jose Serrano,257
+New York,68023,State Senate,29,Dem,Jose Serrano,384
+New York,68037,State Senate,29,Dem,Jose Serrano,460
+New York,68038,State Senate,29,Dem,Jose Serrano,113
+New York,68039,State Senate,29,Dem,Jose Serrano,228
+New York,68040,State Senate,29,Dem,Jose Serrano,491
+New York,68041,State Senate,29,Dem,Jose Serrano,480
+New York,68042,State Senate,29,Dem,Jose Serrano,253
+New York,68043,State Senate,29,Dem,Jose Serrano,315
+New York,68044,State Senate,29,Dem,Jose Serrano,320
+New York,68045,State Senate,29,Dem,Jose Serrano,251
+New York,68046,State Senate,29,Dem,Jose Serrano,253
+New York,68054,State Senate,29,Dem,Jose Serrano,364
+New York,68055,State Senate,29,Dem,Jose Serrano,209
+New York,68071,State Senate,29,Dem,Jose Serrano,350
+New York,68072,State Senate,29,Dem,Jose Serrano,156
+New York,68075,State Senate,29,Dem,Jose Serrano,411
+New York,68076,State Senate,29,Dem,Jose Serrano,313
+New York,68077,State Senate,29,Dem,Jose Serrano,199
+New York,68094,State Senate,29,Dem,Jose Serrano,50
+New York,69001,State Senate,29,Dem,Jose Serrano,352
+New York,69002,State Senate,29,Dem,Jose Serrano,280
+New York,69003,State Senate,29,Dem,Jose Serrano,482
+New York,69004,State Senate,29,Dem,Jose Serrano,382
+New York,69005,State Senate,29,Dem,Jose Serrano,382
+New York,69006,State Senate,29,Dem,Jose Serrano,482
+New York,69007,State Senate,29,Dem,Jose Serrano,404
+New York,69009,State Senate,29,Dem,Jose Serrano,466
+New York,69010,State Senate,29,Dem,Jose Serrano,479
+New York,69011,State Senate,29,Dem,Jose Serrano,494
+New York,69012,State Senate,29,Dem,Jose Serrano,536
+New York,73093,State Senate,29,Dem,Jose Serrano,443
+New York,73094,State Senate,29,Dem,Jose Serrano,309
+New York,73095,State Senate,29,Dem,Jose Serrano,427
+New York,73096,State Senate,29,Dem,Jose Serrano,335
+New York,73098,State Senate,29,Dem,Jose Serrano,251
+New York,76081,State Senate,29,Dem,Jose Serrano,265
+New York,76082,State Senate,29,Dem,Jose Serrano,273
+New York,76083,State Senate,29,Dem,Jose Serrano,578
+New York,76084,State Senate,29,Dem,Jose Serrano,441
+New York,76085,State Senate,29,Dem,Jose Serrano,345
+New York,76086,State Senate,29,Dem,Jose Serrano,336
+New York,76087,State Senate,29,Dem,Jose Serrano,161
+New York,67052,State Senate,29,WF,Jose Serrano,13
+New York,67053,State Senate,29,WF,Jose Serrano,15
+New York,67054,State Senate,29,WF,Jose Serrano,6
+New York,67055,State Senate,29,WF,Jose Serrano,8
+New York,67056,State Senate,29,WF,Jose Serrano,20
+New York,67057,State Senate,29,WF,Jose Serrano,19
+New York,67058,State Senate,29,WF,Jose Serrano,7
+New York,67059,State Senate,29,WF,Jose Serrano,16
+New York,67060,State Senate,29,WF,Jose Serrano,14
+New York,67061,State Senate,29,WF,Jose Serrano,23
+New York,67062,State Senate,29,WF,Jose Serrano,10
+New York,67063,State Senate,29,WF,Jose Serrano,5
+New York,67064,State Senate,29,WF,Jose Serrano,20
+New York,67065,State Senate,29,WF,Jose Serrano,15
+New York,67066,State Senate,29,WF,Jose Serrano,11
+New York,67068,State Senate,29,WF,Jose Serrano,34
+New York,67069,State Senate,29,WF,Jose Serrano,37
+New York,67070,State Senate,29,WF,Jose Serrano,17
+New York,67071,State Senate,29,WF,Jose Serrano,13
+New York,67072,State Senate,29,WF,Jose Serrano,15
+New York,67073,State Senate,29,WF,Jose Serrano,26
+New York,67074,State Senate,29,WF,Jose Serrano,21
+New York,67075,State Senate,29,WF,Jose Serrano,24
+New York,67076,State Senate,29,WF,Jose Serrano,41
+New York,67077,State Senate,29,WF,Jose Serrano,12
+New York,67078,State Senate,29,WF,Jose Serrano,24
+New York,68002,State Senate,29,WF,Jose Serrano,10
+New York,68003,State Senate,29,WF,Jose Serrano,22
+New York,68004,State Senate,29,WF,Jose Serrano,17
+New York,68009,State Senate,29,WF,Jose Serrano,2
+New York,68010,State Senate,29,WF,Jose Serrano,8
+New York,68011,State Senate,29,WF,Jose Serrano,14
+New York,68012,State Senate,29,WF,Jose Serrano,12
+New York,68014,State Senate,29,WF,Jose Serrano,17
+New York,68015,State Senate,29,WF,Jose Serrano,4
+New York,68016,State Senate,29,WF,Jose Serrano,1
+New York,68017,State Senate,29,WF,Jose Serrano,8
+New York,68018,State Senate,29,WF,Jose Serrano,10
+New York,68019,State Senate,29,WF,Jose Serrano,7
+New York,68020,State Senate,29,WF,Jose Serrano,7
+New York,68021,State Senate,29,WF,Jose Serrano,3
+New York,68022,State Senate,29,WF,Jose Serrano,6
+New York,68023,State Senate,29,WF,Jose Serrano,11
+New York,68037,State Senate,29,WF,Jose Serrano,13
+New York,68038,State Senate,29,WF,Jose Serrano,8
+New York,68039,State Senate,29,WF,Jose Serrano,9
+New York,68040,State Senate,29,WF,Jose Serrano,19
+New York,68041,State Senate,29,WF,Jose Serrano,12
+New York,68042,State Senate,29,WF,Jose Serrano,7
+New York,68043,State Senate,29,WF,Jose Serrano,14
+New York,68044,State Senate,29,WF,Jose Serrano,1
+New York,68045,State Senate,29,WF,Jose Serrano,2
+New York,68046,State Senate,29,WF,Jose Serrano,3
+New York,68054,State Senate,29,WF,Jose Serrano,11
+New York,68055,State Senate,29,WF,Jose Serrano,11
+New York,68071,State Senate,29,WF,Jose Serrano,24
+New York,68072,State Senate,29,WF,Jose Serrano,7
+New York,68075,State Senate,29,WF,Jose Serrano,21
+New York,68076,State Senate,29,WF,Jose Serrano,21
+New York,68077,State Senate,29,WF,Jose Serrano,12
+New York,68094,State Senate,29,WF,Jose Serrano,1
+New York,69001,State Senate,29,WF,Jose Serrano,24
+New York,69002,State Senate,29,WF,Jose Serrano,13
+New York,69003,State Senate,29,WF,Jose Serrano,14
+New York,69004,State Senate,29,WF,Jose Serrano,24
+New York,69005,State Senate,29,WF,Jose Serrano,18
+New York,69006,State Senate,29,WF,Jose Serrano,15
+New York,69007,State Senate,29,WF,Jose Serrano,15
+New York,69009,State Senate,29,WF,Jose Serrano,13
+New York,69010,State Senate,29,WF,Jose Serrano,34
+New York,69011,State Senate,29,WF,Jose Serrano,27
+New York,69012,State Senate,29,WF,Jose Serrano,20
+New York,73093,State Senate,29,WF,Jose Serrano,20
+New York,73094,State Senate,29,WF,Jose Serrano,10
+New York,73095,State Senate,29,WF,Jose Serrano,17
+New York,73096,State Senate,29,WF,Jose Serrano,3
+New York,73098,State Senate,29,WF,Jose Serrano,7
+New York,76081,State Senate,29,WF,Jose Serrano,11
+New York,76082,State Senate,29,WF,Jose Serrano,6
+New York,76083,State Senate,29,WF,Jose Serrano,38
+New York,76084,State Senate,29,WF,Jose Serrano,16
+New York,76085,State Senate,29,WF,Jose Serrano,10
+New York,76086,State Senate,29,WF,Jose Serrano,24
+New York,76087,State Senate,29,WF,Jose Serrano,4
+New York,67052,State Senate,29,Rep,Robert Goodman,50
+New York,67053,State Senate,29,Rep,Robert Goodman,47
+New York,67054,State Senate,29,Rep,Robert Goodman,35
+New York,67055,State Senate,29,Rep,Robert Goodman,52
+New York,67056,State Senate,29,Rep,Robert Goodman,40
+New York,67057,State Senate,29,Rep,Robert Goodman,58
+New York,67058,State Senate,29,Rep,Robert Goodman,29
+New York,67059,State Senate,29,Rep,Robert Goodman,29
+New York,67060,State Senate,29,Rep,Robert Goodman,57
+New York,67061,State Senate,29,Rep,Robert Goodman,49
+New York,67062,State Senate,29,Rep,Robert Goodman,43
+New York,67063,State Senate,29,Rep,Robert Goodman,44
+New York,67064,State Senate,29,Rep,Robert Goodman,51
+New York,67065,State Senate,29,Rep,Robert Goodman,58
+New York,67066,State Senate,29,Rep,Robert Goodman,40
+New York,67068,State Senate,29,Rep,Robert Goodman,60
+New York,67069,State Senate,29,Rep,Robert Goodman,71
+New York,67070,State Senate,29,Rep,Robert Goodman,46
+New York,67071,State Senate,29,Rep,Robert Goodman,60
+New York,67072,State Senate,29,Rep,Robert Goodman,57
+New York,67073,State Senate,29,Rep,Robert Goodman,39
+New York,67074,State Senate,29,Rep,Robert Goodman,58
+New York,67075,State Senate,29,Rep,Robert Goodman,36
+New York,67076,State Senate,29,Rep,Robert Goodman,59
+New York,67077,State Senate,29,Rep,Robert Goodman,36
+New York,67078,State Senate,29,Rep,Robert Goodman,44
+New York,68002,State Senate,29,Rep,Robert Goodman,14
+New York,68003,State Senate,29,Rep,Robert Goodman,54
+New York,68004,State Senate,29,Rep,Robert Goodman,79
+New York,68009,State Senate,29,Rep,Robert Goodman,27
+New York,68010,State Senate,29,Rep,Robert Goodman,58
+New York,68011,State Senate,29,Rep,Robert Goodman,85
+New York,68012,State Senate,29,Rep,Robert Goodman,45
+New York,68014,State Senate,29,Rep,Robert Goodman,85
+New York,68015,State Senate,29,Rep,Robert Goodman,26
+New York,68016,State Senate,29,Rep,Robert Goodman,7
+New York,68017,State Senate,29,Rep,Robert Goodman,5
+New York,68018,State Senate,29,Rep,Robert Goodman,8
+New York,68019,State Senate,29,Rep,Robert Goodman,8
+New York,68020,State Senate,29,Rep,Robert Goodman,9
+New York,68021,State Senate,29,Rep,Robert Goodman,3
+New York,68022,State Senate,29,Rep,Robert Goodman,15
+New York,68023,State Senate,29,Rep,Robert Goodman,18
+New York,68037,State Senate,29,Rep,Robert Goodman,17
+New York,68038,State Senate,29,Rep,Robert Goodman,8
+New York,68039,State Senate,29,Rep,Robert Goodman,5
+New York,68040,State Senate,29,Rep,Robert Goodman,15
+New York,68041,State Senate,29,Rep,Robert Goodman,12
+New York,68042,State Senate,29,Rep,Robert Goodman,7
+New York,68043,State Senate,29,Rep,Robert Goodman,8
+New York,68044,State Senate,29,Rep,Robert Goodman,4
+New York,68045,State Senate,29,Rep,Robert Goodman,2
+New York,68046,State Senate,29,Rep,Robert Goodman,15
+New York,68054,State Senate,29,Rep,Robert Goodman,11
+New York,68055,State Senate,29,Rep,Robert Goodman,15
+New York,68071,State Senate,29,Rep,Robert Goodman,10
+New York,68072,State Senate,29,Rep,Robert Goodman,4
+New York,68075,State Senate,29,Rep,Robert Goodman,13
+New York,68076,State Senate,29,Rep,Robert Goodman,9
+New York,68077,State Senate,29,Rep,Robert Goodman,4
+New York,68094,State Senate,29,Rep,Robert Goodman,4
+New York,69001,State Senate,29,Rep,Robert Goodman,22
+New York,69002,State Senate,29,Rep,Robert Goodman,32
+New York,69003,State Senate,29,Rep,Robert Goodman,38
+New York,69004,State Senate,29,Rep,Robert Goodman,43
+New York,69005,State Senate,29,Rep,Robert Goodman,48
+New York,69006,State Senate,29,Rep,Robert Goodman,41
+New York,69007,State Senate,29,Rep,Robert Goodman,45
+New York,69009,State Senate,29,Rep,Robert Goodman,56
+New York,69010,State Senate,29,Rep,Robert Goodman,42
+New York,69011,State Senate,29,Rep,Robert Goodman,46
+New York,69012,State Senate,29,Rep,Robert Goodman,48
+New York,73093,State Senate,29,Rep,Robert Goodman,67
+New York,73094,State Senate,29,Rep,Robert Goodman,41
+New York,73095,State Senate,29,Rep,Robert Goodman,37
+New York,73096,State Senate,29,Rep,Robert Goodman,75
+New York,73098,State Senate,29,Rep,Robert Goodman,31
+New York,76081,State Senate,29,Rep,Robert Goodman,45
+New York,76082,State Senate,29,Rep,Robert Goodman,40
+New York,76083,State Senate,29,Rep,Robert Goodman,38
+New York,76084,State Senate,29,Rep,Robert Goodman,26
+New York,76085,State Senate,29,Rep,Robert Goodman,16
+New York,76086,State Senate,29,Rep,Robert Goodman,25
+New York,76087,State Senate,29,Rep,Robert Goodman,10
+New York,67052,State Senate,29,Green,Thomas Siracuse,21
+New York,67053,State Senate,29,Green,Thomas Siracuse,5
+New York,67054,State Senate,29,Green,Thomas Siracuse,14
+New York,67055,State Senate,29,Green,Thomas Siracuse,7
+New York,67056,State Senate,29,Green,Thomas Siracuse,26
+New York,67057,State Senate,29,Green,Thomas Siracuse,21
+New York,67058,State Senate,29,Green,Thomas Siracuse,7
+New York,67059,State Senate,29,Green,Thomas Siracuse,4
+New York,67060,State Senate,29,Green,Thomas Siracuse,35
+New York,67061,State Senate,29,Green,Thomas Siracuse,25
+New York,67062,State Senate,29,Green,Thomas Siracuse,18
+New York,67063,State Senate,29,Green,Thomas Siracuse,14
+New York,67064,State Senate,29,Green,Thomas Siracuse,23
+New York,67065,State Senate,29,Green,Thomas Siracuse,14
+New York,67066,State Senate,29,Green,Thomas Siracuse,14
+New York,67068,State Senate,29,Green,Thomas Siracuse,23
+New York,67069,State Senate,29,Green,Thomas Siracuse,30
+New York,67070,State Senate,29,Green,Thomas Siracuse,9
+New York,67071,State Senate,29,Green,Thomas Siracuse,7
+New York,67072,State Senate,29,Green,Thomas Siracuse,22
+New York,67073,State Senate,29,Green,Thomas Siracuse,17
+New York,67074,State Senate,29,Green,Thomas Siracuse,24
+New York,67075,State Senate,29,Green,Thomas Siracuse,13
+New York,67076,State Senate,29,Green,Thomas Siracuse,21
+New York,67077,State Senate,29,Green,Thomas Siracuse,13
+New York,67078,State Senate,29,Green,Thomas Siracuse,10
+New York,68002,State Senate,29,Green,Thomas Siracuse,3
+New York,68003,State Senate,29,Green,Thomas Siracuse,21
+New York,68004,State Senate,29,Green,Thomas Siracuse,20
+New York,68009,State Senate,29,Green,Thomas Siracuse,8
+New York,68010,State Senate,29,Green,Thomas Siracuse,9
+New York,68011,State Senate,29,Green,Thomas Siracuse,14
+New York,68012,State Senate,29,Green,Thomas Siracuse,15
+New York,68014,State Senate,29,Green,Thomas Siracuse,16
+New York,68015,State Senate,29,Green,Thomas Siracuse,5
+New York,68016,State Senate,29,Green,Thomas Siracuse,0
+New York,68017,State Senate,29,Green,Thomas Siracuse,0
+New York,68018,State Senate,29,Green,Thomas Siracuse,7
+New York,68019,State Senate,29,Green,Thomas Siracuse,2
+New York,68020,State Senate,29,Green,Thomas Siracuse,10
+New York,68021,State Senate,29,Green,Thomas Siracuse,4
+New York,68022,State Senate,29,Green,Thomas Siracuse,11
+New York,68023,State Senate,29,Green,Thomas Siracuse,18
+New York,68037,State Senate,29,Green,Thomas Siracuse,14
+New York,68038,State Senate,29,Green,Thomas Siracuse,5
+New York,68039,State Senate,29,Green,Thomas Siracuse,3
+New York,68040,State Senate,29,Green,Thomas Siracuse,3
+New York,68041,State Senate,29,Green,Thomas Siracuse,7
+New York,68042,State Senate,29,Green,Thomas Siracuse,4
+New York,68043,State Senate,29,Green,Thomas Siracuse,10
+New York,68044,State Senate,29,Green,Thomas Siracuse,0
+New York,68045,State Senate,29,Green,Thomas Siracuse,4
+New York,68046,State Senate,29,Green,Thomas Siracuse,3
+New York,68054,State Senate,29,Green,Thomas Siracuse,11
+New York,68055,State Senate,29,Green,Thomas Siracuse,13
+New York,68071,State Senate,29,Green,Thomas Siracuse,7
+New York,68072,State Senate,29,Green,Thomas Siracuse,6
+New York,68075,State Senate,29,Green,Thomas Siracuse,17
+New York,68076,State Senate,29,Green,Thomas Siracuse,8
+New York,68077,State Senate,29,Green,Thomas Siracuse,6
+New York,68094,State Senate,29,Green,Thomas Siracuse,0
+New York,69001,State Senate,29,Green,Thomas Siracuse,14
+New York,69002,State Senate,29,Green,Thomas Siracuse,11
+New York,69003,State Senate,29,Green,Thomas Siracuse,15
+New York,69004,State Senate,29,Green,Thomas Siracuse,15
+New York,69005,State Senate,29,Green,Thomas Siracuse,14
+New York,69006,State Senate,29,Green,Thomas Siracuse,16
+New York,69007,State Senate,29,Green,Thomas Siracuse,18
+New York,69009,State Senate,29,Green,Thomas Siracuse,15
+New York,69010,State Senate,29,Green,Thomas Siracuse,19
+New York,69011,State Senate,29,Green,Thomas Siracuse,26
+New York,69012,State Senate,29,Green,Thomas Siracuse,8
+New York,73093,State Senate,29,Green,Thomas Siracuse,27
+New York,73094,State Senate,29,Green,Thomas Siracuse,17
+New York,73095,State Senate,29,Green,Thomas Siracuse,9
+New York,73096,State Senate,29,Green,Thomas Siracuse,11
+New York,73098,State Senate,29,Green,Thomas Siracuse,7
+New York,76081,State Senate,29,Green,Thomas Siracuse,14
+New York,76082,State Senate,29,Green,Thomas Siracuse,13
+New York,76083,State Senate,29,Green,Thomas Siracuse,31
+New York,76084,State Senate,29,Green,Thomas Siracuse,12
+New York,76085,State Senate,29,Green,Thomas Siracuse,5
+New York,76086,State Senate,29,Green,Thomas Siracuse,22
+New York,76087,State Senate,29,Green,Thomas Siracuse,5
+New York,67052,State Senate,29,Ind,writein,0
+New York,67053,State Senate,29,Ind,writein,0
+New York,67054,State Senate,29,Ind,writein,0
+New York,67055,State Senate,29,Ind,writein,0
+New York,67056,State Senate,29,Ind,writein,1
+New York,67057,State Senate,29,Ind,writein,0
+New York,67058,State Senate,29,Ind,writein,1
+New York,67059,State Senate,29,Ind,writein,0
+New York,67060,State Senate,29,Ind,writein,0
+New York,67061,State Senate,29,Ind,writein,1
+New York,67062,State Senate,29,Ind,writein,0
+New York,67063,State Senate,29,Ind,writein,1
+New York,67064,State Senate,29,Ind,writein,1
+New York,67065,State Senate,29,Ind,writein,0
+New York,67066,State Senate,29,Ind,writein,1
+New York,67068,State Senate,29,Ind,writein,1
+New York,67069,State Senate,29,Ind,writein,0
+New York,67070,State Senate,29,Ind,writein,0
+New York,67071,State Senate,29,Ind,writein,1
+New York,67072,State Senate,29,Ind,writein,0
+New York,67073,State Senate,29,Ind,writein,1
+New York,67074,State Senate,29,Ind,writein,1
+New York,67075,State Senate,29,Ind,writein,2
+New York,67076,State Senate,29,Ind,writein,1
+New York,67077,State Senate,29,Ind,writein,0
+New York,67078,State Senate,29,Ind,writein,0
+New York,68002,State Senate,29,Ind,writein,0
+New York,68003,State Senate,29,Ind,writein,0
+New York,68004,State Senate,29,Ind,writein,0
+New York,68009,State Senate,29,Ind,writein,0
+New York,68010,State Senate,29,Ind,writein,1
+New York,68011,State Senate,29,Ind,writein,0
+New York,68012,State Senate,29,Ind,writein,0
+New York,68014,State Senate,29,Ind,writein,1
+New York,68015,State Senate,29,Ind,writein,0
+New York,68016,State Senate,29,Ind,writein,0
+New York,68017,State Senate,29,Ind,writein,1
+New York,68018,State Senate,29,Ind,writein,0
+New York,68019,State Senate,29,Ind,writein,0
+New York,68020,State Senate,29,Ind,writein,0
+New York,68021,State Senate,29,Ind,writein,0
+New York,68022,State Senate,29,Ind,writein,0
+New York,68023,State Senate,29,Ind,writein,0
+New York,68037,State Senate,29,Ind,writein,0
+New York,68038,State Senate,29,Ind,writein,1
+New York,68039,State Senate,29,Ind,writein,0
+New York,68040,State Senate,29,Ind,writein,0
+New York,68041,State Senate,29,Ind,writein,1
+New York,68042,State Senate,29,Ind,writein,0
+New York,68043,State Senate,29,Ind,writein,0
+New York,68044,State Senate,29,Ind,writein,0
+New York,68045,State Senate,29,Ind,writein,0
+New York,68046,State Senate,29,Ind,writein,0
+New York,68054,State Senate,29,Ind,writein,0
+New York,68055,State Senate,29,Ind,writein,1
+New York,68071,State Senate,29,Ind,writein,0
+New York,68072,State Senate,29,Ind,writein,0
+New York,68075,State Senate,29,Ind,writein,0
+New York,68076,State Senate,29,Ind,writein,0
+New York,68077,State Senate,29,Ind,writein,0
+New York,68094,State Senate,29,Ind,writein,0
+New York,69001,State Senate,29,Ind,writein,0
+New York,69002,State Senate,29,Ind,writein,0
+New York,69003,State Senate,29,Ind,writein,1
+New York,69004,State Senate,29,Ind,writein,0
+New York,69005,State Senate,29,Ind,writein,0
+New York,69006,State Senate,29,Ind,writein,0
+New York,69007,State Senate,29,Ind,writein,1
+New York,69009,State Senate,29,Ind,writein,0
+New York,69010,State Senate,29,Ind,writein,1
+New York,69011,State Senate,29,Ind,writein,0
+New York,69012,State Senate,29,Ind,writein,1
+New York,73093,State Senate,29,Ind,writein,0
+New York,73094,State Senate,29,Ind,writein,1
+New York,73095,State Senate,29,Ind,writein,0
+New York,73096,State Senate,29,Ind,writein,0
+New York,73098,State Senate,29,Ind,writein,0
+New York,76081,State Senate,29,Ind,writein,0
+New York,76082,State Senate,29,Ind,writein,0
+New York,76083,State Senate,29,Ind,writein,0
+New York,76084,State Senate,29,Ind,writein,0
+New York,76085,State Senate,29,Ind,writein,0
+New York,76086,State Senate,29,Ind,writein,0
+New York,76087,State Senate,29,Ind,writein,0
+New York,67086,State Senate,30,Dem,Bill Perkins,626
+New York,68013,State Senate,30,Dem,Bill Perkins,144
+New York,68024,State Senate,30,Dem,Bill Perkins,215
+New York,68025,State Senate,30,Dem,Bill Perkins,266
+New York,68026,State Senate,30,Dem,Bill Perkins,273
+New York,68027,State Senate,30,Dem,Bill Perkins,217
+New York,68028,State Senate,30,Dem,Bill Perkins,266
+New York,68029,State Senate,30,Dem,Bill Perkins,149
+New York,68030,State Senate,30,Dem,Bill Perkins,305
+New York,68031,State Senate,30,Dem,Bill Perkins,490
+New York,68032,State Senate,30,Dem,Bill Perkins,433
+New York,68033,State Senate,30,Dem,Bill Perkins,399
+New York,68034,State Senate,30,Dem,Bill Perkins,541
+New York,68035,State Senate,30,Dem,Bill Perkins,180
+New York,68036,State Senate,30,Dem,Bill Perkins,352
+New York,68047,State Senate,30,Dem,Bill Perkins,218
+New York,68048,State Senate,30,Dem,Bill Perkins,315
+New York,68049,State Senate,30,Dem,Bill Perkins,343
+New York,68050,State Senate,30,Dem,Bill Perkins,341
+New York,68051,State Senate,30,Dem,Bill Perkins,308
+New York,68052,State Senate,30,Dem,Bill Perkins,301
+New York,68053,State Senate,30,Dem,Bill Perkins,264
+New York,68056,State Senate,30,Dem,Bill Perkins,452
+New York,68057,State Senate,30,Dem,Bill Perkins,519
+New York,68058,State Senate,30,Dem,Bill Perkins,346
+New York,68059,State Senate,30,Dem,Bill Perkins,456
+New York,68060,State Senate,30,Dem,Bill Perkins,467
+New York,68061,State Senate,30,Dem,Bill Perkins,326
+New York,68062,State Senate,30,Dem,Bill Perkins,249
+New York,68063,State Senate,30,Dem,Bill Perkins,372
+New York,68064,State Senate,30,Dem,Bill Perkins,224
+New York,68065,State Senate,30,Dem,Bill Perkins,224
+New York,68066,State Senate,30,Dem,Bill Perkins,370
+New York,68067,State Senate,30,Dem,Bill Perkins,196
+New York,68068,State Senate,30,Dem,Bill Perkins,234
+New York,68069,State Senate,30,Dem,Bill Perkins,265
+New York,68070,State Senate,30,Dem,Bill Perkins,237
+New York,68073,State Senate,30,Dem,Bill Perkins,436
+New York,68074,State Senate,30,Dem,Bill Perkins,410
+New York,68078,State Senate,30,Dem,Bill Perkins,472
+New York,68079,State Senate,30,Dem,Bill Perkins,386
+New York,68080,State Senate,30,Dem,Bill Perkins,533
+New York,68081,State Senate,30,Dem,Bill Perkins,33
+New York,68082,State Senate,30,Dem,Bill Perkins,431
+New York,68083,State Senate,30,Dem,Bill Perkins,551
+New York,68084,State Senate,30,Dem,Bill Perkins,479
+New York,68085,State Senate,30,Dem,Bill Perkins,419
+New York,68086,State Senate,30,Dem,Bill Perkins,200
+New York,68087,State Senate,30,Dem,Bill Perkins,428
+New York,68088,State Senate,30,Dem,Bill Perkins,409
+New York,68089,State Senate,30,Dem,Bill Perkins,436
+New York,68090,State Senate,30,Dem,Bill Perkins,376
+New York,68091,State Senate,30,Dem,Bill Perkins,284
+New York,68092,State Senate,30,Dem,Bill Perkins,308
+New York,68093,State Senate,30,Dem,Bill Perkins,354
+New York,69013,State Senate,30,Dem,Bill Perkins,350
+New York,69014,State Senate,30,Dem,Bill Perkins,286
+New York,69015,State Senate,30,Dem,Bill Perkins,487
+New York,69016,State Senate,30,Dem,Bill Perkins,404
+New York,69017,State Senate,30,Dem,Bill Perkins,550
+New York,69018,State Senate,30,Dem,Bill Perkins,550
+New York,69019,State Senate,30,Dem,Bill Perkins,347
+New York,69020,State Senate,30,Dem,Bill Perkins,545
+New York,69021,State Senate,30,Dem,Bill Perkins,343
+New York,69028,State Senate,30,Dem,Bill Perkins,251
+New York,69029,State Senate,30,Dem,Bill Perkins,558
+New York,69030,State Senate,30,Dem,Bill Perkins,468
+New York,69031,State Senate,30,Dem,Bill Perkins,490
+New York,69032,State Senate,30,Dem,Bill Perkins,487
+New York,69033,State Senate,30,Dem,Bill Perkins,599
+New York,69034,State Senate,30,Dem,Bill Perkins,564
+New York,69035,State Senate,30,Dem,Bill Perkins,223
+New York,69037,State Senate,30,Dem,Bill Perkins,271
+New York,69038,State Senate,30,Dem,Bill Perkins,407
+New York,69039,State Senate,30,Dem,Bill Perkins,494
+New York,69040,State Senate,30,Dem,Bill Perkins,509
+New York,69041,State Senate,30,Dem,Bill Perkins,451
+New York,69042,State Senate,30,Dem,Bill Perkins,574
+New York,69043,State Senate,30,Dem,Bill Perkins,498
+New York,69044,State Senate,30,Dem,Bill Perkins,452
+New York,69052,State Senate,30,Dem,Bill Perkins,391
+New York,69053,State Senate,30,Dem,Bill Perkins,333
+New York,69054,State Senate,30,Dem,Bill Perkins,432
+New York,69055,State Senate,30,Dem,Bill Perkins,473
+New York,69056,State Senate,30,Dem,Bill Perkins,256
+New York,69057,State Senate,30,Dem,Bill Perkins,607
+New York,69058,State Senate,30,Dem,Bill Perkins,370
+New York,69059,State Senate,30,Dem,Bill Perkins,226
+New York,69067,State Senate,30,Dem,Bill Perkins,244
+New York,69068,State Senate,30,Dem,Bill Perkins,469
+New York,69069,State Senate,30,Dem,Bill Perkins,562
+New York,69070,State Senate,30,Dem,Bill Perkins,247
+New York,69071,State Senate,30,Dem,Bill Perkins,354
+New York,69074,State Senate,30,Dem,Bill Perkins,527
+New York,69075,State Senate,30,Dem,Bill Perkins,488
+New York,69076,State Senate,30,Dem,Bill Perkins,271
+New York,69080,State Senate,30,Dem,Bill Perkins,442
+New York,69081,State Senate,30,Dem,Bill Perkins,494
+New York,69082,State Senate,30,Dem,Bill Perkins,232
+New York,69083,State Senate,30,Dem,Bill Perkins,575
+New York,69087,State Senate,30,Dem,Bill Perkins,500
+New York,69089,State Senate,30,Dem,Bill Perkins,113
+New York,69090,State Senate,30,Dem,Bill Perkins,374
+New York,69091,State Senate,30,Dem,Bill Perkins,353
+New York,69093,State Senate,30,Dem,Bill Perkins,597
+New York,69094,State Senate,30,Dem,Bill Perkins,325
+New York,69095,State Senate,30,Dem,Bill Perkins,484
+New York,69097,State Senate,30,Dem,Bill Perkins,397
+New York,69098,State Senate,30,Dem,Bill Perkins,454
+New York,69099,State Senate,30,Dem,Bill Perkins,601
+New York,69100,State Senate,30,Dem,Bill Perkins,457
+New York,69101,State Senate,30,Dem,Bill Perkins,631
+New York,69102,State Senate,30,Dem,Bill Perkins,670
+New York,69103,State Senate,30,Dem,Bill Perkins,223
+New York,70001,State Senate,30,Dem,Bill Perkins,561
+New York,70002,State Senate,30,Dem,Bill Perkins,329
+New York,70003,State Senate,30,Dem,Bill Perkins,547
+New York,70004,State Senate,30,Dem,Bill Perkins,617
+New York,70005,State Senate,30,Dem,Bill Perkins,593
+New York,70006,State Senate,30,Dem,Bill Perkins,634
+New York,70007,State Senate,30,Dem,Bill Perkins,519
+New York,70008,State Senate,30,Dem,Bill Perkins,483
+New York,70009,State Senate,30,Dem,Bill Perkins,635
+New York,70010,State Senate,30,Dem,Bill Perkins,617
+New York,70011,State Senate,30,Dem,Bill Perkins,481
+New York,70012,State Senate,30,Dem,Bill Perkins,448
+New York,70013,State Senate,30,Dem,Bill Perkins,376
+New York,70014,State Senate,30,Dem,Bill Perkins,385
+New York,70015,State Senate,30,Dem,Bill Perkins,376
+New York,70016,State Senate,30,Dem,Bill Perkins,585
+New York,70017,State Senate,30,Dem,Bill Perkins,154
+New York,70018,State Senate,30,Dem,Bill Perkins,320
+New York,70019,State Senate,30,Dem,Bill Perkins,646
+New York,70020,State Senate,30,Dem,Bill Perkins,580
+New York,70021,State Senate,30,Dem,Bill Perkins,483
+New York,70022,State Senate,30,Dem,Bill Perkins,434
+New York,70023,State Senate,30,Dem,Bill Perkins,443
+New York,70024,State Senate,30,Dem,Bill Perkins,512
+New York,70025,State Senate,30,Dem,Bill Perkins,677
+New York,70026,State Senate,30,Dem,Bill Perkins,665
+New York,70027,State Senate,30,Dem,Bill Perkins,434
+New York,70028,State Senate,30,Dem,Bill Perkins,482
+New York,70029,State Senate,30,Dem,Bill Perkins,368
+New York,70030,State Senate,30,Dem,Bill Perkins,378
+New York,70031,State Senate,30,Dem,Bill Perkins,421
+New York,70032,State Senate,30,Dem,Bill Perkins,370
+New York,70033,State Senate,30,Dem,Bill Perkins,479
+New York,70034,State Senate,30,Dem,Bill Perkins,461
+New York,70035,State Senate,30,Dem,Bill Perkins,390
+New York,70036,State Senate,30,Dem,Bill Perkins,502
+New York,70037,State Senate,30,Dem,Bill Perkins,536
+New York,70038,State Senate,30,Dem,Bill Perkins,332
+New York,70039,State Senate,30,Dem,Bill Perkins,344
+New York,70040,State Senate,30,Dem,Bill Perkins,641
+New York,70041,State Senate,30,Dem,Bill Perkins,587
+New York,70042,State Senate,30,Dem,Bill Perkins,443
+New York,70043,State Senate,30,Dem,Bill Perkins,636
+New York,70044,State Senate,30,Dem,Bill Perkins,531
+New York,70045,State Senate,30,Dem,Bill Perkins,487
+New York,70046,State Senate,30,Dem,Bill Perkins,694
+New York,70047,State Senate,30,Dem,Bill Perkins,590
+New York,70048,State Senate,30,Dem,Bill Perkins,577
+New York,70049,State Senate,30,Dem,Bill Perkins,525
+New York,70050,State Senate,30,Dem,Bill Perkins,551
+New York,70051,State Senate,30,Dem,Bill Perkins,288
+New York,70052,State Senate,30,Dem,Bill Perkins,486
+New York,70053,State Senate,30,Dem,Bill Perkins,598
+New York,70054,State Senate,30,Dem,Bill Perkins,343
+New York,70055,State Senate,30,Dem,Bill Perkins,289
+New York,70056,State Senate,30,Dem,Bill Perkins,484
+New York,70057,State Senate,30,Dem,Bill Perkins,383
+New York,70058,State Senate,30,Dem,Bill Perkins,462
+New York,70059,State Senate,30,Dem,Bill Perkins,367
+New York,70060,State Senate,30,Dem,Bill Perkins,476
+New York,70061,State Senate,30,Dem,Bill Perkins,534
+New York,70062,State Senate,30,Dem,Bill Perkins,586
+New York,70063,State Senate,30,Dem,Bill Perkins,486
+New York,70064,State Senate,30,Dem,Bill Perkins,16
+New York,70065,State Senate,30,Dem,Bill Perkins,475
+New York,70067,State Senate,30,Dem,Bill Perkins,523
+New York,70073,State Senate,30,Dem,Bill Perkins,255
+New York,70074,State Senate,30,Dem,Bill Perkins,612
+New York,70075,State Senate,30,Dem,Bill Perkins,508
+New York,70076,State Senate,30,Dem,Bill Perkins,432
+New York,70088,State Senate,30,Dem,Bill Perkins,338
+New York,70089,State Senate,30,Dem,Bill Perkins,534
+New York,71004,State Senate,30,Dem,Bill Perkins,361
+New York,71008,State Senate,30,Dem,Bill Perkins,458
+New York,71009,State Senate,30,Dem,Bill Perkins,413
+New York,71010,State Senate,30,Dem,Bill Perkins,141
+New York,71011,State Senate,30,Dem,Bill Perkins,535
+New York,71012,State Senate,30,Dem,Bill Perkins,594
+New York,71013,State Senate,30,Dem,Bill Perkins,339
+New York,71014,State Senate,30,Dem,Bill Perkins,420
+New York,71015,State Senate,30,Dem,Bill Perkins,300
+New York,71016,State Senate,30,Dem,Bill Perkins,673
+New York,71017,State Senate,30,Dem,Bill Perkins,304
+New York,71018,State Senate,30,Dem,Bill Perkins,660
+New York,71019,State Senate,30,Dem,Bill Perkins,679
+New York,71020,State Senate,30,Dem,Bill Perkins,701
+New York,71021,State Senate,30,Dem,Bill Perkins,576
+New York,71022,State Senate,30,Dem,Bill Perkins,631
+New York,71023,State Senate,30,Dem,Bill Perkins,525
+New York,71024,State Senate,30,Dem,Bill Perkins,596
+New York,71025,State Senate,30,Dem,Bill Perkins,297
+New York,71026,State Senate,30,Dem,Bill Perkins,540
+New York,71027,State Senate,30,Dem,Bill Perkins,344
+New York,71028,State Senate,30,Dem,Bill Perkins,326
+New York,71031,State Senate,30,Dem,Bill Perkins,303
+New York,71032,State Senate,30,Dem,Bill Perkins,452
+New York,71033,State Senate,30,Dem,Bill Perkins,495
+New York,71034,State Senate,30,Dem,Bill Perkins,528
+New York,71035,State Senate,30,Dem,Bill Perkins,320
+New York,71038,State Senate,30,Dem,Bill Perkins,466
+New York,71044,State Senate,30,Dem,Bill Perkins,517
+New York,71087,State Senate,30,Dem,Bill Perkins,179
+New York,71088,State Senate,30,Dem,Bill Perkins,807
+New York,71089,State Senate,30,Dem,Bill Perkins,379
+New York,71090,State Senate,30,Dem,Bill Perkins,440
+New York,71091,State Senate,30,Dem,Bill Perkins,413
+New York,72001,State Senate,30,Dem,Bill Perkins,285
+New York,67086,State Senate,30,WF,Bill Perkins,39
+New York,68013,State Senate,30,WF,Bill Perkins,7
+New York,68024,State Senate,30,WF,Bill Perkins,6
+New York,68025,State Senate,30,WF,Bill Perkins,5
+New York,68026,State Senate,30,WF,Bill Perkins,5
+New York,68027,State Senate,30,WF,Bill Perkins,4
+New York,68028,State Senate,30,WF,Bill Perkins,5
+New York,68029,State Senate,30,WF,Bill Perkins,4
+New York,68030,State Senate,30,WF,Bill Perkins,11
+New York,68031,State Senate,30,WF,Bill Perkins,16
+New York,68032,State Senate,30,WF,Bill Perkins,7
+New York,68033,State Senate,30,WF,Bill Perkins,23
+New York,68034,State Senate,30,WF,Bill Perkins,18
+New York,68035,State Senate,30,WF,Bill Perkins,5
+New York,68036,State Senate,30,WF,Bill Perkins,13
+New York,68047,State Senate,30,WF,Bill Perkins,9
+New York,68048,State Senate,30,WF,Bill Perkins,4
+New York,68049,State Senate,30,WF,Bill Perkins,6
+New York,68050,State Senate,30,WF,Bill Perkins,5
+New York,68051,State Senate,30,WF,Bill Perkins,7
+New York,68052,State Senate,30,WF,Bill Perkins,6
+New York,68053,State Senate,30,WF,Bill Perkins,3
+New York,68056,State Senate,30,WF,Bill Perkins,12
+New York,68057,State Senate,30,WF,Bill Perkins,10
+New York,68058,State Senate,30,WF,Bill Perkins,3
+New York,68059,State Senate,30,WF,Bill Perkins,2
+New York,68060,State Senate,30,WF,Bill Perkins,6
+New York,68061,State Senate,30,WF,Bill Perkins,5
+New York,68062,State Senate,30,WF,Bill Perkins,7
+New York,68063,State Senate,30,WF,Bill Perkins,11
+New York,68064,State Senate,30,WF,Bill Perkins,6
+New York,68065,State Senate,30,WF,Bill Perkins,2
+New York,68066,State Senate,30,WF,Bill Perkins,6
+New York,68067,State Senate,30,WF,Bill Perkins,2
+New York,68068,State Senate,30,WF,Bill Perkins,11
+New York,68069,State Senate,30,WF,Bill Perkins,4
+New York,68070,State Senate,30,WF,Bill Perkins,7
+New York,68073,State Senate,30,WF,Bill Perkins,26
+New York,68074,State Senate,30,WF,Bill Perkins,15
+New York,68078,State Senate,30,WF,Bill Perkins,23
+New York,68079,State Senate,30,WF,Bill Perkins,7
+New York,68080,State Senate,30,WF,Bill Perkins,34
+New York,68081,State Senate,30,WF,Bill Perkins,2
+New York,68082,State Senate,30,WF,Bill Perkins,16
+New York,68083,State Senate,30,WF,Bill Perkins,18
+New York,68084,State Senate,30,WF,Bill Perkins,10
+New York,68085,State Senate,30,WF,Bill Perkins,4
+New York,68086,State Senate,30,WF,Bill Perkins,8
+New York,68087,State Senate,30,WF,Bill Perkins,14
+New York,68088,State Senate,30,WF,Bill Perkins,14
+New York,68089,State Senate,30,WF,Bill Perkins,9
+New York,68090,State Senate,30,WF,Bill Perkins,13
+New York,68091,State Senate,30,WF,Bill Perkins,0
+New York,68092,State Senate,30,WF,Bill Perkins,6
+New York,68093,State Senate,30,WF,Bill Perkins,7
+New York,69013,State Senate,30,WF,Bill Perkins,23
+New York,69014,State Senate,30,WF,Bill Perkins,17
+New York,69015,State Senate,30,WF,Bill Perkins,28
+New York,69016,State Senate,30,WF,Bill Perkins,12
+New York,69017,State Senate,30,WF,Bill Perkins,18
+New York,69018,State Senate,30,WF,Bill Perkins,29
+New York,69019,State Senate,30,WF,Bill Perkins,11
+New York,69020,State Senate,30,WF,Bill Perkins,20
+New York,69021,State Senate,30,WF,Bill Perkins,21
+New York,69028,State Senate,30,WF,Bill Perkins,2
+New York,69029,State Senate,30,WF,Bill Perkins,42
+New York,69030,State Senate,30,WF,Bill Perkins,48
+New York,69031,State Senate,30,WF,Bill Perkins,32
+New York,69032,State Senate,30,WF,Bill Perkins,64
+New York,69033,State Senate,30,WF,Bill Perkins,45
+New York,69034,State Senate,30,WF,Bill Perkins,36
+New York,69035,State Senate,30,WF,Bill Perkins,10
+New York,69037,State Senate,30,WF,Bill Perkins,19
+New York,69038,State Senate,30,WF,Bill Perkins,21
+New York,69039,State Senate,30,WF,Bill Perkins,40
+New York,69040,State Senate,30,WF,Bill Perkins,35
+New York,69041,State Senate,30,WF,Bill Perkins,37
+New York,69042,State Senate,30,WF,Bill Perkins,33
+New York,69043,State Senate,30,WF,Bill Perkins,39
+New York,69044,State Senate,30,WF,Bill Perkins,35
+New York,69052,State Senate,30,WF,Bill Perkins,25
+New York,69053,State Senate,30,WF,Bill Perkins,2
+New York,69054,State Senate,30,WF,Bill Perkins,14
+New York,69055,State Senate,30,WF,Bill Perkins,23
+New York,69056,State Senate,30,WF,Bill Perkins,3
+New York,69057,State Senate,30,WF,Bill Perkins,17
+New York,69058,State Senate,30,WF,Bill Perkins,24
+New York,69059,State Senate,30,WF,Bill Perkins,17
+New York,69067,State Senate,30,WF,Bill Perkins,10
+New York,69068,State Senate,30,WF,Bill Perkins,21
+New York,69069,State Senate,30,WF,Bill Perkins,45
+New York,69070,State Senate,30,WF,Bill Perkins,14
+New York,69071,State Senate,30,WF,Bill Perkins,29
+New York,69074,State Senate,30,WF,Bill Perkins,26
+New York,69075,State Senate,30,WF,Bill Perkins,20
+New York,69076,State Senate,30,WF,Bill Perkins,18
+New York,69080,State Senate,30,WF,Bill Perkins,19
+New York,69081,State Senate,30,WF,Bill Perkins,20
+New York,69082,State Senate,30,WF,Bill Perkins,15
+New York,69083,State Senate,30,WF,Bill Perkins,16
+New York,69087,State Senate,30,WF,Bill Perkins,50
+New York,69089,State Senate,30,WF,Bill Perkins,2
+New York,69090,State Senate,30,WF,Bill Perkins,36
+New York,69091,State Senate,30,WF,Bill Perkins,29
+New York,69093,State Senate,30,WF,Bill Perkins,68
+New York,69094,State Senate,30,WF,Bill Perkins,26
+New York,69095,State Senate,30,WF,Bill Perkins,57
+New York,69097,State Senate,30,WF,Bill Perkins,43
+New York,69098,State Senate,30,WF,Bill Perkins,41
+New York,69099,State Senate,30,WF,Bill Perkins,78
+New York,69100,State Senate,30,WF,Bill Perkins,22
+New York,69101,State Senate,30,WF,Bill Perkins,10
+New York,69102,State Senate,30,WF,Bill Perkins,5
+New York,69103,State Senate,30,WF,Bill Perkins,3
+New York,70001,State Senate,30,WF,Bill Perkins,17
+New York,70002,State Senate,30,WF,Bill Perkins,9
+New York,70003,State Senate,30,WF,Bill Perkins,19
+New York,70004,State Senate,30,WF,Bill Perkins,20
+New York,70005,State Senate,30,WF,Bill Perkins,21
+New York,70006,State Senate,30,WF,Bill Perkins,27
+New York,70007,State Senate,30,WF,Bill Perkins,20
+New York,70008,State Senate,30,WF,Bill Perkins,28
+New York,70009,State Senate,30,WF,Bill Perkins,30
+New York,70010,State Senate,30,WF,Bill Perkins,21
+New York,70011,State Senate,30,WF,Bill Perkins,23
+New York,70012,State Senate,30,WF,Bill Perkins,21
+New York,70013,State Senate,30,WF,Bill Perkins,4
+New York,70014,State Senate,30,WF,Bill Perkins,22
+New York,70015,State Senate,30,WF,Bill Perkins,9
+New York,70016,State Senate,30,WF,Bill Perkins,22
+New York,70017,State Senate,30,WF,Bill Perkins,6
+New York,70018,State Senate,30,WF,Bill Perkins,18
+New York,70019,State Senate,30,WF,Bill Perkins,37
+New York,70020,State Senate,30,WF,Bill Perkins,15
+New York,70021,State Senate,30,WF,Bill Perkins,23
+New York,70022,State Senate,30,WF,Bill Perkins,23
+New York,70023,State Senate,30,WF,Bill Perkins,18
+New York,70024,State Senate,30,WF,Bill Perkins,15
+New York,70025,State Senate,30,WF,Bill Perkins,15
+New York,70026,State Senate,30,WF,Bill Perkins,21
+New York,70027,State Senate,30,WF,Bill Perkins,18
+New York,70028,State Senate,30,WF,Bill Perkins,17
+New York,70029,State Senate,30,WF,Bill Perkins,7
+New York,70030,State Senate,30,WF,Bill Perkins,7
+New York,70031,State Senate,30,WF,Bill Perkins,9
+New York,70032,State Senate,30,WF,Bill Perkins,6
+New York,70033,State Senate,30,WF,Bill Perkins,13
+New York,70034,State Senate,30,WF,Bill Perkins,17
+New York,70035,State Senate,30,WF,Bill Perkins,15
+New York,70036,State Senate,30,WF,Bill Perkins,17
+New York,70037,State Senate,30,WF,Bill Perkins,8
+New York,70038,State Senate,30,WF,Bill Perkins,4
+New York,70039,State Senate,30,WF,Bill Perkins,5
+New York,70040,State Senate,30,WF,Bill Perkins,17
+New York,70041,State Senate,30,WF,Bill Perkins,17
+New York,70042,State Senate,30,WF,Bill Perkins,11
+New York,70043,State Senate,30,WF,Bill Perkins,41
+New York,70044,State Senate,30,WF,Bill Perkins,23
+New York,70045,State Senate,30,WF,Bill Perkins,18
+New York,70046,State Senate,30,WF,Bill Perkins,9
+New York,70047,State Senate,30,WF,Bill Perkins,18
+New York,70048,State Senate,30,WF,Bill Perkins,14
+New York,70049,State Senate,30,WF,Bill Perkins,8
+New York,70050,State Senate,30,WF,Bill Perkins,18
+New York,70051,State Senate,30,WF,Bill Perkins,8
+New York,70052,State Senate,30,WF,Bill Perkins,11
+New York,70053,State Senate,30,WF,Bill Perkins,13
+New York,70054,State Senate,30,WF,Bill Perkins,1
+New York,70055,State Senate,30,WF,Bill Perkins,7
+New York,70056,State Senate,30,WF,Bill Perkins,8
+New York,70057,State Senate,30,WF,Bill Perkins,6
+New York,70058,State Senate,30,WF,Bill Perkins,10
+New York,70059,State Senate,30,WF,Bill Perkins,8
+New York,70060,State Senate,30,WF,Bill Perkins,5
+New York,70061,State Senate,30,WF,Bill Perkins,5
+New York,70062,State Senate,30,WF,Bill Perkins,14
+New York,70063,State Senate,30,WF,Bill Perkins,9
+New York,70064,State Senate,30,WF,Bill Perkins,6
+New York,70065,State Senate,30,WF,Bill Perkins,40
+New York,70067,State Senate,30,WF,Bill Perkins,43
+New York,70073,State Senate,30,WF,Bill Perkins,5
+New York,70074,State Senate,30,WF,Bill Perkins,30
+New York,70075,State Senate,30,WF,Bill Perkins,14
+New York,70076,State Senate,30,WF,Bill Perkins,6
+New York,70088,State Senate,30,WF,Bill Perkins,16
+New York,70089,State Senate,30,WF,Bill Perkins,23
+New York,71004,State Senate,30,WF,Bill Perkins,9
+New York,71008,State Senate,30,WF,Bill Perkins,19
+New York,71009,State Senate,30,WF,Bill Perkins,17
+New York,71010,State Senate,30,WF,Bill Perkins,4
+New York,71011,State Senate,30,WF,Bill Perkins,23
+New York,71012,State Senate,30,WF,Bill Perkins,23
+New York,71013,State Senate,30,WF,Bill Perkins,10
+New York,71014,State Senate,30,WF,Bill Perkins,3
+New York,71015,State Senate,30,WF,Bill Perkins,5
+New York,71016,State Senate,30,WF,Bill Perkins,16
+New York,71017,State Senate,30,WF,Bill Perkins,7
+New York,71018,State Senate,30,WF,Bill Perkins,8
+New York,71019,State Senate,30,WF,Bill Perkins,10
+New York,71020,State Senate,30,WF,Bill Perkins,7
+New York,71021,State Senate,30,WF,Bill Perkins,10
+New York,71022,State Senate,30,WF,Bill Perkins,5
+New York,71023,State Senate,30,WF,Bill Perkins,14
+New York,71024,State Senate,30,WF,Bill Perkins,16
+New York,71025,State Senate,30,WF,Bill Perkins,7
+New York,71026,State Senate,30,WF,Bill Perkins,28
+New York,71027,State Senate,30,WF,Bill Perkins,22
+New York,71028,State Senate,30,WF,Bill Perkins,12
+New York,71031,State Senate,30,WF,Bill Perkins,14
+New York,71032,State Senate,30,WF,Bill Perkins,19
+New York,71033,State Senate,30,WF,Bill Perkins,19
+New York,71034,State Senate,30,WF,Bill Perkins,16
+New York,71035,State Senate,30,WF,Bill Perkins,7
+New York,71038,State Senate,30,WF,Bill Perkins,11
+New York,71044,State Senate,30,WF,Bill Perkins,16
+New York,71087,State Senate,30,WF,Bill Perkins,7
+New York,71088,State Senate,30,WF,Bill Perkins,9
+New York,71089,State Senate,30,WF,Bill Perkins,6
+New York,71090,State Senate,30,WF,Bill Perkins,11
+New York,71091,State Senate,30,WF,Bill Perkins,6
+New York,72001,State Senate,30,WF,Bill Perkins,13
+New York,67086,State Senate,30,Ind,writein,2
+New York,68013,State Senate,30,Ind,writein,1
+New York,68024,State Senate,30,Ind,writein,0
+New York,68025,State Senate,30,Ind,writein,0
+New York,68026,State Senate,30,Ind,writein,0
+New York,68027,State Senate,30,Ind,writein,0
+New York,68028,State Senate,30,Ind,writein,0
+New York,68029,State Senate,30,Ind,writein,0
+New York,68030,State Senate,30,Ind,writein,0
+New York,68031,State Senate,30,Ind,writein,0
+New York,68032,State Senate,30,Ind,writein,1
+New York,68033,State Senate,30,Ind,writein,0
+New York,68034,State Senate,30,Ind,writein,2
+New York,68035,State Senate,30,Ind,writein,0
+New York,68036,State Senate,30,Ind,writein,0
+New York,68047,State Senate,30,Ind,writein,1
+New York,68048,State Senate,30,Ind,writein,0
+New York,68049,State Senate,30,Ind,writein,0
+New York,68050,State Senate,30,Ind,writein,0
+New York,68051,State Senate,30,Ind,writein,0
+New York,68052,State Senate,30,Ind,writein,0
+New York,68053,State Senate,30,Ind,writein,0
+New York,68056,State Senate,30,Ind,writein,1
+New York,68057,State Senate,30,Ind,writein,2
+New York,68058,State Senate,30,Ind,writein,0
+New York,68059,State Senate,30,Ind,writein,0
+New York,68060,State Senate,30,Ind,writein,0
+New York,68061,State Senate,30,Ind,writein,0
+New York,68062,State Senate,30,Ind,writein,0
+New York,68063,State Senate,30,Ind,writein,0
+New York,68064,State Senate,30,Ind,writein,0
+New York,68065,State Senate,30,Ind,writein,0
+New York,68066,State Senate,30,Ind,writein,0
+New York,68067,State Senate,30,Ind,writein,1
+New York,68068,State Senate,30,Ind,writein,0
+New York,68069,State Senate,30,Ind,writein,0
+New York,68070,State Senate,30,Ind,writein,0
+New York,68073,State Senate,30,Ind,writein,0
+New York,68074,State Senate,30,Ind,writein,0
+New York,68078,State Senate,30,Ind,writein,0
+New York,68079,State Senate,30,Ind,writein,0
+New York,68080,State Senate,30,Ind,writein,2
+New York,68081,State Senate,30,Ind,writein,0
+New York,68082,State Senate,30,Ind,writein,1
+New York,68083,State Senate,30,Ind,writein,0
+New York,68084,State Senate,30,Ind,writein,0
+New York,68085,State Senate,30,Ind,writein,0
+New York,68086,State Senate,30,Ind,writein,1
+New York,68087,State Senate,30,Ind,writein,0
+New York,68088,State Senate,30,Ind,writein,0
+New York,68089,State Senate,30,Ind,writein,0
+New York,68090,State Senate,30,Ind,writein,0
+New York,68091,State Senate,30,Ind,writein,0
+New York,68092,State Senate,30,Ind,writein,0
+New York,68093,State Senate,30,Ind,writein,0
+New York,69013,State Senate,30,Ind,writein,2
+New York,69014,State Senate,30,Ind,writein,0
+New York,69015,State Senate,30,Ind,writein,0
+New York,69016,State Senate,30,Ind,writein,1
+New York,69017,State Senate,30,Ind,writein,1
+New York,69018,State Senate,30,Ind,writein,0
+New York,69019,State Senate,30,Ind,writein,0
+New York,69020,State Senate,30,Ind,writein,1
+New York,69021,State Senate,30,Ind,writein,2
+New York,69028,State Senate,30,Ind,writein,0
+New York,69029,State Senate,30,Ind,writein,1
+New York,69030,State Senate,30,Ind,writein,1
+New York,69031,State Senate,30,Ind,writein,0
+New York,69032,State Senate,30,Ind,writein,0
+New York,69033,State Senate,30,Ind,writein,3
+New York,69034,State Senate,30,Ind,writein,1
+New York,69035,State Senate,30,Ind,writein,2
+New York,69037,State Senate,30,Ind,writein,1
+New York,69038,State Senate,30,Ind,writein,0
+New York,69039,State Senate,30,Ind,writein,2
+New York,69040,State Senate,30,Ind,writein,0
+New York,69041,State Senate,30,Ind,writein,2
+New York,69042,State Senate,30,Ind,writein,3
+New York,69043,State Senate,30,Ind,writein,0
+New York,69044,State Senate,30,Ind,writein,1
+New York,69052,State Senate,30,Ind,writein,2
+New York,69053,State Senate,30,Ind,writein,0
+New York,69054,State Senate,30,Ind,writein,0
+New York,69055,State Senate,30,Ind,writein,1
+New York,69056,State Senate,30,Ind,writein,0
+New York,69057,State Senate,30,Ind,writein,1
+New York,69058,State Senate,30,Ind,writein,0
+New York,69059,State Senate,30,Ind,writein,0
+New York,69067,State Senate,30,Ind,writein,0
+New York,69068,State Senate,30,Ind,writein,1
+New York,69069,State Senate,30,Ind,writein,2
+New York,69070,State Senate,30,Ind,writein,0
+New York,69071,State Senate,30,Ind,writein,0
+New York,69074,State Senate,30,Ind,writein,2
+New York,69075,State Senate,30,Ind,writein,2
+New York,69076,State Senate,30,Ind,writein,0
+New York,69080,State Senate,30,Ind,writein,2
+New York,69081,State Senate,30,Ind,writein,0
+New York,69082,State Senate,30,Ind,writein,0
+New York,69083,State Senate,30,Ind,writein,0
+New York,69087,State Senate,30,Ind,writein,1
+New York,69089,State Senate,30,Ind,writein,0
+New York,69090,State Senate,30,Ind,writein,1
+New York,69091,State Senate,30,Ind,writein,5
+New York,69093,State Senate,30,Ind,writein,2
+New York,69094,State Senate,30,Ind,writein,1
+New York,69095,State Senate,30,Ind,writein,4
+New York,69097,State Senate,30,Ind,writein,1
+New York,69098,State Senate,30,Ind,writein,4
+New York,69099,State Senate,30,Ind,writein,0
+New York,69100,State Senate,30,Ind,writein,0
+New York,69101,State Senate,30,Ind,writein,0
+New York,69102,State Senate,30,Ind,writein,1
+New York,69103,State Senate,30,Ind,writein,0
+New York,70001,State Senate,30,Ind,writein,1
+New York,70002,State Senate,30,Ind,writein,0
+New York,70003,State Senate,30,Ind,writein,3
+New York,70004,State Senate,30,Ind,writein,0
+New York,70005,State Senate,30,Ind,writein,0
+New York,70006,State Senate,30,Ind,writein,4
+New York,70007,State Senate,30,Ind,writein,3
+New York,70008,State Senate,30,Ind,writein,0
+New York,70009,State Senate,30,Ind,writein,2
+New York,70010,State Senate,30,Ind,writein,0
+New York,70011,State Senate,30,Ind,writein,1
+New York,70012,State Senate,30,Ind,writein,1
+New York,70013,State Senate,30,Ind,writein,0
+New York,70014,State Senate,30,Ind,writein,1
+New York,70015,State Senate,30,Ind,writein,0
+New York,70016,State Senate,30,Ind,writein,1
+New York,70017,State Senate,30,Ind,writein,0
+New York,70018,State Senate,30,Ind,writein,1
+New York,70019,State Senate,30,Ind,writein,0
+New York,70020,State Senate,30,Ind,writein,2
+New York,70021,State Senate,30,Ind,writein,0
+New York,70022,State Senate,30,Ind,writein,0
+New York,70023,State Senate,30,Ind,writein,1
+New York,70024,State Senate,30,Ind,writein,1
+New York,70025,State Senate,30,Ind,writein,2
+New York,70026,State Senate,30,Ind,writein,1
+New York,70027,State Senate,30,Ind,writein,1
+New York,70028,State Senate,30,Ind,writein,1
+New York,70029,State Senate,30,Ind,writein,1
+New York,70030,State Senate,30,Ind,writein,0
+New York,70031,State Senate,30,Ind,writein,0
+New York,70032,State Senate,30,Ind,writein,0
+New York,70033,State Senate,30,Ind,writein,2
+New York,70034,State Senate,30,Ind,writein,0
+New York,70035,State Senate,30,Ind,writein,1
+New York,70036,State Senate,30,Ind,writein,0
+New York,70037,State Senate,30,Ind,writein,0
+New York,70038,State Senate,30,Ind,writein,0
+New York,70039,State Senate,30,Ind,writein,1
+New York,70040,State Senate,30,Ind,writein,0
+New York,70041,State Senate,30,Ind,writein,1
+New York,70042,State Senate,30,Ind,writein,0
+New York,70043,State Senate,30,Ind,writein,3
+New York,70044,State Senate,30,Ind,writein,0
+New York,70045,State Senate,30,Ind,writein,0
+New York,70046,State Senate,30,Ind,writein,0
+New York,70047,State Senate,30,Ind,writein,0
+New York,70048,State Senate,30,Ind,writein,1
+New York,70049,State Senate,30,Ind,writein,1
+New York,70050,State Senate,30,Ind,writein,0
+New York,70051,State Senate,30,Ind,writein,0
+New York,70052,State Senate,30,Ind,writein,0
+New York,70053,State Senate,30,Ind,writein,0
+New York,70054,State Senate,30,Ind,writein,0
+New York,70055,State Senate,30,Ind,writein,0
+New York,70056,State Senate,30,Ind,writein,1
+New York,70057,State Senate,30,Ind,writein,0
+New York,70058,State Senate,30,Ind,writein,0
+New York,70059,State Senate,30,Ind,writein,0
+New York,70060,State Senate,30,Ind,writein,0
+New York,70061,State Senate,30,Ind,writein,0
+New York,70062,State Senate,30,Ind,writein,0
+New York,70063,State Senate,30,Ind,writein,1
+New York,70064,State Senate,30,Ind,writein,0
+New York,70065,State Senate,30,Ind,writein,4
+New York,70067,State Senate,30,Ind,writein,1
+New York,70073,State Senate,30,Ind,writein,1
+New York,70074,State Senate,30,Ind,writein,0
+New York,70075,State Senate,30,Ind,writein,1
+New York,70076,State Senate,30,Ind,writein,0
+New York,70088,State Senate,30,Ind,writein,0
+New York,70089,State Senate,30,Ind,writein,1
+New York,71004,State Senate,30,Ind,writein,0
+New York,71008,State Senate,30,Ind,writein,0
+New York,71009,State Senate,30,Ind,writein,2
+New York,71010,State Senate,30,Ind,writein,2
+New York,71011,State Senate,30,Ind,writein,0
+New York,71012,State Senate,30,Ind,writein,2
+New York,71013,State Senate,30,Ind,writein,2
+New York,71014,State Senate,30,Ind,writein,0
+New York,71015,State Senate,30,Ind,writein,0
+New York,71016,State Senate,30,Ind,writein,0
+New York,71017,State Senate,30,Ind,writein,0
+New York,71018,State Senate,30,Ind,writein,0
+New York,71019,State Senate,30,Ind,writein,0
+New York,71020,State Senate,30,Ind,writein,0
+New York,71021,State Senate,30,Ind,writein,1
+New York,71022,State Senate,30,Ind,writein,0
+New York,71023,State Senate,30,Ind,writein,0
+New York,71024,State Senate,30,Ind,writein,1
+New York,71025,State Senate,30,Ind,writein,0
+New York,71026,State Senate,30,Ind,writein,0
+New York,71027,State Senate,30,Ind,writein,0
+New York,71028,State Senate,30,Ind,writein,1
+New York,71031,State Senate,30,Ind,writein,1
+New York,71032,State Senate,30,Ind,writein,1
+New York,71033,State Senate,30,Ind,writein,2
+New York,71034,State Senate,30,Ind,writein,1
+New York,71035,State Senate,30,Ind,writein,0
+New York,71038,State Senate,30,Ind,writein,2
+New York,71044,State Senate,30,Ind,writein,1
+New York,71087,State Senate,30,Ind,writein,0
+New York,71088,State Senate,30,Ind,writein,0
+New York,71089,State Senate,30,Ind,writein,0
+New York,71090,State Senate,30,Ind,writein,0
+New York,71091,State Senate,30,Ind,writein,0
+New York,72001,State Senate,30,Ind,writein,2
+New York,67001,State Senate,31,Dem,Adriano Espillait,383
+New York,67003,State Senate,31,Dem,Adriano Espillait,535
+New York,67005,State Senate,31,Dem,Adriano Espillait,453
+New York,67007,State Senate,31,Dem,Adriano Espillait,286
+New York,67025,State Senate,31,Dem,Adriano Espillait,313
+New York,67026,State Senate,31,Dem,Adriano Espillait,391
+New York,67027,State Senate,31,Dem,Adriano Espillait,449
+New York,67028,State Senate,31,Dem,Adriano Espillait,655
+New York,67029,State Senate,31,Dem,Adriano Espillait,78
+New York,67030,State Senate,31,Dem,Adriano Espillait,138
+New York,67051,State Senate,31,Dem,Adriano Espillait,52
+New York,67067,State Senate,31,Dem,Adriano Espillait,502
+New York,67079,State Senate,31,Dem,Adriano Espillait,324
+New York,67080,State Senate,31,Dem,Adriano Espillait,555
+New York,67081,State Senate,31,Dem,Adriano Espillait,385
+New York,67082,State Senate,31,Dem,Adriano Espillait,430
+New York,67083,State Senate,31,Dem,Adriano Espillait,552
+New York,67084,State Senate,31,Dem,Adriano Espillait,328
+New York,67085,State Senate,31,Dem,Adriano Espillait,585
+New York,67087,State Senate,31,Dem,Adriano Espillait,514
+New York,67088,State Senate,31,Dem,Adriano Espillait,589
+New York,67089,State Senate,31,Dem,Adriano Espillait,577
+New York,67090,State Senate,31,Dem,Adriano Espillait,572
+New York,67091,State Senate,31,Dem,Adriano Espillait,422
+New York,67092,State Senate,31,Dem,Adriano Espillait,383
+New York,67093,State Senate,31,Dem,Adriano Espillait,378
+New York,67094,State Senate,31,Dem,Adriano Espillait,481
+New York,67095,State Senate,31,Dem,Adriano Espillait,331
+New York,67096,State Senate,31,Dem,Adriano Espillait,324
+New York,67097,State Senate,31,Dem,Adriano Espillait,385
+New York,67098,State Senate,31,Dem,Adriano Espillait,415
+New York,67099,State Senate,31,Dem,Adriano Espillait,359
+New York,67100,State Senate,31,Dem,Adriano Espillait,0
+New York,67101,State Senate,31,Dem,Adriano Espillait,0
+New York,69022,State Senate,31,Dem,Adriano Espillait,452
+New York,69023,State Senate,31,Dem,Adriano Espillait,304
+New York,69024,State Senate,31,Dem,Adriano Espillait,416
+New York,69025,State Senate,31,Dem,Adriano Espillait,489
+New York,69026,State Senate,31,Dem,Adriano Espillait,595
+New York,69027,State Senate,31,Dem,Adriano Espillait,212
+New York,69036,State Senate,31,Dem,Adriano Espillait,70
+New York,69045,State Senate,31,Dem,Adriano Espillait,340
+New York,69046,State Senate,31,Dem,Adriano Espillait,550
+New York,69047,State Senate,31,Dem,Adriano Espillait,543
+New York,69048,State Senate,31,Dem,Adriano Espillait,437
+New York,69049,State Senate,31,Dem,Adriano Espillait,444
+New York,69050,State Senate,31,Dem,Adriano Espillait,390
+New York,69051,State Senate,31,Dem,Adriano Espillait,382
+New York,69060,State Senate,31,Dem,Adriano Espillait,475
+New York,69061,State Senate,31,Dem,Adriano Espillait,414
+New York,69062,State Senate,31,Dem,Adriano Espillait,413
+New York,69063,State Senate,31,Dem,Adriano Espillait,271
+New York,69064,State Senate,31,Dem,Adriano Espillait,429
+New York,69065,State Senate,31,Dem,Adriano Espillait,399
+New York,69066,State Senate,31,Dem,Adriano Espillait,531
+New York,69072,State Senate,31,Dem,Adriano Espillait,633
+New York,69073,State Senate,31,Dem,Adriano Espillait,632
+New York,69077,State Senate,31,Dem,Adriano Espillait,510
+New York,69078,State Senate,31,Dem,Adriano Espillait,430
+New York,69079,State Senate,31,Dem,Adriano Espillait,384
+New York,69084,State Senate,31,Dem,Adriano Espillait,399
+New York,69085,State Senate,31,Dem,Adriano Espillait,268
+New York,69086,State Senate,31,Dem,Adriano Espillait,587
+New York,69088,State Senate,31,Dem,Adriano Espillait,44
+New York,69092,State Senate,31,Dem,Adriano Espillait,429
+New York,69096,State Senate,31,Dem,Adriano Espillait,34
+New York,69105,State Senate,31,Dem,Adriano Espillait,0
+New York,69106,State Senate,31,Dem,Adriano Espillait,0
+New York,69107,State Senate,31,Dem,Adriano Espillait,0
+New York,70068,State Senate,31,Dem,Adriano Espillait,380
+New York,70070,State Senate,31,Dem,Adriano Espillait,269
+New York,70071,State Senate,31,Dem,Adriano Espillait,525
+New York,70072,State Senate,31,Dem,Adriano Espillait,594
+New York,70077,State Senate,31,Dem,Adriano Espillait,391
+New York,70078,State Senate,31,Dem,Adriano Espillait,282
+New York,70079,State Senate,31,Dem,Adriano Espillait,296
+New York,70080,State Senate,31,Dem,Adriano Espillait,396
+New York,70081,State Senate,31,Dem,Adriano Espillait,366
+New York,70082,State Senate,31,Dem,Adriano Espillait,347
+New York,70083,State Senate,31,Dem,Adriano Espillait,264
+New York,70084,State Senate,31,Dem,Adriano Espillait,319
+New York,70085,State Senate,31,Dem,Adriano Espillait,451
+New York,70086,State Senate,31,Dem,Adriano Espillait,407
+New York,70087,State Senate,31,Dem,Adriano Espillait,475
+New York,70090,State Senate,31,Dem,Adriano Espillait,0
+New York,71001,State Senate,31,Dem,Adriano Espillait,499
+New York,71002,State Senate,31,Dem,Adriano Espillait,406
+New York,71003,State Senate,31,Dem,Adriano Espillait,249
+New York,71005,State Senate,31,Dem,Adriano Espillait,514
+New York,71006,State Senate,31,Dem,Adriano Espillait,418
+New York,71007,State Senate,31,Dem,Adriano Espillait,293
+New York,71029,State Senate,31,Dem,Adriano Espillait,303
+New York,71030,State Senate,31,Dem,Adriano Espillait,326
+New York,71036,State Senate,31,Dem,Adriano Espillait,302
+New York,71037,State Senate,31,Dem,Adriano Espillait,462
+New York,71039,State Senate,31,Dem,Adriano Espillait,360
+New York,71040,State Senate,31,Dem,Adriano Espillait,436
+New York,71041,State Senate,31,Dem,Adriano Espillait,524
+New York,71042,State Senate,31,Dem,Adriano Espillait,401
+New York,71043,State Senate,31,Dem,Adriano Espillait,501
+New York,71045,State Senate,31,Dem,Adriano Espillait,306
+New York,71046,State Senate,31,Dem,Adriano Espillait,451
+New York,71047,State Senate,31,Dem,Adriano Espillait,373
+New York,71048,State Senate,31,Dem,Adriano Espillait,361
+New York,71049,State Senate,31,Dem,Adriano Espillait,457
+New York,71050,State Senate,31,Dem,Adriano Espillait,434
+New York,71051,State Senate,31,Dem,Adriano Espillait,111
+New York,71052,State Senate,31,Dem,Adriano Espillait,427
+New York,71053,State Senate,31,Dem,Adriano Espillait,341
+New York,71054,State Senate,31,Dem,Adriano Espillait,389
+New York,71055,State Senate,31,Dem,Adriano Espillait,282
+New York,71056,State Senate,31,Dem,Adriano Espillait,504
+New York,71057,State Senate,31,Dem,Adriano Espillait,298
+New York,71058,State Senate,31,Dem,Adriano Espillait,311
+New York,71059,State Senate,31,Dem,Adriano Espillait,267
+New York,71060,State Senate,31,Dem,Adriano Espillait,337
+New York,71061,State Senate,31,Dem,Adriano Espillait,417
+New York,71062,State Senate,31,Dem,Adriano Espillait,302
+New York,71063,State Senate,31,Dem,Adriano Espillait,467
+New York,71064,State Senate,31,Dem,Adriano Espillait,437
+New York,71065,State Senate,31,Dem,Adriano Espillait,554
+New York,71066,State Senate,31,Dem,Adriano Espillait,498
+New York,71067,State Senate,31,Dem,Adriano Espillait,71
+New York,71068,State Senate,31,Dem,Adriano Espillait,96
+New York,71069,State Senate,31,Dem,Adriano Espillait,428
+New York,71070,State Senate,31,Dem,Adriano Espillait,483
+New York,71071,State Senate,31,Dem,Adriano Espillait,79
+New York,71072,State Senate,31,Dem,Adriano Espillait,424
+New York,71073,State Senate,31,Dem,Adriano Espillait,353
+New York,71074,State Senate,31,Dem,Adriano Espillait,373
+New York,71075,State Senate,31,Dem,Adriano Espillait,399
+New York,71076,State Senate,31,Dem,Adriano Espillait,575
+New York,71077,State Senate,31,Dem,Adriano Espillait,474
+New York,71078,State Senate,31,Dem,Adriano Espillait,484
+New York,71079,State Senate,31,Dem,Adriano Espillait,416
+New York,71080,State Senate,31,Dem,Adriano Espillait,291
+New York,71081,State Senate,31,Dem,Adriano Espillait,364
+New York,71082,State Senate,31,Dem,Adriano Espillait,321
+New York,71083,State Senate,31,Dem,Adriano Espillait,630
+New York,71084,State Senate,31,Dem,Adriano Espillait,584
+New York,71085,State Senate,31,Dem,Adriano Espillait,343
+New York,71086,State Senate,31,Dem,Adriano Espillait,65
+New York,71092,State Senate,31,Dem,Adriano Espillait,0
+New York,72002,State Senate,31,Dem,Adriano Espillait,483
+New York,72003,State Senate,31,Dem,Adriano Espillait,349
+New York,72004,State Senate,31,Dem,Adriano Espillait,537
+New York,72005,State Senate,31,Dem,Adriano Espillait,477
+New York,72006,State Senate,31,Dem,Adriano Espillait,467
+New York,72007,State Senate,31,Dem,Adriano Espillait,453
+New York,72008,State Senate,31,Dem,Adriano Espillait,500
+New York,72009,State Senate,31,Dem,Adriano Espillait,557
+New York,72010,State Senate,31,Dem,Adriano Espillait,426
+New York,72011,State Senate,31,Dem,Adriano Espillait,446
+New York,72012,State Senate,31,Dem,Adriano Espillait,477
+New York,72013,State Senate,31,Dem,Adriano Espillait,320
+New York,72014,State Senate,31,Dem,Adriano Espillait,496
+New York,72015,State Senate,31,Dem,Adriano Espillait,436
+New York,72016,State Senate,31,Dem,Adriano Espillait,469
+New York,72017,State Senate,31,Dem,Adriano Espillait,476
+New York,72018,State Senate,31,Dem,Adriano Espillait,279
+New York,72019,State Senate,31,Dem,Adriano Espillait,305
+New York,72020,State Senate,31,Dem,Adriano Espillait,480
+New York,72021,State Senate,31,Dem,Adriano Espillait,383
+New York,72022,State Senate,31,Dem,Adriano Espillait,395
+New York,72023,State Senate,31,Dem,Adriano Espillait,518
+New York,72024,State Senate,31,Dem,Adriano Espillait,485
+New York,72025,State Senate,31,Dem,Adriano Espillait,393
+New York,72026,State Senate,31,Dem,Adriano Espillait,267
+New York,72027,State Senate,31,Dem,Adriano Espillait,301
+New York,72028,State Senate,31,Dem,Adriano Espillait,210
+New York,72029,State Senate,31,Dem,Adriano Espillait,388
+New York,72030,State Senate,31,Dem,Adriano Espillait,465
+New York,72031,State Senate,31,Dem,Adriano Espillait,515
+New York,72032,State Senate,31,Dem,Adriano Espillait,457
+New York,72033,State Senate,31,Dem,Adriano Espillait,239
+New York,72034,State Senate,31,Dem,Adriano Espillait,453
+New York,72035,State Senate,31,Dem,Adriano Espillait,453
+New York,72036,State Senate,31,Dem,Adriano Espillait,360
+New York,72037,State Senate,31,Dem,Adriano Espillait,228
+New York,72038,State Senate,31,Dem,Adriano Espillait,399
+New York,72039,State Senate,31,Dem,Adriano Espillait,527
+New York,72040,State Senate,31,Dem,Adriano Espillait,265
+New York,72041,State Senate,31,Dem,Adriano Espillait,529
+New York,72042,State Senate,31,Dem,Adriano Espillait,604
+New York,72043,State Senate,31,Dem,Adriano Espillait,460
+New York,72044,State Senate,31,Dem,Adriano Espillait,591
+New York,72045,State Senate,31,Dem,Adriano Espillait,546
+New York,72046,State Senate,31,Dem,Adriano Espillait,439
+New York,72047,State Senate,31,Dem,Adriano Espillait,389
+New York,72048,State Senate,31,Dem,Adriano Espillait,377
+New York,72049,State Senate,31,Dem,Adriano Espillait,502
+New York,72050,State Senate,31,Dem,Adriano Espillait,388
+New York,72051,State Senate,31,Dem,Adriano Espillait,322
+New York,72052,State Senate,31,Dem,Adriano Espillait,425
+New York,72053,State Senate,31,Dem,Adriano Espillait,516
+New York,72054,State Senate,31,Dem,Adriano Espillait,371
+New York,72055,State Senate,31,Dem,Adriano Espillait,292
+New York,72056,State Senate,31,Dem,Adriano Espillait,383
+New York,72057,State Senate,31,Dem,Adriano Espillait,565
+New York,72058,State Senate,31,Dem,Adriano Espillait,476
+New York,72059,State Senate,31,Dem,Adriano Espillait,231
+New York,72060,State Senate,31,Dem,Adriano Espillait,574
+New York,72061,State Senate,31,Dem,Adriano Espillait,337
+New York,72062,State Senate,31,Dem,Adriano Espillait,337
+New York,72063,State Senate,31,Dem,Adriano Espillait,467
+New York,72064,State Senate,31,Dem,Adriano Espillait,534
+New York,72065,State Senate,31,Dem,Adriano Espillait,280
+New York,72066,State Senate,31,Dem,Adriano Espillait,515
+New York,72067,State Senate,31,Dem,Adriano Espillait,509
+New York,72068,State Senate,31,Dem,Adriano Espillait,588
+New York,72069,State Senate,31,Dem,Adriano Espillait,368
+New York,72070,State Senate,31,Dem,Adriano Espillait,328
+New York,72071,State Senate,31,Dem,Adriano Espillait,389
+New York,72072,State Senate,31,Dem,Adriano Espillait,427
+New York,72073,State Senate,31,Dem,Adriano Espillait,114
+New York,72074,State Senate,31,Dem,Adriano Espillait,502
+New York,72075,State Senate,31,Dem,Adriano Espillait,557
+New York,72077,State Senate,31,Dem,Adriano Espillait,1
+New York,75045,State Senate,31,Dem,Adriano Espillait,234
+New York,75060,State Senate,31,Dem,Adriano Espillait,3
+New York,75061,State Senate,31,Dem,Adriano Espillait,13
+New York,75067,State Senate,31,Dem,Adriano Espillait,183
+New York,67001,State Senate,31,Rep,Martin Chicon,59
+New York,67003,State Senate,31,Rep,Martin Chicon,141
+New York,67005,State Senate,31,Rep,Martin Chicon,50
+New York,67007,State Senate,31,Rep,Martin Chicon,43
+New York,67025,State Senate,31,Rep,Martin Chicon,14
+New York,67026,State Senate,31,Rep,Martin Chicon,26
+New York,67027,State Senate,31,Rep,Martin Chicon,31
+New York,67028,State Senate,31,Rep,Martin Chicon,213
+New York,67029,State Senate,31,Rep,Martin Chicon,31
+New York,67030,State Senate,31,Rep,Martin Chicon,70
+New York,67051,State Senate,31,Rep,Martin Chicon,32
+New York,67067,State Senate,31,Rep,Martin Chicon,113
+New York,67079,State Senate,31,Rep,Martin Chicon,66
+New York,67080,State Senate,31,Rep,Martin Chicon,108
+New York,67081,State Senate,31,Rep,Martin Chicon,74
+New York,67082,State Senate,31,Rep,Martin Chicon,95
+New York,67083,State Senate,31,Rep,Martin Chicon,95
+New York,67084,State Senate,31,Rep,Martin Chicon,92
+New York,67085,State Senate,31,Rep,Martin Chicon,91
+New York,67087,State Senate,31,Rep,Martin Chicon,117
+New York,67088,State Senate,31,Rep,Martin Chicon,120
+New York,67089,State Senate,31,Rep,Martin Chicon,135
+New York,67090,State Senate,31,Rep,Martin Chicon,116
+New York,67091,State Senate,31,Rep,Martin Chicon,77
+New York,67092,State Senate,31,Rep,Martin Chicon,72
+New York,67093,State Senate,31,Rep,Martin Chicon,78
+New York,67094,State Senate,31,Rep,Martin Chicon,70
+New York,67095,State Senate,31,Rep,Martin Chicon,69
+New York,67096,State Senate,31,Rep,Martin Chicon,51
+New York,67097,State Senate,31,Rep,Martin Chicon,74
+New York,67098,State Senate,31,Rep,Martin Chicon,68
+New York,67099,State Senate,31,Rep,Martin Chicon,64
+New York,67100,State Senate,31,Rep,Martin Chicon,0
+New York,67101,State Senate,31,Rep,Martin Chicon,0
+New York,69022,State Senate,31,Rep,Martin Chicon,84
+New York,69023,State Senate,31,Rep,Martin Chicon,50
+New York,69024,State Senate,31,Rep,Martin Chicon,52
+New York,69025,State Senate,31,Rep,Martin Chicon,70
+New York,69026,State Senate,31,Rep,Martin Chicon,60
+New York,69027,State Senate,31,Rep,Martin Chicon,49
+New York,69036,State Senate,31,Rep,Martin Chicon,9
+New York,69045,State Senate,31,Rep,Martin Chicon,80
+New York,69046,State Senate,31,Rep,Martin Chicon,68
+New York,69047,State Senate,31,Rep,Martin Chicon,60
+New York,69048,State Senate,31,Rep,Martin Chicon,45
+New York,69049,State Senate,31,Rep,Martin Chicon,61
+New York,69050,State Senate,31,Rep,Martin Chicon,53
+New York,69051,State Senate,31,Rep,Martin Chicon,64
+New York,69060,State Senate,31,Rep,Martin Chicon,48
+New York,69061,State Senate,31,Rep,Martin Chicon,50
+New York,69062,State Senate,31,Rep,Martin Chicon,43
+New York,69063,State Senate,31,Rep,Martin Chicon,22
+New York,69064,State Senate,31,Rep,Martin Chicon,53
+New York,69065,State Senate,31,Rep,Martin Chicon,58
+New York,69066,State Senate,31,Rep,Martin Chicon,41
+New York,69072,State Senate,31,Rep,Martin Chicon,73
+New York,69073,State Senate,31,Rep,Martin Chicon,78
+New York,69077,State Senate,31,Rep,Martin Chicon,38
+New York,69078,State Senate,31,Rep,Martin Chicon,44
+New York,69079,State Senate,31,Rep,Martin Chicon,22
+New York,69084,State Senate,31,Rep,Martin Chicon,46
+New York,69085,State Senate,31,Rep,Martin Chicon,31
+New York,69086,State Senate,31,Rep,Martin Chicon,58
+New York,69088,State Senate,31,Rep,Martin Chicon,8
+New York,69092,State Senate,31,Rep,Martin Chicon,39
+New York,69096,State Senate,31,Rep,Martin Chicon,1
+New York,69105,State Senate,31,Rep,Martin Chicon,0
+New York,69106,State Senate,31,Rep,Martin Chicon,0
+New York,69107,State Senate,31,Rep,Martin Chicon,0
+New York,70068,State Senate,31,Rep,Martin Chicon,37
+New York,70070,State Senate,31,Rep,Martin Chicon,5
+New York,70071,State Senate,31,Rep,Martin Chicon,15
+New York,70072,State Senate,31,Rep,Martin Chicon,12
+New York,70077,State Senate,31,Rep,Martin Chicon,5
+New York,70078,State Senate,31,Rep,Martin Chicon,3
+New York,70079,State Senate,31,Rep,Martin Chicon,9
+New York,70080,State Senate,31,Rep,Martin Chicon,11
+New York,70081,State Senate,31,Rep,Martin Chicon,22
+New York,70082,State Senate,31,Rep,Martin Chicon,26
+New York,70083,State Senate,31,Rep,Martin Chicon,16
+New York,70084,State Senate,31,Rep,Martin Chicon,21
+New York,70085,State Senate,31,Rep,Martin Chicon,17
+New York,70086,State Senate,31,Rep,Martin Chicon,15
+New York,70087,State Senate,31,Rep,Martin Chicon,20
+New York,70090,State Senate,31,Rep,Martin Chicon,0
+New York,71001,State Senate,31,Rep,Martin Chicon,19
+New York,71002,State Senate,31,Rep,Martin Chicon,13
+New York,71003,State Senate,31,Rep,Martin Chicon,10
+New York,71005,State Senate,31,Rep,Martin Chicon,18
+New York,71006,State Senate,31,Rep,Martin Chicon,21
+New York,71007,State Senate,31,Rep,Martin Chicon,9
+New York,71029,State Senate,31,Rep,Martin Chicon,15
+New York,71030,State Senate,31,Rep,Martin Chicon,19
+New York,71036,State Senate,31,Rep,Martin Chicon,14
+New York,71037,State Senate,31,Rep,Martin Chicon,14
+New York,71039,State Senate,31,Rep,Martin Chicon,13
+New York,71040,State Senate,31,Rep,Martin Chicon,32
+New York,71041,State Senate,31,Rep,Martin Chicon,32
+New York,71042,State Senate,31,Rep,Martin Chicon,25
+New York,71043,State Senate,31,Rep,Martin Chicon,10
+New York,71045,State Senate,31,Rep,Martin Chicon,11
+New York,71046,State Senate,31,Rep,Martin Chicon,21
+New York,71047,State Senate,31,Rep,Martin Chicon,13
+New York,71048,State Senate,31,Rep,Martin Chicon,23
+New York,71049,State Senate,31,Rep,Martin Chicon,11
+New York,71050,State Senate,31,Rep,Martin Chicon,13
+New York,71051,State Senate,31,Rep,Martin Chicon,3
+New York,71052,State Senate,31,Rep,Martin Chicon,11
+New York,71053,State Senate,31,Rep,Martin Chicon,11
+New York,71054,State Senate,31,Rep,Martin Chicon,11
+New York,71055,State Senate,31,Rep,Martin Chicon,12
+New York,71056,State Senate,31,Rep,Martin Chicon,16
+New York,71057,State Senate,31,Rep,Martin Chicon,9
+New York,71058,State Senate,31,Rep,Martin Chicon,11
+New York,71059,State Senate,31,Rep,Martin Chicon,14
+New York,71060,State Senate,31,Rep,Martin Chicon,21
+New York,71061,State Senate,31,Rep,Martin Chicon,40
+New York,71062,State Senate,31,Rep,Martin Chicon,21
+New York,71063,State Senate,31,Rep,Martin Chicon,49
+New York,71064,State Senate,31,Rep,Martin Chicon,33
+New York,71065,State Senate,31,Rep,Martin Chicon,28
+New York,71066,State Senate,31,Rep,Martin Chicon,22
+New York,71067,State Senate,31,Rep,Martin Chicon,24
+New York,71068,State Senate,31,Rep,Martin Chicon,15
+New York,71069,State Senate,31,Rep,Martin Chicon,35
+New York,71070,State Senate,31,Rep,Martin Chicon,48
+New York,71071,State Senate,31,Rep,Martin Chicon,2
+New York,71072,State Senate,31,Rep,Martin Chicon,49
+New York,71073,State Senate,31,Rep,Martin Chicon,44
+New York,71074,State Senate,31,Rep,Martin Chicon,43
+New York,71075,State Senate,31,Rep,Martin Chicon,31
+New York,71076,State Senate,31,Rep,Martin Chicon,58
+New York,71077,State Senate,31,Rep,Martin Chicon,55
+New York,71078,State Senate,31,Rep,Martin Chicon,54
+New York,71079,State Senate,31,Rep,Martin Chicon,48
+New York,71080,State Senate,31,Rep,Martin Chicon,37
+New York,71081,State Senate,31,Rep,Martin Chicon,61
+New York,71082,State Senate,31,Rep,Martin Chicon,130
+New York,71083,State Senate,31,Rep,Martin Chicon,103
+New York,71084,State Senate,31,Rep,Martin Chicon,120
+New York,71085,State Senate,31,Rep,Martin Chicon,51
+New York,71086,State Senate,31,Rep,Martin Chicon,6
+New York,71092,State Senate,31,Rep,Martin Chicon,0
+New York,72002,State Senate,31,Rep,Martin Chicon,9
+New York,72003,State Senate,31,Rep,Martin Chicon,12
+New York,72004,State Senate,31,Rep,Martin Chicon,20
+New York,72005,State Senate,31,Rep,Martin Chicon,5
+New York,72006,State Senate,31,Rep,Martin Chicon,9
+New York,72007,State Senate,31,Rep,Martin Chicon,18
+New York,72008,State Senate,31,Rep,Martin Chicon,28
+New York,72009,State Senate,31,Rep,Martin Chicon,15
+New York,72010,State Senate,31,Rep,Martin Chicon,16
+New York,72011,State Senate,31,Rep,Martin Chicon,15
+New York,72012,State Senate,31,Rep,Martin Chicon,15
+New York,72013,State Senate,31,Rep,Martin Chicon,17
+New York,72014,State Senate,31,Rep,Martin Chicon,8
+New York,72015,State Senate,31,Rep,Martin Chicon,9
+New York,72016,State Senate,31,Rep,Martin Chicon,25
+New York,72017,State Senate,31,Rep,Martin Chicon,24
+New York,72018,State Senate,31,Rep,Martin Chicon,91
+New York,72019,State Senate,31,Rep,Martin Chicon,62
+New York,72020,State Senate,31,Rep,Martin Chicon,26
+New York,72021,State Senate,31,Rep,Martin Chicon,29
+New York,72022,State Senate,31,Rep,Martin Chicon,39
+New York,72023,State Senate,31,Rep,Martin Chicon,50
+New York,72024,State Senate,31,Rep,Martin Chicon,36
+New York,72025,State Senate,31,Rep,Martin Chicon,25
+New York,72026,State Senate,31,Rep,Martin Chicon,37
+New York,72027,State Senate,31,Rep,Martin Chicon,12
+New York,72028,State Senate,31,Rep,Martin Chicon,19
+New York,72029,State Senate,31,Rep,Martin Chicon,14
+New York,72030,State Senate,31,Rep,Martin Chicon,23
+New York,72031,State Senate,31,Rep,Martin Chicon,14
+New York,72032,State Senate,31,Rep,Martin Chicon,10
+New York,72033,State Senate,31,Rep,Martin Chicon,61
+New York,72034,State Senate,31,Rep,Martin Chicon,15
+New York,72035,State Senate,31,Rep,Martin Chicon,17
+New York,72036,State Senate,31,Rep,Martin Chicon,47
+New York,72037,State Senate,31,Rep,Martin Chicon,66
+New York,72038,State Senate,31,Rep,Martin Chicon,51
+New York,72039,State Senate,31,Rep,Martin Chicon,43
+New York,72040,State Senate,31,Rep,Martin Chicon,22
+New York,72041,State Senate,31,Rep,Martin Chicon,52
+New York,72042,State Senate,31,Rep,Martin Chicon,60
+New York,72043,State Senate,31,Rep,Martin Chicon,19
+New York,72044,State Senate,31,Rep,Martin Chicon,32
+New York,72045,State Senate,31,Rep,Martin Chicon,22
+New York,72046,State Senate,31,Rep,Martin Chicon,31
+New York,72047,State Senate,31,Rep,Martin Chicon,17
+New York,72048,State Senate,31,Rep,Martin Chicon,4
+New York,72049,State Senate,31,Rep,Martin Chicon,20
+New York,72050,State Senate,31,Rep,Martin Chicon,8
+New York,72051,State Senate,31,Rep,Martin Chicon,11
+New York,72052,State Senate,31,Rep,Martin Chicon,20
+New York,72053,State Senate,31,Rep,Martin Chicon,34
+New York,72054,State Senate,31,Rep,Martin Chicon,11
+New York,72055,State Senate,31,Rep,Martin Chicon,19
+New York,72056,State Senate,31,Rep,Martin Chicon,14
+New York,72057,State Senate,31,Rep,Martin Chicon,73
+New York,72058,State Senate,31,Rep,Martin Chicon,50
+New York,72059,State Senate,31,Rep,Martin Chicon,29
+New York,72060,State Senate,31,Rep,Martin Chicon,42
+New York,72061,State Senate,31,Rep,Martin Chicon,19
+New York,72062,State Senate,31,Rep,Martin Chicon,19
+New York,72063,State Senate,31,Rep,Martin Chicon,21
+New York,72064,State Senate,31,Rep,Martin Chicon,68
+New York,72065,State Senate,31,Rep,Martin Chicon,16
+New York,72066,State Senate,31,Rep,Martin Chicon,63
+New York,72067,State Senate,31,Rep,Martin Chicon,69
+New York,72068,State Senate,31,Rep,Martin Chicon,66
+New York,72069,State Senate,31,Rep,Martin Chicon,56
+New York,72070,State Senate,31,Rep,Martin Chicon,21
+New York,72071,State Senate,31,Rep,Martin Chicon,10
+New York,72072,State Senate,31,Rep,Martin Chicon,12
+New York,72073,State Senate,31,Rep,Martin Chicon,4
+New York,72074,State Senate,31,Rep,Martin Chicon,35
+New York,72075,State Senate,31,Rep,Martin Chicon,24
+New York,72077,State Senate,31,Rep,Martin Chicon,0
+New York,75045,State Senate,31,Rep,Martin Chicon,15
+New York,75060,State Senate,31,Rep,Martin Chicon,0
+New York,75061,State Senate,31,Rep,Martin Chicon,4
+New York,75067,State Senate,31,Rep,Martin Chicon,17
+New York,67001,State Senate,31,Ind,writein,1
+New York,67003,State Senate,31,Ind,writein,1
+New York,67005,State Senate,31,Ind,writein,0
+New York,67007,State Senate,31,Ind,writein,0
+New York,67025,State Senate,31,Ind,writein,1
+New York,67026,State Senate,31,Ind,writein,1
+New York,67027,State Senate,31,Ind,writein,1
+New York,67028,State Senate,31,Ind,writein,0
+New York,67029,State Senate,31,Ind,writein,0
+New York,67030,State Senate,31,Ind,writein,0
+New York,67051,State Senate,31,Ind,writein,0
+New York,67067,State Senate,31,Ind,writein,0
+New York,67079,State Senate,31,Ind,writein,1
+New York,67080,State Senate,31,Ind,writein,0
+New York,67081,State Senate,31,Ind,writein,0
+New York,67082,State Senate,31,Ind,writein,1
+New York,67083,State Senate,31,Ind,writein,1
+New York,67084,State Senate,31,Ind,writein,0
+New York,67085,State Senate,31,Ind,writein,1
+New York,67087,State Senate,31,Ind,writein,0
+New York,67088,State Senate,31,Ind,writein,0
+New York,67089,State Senate,31,Ind,writein,1
+New York,67090,State Senate,31,Ind,writein,3
+New York,67091,State Senate,31,Ind,writein,0
+New York,67092,State Senate,31,Ind,writein,1
+New York,67093,State Senate,31,Ind,writein,3
+New York,67094,State Senate,31,Ind,writein,2
+New York,67095,State Senate,31,Ind,writein,0
+New York,67096,State Senate,31,Ind,writein,0
+New York,67097,State Senate,31,Ind,writein,0
+New York,67098,State Senate,31,Ind,writein,0
+New York,67099,State Senate,31,Ind,writein,0
+New York,67100,State Senate,31,Ind,writein,0
+New York,67101,State Senate,31,Ind,writein,0
+New York,69022,State Senate,31,Ind,writein,1
+New York,69023,State Senate,31,Ind,writein,0
+New York,69024,State Senate,31,Ind,writein,0
+New York,69025,State Senate,31,Ind,writein,1
+New York,69026,State Senate,31,Ind,writein,0
+New York,69027,State Senate,31,Ind,writein,0
+New York,69036,State Senate,31,Ind,writein,0
+New York,69045,State Senate,31,Ind,writein,2
+New York,69046,State Senate,31,Ind,writein,0
+New York,69047,State Senate,31,Ind,writein,0
+New York,69048,State Senate,31,Ind,writein,1
+New York,69049,State Senate,31,Ind,writein,2
+New York,69050,State Senate,31,Ind,writein,1
+New York,69051,State Senate,31,Ind,writein,1
+New York,69060,State Senate,31,Ind,writein,0
+New York,69061,State Senate,31,Ind,writein,0
+New York,69062,State Senate,31,Ind,writein,0
+New York,69063,State Senate,31,Ind,writein,0
+New York,69064,State Senate,31,Ind,writein,0
+New York,69065,State Senate,31,Ind,writein,0
+New York,69066,State Senate,31,Ind,writein,0
+New York,69072,State Senate,31,Ind,writein,1
+New York,69073,State Senate,31,Ind,writein,1
+New York,69077,State Senate,31,Ind,writein,1
+New York,69078,State Senate,31,Ind,writein,0
+New York,69079,State Senate,31,Ind,writein,1
+New York,69084,State Senate,31,Ind,writein,1
+New York,69085,State Senate,31,Ind,writein,0
+New York,69086,State Senate,31,Ind,writein,2
+New York,69088,State Senate,31,Ind,writein,0
+New York,69092,State Senate,31,Ind,writein,1
+New York,69096,State Senate,31,Ind,writein,0
+New York,69105,State Senate,31,Ind,writein,0
+New York,69106,State Senate,31,Ind,writein,0
+New York,69107,State Senate,31,Ind,writein,0
+New York,70068,State Senate,31,Ind,writein,1
+New York,70070,State Senate,31,Ind,writein,0
+New York,70071,State Senate,31,Ind,writein,1
+New York,70072,State Senate,31,Ind,writein,1
+New York,70077,State Senate,31,Ind,writein,0
+New York,70078,State Senate,31,Ind,writein,0
+New York,70079,State Senate,31,Ind,writein,0
+New York,70080,State Senate,31,Ind,writein,0
+New York,70081,State Senate,31,Ind,writein,1
+New York,70082,State Senate,31,Ind,writein,0
+New York,70083,State Senate,31,Ind,writein,1
+New York,70084,State Senate,31,Ind,writein,0
+New York,70085,State Senate,31,Ind,writein,1
+New York,70086,State Senate,31,Ind,writein,0
+New York,70087,State Senate,31,Ind,writein,1
+New York,70090,State Senate,31,Ind,writein,0
+New York,71001,State Senate,31,Ind,writein,1
+New York,71002,State Senate,31,Ind,writein,1
+New York,71003,State Senate,31,Ind,writein,1
+New York,71005,State Senate,31,Ind,writein,1
+New York,71006,State Senate,31,Ind,writein,1
+New York,71007,State Senate,31,Ind,writein,1
+New York,71029,State Senate,31,Ind,writein,0
+New York,71030,State Senate,31,Ind,writein,0
+New York,71036,State Senate,31,Ind,writein,0
+New York,71037,State Senate,31,Ind,writein,1
+New York,71039,State Senate,31,Ind,writein,0
+New York,71040,State Senate,31,Ind,writein,3
+New York,71041,State Senate,31,Ind,writein,0
+New York,71042,State Senate,31,Ind,writein,1
+New York,71043,State Senate,31,Ind,writein,0
+New York,71045,State Senate,31,Ind,writein,0
+New York,71046,State Senate,31,Ind,writein,0
+New York,71047,State Senate,31,Ind,writein,2
+New York,71048,State Senate,31,Ind,writein,3
+New York,71049,State Senate,31,Ind,writein,0
+New York,71050,State Senate,31,Ind,writein,0
+New York,71051,State Senate,31,Ind,writein,1
+New York,71052,State Senate,31,Ind,writein,0
+New York,71053,State Senate,31,Ind,writein,1
+New York,71054,State Senate,31,Ind,writein,0
+New York,71055,State Senate,31,Ind,writein,0
+New York,71056,State Senate,31,Ind,writein,0
+New York,71057,State Senate,31,Ind,writein,0
+New York,71058,State Senate,31,Ind,writein,0
+New York,71059,State Senate,31,Ind,writein,0
+New York,71060,State Senate,31,Ind,writein,0
+New York,71061,State Senate,31,Ind,writein,0
+New York,71062,State Senate,31,Ind,writein,0
+New York,71063,State Senate,31,Ind,writein,2
+New York,71064,State Senate,31,Ind,writein,0
+New York,71065,State Senate,31,Ind,writein,0
+New York,71066,State Senate,31,Ind,writein,1
+New York,71067,State Senate,31,Ind,writein,0
+New York,71068,State Senate,31,Ind,writein,1
+New York,71069,State Senate,31,Ind,writein,0
+New York,71070,State Senate,31,Ind,writein,0
+New York,71071,State Senate,31,Ind,writein,0
+New York,71072,State Senate,31,Ind,writein,1
+New York,71073,State Senate,31,Ind,writein,1
+New York,71074,State Senate,31,Ind,writein,0
+New York,71075,State Senate,31,Ind,writein,1
+New York,71076,State Senate,31,Ind,writein,1
+New York,71077,State Senate,31,Ind,writein,0
+New York,71078,State Senate,31,Ind,writein,0
+New York,71079,State Senate,31,Ind,writein,0
+New York,71080,State Senate,31,Ind,writein,1
+New York,71081,State Senate,31,Ind,writein,0
+New York,71082,State Senate,31,Ind,writein,2
+New York,71083,State Senate,31,Ind,writein,1
+New York,71084,State Senate,31,Ind,writein,0
+New York,71085,State Senate,31,Ind,writein,0
+New York,71086,State Senate,31,Ind,writein,0
+New York,71092,State Senate,31,Ind,writein,0
+New York,72002,State Senate,31,Ind,writein,0
+New York,72003,State Senate,31,Ind,writein,0
+New York,72004,State Senate,31,Ind,writein,0
+New York,72005,State Senate,31,Ind,writein,0
+New York,72006,State Senate,31,Ind,writein,0
+New York,72007,State Senate,31,Ind,writein,0
+New York,72008,State Senate,31,Ind,writein,0
+New York,72009,State Senate,31,Ind,writein,0
+New York,72010,State Senate,31,Ind,writein,0
+New York,72011,State Senate,31,Ind,writein,0
+New York,72012,State Senate,31,Ind,writein,0
+New York,72013,State Senate,31,Ind,writein,0
+New York,72014,State Senate,31,Ind,writein,0
+New York,72015,State Senate,31,Ind,writein,2
+New York,72016,State Senate,31,Ind,writein,0
+New York,72017,State Senate,31,Ind,writein,1
+New York,72018,State Senate,31,Ind,writein,0
+New York,72019,State Senate,31,Ind,writein,0
+New York,72020,State Senate,31,Ind,writein,0
+New York,72021,State Senate,31,Ind,writein,2
+New York,72022,State Senate,31,Ind,writein,2
+New York,72023,State Senate,31,Ind,writein,0
+New York,72024,State Senate,31,Ind,writein,0
+New York,72025,State Senate,31,Ind,writein,0
+New York,72026,State Senate,31,Ind,writein,1
+New York,72027,State Senate,31,Ind,writein,0
+New York,72028,State Senate,31,Ind,writein,0
+New York,72029,State Senate,31,Ind,writein,0
+New York,72030,State Senate,31,Ind,writein,0
+New York,72031,State Senate,31,Ind,writein,0
+New York,72032,State Senate,31,Ind,writein,0
+New York,72033,State Senate,31,Ind,writein,0
+New York,72034,State Senate,31,Ind,writein,0
+New York,72035,State Senate,31,Ind,writein,0
+New York,72036,State Senate,31,Ind,writein,1
+New York,72037,State Senate,31,Ind,writein,0
+New York,72038,State Senate,31,Ind,writein,1
+New York,72039,State Senate,31,Ind,writein,1
+New York,72040,State Senate,31,Ind,writein,1
+New York,72041,State Senate,31,Ind,writein,0
+New York,72042,State Senate,31,Ind,writein,0
+New York,72043,State Senate,31,Ind,writein,0
+New York,72044,State Senate,31,Ind,writein,0
+New York,72045,State Senate,31,Ind,writein,0
+New York,72046,State Senate,31,Ind,writein,1
+New York,72047,State Senate,31,Ind,writein,1
+New York,72048,State Senate,31,Ind,writein,0
+New York,72049,State Senate,31,Ind,writein,0
+New York,72050,State Senate,31,Ind,writein,1
+New York,72051,State Senate,31,Ind,writein,0
+New York,72052,State Senate,31,Ind,writein,1
+New York,72053,State Senate,31,Ind,writein,0
+New York,72054,State Senate,31,Ind,writein,1
+New York,72055,State Senate,31,Ind,writein,0
+New York,72056,State Senate,31,Ind,writein,0
+New York,72057,State Senate,31,Ind,writein,3
+New York,72058,State Senate,31,Ind,writein,2
+New York,72059,State Senate,31,Ind,writein,1
+New York,72060,State Senate,31,Ind,writein,3
+New York,72061,State Senate,31,Ind,writein,0
+New York,72062,State Senate,31,Ind,writein,0
+New York,72063,State Senate,31,Ind,writein,0
+New York,72064,State Senate,31,Ind,writein,0
+New York,72065,State Senate,31,Ind,writein,1
+New York,72066,State Senate,31,Ind,writein,2
+New York,72067,State Senate,31,Ind,writein,2
+New York,72068,State Senate,31,Ind,writein,3
+New York,72069,State Senate,31,Ind,writein,2
+New York,72070,State Senate,31,Ind,writein,2
+New York,72071,State Senate,31,Ind,writein,0
+New York,72072,State Senate,31,Ind,writein,0
+New York,72073,State Senate,31,Ind,writein,0
+New York,72074,State Senate,31,Ind,writein,1
+New York,72075,State Senate,31,Ind,writein,0
+New York,72077,State Senate,31,Ind,writein,0
+New York,75045,State Senate,31,Ind,writein,0
+New York,75060,State Senate,31,Ind,writein,0
+New York,75061,State Senate,31,Ind,writein,0
+New York,75067,State Senate,31,Ind,writein,0
 New York,65018,U.S. House,07,Dem,Nydia Velazquez,278
 New York,65019,U.S. House,07,Dem,Nydia Velazquez,275
 New York,65020,U.S. House,07,Dem,Nydia Velazquez,258

--- a/2012/counties/20121106__ny__general__queens__precinct.csv
+++ b/2012/counties/20121106__ny__general__queens__precinct.csv
@@ -14908,5320 +14908,5320 @@ Queens,40048,President,,,writeins,1
 Queens,40049,President,,,writeins,0
 Queens,40050,President,,,writeins,0
 Queens,40051,President,,,writeins,0
-Queens,23018,State Senate,SD10,Dem,James Sanders,199
-Queens,23019,State Senate,SD10,Dem,James Sanders,248
-Queens,23029,State Senate,SD10,Dem,James Sanders,370
-Queens,23030,State Senate,SD10,Dem,James Sanders,408
-Queens,23031,State Senate,SD10,Dem,James Sanders,329
-Queens,23032,State Senate,SD10,Dem,James Sanders,425
-Queens,23033,State Senate,SD10,Dem,James Sanders,293
-Queens,23034,State Senate,SD10,Dem,James Sanders,191
-Queens,23035,State Senate,SD10,Dem,James Sanders,411
-Queens,23036,State Senate,SD10,Dem,James Sanders,270
-Queens,23037,State Senate,SD10,Dem,James Sanders,254
-Queens,23038,State Senate,SD10,Dem,James Sanders,7
-Queens,23073,State Senate,SD10,Dem,James Sanders,4
-Queens,24063,State Senate,SD10,Dem,James Sanders,299
-Queens,24064,State Senate,SD10,Dem,James Sanders,234
-Queens,24068,State Senate,SD10,Dem,James Sanders,377
-Queens,24069,State Senate,SD10,Dem,James Sanders,408
-Queens,24070,State Senate,SD10,Dem,James Sanders,406
-Queens,24071,State Senate,SD10,Dem,James Sanders,506
-Queens,24072,State Senate,SD10,Dem,James Sanders,536
-Queens,24073,State Senate,SD10,Dem,James Sanders,467
-Queens,24074,State Senate,SD10,Dem,James Sanders,330
-Queens,24075,State Senate,SD10,Dem,James Sanders,276
-Queens,24076,State Senate,SD10,Dem,James Sanders,407
-Queens,24077,State Senate,SD10,Dem,James Sanders,250
-Queens,28001,State Senate,SD10,Dem,James Sanders,294
-Queens,28002,State Senate,SD10,Dem,James Sanders,183
-Queens,28004,State Senate,SD10,Dem,James Sanders,315
-Queens,28008,State Senate,SD10,Dem,James Sanders,73
-Queens,29035,State Senate,SD10,Dem,James Sanders,469
-Queens,29040,State Senate,SD10,Dem,James Sanders,386
-Queens,29041,State Senate,SD10,Dem,James Sanders,395
-Queens,29042,State Senate,SD10,Dem,James Sanders,641
-Queens,29043,State Senate,SD10,Dem,James Sanders,679
-Queens,29044,State Senate,SD10,Dem,James Sanders,674
-Queens,29045,State Senate,SD10,Dem,James Sanders,647
-Queens,29046,State Senate,SD10,Dem,James Sanders,698
-Queens,29047,State Senate,SD10,Dem,James Sanders,722
-Queens,29048,State Senate,SD10,Dem,James Sanders,258
-Queens,29049,State Senate,SD10,Dem,James Sanders,505
-Queens,31001,State Senate,SD10,Dem,James Sanders,387
-Queens,31002,State Senate,SD10,Dem,James Sanders,446
-Queens,31003,State Senate,SD10,Dem,James Sanders,411
-Queens,31004,State Senate,SD10,Dem,James Sanders,422
-Queens,31005,State Senate,SD10,Dem,James Sanders,408
-Queens,31007,State Senate,SD10,Dem,James Sanders,239
-Queens,31008,State Senate,SD10,Dem,James Sanders,247
-Queens,31009,State Senate,SD10,Dem,James Sanders,340
-Queens,31010,State Senate,SD10,Dem,James Sanders,398
-Queens,31011,State Senate,SD10,Dem,James Sanders,499
-Queens,31012,State Senate,SD10,Dem,James Sanders,398
-Queens,31013,State Senate,SD10,Dem,James Sanders,475
-Queens,31014,State Senate,SD10,Dem,James Sanders,510
-Queens,31015,State Senate,SD10,Dem,James Sanders,535
-Queens,31016,State Senate,SD10,Dem,James Sanders,223
-Queens,31017,State Senate,SD10,Dem,James Sanders,375
-Queens,31018,State Senate,SD10,Dem,James Sanders,575
-Queens,31019,State Senate,SD10,Dem,James Sanders,587
-Queens,31020,State Senate,SD10,Dem,James Sanders,147
-Queens,31022,State Senate,SD10,Dem,James Sanders,391
-Queens,31023,State Senate,SD10,Dem,James Sanders,117
-Queens,31024,State Senate,SD10,Dem,James Sanders,535
-Queens,31025,State Senate,SD10,Dem,James Sanders,524
-Queens,31026,State Senate,SD10,Dem,James Sanders,357
-Queens,31033,State Senate,SD10,Dem,James Sanders,207
-Queens,31034,State Senate,SD10,Dem,James Sanders,694
-Queens,31035,State Senate,SD10,Dem,James Sanders,603
-Queens,31036,State Senate,SD10,Dem,James Sanders,728
-Queens,31037,State Senate,SD10,Dem,James Sanders,344
-Queens,31038,State Senate,SD10,Dem,James Sanders,737
-Queens,31040,State Senate,SD10,Dem,James Sanders,667
-Queens,31041,State Senate,SD10,Dem,James Sanders,710
-Queens,31042,State Senate,SD10,Dem,James Sanders,722
-Queens,31043,State Senate,SD10,Dem,James Sanders,630
-Queens,31044,State Senate,SD10,Dem,James Sanders,705
-Queens,31045,State Senate,SD10,Dem,James Sanders,10
-Queens,31046,State Senate,SD10,Dem,James Sanders,614
-Queens,31047,State Senate,SD10,Dem,James Sanders,393
-Queens,31050,State Senate,SD10,Dem,James Sanders,425
-Queens,31051,State Senate,SD10,Dem,James Sanders,455
-Queens,31052,State Senate,SD10,Dem,James Sanders,435
-Queens,31053,State Senate,SD10,Dem,James Sanders,361
-Queens,31054,State Senate,SD10,Dem,James Sanders,359
-Queens,31055,State Senate,SD10,Dem,James Sanders,232
-Queens,31056,State Senate,SD10,Dem,James Sanders,287
-Queens,31058,State Senate,SD10,Dem,James Sanders,308
-Queens,31059,State Senate,SD10,Dem,James Sanders,238
-Queens,31061,State Senate,SD10,Dem,James Sanders,213
-Queens,31062,State Senate,SD10,Dem,James Sanders,198
-Queens,31063,State Senate,SD10,Dem,James Sanders,342
-Queens,31064,State Senate,SD10,Dem,James Sanders,296
-Queens,31066,State Senate,SD10,Dem,James Sanders,75
-Queens,31067,State Senate,SD10,Dem,James Sanders,235
-Queens,31068,State Senate,SD10,Dem,James Sanders,322
-Queens,31069,State Senate,SD10,Dem,James Sanders,235
-Queens,31070,State Senate,SD10,Dem,James Sanders,157
-Queens,31071,State Senate,SD10,Dem,James Sanders,180
-Queens,31072,State Senate,SD10,Dem,James Sanders,6
-Queens,31074,State Senate,SD10,Dem,James Sanders,2
-Queens,32012,State Senate,SD10,Dem,James Sanders,2
-Queens,32013,State Senate,SD10,Dem,James Sanders,59
-Queens,32017,State Senate,SD10,Dem,James Sanders,507
-Queens,32018,State Senate,SD10,Dem,James Sanders,364
-Queens,32019,State Senate,SD10,Dem,James Sanders,380
-Queens,32020,State Senate,SD10,Dem,James Sanders,425
-Queens,32021,State Senate,SD10,Dem,James Sanders,526
-Queens,32022,State Senate,SD10,Dem,James Sanders,553
-Queens,32025,State Senate,SD10,Dem,James Sanders,526
-Queens,32026,State Senate,SD10,Dem,James Sanders,517
-Queens,32027,State Senate,SD10,Dem,James Sanders,555
-Queens,32028,State Senate,SD10,Dem,James Sanders,526
-Queens,32029,State Senate,SD10,Dem,James Sanders,642
-Queens,32030,State Senate,SD10,Dem,James Sanders,425
-Queens,32031,State Senate,SD10,Dem,James Sanders,517
-Queens,32032,State Senate,SD10,Dem,James Sanders,345
-Queens,32033,State Senate,SD10,Dem,James Sanders,603
-Queens,32034,State Senate,SD10,Dem,James Sanders,576
-Queens,32035,State Senate,SD10,Dem,James Sanders,572
-Queens,32036,State Senate,SD10,Dem,James Sanders,578
-Queens,32037,State Senate,SD10,Dem,James Sanders,295
-Queens,32038,State Senate,SD10,Dem,James Sanders,554
-Queens,32039,State Senate,SD10,Dem,James Sanders,582
-Queens,32046,State Senate,SD10,Dem,James Sanders,750
-Queens,32047,State Senate,SD10,Dem,James Sanders,588
-Queens,32048,State Senate,SD10,Dem,James Sanders,474
-Queens,32049,State Senate,SD10,Dem,James Sanders,529
-Queens,32050,State Senate,SD10,Dem,James Sanders,572
-Queens,32051,State Senate,SD10,Dem,James Sanders,551
-Queens,32052,State Senate,SD10,Dem,James Sanders,409
-Queens,32053,State Senate,SD10,Dem,James Sanders,640
-Queens,32054,State Senate,SD10,Dem,James Sanders,301
-Queens,32055,State Senate,SD10,Dem,James Sanders,359
-Queens,32056,State Senate,SD10,Dem,James Sanders,204
-Queens,32057,State Senate,SD10,Dem,James Sanders,655
-Queens,32058,State Senate,SD10,Dem,James Sanders,661
-Queens,32059,State Senate,SD10,Dem,James Sanders,643
-Queens,32060,State Senate,SD10,Dem,James Sanders,697
-Queens,32061,State Senate,SD10,Dem,James Sanders,614
-Queens,32062,State Senate,SD10,Dem,James Sanders,612
-Queens,32063,State Senate,SD10,Dem,James Sanders,548
-Queens,32064,State Senate,SD10,Dem,James Sanders,526
-Queens,32065,State Senate,SD10,Dem,James Sanders,548
-Queens,32066,State Senate,SD10,Dem,James Sanders,543
-Queens,32067,State Senate,SD10,Dem,James Sanders,503
-Queens,32068,State Senate,SD10,Dem,James Sanders,511
-Queens,32069,State Senate,SD10,Dem,James Sanders,498
-Queens,32070,State Senate,SD10,Dem,James Sanders,499
-Queens,32071,State Senate,SD10,Dem,James Sanders,513
-Queens,32072,State Senate,SD10,Dem,James Sanders,541
-Queens,32073,State Senate,SD10,Dem,James Sanders,415
-Queens,32074,State Senate,SD10,Dem,James Sanders,343
-Queens,38034,State Senate,SD10,Dem,James Sanders,97
-Queens,38036,State Senate,SD10,Dem,James Sanders,94
-Queens,38038,State Senate,SD10,Dem,James Sanders,445
-Queens,38039,State Senate,SD10,Dem,James Sanders,453
-Queens,38040,State Senate,SD10,Dem,James Sanders,330
-Queens,38041,State Senate,SD10,Dem,James Sanders,401
-Queens,38042,State Senate,SD10,Dem,James Sanders,344
-Queens,38043,State Senate,SD10,Dem,James Sanders,336
-Queens,38044,State Senate,SD10,Dem,James Sanders,223
-Queens,38045,State Senate,SD10,Dem,James Sanders,79
-Queens,38046,State Senate,SD10,Dem,James Sanders,249
-Queens,38047,State Senate,SD10,Dem,James Sanders,251
-Queens,38048,State Senate,SD10,Dem,James Sanders,364
-Queens,38049,State Senate,SD10,Dem,James Sanders,417
-Queens,23018,State Senate,SD10,Ind,writein,0
-Queens,23019,State Senate,SD10,Ind,writein,3
-Queens,23029,State Senate,SD10,Ind,writein,5
-Queens,23030,State Senate,SD10,Ind,writein,5
-Queens,23031,State Senate,SD10,Ind,writein,0
-Queens,23032,State Senate,SD10,Ind,writein,1
-Queens,23033,State Senate,SD10,Ind,writein,0
-Queens,23034,State Senate,SD10,Ind,writein,0
-Queens,23035,State Senate,SD10,Ind,writein,0
-Queens,23036,State Senate,SD10,Ind,writein,0
-Queens,23037,State Senate,SD10,Ind,writein,0
-Queens,23038,State Senate,SD10,Ind,writein,0
-Queens,23073,State Senate,SD10,Ind,writein,0
-Queens,24063,State Senate,SD10,Ind,writein,0
-Queens,24064,State Senate,SD10,Ind,writein,0
-Queens,24068,State Senate,SD10,Ind,writein,3
-Queens,24069,State Senate,SD10,Ind,writein,0
-Queens,24070,State Senate,SD10,Ind,writein,3
-Queens,24071,State Senate,SD10,Ind,writein,1
-Queens,24072,State Senate,SD10,Ind,writein,1
-Queens,24073,State Senate,SD10,Ind,writein,0
-Queens,24074,State Senate,SD10,Ind,writein,1
-Queens,24075,State Senate,SD10,Ind,writein,0
-Queens,24076,State Senate,SD10,Ind,writein,0
-Queens,24077,State Senate,SD10,Ind,writein,0
-Queens,28001,State Senate,SD10,Ind,writein,1
-Queens,28002,State Senate,SD10,Ind,writein,1
-Queens,28004,State Senate,SD10,Ind,writein,0
-Queens,28008,State Senate,SD10,Ind,writein,2
-Queens,29035,State Senate,SD10,Ind,writein,0
-Queens,29040,State Senate,SD10,Ind,writein,2
-Queens,29041,State Senate,SD10,Ind,writein,1
-Queens,29042,State Senate,SD10,Ind,writein,0
-Queens,29043,State Senate,SD10,Ind,writein,0
-Queens,29044,State Senate,SD10,Ind,writein,0
-Queens,29045,State Senate,SD10,Ind,writein,0
-Queens,29046,State Senate,SD10,Ind,writein,0
-Queens,29047,State Senate,SD10,Ind,writein,0
-Queens,29048,State Senate,SD10,Ind,writein,0
-Queens,29049,State Senate,SD10,Ind,writein,0
-Queens,31001,State Senate,SD10,Ind,writein,0
-Queens,31002,State Senate,SD10,Ind,writein,1
-Queens,31003,State Senate,SD10,Ind,writein,0
-Queens,31004,State Senate,SD10,Ind,writein,1
-Queens,31005,State Senate,SD10,Ind,writein,0
-Queens,31007,State Senate,SD10,Ind,writein,0
-Queens,31008,State Senate,SD10,Ind,writein,0
-Queens,31009,State Senate,SD10,Ind,writein,0
-Queens,31010,State Senate,SD10,Ind,writein,1
-Queens,31011,State Senate,SD10,Ind,writein,0
-Queens,31012,State Senate,SD10,Ind,writein,0
-Queens,31013,State Senate,SD10,Ind,writein,0
-Queens,31014,State Senate,SD10,Ind,writein,1
-Queens,31015,State Senate,SD10,Ind,writein,0
-Queens,31016,State Senate,SD10,Ind,writein,0
-Queens,31017,State Senate,SD10,Ind,writein,0
-Queens,31018,State Senate,SD10,Ind,writein,1
-Queens,31019,State Senate,SD10,Ind,writein,2
-Queens,31020,State Senate,SD10,Ind,writein,0
-Queens,31022,State Senate,SD10,Ind,writein,2
-Queens,31023,State Senate,SD10,Ind,writein,2
-Queens,31024,State Senate,SD10,Ind,writein,1
-Queens,31025,State Senate,SD10,Ind,writein,1
-Queens,31026,State Senate,SD10,Ind,writein,2
-Queens,31033,State Senate,SD10,Ind,writein,0
-Queens,31034,State Senate,SD10,Ind,writein,1
-Queens,31035,State Senate,SD10,Ind,writein,0
-Queens,31036,State Senate,SD10,Ind,writein,1
-Queens,31037,State Senate,SD10,Ind,writein,0
-Queens,31038,State Senate,SD10,Ind,writein,0
-Queens,31040,State Senate,SD10,Ind,writein,0
-Queens,31041,State Senate,SD10,Ind,writein,0
-Queens,31042,State Senate,SD10,Ind,writein,0
-Queens,31043,State Senate,SD10,Ind,writein,0
-Queens,31044,State Senate,SD10,Ind,writein,0
-Queens,31045,State Senate,SD10,Ind,writein,0
-Queens,31046,State Senate,SD10,Ind,writein,1
-Queens,31047,State Senate,SD10,Ind,writein,0
-Queens,31050,State Senate,SD10,Ind,writein,0
-Queens,31051,State Senate,SD10,Ind,writein,1
-Queens,31052,State Senate,SD10,Ind,writein,0
-Queens,31053,State Senate,SD10,Ind,writein,0
-Queens,31054,State Senate,SD10,Ind,writein,0
-Queens,31055,State Senate,SD10,Ind,writein,0
-Queens,31056,State Senate,SD10,Ind,writein,0
-Queens,31058,State Senate,SD10,Ind,writein,0
-Queens,31059,State Senate,SD10,Ind,writein,0
-Queens,31061,State Senate,SD10,Ind,writein,0
-Queens,31062,State Senate,SD10,Ind,writein,1
-Queens,31063,State Senate,SD10,Ind,writein,0
-Queens,31064,State Senate,SD10,Ind,writein,0
-Queens,31066,State Senate,SD10,Ind,writein,1
-Queens,31067,State Senate,SD10,Ind,writein,1
-Queens,31068,State Senate,SD10,Ind,writein,5
-Queens,31069,State Senate,SD10,Ind,writein,0
-Queens,31070,State Senate,SD10,Ind,writein,1
-Queens,31071,State Senate,SD10,Ind,writein,1
-Queens,31072,State Senate,SD10,Ind,writein,0
-Queens,31074,State Senate,SD10,Ind,writein,0
-Queens,32012,State Senate,SD10,Ind,writein,0
-Queens,32013,State Senate,SD10,Ind,writein,0
-Queens,32017,State Senate,SD10,Ind,writein,0
-Queens,32018,State Senate,SD10,Ind,writein,0
-Queens,32019,State Senate,SD10,Ind,writein,0
-Queens,32020,State Senate,SD10,Ind,writein,1
-Queens,32021,State Senate,SD10,Ind,writein,0
-Queens,32022,State Senate,SD10,Ind,writein,0
-Queens,32025,State Senate,SD10,Ind,writein,1
-Queens,32026,State Senate,SD10,Ind,writein,0
-Queens,32027,State Senate,SD10,Ind,writein,1
-Queens,32028,State Senate,SD10,Ind,writein,1
-Queens,32029,State Senate,SD10,Ind,writein,0
-Queens,32030,State Senate,SD10,Ind,writein,1
-Queens,32031,State Senate,SD10,Ind,writein,0
-Queens,32032,State Senate,SD10,Ind,writein,0
-Queens,32033,State Senate,SD10,Ind,writein,0
-Queens,32034,State Senate,SD10,Ind,writein,2
-Queens,32035,State Senate,SD10,Ind,writein,0
-Queens,32036,State Senate,SD10,Ind,writein,0
-Queens,32037,State Senate,SD10,Ind,writein,0
-Queens,32038,State Senate,SD10,Ind,writein,5
-Queens,32039,State Senate,SD10,Ind,writein,0
-Queens,32046,State Senate,SD10,Ind,writein,0
-Queens,32047,State Senate,SD10,Ind,writein,0
-Queens,32048,State Senate,SD10,Ind,writein,0
-Queens,32049,State Senate,SD10,Ind,writein,0
-Queens,32050,State Senate,SD10,Ind,writein,0
-Queens,32051,State Senate,SD10,Ind,writein,1
-Queens,32052,State Senate,SD10,Ind,writein,0
-Queens,32053,State Senate,SD10,Ind,writein,0
-Queens,32054,State Senate,SD10,Ind,writein,0
-Queens,32055,State Senate,SD10,Ind,writein,0
-Queens,32056,State Senate,SD10,Ind,writein,0
-Queens,32057,State Senate,SD10,Ind,writein,1
-Queens,32058,State Senate,SD10,Ind,writein,0
-Queens,32059,State Senate,SD10,Ind,writein,0
-Queens,32060,State Senate,SD10,Ind,writein,0
-Queens,32061,State Senate,SD10,Ind,writein,0
-Queens,32062,State Senate,SD10,Ind,writein,1
-Queens,32063,State Senate,SD10,Ind,writein,0
-Queens,32064,State Senate,SD10,Ind,writein,0
-Queens,32065,State Senate,SD10,Ind,writein,1
-Queens,32066,State Senate,SD10,Ind,writein,0
-Queens,32067,State Senate,SD10,Ind,writein,0
-Queens,32068,State Senate,SD10,Ind,writein,1
-Queens,32069,State Senate,SD10,Ind,writein,1
-Queens,32070,State Senate,SD10,Ind,writein,0
-Queens,32071,State Senate,SD10,Ind,writein,0
-Queens,32072,State Senate,SD10,Ind,writein,0
-Queens,32073,State Senate,SD10,Ind,writein,0
-Queens,32074,State Senate,SD10,Ind,writein,0
-Queens,38034,State Senate,SD10,Ind,writein,1
-Queens,38036,State Senate,SD10,Ind,writein,0
-Queens,38038,State Senate,SD10,Ind,writein,0
-Queens,38039,State Senate,SD10,Ind,writein,1
-Queens,38040,State Senate,SD10,Ind,writein,2
-Queens,38041,State Senate,SD10,Ind,writein,0
-Queens,38042,State Senate,SD10,Ind,writein,0
-Queens,38043,State Senate,SD10,Ind,writein,1
-Queens,38044,State Senate,SD10,Ind,writein,1
-Queens,38045,State Senate,SD10,Ind,writein,1
-Queens,38046,State Senate,SD10,Ind,writein,0
-Queens,38047,State Senate,SD10,Ind,writein,1
-Queens,38048,State Senate,SD10,Ind,writein,4
-Queens,38049,State Senate,SD10,Ind,writein,4
-Queens,24001,State Senate,SD11,Rep,Joseph Concannon,111
-Queens,24002,State Senate,SD11,Rep,Joseph Concannon,113
-Queens,24003,State Senate,SD11,Rep,Joseph Concannon,96
-Queens,24004,State Senate,SD11,Rep,Joseph Concannon,66
-Queens,24005,State Senate,SD11,Rep,Joseph Concannon,97
-Queens,24006,State Senate,SD11,Rep,Joseph Concannon,137
-Queens,24007,State Senate,SD11,Rep,Joseph Concannon,66
-Queens,24010,State Senate,SD11,Rep,Joseph Concannon,42
-Queens,24011,State Senate,SD11,Rep,Joseph Concannon,118
-Queens,24012,State Senate,SD11,Rep,Joseph Concannon,11
-Queens,24017,State Senate,SD11,Rep,Joseph Concannon,89
-Queens,24018,State Senate,SD11,Rep,Joseph Concannon,145
-Queens,24019,State Senate,SD11,Rep,Joseph Concannon,162
-Queens,24020,State Senate,SD11,Rep,Joseph Concannon,126
-Queens,24021,State Senate,SD11,Rep,Joseph Concannon,144
-Queens,24022,State Senate,SD11,Rep,Joseph Concannon,80
-Queens,24024,State Senate,SD11,Rep,Joseph Concannon,166
-Queens,24025,State Senate,SD11,Rep,Joseph Concannon,164
-Queens,24028,State Senate,SD11,Rep,Joseph Concannon,159
-Queens,24032,State Senate,SD11,Rep,Joseph Concannon,103
-Queens,24033,State Senate,SD11,Rep,Joseph Concannon,218
-Queens,24034,State Senate,SD11,Rep,Joseph Concannon,134
-Queens,24035,State Senate,SD11,Rep,Joseph Concannon,102
-Queens,24036,State Senate,SD11,Rep,Joseph Concannon,13
-Queens,24038,State Senate,SD11,Rep,Joseph Concannon,4
-Queens,24042,State Senate,SD11,Rep,Joseph Concannon,39
-Queens,24050,State Senate,SD11,Rep,Joseph Concannon,92
-Queens,24051,State Senate,SD11,Rep,Joseph Concannon,47
-Queens,24052,State Senate,SD11,Rep,Joseph Concannon,59
-Queens,24053,State Senate,SD11,Rep,Joseph Concannon,87
-Queens,24054,State Senate,SD11,Rep,Joseph Concannon,31
-Queens,24055,State Senate,SD11,Rep,Joseph Concannon,15
-Queens,24057,State Senate,SD11,Rep,Joseph Concannon,17
-Queens,24067,State Senate,SD11,Rep,Joseph Concannon,47
-Queens,25010,State Senate,SD11,Rep,Joseph Concannon,183
-Queens,25011,State Senate,SD11,Rep,Joseph Concannon,169
-Queens,25012,State Senate,SD11,Rep,Joseph Concannon,222
-Queens,25013,State Senate,SD11,Rep,Joseph Concannon,118
-Queens,25014,State Senate,SD11,Rep,Joseph Concannon,132
-Queens,25015,State Senate,SD11,Rep,Joseph Concannon,85
-Queens,25016,State Senate,SD11,Rep,Joseph Concannon,134
-Queens,25017,State Senate,SD11,Rep,Joseph Concannon,118
-Queens,25018,State Senate,SD11,Rep,Joseph Concannon,86
-Queens,25019,State Senate,SD11,Rep,Joseph Concannon,69
-Queens,25026,State Senate,SD11,Rep,Joseph Concannon,8
-Queens,25027,State Senate,SD11,Rep,Joseph Concannon,130
-Queens,25028,State Senate,SD11,Rep,Joseph Concannon,50
-Queens,25029,State Senate,SD11,Rep,Joseph Concannon,147
-Queens,25030,State Senate,SD11,Rep,Joseph Concannon,130
-Queens,25031,State Senate,SD11,Rep,Joseph Concannon,45
-Queens,25032,State Senate,SD11,Rep,Joseph Concannon,55
-Queens,25033,State Senate,SD11,Rep,Joseph Concannon,89
-Queens,25035,State Senate,SD11,Rep,Joseph Concannon,99
-Queens,25036,State Senate,SD11,Rep,Joseph Concannon,75
-Queens,25037,State Senate,SD11,Rep,Joseph Concannon,125
-Queens,25038,State Senate,SD11,Rep,Joseph Concannon,148
-Queens,25039,State Senate,SD11,Rep,Joseph Concannon,165
-Queens,25040,State Senate,SD11,Rep,Joseph Concannon,166
-Queens,25041,State Senate,SD11,Rep,Joseph Concannon,32
-Queens,25065,State Senate,SD11,Rep,Joseph Concannon,58
-Queens,25066,State Senate,SD11,Rep,Joseph Concannon,8
-Queens,25067,State Senate,SD11,Rep,Joseph Concannon,135
-Queens,25068,State Senate,SD11,Rep,Joseph Concannon,107
-Queens,26001,State Senate,SD11,Rep,Joseph Concannon,71
-Queens,26002,State Senate,SD11,Rep,Joseph Concannon,23
-Queens,26003,State Senate,SD11,Rep,Joseph Concannon,165
-Queens,26004,State Senate,SD11,Rep,Joseph Concannon,145
-Queens,26005,State Senate,SD11,Rep,Joseph Concannon,154
-Queens,26006,State Senate,SD11,Rep,Joseph Concannon,128
-Queens,26007,State Senate,SD11,Rep,Joseph Concannon,107
-Queens,26008,State Senate,SD11,Rep,Joseph Concannon,177
-Queens,26009,State Senate,SD11,Rep,Joseph Concannon,140
-Queens,26010,State Senate,SD11,Rep,Joseph Concannon,146
-Queens,26011,State Senate,SD11,Rep,Joseph Concannon,148
-Queens,26012,State Senate,SD11,Rep,Joseph Concannon,160
-Queens,26013,State Senate,SD11,Rep,Joseph Concannon,164
-Queens,26014,State Senate,SD11,Rep,Joseph Concannon,193
-Queens,26015,State Senate,SD11,Rep,Joseph Concannon,120
-Queens,26016,State Senate,SD11,Rep,Joseph Concannon,188
-Queens,26017,State Senate,SD11,Rep,Joseph Concannon,190
-Queens,26018,State Senate,SD11,Rep,Joseph Concannon,212
-Queens,26019,State Senate,SD11,Rep,Joseph Concannon,148
-Queens,26020,State Senate,SD11,Rep,Joseph Concannon,159
-Queens,26021,State Senate,SD11,Rep,Joseph Concannon,93
-Queens,26022,State Senate,SD11,Rep,Joseph Concannon,123
-Queens,26023,State Senate,SD11,Rep,Joseph Concannon,113
-Queens,26024,State Senate,SD11,Rep,Joseph Concannon,86
-Queens,26025,State Senate,SD11,Rep,Joseph Concannon,125
-Queens,26026,State Senate,SD11,Rep,Joseph Concannon,43
-Queens,26027,State Senate,SD11,Rep,Joseph Concannon,154
-Queens,26028,State Senate,SD11,Rep,Joseph Concannon,176
-Queens,26029,State Senate,SD11,Rep,Joseph Concannon,218
-Queens,26030,State Senate,SD11,Rep,Joseph Concannon,219
-Queens,26031,State Senate,SD11,Rep,Joseph Concannon,244
-Queens,26032,State Senate,SD11,Rep,Joseph Concannon,143
-Queens,26033,State Senate,SD11,Rep,Joseph Concannon,202
-Queens,26034,State Senate,SD11,Rep,Joseph Concannon,98
-Queens,26035,State Senate,SD11,Rep,Joseph Concannon,165
-Queens,26036,State Senate,SD11,Rep,Joseph Concannon,125
-Queens,26037,State Senate,SD11,Rep,Joseph Concannon,158
-Queens,26042,State Senate,SD11,Rep,Joseph Concannon,89
-Queens,26043,State Senate,SD11,Rep,Joseph Concannon,88
-Queens,26045,State Senate,SD11,Rep,Joseph Concannon,112
-Queens,26046,State Senate,SD11,Rep,Joseph Concannon,129
-Queens,26047,State Senate,SD11,Rep,Joseph Concannon,114
-Queens,26048,State Senate,SD11,Rep,Joseph Concannon,104
-Queens,26049,State Senate,SD11,Rep,Joseph Concannon,82
-Queens,26050,State Senate,SD11,Rep,Joseph Concannon,102
-Queens,26051,State Senate,SD11,Rep,Joseph Concannon,60
-Queens,26052,State Senate,SD11,Rep,Joseph Concannon,78
-Queens,26053,State Senate,SD11,Rep,Joseph Concannon,153
-Queens,26054,State Senate,SD11,Rep,Joseph Concannon,142
-Queens,26055,State Senate,SD11,Rep,Joseph Concannon,98
-Queens,26056,State Senate,SD11,Rep,Joseph Concannon,69
-Queens,26057,State Senate,SD11,Rep,Joseph Concannon,125
-Queens,26058,State Senate,SD11,Rep,Joseph Concannon,127
-Queens,26059,State Senate,SD11,Rep,Joseph Concannon,172
-Queens,26060,State Senate,SD11,Rep,Joseph Concannon,187
-Queens,26061,State Senate,SD11,Rep,Joseph Concannon,159
-Queens,26062,State Senate,SD11,Rep,Joseph Concannon,146
-Queens,26063,State Senate,SD11,Rep,Joseph Concannon,163
-Queens,26064,State Senate,SD11,Rep,Joseph Concannon,138
-Queens,26065,State Senate,SD11,Rep,Joseph Concannon,139
-Queens,26066,State Senate,SD11,Rep,Joseph Concannon,204
-Queens,26067,State Senate,SD11,Rep,Joseph Concannon,184
-Queens,26068,State Senate,SD11,Rep,Joseph Concannon,206
-Queens,26069,State Senate,SD11,Rep,Joseph Concannon,210
-Queens,26070,State Senate,SD11,Rep,Joseph Concannon,100
-Queens,26071,State Senate,SD11,Rep,Joseph Concannon,76
-Queens,26072,State Senate,SD11,Rep,Joseph Concannon,134
-Queens,26073,State Senate,SD11,Rep,Joseph Concannon,74
-Queens,26074,State Senate,SD11,Rep,Joseph Concannon,126
-Queens,26076,State Senate,SD11,Rep,Joseph Concannon,91
-Queens,26077,State Senate,SD11,Rep,Joseph Concannon,134
-Queens,27010,State Senate,SD11,Rep,Joseph Concannon,6
-Queens,27033,State Senate,SD11,Rep,Joseph Concannon,13
-Queens,27060,State Senate,SD11,Rep,Joseph Concannon,104
-Queens,27061,State Senate,SD11,Rep,Joseph Concannon,102
-Queens,27062,State Senate,SD11,Rep,Joseph Concannon,93
-Queens,27063,State Senate,SD11,Rep,Joseph Concannon,69
-Queens,27064,State Senate,SD11,Rep,Joseph Concannon,78
-Queens,27065,State Senate,SD11,Rep,Joseph Concannon,114
-Queens,27066,State Senate,SD11,Rep,Joseph Concannon,127
-Queens,27067,State Senate,SD11,Rep,Joseph Concannon,98
-Queens,27068,State Senate,SD11,Rep,Joseph Concannon,82
-Queens,27069,State Senate,SD11,Rep,Joseph Concannon,101
-Queens,27070,State Senate,SD11,Rep,Joseph Concannon,150
-Queens,27071,State Senate,SD11,Rep,Joseph Concannon,234
-Queens,27072,State Senate,SD11,Rep,Joseph Concannon,157
-Queens,29004,State Senate,SD11,Rep,Joseph Concannon,24
-Queens,29005,State Senate,SD11,Rep,Joseph Concannon,4
-Queens,29007,State Senate,SD11,Rep,Joseph Concannon,11
-Queens,29009,State Senate,SD11,Rep,Joseph Concannon,57
-Queens,29010,State Senate,SD11,Rep,Joseph Concannon,63
-Queens,29011,State Senate,SD11,Rep,Joseph Concannon,31
-Queens,32002,State Senate,SD11,Rep,Joseph Concannon,0
-Queens,32007,State Senate,SD11,Rep,Joseph Concannon,7
-Queens,32008,State Senate,SD11,Rep,Joseph Concannon,5
-Queens,32009,State Senate,SD11,Rep,Joseph Concannon,3
-Queens,32010,State Senate,SD11,Rep,Joseph Concannon,2
-Queens,33001,State Senate,SD11,Rep,Joseph Concannon,123
-Queens,33002,State Senate,SD11,Rep,Joseph Concannon,167
-Queens,33003,State Senate,SD11,Rep,Joseph Concannon,125
-Queens,33004,State Senate,SD11,Rep,Joseph Concannon,106
-Queens,33005,State Senate,SD11,Rep,Joseph Concannon,139
-Queens,33006,State Senate,SD11,Rep,Joseph Concannon,163
-Queens,33007,State Senate,SD11,Rep,Joseph Concannon,162
-Queens,33008,State Senate,SD11,Rep,Joseph Concannon,83
-Queens,33009,State Senate,SD11,Rep,Joseph Concannon,145
-Queens,33010,State Senate,SD11,Rep,Joseph Concannon,80
-Queens,33011,State Senate,SD11,Rep,Joseph Concannon,146
-Queens,33012,State Senate,SD11,Rep,Joseph Concannon,149
-Queens,33013,State Senate,SD11,Rep,Joseph Concannon,119
-Queens,33014,State Senate,SD11,Rep,Joseph Concannon,80
-Queens,33015,State Senate,SD11,Rep,Joseph Concannon,74
-Queens,40001,State Senate,SD11,Rep,Joseph Concannon,166
-Queens,40002,State Senate,SD11,Rep,Joseph Concannon,121
-Queens,40003,State Senate,SD11,Rep,Joseph Concannon,3
-Queens,40004,State Senate,SD11,Rep,Joseph Concannon,96
-Queens,40005,State Senate,SD11,Rep,Joseph Concannon,189
-Queens,40006,State Senate,SD11,Rep,Joseph Concannon,189
-Queens,40007,State Senate,SD11,Rep,Joseph Concannon,185
-Queens,40008,State Senate,SD11,Rep,Joseph Concannon,76
-Queens,40009,State Senate,SD11,Rep,Joseph Concannon,160
-Queens,40010,State Senate,SD11,Rep,Joseph Concannon,0
-Queens,40013,State Senate,SD11,Rep,Joseph Concannon,85
-Queens,40014,State Senate,SD11,Rep,Joseph Concannon,105
-Queens,40015,State Senate,SD11,Rep,Joseph Concannon,73
-Queens,40028,State Senate,SD11,Rep,Joseph Concannon,29
-Queens,40047,State Senate,SD11,Rep,Joseph Concannon,75
-Queens,40048,State Senate,SD11,Rep,Joseph Concannon,78
-Queens,40049,State Senate,SD11,Rep,Joseph Concannon,45
-Queens,40050,State Senate,SD11,Rep,Joseph Concannon,14
-Queens,40051,State Senate,SD11,Rep,Joseph Concannon,16
-Queens,24001,State Senate,SD11,Con,Joseph Concannon,15
-Queens,24002,State Senate,SD11,Con,Joseph Concannon,11
-Queens,24003,State Senate,SD11,Con,Joseph Concannon,19
-Queens,24004,State Senate,SD11,Con,Joseph Concannon,6
-Queens,24005,State Senate,SD11,Con,Joseph Concannon,15
-Queens,24006,State Senate,SD11,Con,Joseph Concannon,13
-Queens,24007,State Senate,SD11,Con,Joseph Concannon,16
-Queens,24010,State Senate,SD11,Con,Joseph Concannon,6
-Queens,24011,State Senate,SD11,Con,Joseph Concannon,11
-Queens,24012,State Senate,SD11,Con,Joseph Concannon,2
-Queens,24017,State Senate,SD11,Con,Joseph Concannon,10
-Queens,24018,State Senate,SD11,Con,Joseph Concannon,16
-Queens,24019,State Senate,SD11,Con,Joseph Concannon,17
-Queens,24020,State Senate,SD11,Con,Joseph Concannon,8
-Queens,24021,State Senate,SD11,Con,Joseph Concannon,16
-Queens,24022,State Senate,SD11,Con,Joseph Concannon,7
-Queens,24024,State Senate,SD11,Con,Joseph Concannon,17
-Queens,24025,State Senate,SD11,Con,Joseph Concannon,13
-Queens,24028,State Senate,SD11,Con,Joseph Concannon,5
-Queens,24032,State Senate,SD11,Con,Joseph Concannon,6
-Queens,24033,State Senate,SD11,Con,Joseph Concannon,13
-Queens,24034,State Senate,SD11,Con,Joseph Concannon,4
-Queens,24035,State Senate,SD11,Con,Joseph Concannon,6
-Queens,24036,State Senate,SD11,Con,Joseph Concannon,0
-Queens,24038,State Senate,SD11,Con,Joseph Concannon,0
-Queens,24042,State Senate,SD11,Con,Joseph Concannon,4
-Queens,24050,State Senate,SD11,Con,Joseph Concannon,7
-Queens,24051,State Senate,SD11,Con,Joseph Concannon,12
-Queens,24052,State Senate,SD11,Con,Joseph Concannon,3
-Queens,24053,State Senate,SD11,Con,Joseph Concannon,10
-Queens,24054,State Senate,SD11,Con,Joseph Concannon,1
-Queens,24055,State Senate,SD11,Con,Joseph Concannon,1
-Queens,24057,State Senate,SD11,Con,Joseph Concannon,0
-Queens,24067,State Senate,SD11,Con,Joseph Concannon,2
-Queens,25010,State Senate,SD11,Con,Joseph Concannon,6
-Queens,25011,State Senate,SD11,Con,Joseph Concannon,12
-Queens,25012,State Senate,SD11,Con,Joseph Concannon,14
-Queens,25013,State Senate,SD11,Con,Joseph Concannon,12
-Queens,25014,State Senate,SD11,Con,Joseph Concannon,9
-Queens,25015,State Senate,SD11,Con,Joseph Concannon,15
-Queens,25016,State Senate,SD11,Con,Joseph Concannon,18
-Queens,25017,State Senate,SD11,Con,Joseph Concannon,10
-Queens,25018,State Senate,SD11,Con,Joseph Concannon,8
-Queens,25019,State Senate,SD11,Con,Joseph Concannon,12
-Queens,25026,State Senate,SD11,Con,Joseph Concannon,1
-Queens,25027,State Senate,SD11,Con,Joseph Concannon,20
-Queens,25028,State Senate,SD11,Con,Joseph Concannon,7
-Queens,25029,State Senate,SD11,Con,Joseph Concannon,20
-Queens,25030,State Senate,SD11,Con,Joseph Concannon,10
-Queens,25031,State Senate,SD11,Con,Joseph Concannon,9
-Queens,25032,State Senate,SD11,Con,Joseph Concannon,2
-Queens,25033,State Senate,SD11,Con,Joseph Concannon,15
-Queens,25035,State Senate,SD11,Con,Joseph Concannon,16
-Queens,25036,State Senate,SD11,Con,Joseph Concannon,11
-Queens,25037,State Senate,SD11,Con,Joseph Concannon,12
-Queens,25038,State Senate,SD11,Con,Joseph Concannon,13
-Queens,25039,State Senate,SD11,Con,Joseph Concannon,25
-Queens,25040,State Senate,SD11,Con,Joseph Concannon,23
-Queens,25041,State Senate,SD11,Con,Joseph Concannon,0
-Queens,25065,State Senate,SD11,Con,Joseph Concannon,9
-Queens,25066,State Senate,SD11,Con,Joseph Concannon,1
-Queens,25067,State Senate,SD11,Con,Joseph Concannon,10
-Queens,25068,State Senate,SD11,Con,Joseph Concannon,15
-Queens,26001,State Senate,SD11,Con,Joseph Concannon,6
-Queens,26002,State Senate,SD11,Con,Joseph Concannon,1
-Queens,26003,State Senate,SD11,Con,Joseph Concannon,14
-Queens,26004,State Senate,SD11,Con,Joseph Concannon,11
-Queens,26005,State Senate,SD11,Con,Joseph Concannon,26
-Queens,26006,State Senate,SD11,Con,Joseph Concannon,15
-Queens,26007,State Senate,SD11,Con,Joseph Concannon,5
-Queens,26008,State Senate,SD11,Con,Joseph Concannon,20
-Queens,26009,State Senate,SD11,Con,Joseph Concannon,16
-Queens,26010,State Senate,SD11,Con,Joseph Concannon,14
-Queens,26011,State Senate,SD11,Con,Joseph Concannon,24
-Queens,26012,State Senate,SD11,Con,Joseph Concannon,19
-Queens,26013,State Senate,SD11,Con,Joseph Concannon,19
-Queens,26014,State Senate,SD11,Con,Joseph Concannon,20
-Queens,26015,State Senate,SD11,Con,Joseph Concannon,15
-Queens,26016,State Senate,SD11,Con,Joseph Concannon,17
-Queens,26017,State Senate,SD11,Con,Joseph Concannon,14
-Queens,26018,State Senate,SD11,Con,Joseph Concannon,18
-Queens,26019,State Senate,SD11,Con,Joseph Concannon,11
-Queens,26020,State Senate,SD11,Con,Joseph Concannon,12
-Queens,26021,State Senate,SD11,Con,Joseph Concannon,8
-Queens,26022,State Senate,SD11,Con,Joseph Concannon,8
-Queens,26023,State Senate,SD11,Con,Joseph Concannon,9
-Queens,26024,State Senate,SD11,Con,Joseph Concannon,9
-Queens,26025,State Senate,SD11,Con,Joseph Concannon,5
-Queens,26026,State Senate,SD11,Con,Joseph Concannon,3
-Queens,26027,State Senate,SD11,Con,Joseph Concannon,14
-Queens,26028,State Senate,SD11,Con,Joseph Concannon,18
-Queens,26029,State Senate,SD11,Con,Joseph Concannon,14
-Queens,26030,State Senate,SD11,Con,Joseph Concannon,28
-Queens,26031,State Senate,SD11,Con,Joseph Concannon,22
-Queens,26032,State Senate,SD11,Con,Joseph Concannon,16
-Queens,26033,State Senate,SD11,Con,Joseph Concannon,37
-Queens,26034,State Senate,SD11,Con,Joseph Concannon,15
-Queens,26035,State Senate,SD11,Con,Joseph Concannon,15
-Queens,26036,State Senate,SD11,Con,Joseph Concannon,17
-Queens,26037,State Senate,SD11,Con,Joseph Concannon,16
-Queens,26042,State Senate,SD11,Con,Joseph Concannon,16
-Queens,26043,State Senate,SD11,Con,Joseph Concannon,2
-Queens,26045,State Senate,SD11,Con,Joseph Concannon,16
-Queens,26046,State Senate,SD11,Con,Joseph Concannon,10
-Queens,26047,State Senate,SD11,Con,Joseph Concannon,12
-Queens,26048,State Senate,SD11,Con,Joseph Concannon,6
-Queens,26049,State Senate,SD11,Con,Joseph Concannon,12
-Queens,26050,State Senate,SD11,Con,Joseph Concannon,8
-Queens,26051,State Senate,SD11,Con,Joseph Concannon,9
-Queens,26052,State Senate,SD11,Con,Joseph Concannon,9
-Queens,26053,State Senate,SD11,Con,Joseph Concannon,13
-Queens,26054,State Senate,SD11,Con,Joseph Concannon,25
-Queens,26055,State Senate,SD11,Con,Joseph Concannon,16
-Queens,26056,State Senate,SD11,Con,Joseph Concannon,15
-Queens,26057,State Senate,SD11,Con,Joseph Concannon,19
-Queens,26058,State Senate,SD11,Con,Joseph Concannon,16
-Queens,26059,State Senate,SD11,Con,Joseph Concannon,34
-Queens,26060,State Senate,SD11,Con,Joseph Concannon,28
-Queens,26061,State Senate,SD11,Con,Joseph Concannon,12
-Queens,26062,State Senate,SD11,Con,Joseph Concannon,15
-Queens,26063,State Senate,SD11,Con,Joseph Concannon,19
-Queens,26064,State Senate,SD11,Con,Joseph Concannon,18
-Queens,26065,State Senate,SD11,Con,Joseph Concannon,22
-Queens,26066,State Senate,SD11,Con,Joseph Concannon,34
-Queens,26067,State Senate,SD11,Con,Joseph Concannon,18
-Queens,26068,State Senate,SD11,Con,Joseph Concannon,13
-Queens,26069,State Senate,SD11,Con,Joseph Concannon,21
-Queens,26070,State Senate,SD11,Con,Joseph Concannon,22
-Queens,26071,State Senate,SD11,Con,Joseph Concannon,2
-Queens,26072,State Senate,SD11,Con,Joseph Concannon,9
-Queens,26073,State Senate,SD11,Con,Joseph Concannon,4
-Queens,26074,State Senate,SD11,Con,Joseph Concannon,12
-Queens,26076,State Senate,SD11,Con,Joseph Concannon,7
-Queens,26077,State Senate,SD11,Con,Joseph Concannon,17
-Queens,27010,State Senate,SD11,Con,Joseph Concannon,0
-Queens,27033,State Senate,SD11,Con,Joseph Concannon,0
-Queens,27060,State Senate,SD11,Con,Joseph Concannon,4
-Queens,27061,State Senate,SD11,Con,Joseph Concannon,8
-Queens,27062,State Senate,SD11,Con,Joseph Concannon,14
-Queens,27063,State Senate,SD11,Con,Joseph Concannon,10
-Queens,27064,State Senate,SD11,Con,Joseph Concannon,16
-Queens,27065,State Senate,SD11,Con,Joseph Concannon,8
-Queens,27066,State Senate,SD11,Con,Joseph Concannon,15
-Queens,27067,State Senate,SD11,Con,Joseph Concannon,17
-Queens,27068,State Senate,SD11,Con,Joseph Concannon,9
-Queens,27069,State Senate,SD11,Con,Joseph Concannon,9
-Queens,27070,State Senate,SD11,Con,Joseph Concannon,6
-Queens,27071,State Senate,SD11,Con,Joseph Concannon,19
-Queens,27072,State Senate,SD11,Con,Joseph Concannon,18
-Queens,29004,State Senate,SD11,Con,Joseph Concannon,2
-Queens,29005,State Senate,SD11,Con,Joseph Concannon,0
-Queens,29007,State Senate,SD11,Con,Joseph Concannon,1
-Queens,29009,State Senate,SD11,Con,Joseph Concannon,1
-Queens,29010,State Senate,SD11,Con,Joseph Concannon,4
-Queens,29011,State Senate,SD11,Con,Joseph Concannon,0
-Queens,32002,State Senate,SD11,Con,Joseph Concannon,0
-Queens,32007,State Senate,SD11,Con,Joseph Concannon,1
-Queens,32008,State Senate,SD11,Con,Joseph Concannon,0
-Queens,32009,State Senate,SD11,Con,Joseph Concannon,0
-Queens,32010,State Senate,SD11,Con,Joseph Concannon,1
-Queens,33001,State Senate,SD11,Con,Joseph Concannon,14
-Queens,33002,State Senate,SD11,Con,Joseph Concannon,15
-Queens,33003,State Senate,SD11,Con,Joseph Concannon,13
-Queens,33004,State Senate,SD11,Con,Joseph Concannon,17
-Queens,33005,State Senate,SD11,Con,Joseph Concannon,16
-Queens,33006,State Senate,SD11,Con,Joseph Concannon,39
-Queens,33007,State Senate,SD11,Con,Joseph Concannon,23
-Queens,33008,State Senate,SD11,Con,Joseph Concannon,13
-Queens,33009,State Senate,SD11,Con,Joseph Concannon,37
-Queens,33010,State Senate,SD11,Con,Joseph Concannon,13
-Queens,33011,State Senate,SD11,Con,Joseph Concannon,19
-Queens,33012,State Senate,SD11,Con,Joseph Concannon,27
-Queens,33013,State Senate,SD11,Con,Joseph Concannon,7
-Queens,33014,State Senate,SD11,Con,Joseph Concannon,3
-Queens,33015,State Senate,SD11,Con,Joseph Concannon,14
-Queens,40001,State Senate,SD11,Con,Joseph Concannon,16
-Queens,40002,State Senate,SD11,Con,Joseph Concannon,15
-Queens,40003,State Senate,SD11,Con,Joseph Concannon,1
-Queens,40004,State Senate,SD11,Con,Joseph Concannon,13
-Queens,40005,State Senate,SD11,Con,Joseph Concannon,17
-Queens,40006,State Senate,SD11,Con,Joseph Concannon,22
-Queens,40007,State Senate,SD11,Con,Joseph Concannon,22
-Queens,40008,State Senate,SD11,Con,Joseph Concannon,10
-Queens,40009,State Senate,SD11,Con,Joseph Concannon,19
-Queens,40010,State Senate,SD11,Con,Joseph Concannon,0
-Queens,40013,State Senate,SD11,Con,Joseph Concannon,13
-Queens,40014,State Senate,SD11,Con,Joseph Concannon,6
-Queens,40015,State Senate,SD11,Con,Joseph Concannon,5
-Queens,40028,State Senate,SD11,Con,Joseph Concannon,2
-Queens,40047,State Senate,SD11,Con,Joseph Concannon,21
-Queens,40048,State Senate,SD11,Con,Joseph Concannon,9
-Queens,40049,State Senate,SD11,Con,Joseph Concannon,7
-Queens,40050,State Senate,SD11,Con,Joseph Concannon,1
-Queens,40051,State Senate,SD11,Con,Joseph Concannon,2
-Queens,24001,State Senate,SD11,Dem,Tony Avella,504
-Queens,24002,State Senate,SD11,Dem,Tony Avella,481
-Queens,24003,State Senate,SD11,Dem,Tony Avella,377
-Queens,24004,State Senate,SD11,Dem,Tony Avella,212
-Queens,24005,State Senate,SD11,Dem,Tony Avella,418
-Queens,24006,State Senate,SD11,Dem,Tony Avella,354
-Queens,24007,State Senate,SD11,Dem,Tony Avella,311
-Queens,24010,State Senate,SD11,Dem,Tony Avella,190
-Queens,24011,State Senate,SD11,Dem,Tony Avella,507
-Queens,24012,State Senate,SD11,Dem,Tony Avella,59
-Queens,24017,State Senate,SD11,Dem,Tony Avella,387
-Queens,24018,State Senate,SD11,Dem,Tony Avella,482
-Queens,24019,State Senate,SD11,Dem,Tony Avella,397
-Queens,24020,State Senate,SD11,Dem,Tony Avella,466
-Queens,24021,State Senate,SD11,Dem,Tony Avella,478
-Queens,24022,State Senate,SD11,Dem,Tony Avella,182
-Queens,24024,State Senate,SD11,Dem,Tony Avella,424
-Queens,24025,State Senate,SD11,Dem,Tony Avella,454
-Queens,24028,State Senate,SD11,Dem,Tony Avella,303
-Queens,24032,State Senate,SD11,Dem,Tony Avella,172
-Queens,24033,State Senate,SD11,Dem,Tony Avella,264
-Queens,24034,State Senate,SD11,Dem,Tony Avella,177
-Queens,24035,State Senate,SD11,Dem,Tony Avella,338
-Queens,24036,State Senate,SD11,Dem,Tony Avella,174
-Queens,24038,State Senate,SD11,Dem,Tony Avella,10
-Queens,24042,State Senate,SD11,Dem,Tony Avella,188
-Queens,24050,State Senate,SD11,Dem,Tony Avella,393
-Queens,24051,State Senate,SD11,Dem,Tony Avella,426
-Queens,24052,State Senate,SD11,Dem,Tony Avella,390
-Queens,24053,State Senate,SD11,Dem,Tony Avella,489
-Queens,24054,State Senate,SD11,Dem,Tony Avella,402
-Queens,24055,State Senate,SD11,Dem,Tony Avella,292
-Queens,24057,State Senate,SD11,Dem,Tony Avella,156
-Queens,24067,State Senate,SD11,Dem,Tony Avella,300
-Queens,25010,State Senate,SD11,Dem,Tony Avella,291
-Queens,25011,State Senate,SD11,Dem,Tony Avella,251
-Queens,25012,State Senate,SD11,Dem,Tony Avella,286
-Queens,25013,State Senate,SD11,Dem,Tony Avella,229
-Queens,25014,State Senate,SD11,Dem,Tony Avella,210
-Queens,25015,State Senate,SD11,Dem,Tony Avella,245
-Queens,25016,State Senate,SD11,Dem,Tony Avella,371
-Queens,25017,State Senate,SD11,Dem,Tony Avella,409
-Queens,25018,State Senate,SD11,Dem,Tony Avella,502
-Queens,25019,State Senate,SD11,Dem,Tony Avella,513
-Queens,25026,State Senate,SD11,Dem,Tony Avella,47
-Queens,25027,State Senate,SD11,Dem,Tony Avella,295
-Queens,25028,State Senate,SD11,Dem,Tony Avella,155
-Queens,25029,State Senate,SD11,Dem,Tony Avella,346
-Queens,25030,State Senate,SD11,Dem,Tony Avella,426
-Queens,25031,State Senate,SD11,Dem,Tony Avella,422
-Queens,25032,State Senate,SD11,Dem,Tony Avella,296
-Queens,25033,State Senate,SD11,Dem,Tony Avella,374
-Queens,25035,State Senate,SD11,Dem,Tony Avella,219
-Queens,25036,State Senate,SD11,Dem,Tony Avella,229
-Queens,25037,State Senate,SD11,Dem,Tony Avella,340
-Queens,25038,State Senate,SD11,Dem,Tony Avella,280
-Queens,25039,State Senate,SD11,Dem,Tony Avella,381
-Queens,25040,State Senate,SD11,Dem,Tony Avella,370
-Queens,25041,State Senate,SD11,Dem,Tony Avella,98
-Queens,25065,State Senate,SD11,Dem,Tony Avella,290
-Queens,25066,State Senate,SD11,Dem,Tony Avella,40
-Queens,25067,State Senate,SD11,Dem,Tony Avella,407
-Queens,25068,State Senate,SD11,Dem,Tony Avella,233
-Queens,26001,State Senate,SD11,Dem,Tony Avella,132
-Queens,26002,State Senate,SD11,Dem,Tony Avella,75
-Queens,26003,State Senate,SD11,Dem,Tony Avella,399
-Queens,26004,State Senate,SD11,Dem,Tony Avella,334
-Queens,26005,State Senate,SD11,Dem,Tony Avella,363
-Queens,26006,State Senate,SD11,Dem,Tony Avella,334
-Queens,26007,State Senate,SD11,Dem,Tony Avella,264
-Queens,26008,State Senate,SD11,Dem,Tony Avella,445
-Queens,26009,State Senate,SD11,Dem,Tony Avella,404
-Queens,26010,State Senate,SD11,Dem,Tony Avella,421
-Queens,26011,State Senate,SD11,Dem,Tony Avella,269
-Queens,26012,State Senate,SD11,Dem,Tony Avella,214
-Queens,26013,State Senate,SD11,Dem,Tony Avella,369
-Queens,26014,State Senate,SD11,Dem,Tony Avella,311
-Queens,26015,State Senate,SD11,Dem,Tony Avella,349
-Queens,26016,State Senate,SD11,Dem,Tony Avella,412
-Queens,26017,State Senate,SD11,Dem,Tony Avella,402
-Queens,26018,State Senate,SD11,Dem,Tony Avella,200
-Queens,26019,State Senate,SD11,Dem,Tony Avella,433
-Queens,26020,State Senate,SD11,Dem,Tony Avella,500
-Queens,26021,State Senate,SD11,Dem,Tony Avella,334
-Queens,26022,State Senate,SD11,Dem,Tony Avella,546
-Queens,26023,State Senate,SD11,Dem,Tony Avella,459
-Queens,26024,State Senate,SD11,Dem,Tony Avella,418
-Queens,26025,State Senate,SD11,Dem,Tony Avella,343
-Queens,26026,State Senate,SD11,Dem,Tony Avella,232
-Queens,26027,State Senate,SD11,Dem,Tony Avella,478
-Queens,26028,State Senate,SD11,Dem,Tony Avella,354
-Queens,26029,State Senate,SD11,Dem,Tony Avella,349
-Queens,26030,State Senate,SD11,Dem,Tony Avella,384
-Queens,26031,State Senate,SD11,Dem,Tony Avella,372
-Queens,26032,State Senate,SD11,Dem,Tony Avella,376
-Queens,26033,State Senate,SD11,Dem,Tony Avella,384
-Queens,26034,State Senate,SD11,Dem,Tony Avella,169
-Queens,26035,State Senate,SD11,Dem,Tony Avella,352
-Queens,26036,State Senate,SD11,Dem,Tony Avella,382
-Queens,26037,State Senate,SD11,Dem,Tony Avella,386
-Queens,26042,State Senate,SD11,Dem,Tony Avella,274
-Queens,26043,State Senate,SD11,Dem,Tony Avella,124
-Queens,26045,State Senate,SD11,Dem,Tony Avella,450
-Queens,26046,State Senate,SD11,Dem,Tony Avella,447
-Queens,26047,State Senate,SD11,Dem,Tony Avella,510
-Queens,26048,State Senate,SD11,Dem,Tony Avella,242
-Queens,26049,State Senate,SD11,Dem,Tony Avella,224
-Queens,26050,State Senate,SD11,Dem,Tony Avella,333
-Queens,26051,State Senate,SD11,Dem,Tony Avella,228
-Queens,26052,State Senate,SD11,Dem,Tony Avella,298
-Queens,26053,State Senate,SD11,Dem,Tony Avella,430
-Queens,26054,State Senate,SD11,Dem,Tony Avella,340
-Queens,26055,State Senate,SD11,Dem,Tony Avella,304
-Queens,26056,State Senate,SD11,Dem,Tony Avella,171
-Queens,26057,State Senate,SD11,Dem,Tony Avella,379
-Queens,26058,State Senate,SD11,Dem,Tony Avella,391
-Queens,26059,State Senate,SD11,Dem,Tony Avella,374
-Queens,26060,State Senate,SD11,Dem,Tony Avella,389
-Queens,26061,State Senate,SD11,Dem,Tony Avella,370
-Queens,26062,State Senate,SD11,Dem,Tony Avella,380
-Queens,26063,State Senate,SD11,Dem,Tony Avella,410
-Queens,26064,State Senate,SD11,Dem,Tony Avella,319
-Queens,26065,State Senate,SD11,Dem,Tony Avella,417
-Queens,26066,State Senate,SD11,Dem,Tony Avella,409
-Queens,26067,State Senate,SD11,Dem,Tony Avella,321
-Queens,26068,State Senate,SD11,Dem,Tony Avella,283
-Queens,26069,State Senate,SD11,Dem,Tony Avella,407
-Queens,26070,State Senate,SD11,Dem,Tony Avella,403
-Queens,26071,State Senate,SD11,Dem,Tony Avella,351
-Queens,26072,State Senate,SD11,Dem,Tony Avella,562
-Queens,26073,State Senate,SD11,Dem,Tony Avella,352
-Queens,26074,State Senate,SD11,Dem,Tony Avella,433
-Queens,26076,State Senate,SD11,Dem,Tony Avella,290
-Queens,26077,State Senate,SD11,Dem,Tony Avella,366
-Queens,27010,State Senate,SD11,Dem,Tony Avella,27
-Queens,27033,State Senate,SD11,Dem,Tony Avella,45
-Queens,27060,State Senate,SD11,Dem,Tony Avella,365
-Queens,27061,State Senate,SD11,Dem,Tony Avella,382
-Queens,27062,State Senate,SD11,Dem,Tony Avella,388
-Queens,27063,State Senate,SD11,Dem,Tony Avella,293
-Queens,27064,State Senate,SD11,Dem,Tony Avella,399
-Queens,27065,State Senate,SD11,Dem,Tony Avella,337
-Queens,27066,State Senate,SD11,Dem,Tony Avella,382
-Queens,27067,State Senate,SD11,Dem,Tony Avella,369
-Queens,27068,State Senate,SD11,Dem,Tony Avella,309
-Queens,27069,State Senate,SD11,Dem,Tony Avella,270
-Queens,27070,State Senate,SD11,Dem,Tony Avella,133
-Queens,27071,State Senate,SD11,Dem,Tony Avella,342
-Queens,27072,State Senate,SD11,Dem,Tony Avella,296
-Queens,29004,State Senate,SD11,Dem,Tony Avella,453
-Queens,29005,State Senate,SD11,Dem,Tony Avella,87
-Queens,29007,State Senate,SD11,Dem,Tony Avella,32
-Queens,29009,State Senate,SD11,Dem,Tony Avella,417
-Queens,29010,State Senate,SD11,Dem,Tony Avella,420
-Queens,29011,State Senate,SD11,Dem,Tony Avella,178
-Queens,32002,State Senate,SD11,Dem,Tony Avella,13
-Queens,32007,State Senate,SD11,Dem,Tony Avella,78
-Queens,32008,State Senate,SD11,Dem,Tony Avella,72
-Queens,32009,State Senate,SD11,Dem,Tony Avella,91
-Queens,32010,State Senate,SD11,Dem,Tony Avella,29
-Queens,33001,State Senate,SD11,Dem,Tony Avella,351
-Queens,33002,State Senate,SD11,Dem,Tony Avella,364
-Queens,33003,State Senate,SD11,Dem,Tony Avella,387
-Queens,33004,State Senate,SD11,Dem,Tony Avella,437
-Queens,33005,State Senate,SD11,Dem,Tony Avella,418
-Queens,33006,State Senate,SD11,Dem,Tony Avella,395
-Queens,33007,State Senate,SD11,Dem,Tony Avella,410
-Queens,33008,State Senate,SD11,Dem,Tony Avella,233
-Queens,33009,State Senate,SD11,Dem,Tony Avella,333
-Queens,33010,State Senate,SD11,Dem,Tony Avella,235
-Queens,33011,State Senate,SD11,Dem,Tony Avella,258
-Queens,33012,State Senate,SD11,Dem,Tony Avella,391
-Queens,33013,State Senate,SD11,Dem,Tony Avella,447
-Queens,33014,State Senate,SD11,Dem,Tony Avella,389
-Queens,33015,State Senate,SD11,Dem,Tony Avella,278
-Queens,40001,State Senate,SD11,Dem,Tony Avella,240
-Queens,40002,State Senate,SD11,Dem,Tony Avella,229
-Queens,40003,State Senate,SD11,Dem,Tony Avella,22
-Queens,40004,State Senate,SD11,Dem,Tony Avella,206
-Queens,40005,State Senate,SD11,Dem,Tony Avella,324
-Queens,40006,State Senate,SD11,Dem,Tony Avella,289
-Queens,40007,State Senate,SD11,Dem,Tony Avella,400
-Queens,40008,State Senate,SD11,Dem,Tony Avella,257
-Queens,40009,State Senate,SD11,Dem,Tony Avella,277
-Queens,40010,State Senate,SD11,Dem,Tony Avella,2
-Queens,40013,State Senate,SD11,Dem,Tony Avella,221
-Queens,40014,State Senate,SD11,Dem,Tony Avella,369
-Queens,40015,State Senate,SD11,Dem,Tony Avella,298
-Queens,40028,State Senate,SD11,Dem,Tony Avella,152
-Queens,40047,State Senate,SD11,Dem,Tony Avella,341
-Queens,40048,State Senate,SD11,Dem,Tony Avella,386
-Queens,40049,State Senate,SD11,Dem,Tony Avella,182
-Queens,40050,State Senate,SD11,Dem,Tony Avella,316
-Queens,40051,State Senate,SD11,Dem,Tony Avella,322
-Queens,24001,State Senate,SD11,WF,Tony Avella,13
-Queens,24002,State Senate,SD11,WF,Tony Avella,25
-Queens,24003,State Senate,SD11,WF,Tony Avella,12
-Queens,24004,State Senate,SD11,WF,Tony Avella,10
-Queens,24005,State Senate,SD11,WF,Tony Avella,19
-Queens,24006,State Senate,SD11,WF,Tony Avella,13
-Queens,24007,State Senate,SD11,WF,Tony Avella,10
-Queens,24010,State Senate,SD11,WF,Tony Avella,4
-Queens,24011,State Senate,SD11,WF,Tony Avella,14
-Queens,24012,State Senate,SD11,WF,Tony Avella,3
-Queens,24017,State Senate,SD11,WF,Tony Avella,10
-Queens,24018,State Senate,SD11,WF,Tony Avella,19
-Queens,24019,State Senate,SD11,WF,Tony Avella,13
-Queens,24020,State Senate,SD11,WF,Tony Avella,12
-Queens,24021,State Senate,SD11,WF,Tony Avella,21
-Queens,24022,State Senate,SD11,WF,Tony Avella,12
-Queens,24024,State Senate,SD11,WF,Tony Avella,20
-Queens,24025,State Senate,SD11,WF,Tony Avella,10
-Queens,24028,State Senate,SD11,WF,Tony Avella,12
-Queens,24032,State Senate,SD11,WF,Tony Avella,4
-Queens,24033,State Senate,SD11,WF,Tony Avella,14
-Queens,24034,State Senate,SD11,WF,Tony Avella,10
-Queens,24035,State Senate,SD11,WF,Tony Avella,9
-Queens,24036,State Senate,SD11,WF,Tony Avella,0
-Queens,24038,State Senate,SD11,WF,Tony Avella,1
-Queens,24042,State Senate,SD11,WF,Tony Avella,10
-Queens,24050,State Senate,SD11,WF,Tony Avella,12
-Queens,24051,State Senate,SD11,WF,Tony Avella,6
-Queens,24052,State Senate,SD11,WF,Tony Avella,4
-Queens,24053,State Senate,SD11,WF,Tony Avella,12
-Queens,24054,State Senate,SD11,WF,Tony Avella,7
-Queens,24055,State Senate,SD11,WF,Tony Avella,3
-Queens,24057,State Senate,SD11,WF,Tony Avella,2
-Queens,24067,State Senate,SD11,WF,Tony Avella,5
-Queens,25010,State Senate,SD11,WF,Tony Avella,9
-Queens,25011,State Senate,SD11,WF,Tony Avella,10
-Queens,25012,State Senate,SD11,WF,Tony Avella,10
-Queens,25013,State Senate,SD11,WF,Tony Avella,19
-Queens,25014,State Senate,SD11,WF,Tony Avella,9
-Queens,25015,State Senate,SD11,WF,Tony Avella,10
-Queens,25016,State Senate,SD11,WF,Tony Avella,16
-Queens,25017,State Senate,SD11,WF,Tony Avella,9
-Queens,25018,State Senate,SD11,WF,Tony Avella,17
-Queens,25019,State Senate,SD11,WF,Tony Avella,8
-Queens,25026,State Senate,SD11,WF,Tony Avella,2
-Queens,25027,State Senate,SD11,WF,Tony Avella,15
-Queens,25028,State Senate,SD11,WF,Tony Avella,10
-Queens,25029,State Senate,SD11,WF,Tony Avella,19
-Queens,25030,State Senate,SD11,WF,Tony Avella,11
-Queens,25031,State Senate,SD11,WF,Tony Avella,18
-Queens,25032,State Senate,SD11,WF,Tony Avella,8
-Queens,25033,State Senate,SD11,WF,Tony Avella,15
-Queens,25035,State Senate,SD11,WF,Tony Avella,1
-Queens,25036,State Senate,SD11,WF,Tony Avella,16
-Queens,25037,State Senate,SD11,WF,Tony Avella,19
-Queens,25038,State Senate,SD11,WF,Tony Avella,11
-Queens,25039,State Senate,SD11,WF,Tony Avella,16
-Queens,25040,State Senate,SD11,WF,Tony Avella,17
-Queens,25041,State Senate,SD11,WF,Tony Avella,3
-Queens,25065,State Senate,SD11,WF,Tony Avella,14
-Queens,25066,State Senate,SD11,WF,Tony Avella,1
-Queens,25067,State Senate,SD11,WF,Tony Avella,10
-Queens,25068,State Senate,SD11,WF,Tony Avella,4
-Queens,26001,State Senate,SD11,WF,Tony Avella,4
-Queens,26002,State Senate,SD11,WF,Tony Avella,2
-Queens,26003,State Senate,SD11,WF,Tony Avella,16
-Queens,26004,State Senate,SD11,WF,Tony Avella,31
-Queens,26005,State Senate,SD11,WF,Tony Avella,22
-Queens,26006,State Senate,SD11,WF,Tony Avella,13
-Queens,26007,State Senate,SD11,WF,Tony Avella,13
-Queens,26008,State Senate,SD11,WF,Tony Avella,13
-Queens,26009,State Senate,SD11,WF,Tony Avella,26
-Queens,26010,State Senate,SD11,WF,Tony Avella,19
-Queens,26011,State Senate,SD11,WF,Tony Avella,14
-Queens,26012,State Senate,SD11,WF,Tony Avella,10
-Queens,26013,State Senate,SD11,WF,Tony Avella,13
-Queens,26014,State Senate,SD11,WF,Tony Avella,12
-Queens,26015,State Senate,SD11,WF,Tony Avella,7
-Queens,26016,State Senate,SD11,WF,Tony Avella,7
-Queens,26017,State Senate,SD11,WF,Tony Avella,22
-Queens,26018,State Senate,SD11,WF,Tony Avella,12
-Queens,26019,State Senate,SD11,WF,Tony Avella,9
-Queens,26020,State Senate,SD11,WF,Tony Avella,9
-Queens,26021,State Senate,SD11,WF,Tony Avella,8
-Queens,26022,State Senate,SD11,WF,Tony Avella,19
-Queens,26023,State Senate,SD11,WF,Tony Avella,13
-Queens,26024,State Senate,SD11,WF,Tony Avella,9
-Queens,26025,State Senate,SD11,WF,Tony Avella,3
-Queens,26026,State Senate,SD11,WF,Tony Avella,5
-Queens,26027,State Senate,SD11,WF,Tony Avella,15
-Queens,26028,State Senate,SD11,WF,Tony Avella,11
-Queens,26029,State Senate,SD11,WF,Tony Avella,21
-Queens,26030,State Senate,SD11,WF,Tony Avella,13
-Queens,26031,State Senate,SD11,WF,Tony Avella,12
-Queens,26032,State Senate,SD11,WF,Tony Avella,15
-Queens,26033,State Senate,SD11,WF,Tony Avella,20
-Queens,26034,State Senate,SD11,WF,Tony Avella,14
-Queens,26035,State Senate,SD11,WF,Tony Avella,16
-Queens,26036,State Senate,SD11,WF,Tony Avella,16
-Queens,26037,State Senate,SD11,WF,Tony Avella,21
-Queens,26042,State Senate,SD11,WF,Tony Avella,11
-Queens,26043,State Senate,SD11,WF,Tony Avella,2
-Queens,26045,State Senate,SD11,WF,Tony Avella,14
-Queens,26046,State Senate,SD11,WF,Tony Avella,13
-Queens,26047,State Senate,SD11,WF,Tony Avella,20
-Queens,26048,State Senate,SD11,WF,Tony Avella,2
-Queens,26049,State Senate,SD11,WF,Tony Avella,10
-Queens,26050,State Senate,SD11,WF,Tony Avella,12
-Queens,26051,State Senate,SD11,WF,Tony Avella,10
-Queens,26052,State Senate,SD11,WF,Tony Avella,17
-Queens,26053,State Senate,SD11,WF,Tony Avella,19
-Queens,26054,State Senate,SD11,WF,Tony Avella,10
-Queens,26055,State Senate,SD11,WF,Tony Avella,8
-Queens,26056,State Senate,SD11,WF,Tony Avella,11
-Queens,26057,State Senate,SD11,WF,Tony Avella,19
-Queens,26058,State Senate,SD11,WF,Tony Avella,9
-Queens,26059,State Senate,SD11,WF,Tony Avella,18
-Queens,26060,State Senate,SD11,WF,Tony Avella,21
-Queens,26061,State Senate,SD11,WF,Tony Avella,18
-Queens,26062,State Senate,SD11,WF,Tony Avella,18
-Queens,26063,State Senate,SD11,WF,Tony Avella,27
-Queens,26064,State Senate,SD11,WF,Tony Avella,23
-Queens,26065,State Senate,SD11,WF,Tony Avella,17
-Queens,26066,State Senate,SD11,WF,Tony Avella,28
-Queens,26067,State Senate,SD11,WF,Tony Avella,10
-Queens,26068,State Senate,SD11,WF,Tony Avella,23
-Queens,26069,State Senate,SD11,WF,Tony Avella,29
-Queens,26070,State Senate,SD11,WF,Tony Avella,12
-Queens,26071,State Senate,SD11,WF,Tony Avella,5
-Queens,26072,State Senate,SD11,WF,Tony Avella,16
-Queens,26073,State Senate,SD11,WF,Tony Avella,3
-Queens,26074,State Senate,SD11,WF,Tony Avella,18
-Queens,26076,State Senate,SD11,WF,Tony Avella,11
-Queens,26077,State Senate,SD11,WF,Tony Avella,11
-Queens,27010,State Senate,SD11,WF,Tony Avella,0
-Queens,27033,State Senate,SD11,WF,Tony Avella,0
-Queens,27060,State Senate,SD11,WF,Tony Avella,6
-Queens,27061,State Senate,SD11,WF,Tony Avella,15
-Queens,27062,State Senate,SD11,WF,Tony Avella,23
-Queens,27063,State Senate,SD11,WF,Tony Avella,12
-Queens,27064,State Senate,SD11,WF,Tony Avella,29
-Queens,27065,State Senate,SD11,WF,Tony Avella,19
-Queens,27066,State Senate,SD11,WF,Tony Avella,21
-Queens,27067,State Senate,SD11,WF,Tony Avella,23
-Queens,27068,State Senate,SD11,WF,Tony Avella,16
-Queens,27069,State Senate,SD11,WF,Tony Avella,7
-Queens,27070,State Senate,SD11,WF,Tony Avella,8
-Queens,27071,State Senate,SD11,WF,Tony Avella,15
-Queens,27072,State Senate,SD11,WF,Tony Avella,15
-Queens,29004,State Senate,SD11,WF,Tony Avella,4
-Queens,29005,State Senate,SD11,WF,Tony Avella,1
-Queens,29007,State Senate,SD11,WF,Tony Avella,2
-Queens,29009,State Senate,SD11,WF,Tony Avella,6
-Queens,29010,State Senate,SD11,WF,Tony Avella,8
-Queens,29011,State Senate,SD11,WF,Tony Avella,7
-Queens,32002,State Senate,SD11,WF,Tony Avella,0
-Queens,32007,State Senate,SD11,WF,Tony Avella,3
-Queens,32008,State Senate,SD11,WF,Tony Avella,3
-Queens,32009,State Senate,SD11,WF,Tony Avella,0
-Queens,32010,State Senate,SD11,WF,Tony Avella,0
-Queens,33001,State Senate,SD11,WF,Tony Avella,15
-Queens,33002,State Senate,SD11,WF,Tony Avella,11
-Queens,33003,State Senate,SD11,WF,Tony Avella,10
-Queens,33004,State Senate,SD11,WF,Tony Avella,7
-Queens,33005,State Senate,SD11,WF,Tony Avella,11
-Queens,33006,State Senate,SD11,WF,Tony Avella,17
-Queens,33007,State Senate,SD11,WF,Tony Avella,11
-Queens,33008,State Senate,SD11,WF,Tony Avella,11
-Queens,33009,State Senate,SD11,WF,Tony Avella,18
-Queens,33010,State Senate,SD11,WF,Tony Avella,6
-Queens,33011,State Senate,SD11,WF,Tony Avella,15
-Queens,33012,State Senate,SD11,WF,Tony Avella,17
-Queens,33013,State Senate,SD11,WF,Tony Avella,9
-Queens,33014,State Senate,SD11,WF,Tony Avella,8
-Queens,33015,State Senate,SD11,WF,Tony Avella,5
-Queens,40001,State Senate,SD11,WF,Tony Avella,17
-Queens,40002,State Senate,SD11,WF,Tony Avella,19
-Queens,40003,State Senate,SD11,WF,Tony Avella,0
-Queens,40004,State Senate,SD11,WF,Tony Avella,10
-Queens,40005,State Senate,SD11,WF,Tony Avella,13
-Queens,40006,State Senate,SD11,WF,Tony Avella,12
-Queens,40007,State Senate,SD11,WF,Tony Avella,9
-Queens,40008,State Senate,SD11,WF,Tony Avella,12
-Queens,40009,State Senate,SD11,WF,Tony Avella,10
-Queens,40010,State Senate,SD11,WF,Tony Avella,0
-Queens,40013,State Senate,SD11,WF,Tony Avella,17
-Queens,40014,State Senate,SD11,WF,Tony Avella,17
-Queens,40015,State Senate,SD11,WF,Tony Avella,15
-Queens,40028,State Senate,SD11,WF,Tony Avella,8
-Queens,40047,State Senate,SD11,WF,Tony Avella,8
-Queens,40048,State Senate,SD11,WF,Tony Avella,20
-Queens,40049,State Senate,SD11,WF,Tony Avella,2
-Queens,40050,State Senate,SD11,WF,Tony Avella,8
-Queens,40051,State Senate,SD11,WF,Tony Avella,9
-Queens,24001,State Senate,SD11,Ind,Tony Avella,14
-Queens,24002,State Senate,SD11,Ind,Tony Avella,9
-Queens,24003,State Senate,SD11,Ind,Tony Avella,6
-Queens,24004,State Senate,SD11,Ind,Tony Avella,4
-Queens,24005,State Senate,SD11,Ind,Tony Avella,8
-Queens,24006,State Senate,SD11,Ind,Tony Avella,5
-Queens,24007,State Senate,SD11,Ind,Tony Avella,6
-Queens,24010,State Senate,SD11,Ind,Tony Avella,5
-Queens,24011,State Senate,SD11,Ind,Tony Avella,8
-Queens,24012,State Senate,SD11,Ind,Tony Avella,3
-Queens,24017,State Senate,SD11,Ind,Tony Avella,6
-Queens,24018,State Senate,SD11,Ind,Tony Avella,11
-Queens,24019,State Senate,SD11,Ind,Tony Avella,8
-Queens,24020,State Senate,SD11,Ind,Tony Avella,10
-Queens,24021,State Senate,SD11,Ind,Tony Avella,10
-Queens,24022,State Senate,SD11,Ind,Tony Avella,3
-Queens,24024,State Senate,SD11,Ind,Tony Avella,11
-Queens,24025,State Senate,SD11,Ind,Tony Avella,8
-Queens,24028,State Senate,SD11,Ind,Tony Avella,10
-Queens,24032,State Senate,SD11,Ind,Tony Avella,4
-Queens,24033,State Senate,SD11,Ind,Tony Avella,8
-Queens,24034,State Senate,SD11,Ind,Tony Avella,6
-Queens,24035,State Senate,SD11,Ind,Tony Avella,6
-Queens,24036,State Senate,SD11,Ind,Tony Avella,4
-Queens,24038,State Senate,SD11,Ind,Tony Avella,1
-Queens,24042,State Senate,SD11,Ind,Tony Avella,6
-Queens,24050,State Senate,SD11,Ind,Tony Avella,6
-Queens,24051,State Senate,SD11,Ind,Tony Avella,7
-Queens,24052,State Senate,SD11,Ind,Tony Avella,1
-Queens,24053,State Senate,SD11,Ind,Tony Avella,8
-Queens,24054,State Senate,SD11,Ind,Tony Avella,4
-Queens,24055,State Senate,SD11,Ind,Tony Avella,2
-Queens,24057,State Senate,SD11,Ind,Tony Avella,2
-Queens,24067,State Senate,SD11,Ind,Tony Avella,1
-Queens,25010,State Senate,SD11,Ind,Tony Avella,0
-Queens,25011,State Senate,SD11,Ind,Tony Avella,1
-Queens,25012,State Senate,SD11,Ind,Tony Avella,6
-Queens,25013,State Senate,SD11,Ind,Tony Avella,11
-Queens,25014,State Senate,SD11,Ind,Tony Avella,7
-Queens,25015,State Senate,SD11,Ind,Tony Avella,6
-Queens,25016,State Senate,SD11,Ind,Tony Avella,6
-Queens,25017,State Senate,SD11,Ind,Tony Avella,8
-Queens,25018,State Senate,SD11,Ind,Tony Avella,6
-Queens,25019,State Senate,SD11,Ind,Tony Avella,12
-Queens,25026,State Senate,SD11,Ind,Tony Avella,1
-Queens,25027,State Senate,SD11,Ind,Tony Avella,16
-Queens,25028,State Senate,SD11,Ind,Tony Avella,3
-Queens,25029,State Senate,SD11,Ind,Tony Avella,26
-Queens,25030,State Senate,SD11,Ind,Tony Avella,5
-Queens,25031,State Senate,SD11,Ind,Tony Avella,10
-Queens,25032,State Senate,SD11,Ind,Tony Avella,2
-Queens,25033,State Senate,SD11,Ind,Tony Avella,7
-Queens,25035,State Senate,SD11,Ind,Tony Avella,7
-Queens,25036,State Senate,SD11,Ind,Tony Avella,10
-Queens,25037,State Senate,SD11,Ind,Tony Avella,9
-Queens,25038,State Senate,SD11,Ind,Tony Avella,6
-Queens,25039,State Senate,SD11,Ind,Tony Avella,15
-Queens,25040,State Senate,SD11,Ind,Tony Avella,7
-Queens,25041,State Senate,SD11,Ind,Tony Avella,1
-Queens,25065,State Senate,SD11,Ind,Tony Avella,8
-Queens,25066,State Senate,SD11,Ind,Tony Avella,2
-Queens,25067,State Senate,SD11,Ind,Tony Avella,10
-Queens,25068,State Senate,SD11,Ind,Tony Avella,6
-Queens,26001,State Senate,SD11,Ind,Tony Avella,7
-Queens,26002,State Senate,SD11,Ind,Tony Avella,2
-Queens,26003,State Senate,SD11,Ind,Tony Avella,14
-Queens,26004,State Senate,SD11,Ind,Tony Avella,15
-Queens,26005,State Senate,SD11,Ind,Tony Avella,14
-Queens,26006,State Senate,SD11,Ind,Tony Avella,6
-Queens,26007,State Senate,SD11,Ind,Tony Avella,2
-Queens,26008,State Senate,SD11,Ind,Tony Avella,10
-Queens,26009,State Senate,SD11,Ind,Tony Avella,14
-Queens,26010,State Senate,SD11,Ind,Tony Avella,8
-Queens,26011,State Senate,SD11,Ind,Tony Avella,10
-Queens,26012,State Senate,SD11,Ind,Tony Avella,6
-Queens,26013,State Senate,SD11,Ind,Tony Avella,6
-Queens,26014,State Senate,SD11,Ind,Tony Avella,8
-Queens,26015,State Senate,SD11,Ind,Tony Avella,2
-Queens,26016,State Senate,SD11,Ind,Tony Avella,7
-Queens,26017,State Senate,SD11,Ind,Tony Avella,16
-Queens,26018,State Senate,SD11,Ind,Tony Avella,12
-Queens,26019,State Senate,SD11,Ind,Tony Avella,4
-Queens,26020,State Senate,SD11,Ind,Tony Avella,13
-Queens,26021,State Senate,SD11,Ind,Tony Avella,8
-Queens,26022,State Senate,SD11,Ind,Tony Avella,11
-Queens,26023,State Senate,SD11,Ind,Tony Avella,10
-Queens,26024,State Senate,SD11,Ind,Tony Avella,4
-Queens,26025,State Senate,SD11,Ind,Tony Avella,5
-Queens,26026,State Senate,SD11,Ind,Tony Avella,1
-Queens,26027,State Senate,SD11,Ind,Tony Avella,8
-Queens,26028,State Senate,SD11,Ind,Tony Avella,11
-Queens,26029,State Senate,SD11,Ind,Tony Avella,24
-Queens,26030,State Senate,SD11,Ind,Tony Avella,16
-Queens,26031,State Senate,SD11,Ind,Tony Avella,17
-Queens,26032,State Senate,SD11,Ind,Tony Avella,18
-Queens,26033,State Senate,SD11,Ind,Tony Avella,7
-Queens,26034,State Senate,SD11,Ind,Tony Avella,12
-Queens,26035,State Senate,SD11,Ind,Tony Avella,18
-Queens,26036,State Senate,SD11,Ind,Tony Avella,10
-Queens,26037,State Senate,SD11,Ind,Tony Avella,16
-Queens,26042,State Senate,SD11,Ind,Tony Avella,7
-Queens,26043,State Senate,SD11,Ind,Tony Avella,7
-Queens,26045,State Senate,SD11,Ind,Tony Avella,15
-Queens,26046,State Senate,SD11,Ind,Tony Avella,11
-Queens,26047,State Senate,SD11,Ind,Tony Avella,7
-Queens,26048,State Senate,SD11,Ind,Tony Avella,6
-Queens,26049,State Senate,SD11,Ind,Tony Avella,7
-Queens,26050,State Senate,SD11,Ind,Tony Avella,9
-Queens,26051,State Senate,SD11,Ind,Tony Avella,10
-Queens,26052,State Senate,SD11,Ind,Tony Avella,7
-Queens,26053,State Senate,SD11,Ind,Tony Avella,7
-Queens,26054,State Senate,SD11,Ind,Tony Avella,7
-Queens,26055,State Senate,SD11,Ind,Tony Avella,8
-Queens,26056,State Senate,SD11,Ind,Tony Avella,8
-Queens,26057,State Senate,SD11,Ind,Tony Avella,10
-Queens,26058,State Senate,SD11,Ind,Tony Avella,17
-Queens,26059,State Senate,SD11,Ind,Tony Avella,7
-Queens,26060,State Senate,SD11,Ind,Tony Avella,12
-Queens,26061,State Senate,SD11,Ind,Tony Avella,13
-Queens,26062,State Senate,SD11,Ind,Tony Avella,9
-Queens,26063,State Senate,SD11,Ind,Tony Avella,9
-Queens,26064,State Senate,SD11,Ind,Tony Avella,8
-Queens,26065,State Senate,SD11,Ind,Tony Avella,12
-Queens,26066,State Senate,SD11,Ind,Tony Avella,16
-Queens,26067,State Senate,SD11,Ind,Tony Avella,10
-Queens,26068,State Senate,SD11,Ind,Tony Avella,12
-Queens,26069,State Senate,SD11,Ind,Tony Avella,16
-Queens,26070,State Senate,SD11,Ind,Tony Avella,9
-Queens,26071,State Senate,SD11,Ind,Tony Avella,3
-Queens,26072,State Senate,SD11,Ind,Tony Avella,10
-Queens,26073,State Senate,SD11,Ind,Tony Avella,8
-Queens,26074,State Senate,SD11,Ind,Tony Avella,9
-Queens,26076,State Senate,SD11,Ind,Tony Avella,6
-Queens,26077,State Senate,SD11,Ind,Tony Avella,9
-Queens,27010,State Senate,SD11,Ind,Tony Avella,0
-Queens,27033,State Senate,SD11,Ind,Tony Avella,1
-Queens,27060,State Senate,SD11,Ind,Tony Avella,11
-Queens,27061,State Senate,SD11,Ind,Tony Avella,16
-Queens,27062,State Senate,SD11,Ind,Tony Avella,6
-Queens,27063,State Senate,SD11,Ind,Tony Avella,5
-Queens,27064,State Senate,SD11,Ind,Tony Avella,9
-Queens,27065,State Senate,SD11,Ind,Tony Avella,11
-Queens,27066,State Senate,SD11,Ind,Tony Avella,9
-Queens,27067,State Senate,SD11,Ind,Tony Avella,10
-Queens,27068,State Senate,SD11,Ind,Tony Avella,5
-Queens,27069,State Senate,SD11,Ind,Tony Avella,8
-Queens,27070,State Senate,SD11,Ind,Tony Avella,2
-Queens,27071,State Senate,SD11,Ind,Tony Avella,15
-Queens,27072,State Senate,SD11,Ind,Tony Avella,18
-Queens,29004,State Senate,SD11,Ind,Tony Avella,1
-Queens,29005,State Senate,SD11,Ind,Tony Avella,0
-Queens,29007,State Senate,SD11,Ind,Tony Avella,1
-Queens,29009,State Senate,SD11,Ind,Tony Avella,2
-Queens,29010,State Senate,SD11,Ind,Tony Avella,0
-Queens,29011,State Senate,SD11,Ind,Tony Avella,1
-Queens,32002,State Senate,SD11,Ind,Tony Avella,0
-Queens,32007,State Senate,SD11,Ind,Tony Avella,1
-Queens,32008,State Senate,SD11,Ind,Tony Avella,0
-Queens,32009,State Senate,SD11,Ind,Tony Avella,0
-Queens,32010,State Senate,SD11,Ind,Tony Avella,0
-Queens,33001,State Senate,SD11,Ind,Tony Avella,14
-Queens,33002,State Senate,SD11,Ind,Tony Avella,10
-Queens,33003,State Senate,SD11,Ind,Tony Avella,11
-Queens,33004,State Senate,SD11,Ind,Tony Avella,10
-Queens,33005,State Senate,SD11,Ind,Tony Avella,5
-Queens,33006,State Senate,SD11,Ind,Tony Avella,14
-Queens,33007,State Senate,SD11,Ind,Tony Avella,17
-Queens,33008,State Senate,SD11,Ind,Tony Avella,5
-Queens,33009,State Senate,SD11,Ind,Tony Avella,9
-Queens,33010,State Senate,SD11,Ind,Tony Avella,3
-Queens,33011,State Senate,SD11,Ind,Tony Avella,4
-Queens,33012,State Senate,SD11,Ind,Tony Avella,7
-Queens,33013,State Senate,SD11,Ind,Tony Avella,4
-Queens,33014,State Senate,SD11,Ind,Tony Avella,5
-Queens,33015,State Senate,SD11,Ind,Tony Avella,3
-Queens,40001,State Senate,SD11,Ind,Tony Avella,4
-Queens,40002,State Senate,SD11,Ind,Tony Avella,11
-Queens,40003,State Senate,SD11,Ind,Tony Avella,3
-Queens,40004,State Senate,SD11,Ind,Tony Avella,9
-Queens,40005,State Senate,SD11,Ind,Tony Avella,4
-Queens,40006,State Senate,SD11,Ind,Tony Avella,6
-Queens,40007,State Senate,SD11,Ind,Tony Avella,11
-Queens,40008,State Senate,SD11,Ind,Tony Avella,11
-Queens,40009,State Senate,SD11,Ind,Tony Avella,5
-Queens,40010,State Senate,SD11,Ind,Tony Avella,0
-Queens,40013,State Senate,SD11,Ind,Tony Avella,3
-Queens,40014,State Senate,SD11,Ind,Tony Avella,9
-Queens,40015,State Senate,SD11,Ind,Tony Avella,2
-Queens,40028,State Senate,SD11,Ind,Tony Avella,2
-Queens,40047,State Senate,SD11,Ind,Tony Avella,10
-Queens,40048,State Senate,SD11,Ind,Tony Avella,3
-Queens,40049,State Senate,SD11,Ind,Tony Avella,2
-Queens,40050,State Senate,SD11,Ind,Tony Avella,1
-Queens,40051,State Senate,SD11,Ind,Tony Avella,4
-Queens,24001,State Senate,SD11,Ind,writein,0
-Queens,24002,State Senate,SD11,Ind,writein,1
-Queens,24003,State Senate,SD11,Ind,writein,0
-Queens,24004,State Senate,SD11,Ind,writein,0
-Queens,24005,State Senate,SD11,Ind,writein,1
-Queens,24006,State Senate,SD11,Ind,writein,0
-Queens,24007,State Senate,SD11,Ind,writein,0
-Queens,24010,State Senate,SD11,Ind,writein,0
-Queens,24011,State Senate,SD11,Ind,writein,0
-Queens,24012,State Senate,SD11,Ind,writein,0
-Queens,24017,State Senate,SD11,Ind,writein,1
-Queens,24018,State Senate,SD11,Ind,writein,0
-Queens,24019,State Senate,SD11,Ind,writein,0
-Queens,24020,State Senate,SD11,Ind,writein,0
-Queens,24021,State Senate,SD11,Ind,writein,1
-Queens,24022,State Senate,SD11,Ind,writein,1
-Queens,24024,State Senate,SD11,Ind,writein,0
-Queens,24025,State Senate,SD11,Ind,writein,0
-Queens,24028,State Senate,SD11,Ind,writein,0
-Queens,24032,State Senate,SD11,Ind,writein,0
-Queens,24033,State Senate,SD11,Ind,writein,0
-Queens,24034,State Senate,SD11,Ind,writein,0
-Queens,24035,State Senate,SD11,Ind,writein,0
-Queens,24036,State Senate,SD11,Ind,writein,0
-Queens,24038,State Senate,SD11,Ind,writein,0
-Queens,24042,State Senate,SD11,Ind,writein,0
-Queens,24050,State Senate,SD11,Ind,writein,0
-Queens,24051,State Senate,SD11,Ind,writein,1
-Queens,24052,State Senate,SD11,Ind,writein,0
-Queens,24053,State Senate,SD11,Ind,writein,2
-Queens,24054,State Senate,SD11,Ind,writein,0
-Queens,24055,State Senate,SD11,Ind,writein,0
-Queens,24057,State Senate,SD11,Ind,writein,0
-Queens,24067,State Senate,SD11,Ind,writein,0
-Queens,25010,State Senate,SD11,Ind,writein,0
-Queens,25011,State Senate,SD11,Ind,writein,0
-Queens,25012,State Senate,SD11,Ind,writein,0
-Queens,25013,State Senate,SD11,Ind,writein,3
-Queens,25014,State Senate,SD11,Ind,writein,1
-Queens,25015,State Senate,SD11,Ind,writein,0
-Queens,25016,State Senate,SD11,Ind,writein,0
-Queens,25017,State Senate,SD11,Ind,writein,0
-Queens,25018,State Senate,SD11,Ind,writein,0
-Queens,25019,State Senate,SD11,Ind,writein,1
-Queens,25026,State Senate,SD11,Ind,writein,0
-Queens,25027,State Senate,SD11,Ind,writein,1
-Queens,25028,State Senate,SD11,Ind,writein,0
-Queens,25029,State Senate,SD11,Ind,writein,1
-Queens,25030,State Senate,SD11,Ind,writein,1
-Queens,25031,State Senate,SD11,Ind,writein,1
-Queens,25032,State Senate,SD11,Ind,writein,0
-Queens,25033,State Senate,SD11,Ind,writein,0
-Queens,25035,State Senate,SD11,Ind,writein,0
-Queens,25036,State Senate,SD11,Ind,writein,0
-Queens,25037,State Senate,SD11,Ind,writein,0
-Queens,25038,State Senate,SD11,Ind,writein,0
-Queens,25039,State Senate,SD11,Ind,writein,0
-Queens,25040,State Senate,SD11,Ind,writein,0
-Queens,25041,State Senate,SD11,Ind,writein,1
-Queens,25065,State Senate,SD11,Ind,writein,0
-Queens,25066,State Senate,SD11,Ind,writein,0
-Queens,25067,State Senate,SD11,Ind,writein,0
-Queens,25068,State Senate,SD11,Ind,writein,0
-Queens,26001,State Senate,SD11,Ind,writein,0
-Queens,26002,State Senate,SD11,Ind,writein,0
-Queens,26003,State Senate,SD11,Ind,writein,0
-Queens,26004,State Senate,SD11,Ind,writein,1
-Queens,26005,State Senate,SD11,Ind,writein,0
-Queens,26006,State Senate,SD11,Ind,writein,0
-Queens,26007,State Senate,SD11,Ind,writein,0
-Queens,26008,State Senate,SD11,Ind,writein,0
-Queens,26009,State Senate,SD11,Ind,writein,0
-Queens,26010,State Senate,SD11,Ind,writein,2
-Queens,26011,State Senate,SD11,Ind,writein,0
-Queens,26012,State Senate,SD11,Ind,writein,0
-Queens,26013,State Senate,SD11,Ind,writein,0
-Queens,26014,State Senate,SD11,Ind,writein,0
-Queens,26015,State Senate,SD11,Ind,writein,0
-Queens,26016,State Senate,SD11,Ind,writein,1
-Queens,26017,State Senate,SD11,Ind,writein,0
-Queens,26018,State Senate,SD11,Ind,writein,0
-Queens,26019,State Senate,SD11,Ind,writein,0
-Queens,26020,State Senate,SD11,Ind,writein,0
-Queens,26021,State Senate,SD11,Ind,writein,0
-Queens,26022,State Senate,SD11,Ind,writein,0
-Queens,26023,State Senate,SD11,Ind,writein,0
-Queens,26024,State Senate,SD11,Ind,writein,0
-Queens,26025,State Senate,SD11,Ind,writein,0
-Queens,26026,State Senate,SD11,Ind,writein,0
-Queens,26027,State Senate,SD11,Ind,writein,0
-Queens,26028,State Senate,SD11,Ind,writein,1
-Queens,26029,State Senate,SD11,Ind,writein,0
-Queens,26030,State Senate,SD11,Ind,writein,0
-Queens,26031,State Senate,SD11,Ind,writein,0
-Queens,26032,State Senate,SD11,Ind,writein,0
-Queens,26033,State Senate,SD11,Ind,writein,1
-Queens,26034,State Senate,SD11,Ind,writein,0
-Queens,26035,State Senate,SD11,Ind,writein,0
-Queens,26036,State Senate,SD11,Ind,writein,0
-Queens,26037,State Senate,SD11,Ind,writein,1
-Queens,26042,State Senate,SD11,Ind,writein,0
-Queens,26043,State Senate,SD11,Ind,writein,0
-Queens,26045,State Senate,SD11,Ind,writein,1
-Queens,26046,State Senate,SD11,Ind,writein,0
-Queens,26047,State Senate,SD11,Ind,writein,0
-Queens,26048,State Senate,SD11,Ind,writein,0
-Queens,26049,State Senate,SD11,Ind,writein,0
-Queens,26050,State Senate,SD11,Ind,writein,0
-Queens,26051,State Senate,SD11,Ind,writein,1
-Queens,26052,State Senate,SD11,Ind,writein,0
-Queens,26053,State Senate,SD11,Ind,writein,1
-Queens,26054,State Senate,SD11,Ind,writein,0
-Queens,26055,State Senate,SD11,Ind,writein,2
-Queens,26056,State Senate,SD11,Ind,writein,0
-Queens,26057,State Senate,SD11,Ind,writein,1
-Queens,26058,State Senate,SD11,Ind,writein,0
-Queens,26059,State Senate,SD11,Ind,writein,0
-Queens,26060,State Senate,SD11,Ind,writein,0
-Queens,26061,State Senate,SD11,Ind,writein,0
-Queens,26062,State Senate,SD11,Ind,writein,0
-Queens,26063,State Senate,SD11,Ind,writein,0
-Queens,26064,State Senate,SD11,Ind,writein,0
-Queens,26065,State Senate,SD11,Ind,writein,0
-Queens,26066,State Senate,SD11,Ind,writein,1
-Queens,26067,State Senate,SD11,Ind,writein,0
-Queens,26068,State Senate,SD11,Ind,writein,0
-Queens,26069,State Senate,SD11,Ind,writein,0
-Queens,26070,State Senate,SD11,Ind,writein,1
-Queens,26071,State Senate,SD11,Ind,writein,0
-Queens,26072,State Senate,SD11,Ind,writein,0
-Queens,26073,State Senate,SD11,Ind,writein,0
-Queens,26074,State Senate,SD11,Ind,writein,0
-Queens,26076,State Senate,SD11,Ind,writein,0
-Queens,26077,State Senate,SD11,Ind,writein,0
-Queens,27010,State Senate,SD11,Ind,writein,0
-Queens,27033,State Senate,SD11,Ind,writein,0
-Queens,27060,State Senate,SD11,Ind,writein,0
-Queens,27061,State Senate,SD11,Ind,writein,1
-Queens,27062,State Senate,SD11,Ind,writein,0
-Queens,27063,State Senate,SD11,Ind,writein,1
-Queens,27064,State Senate,SD11,Ind,writein,0
-Queens,27065,State Senate,SD11,Ind,writein,1
-Queens,27066,State Senate,SD11,Ind,writein,0
-Queens,27067,State Senate,SD11,Ind,writein,0
-Queens,27068,State Senate,SD11,Ind,writein,0
-Queens,27069,State Senate,SD11,Ind,writein,0
-Queens,27070,State Senate,SD11,Ind,writein,1
-Queens,27071,State Senate,SD11,Ind,writein,1
-Queens,27072,State Senate,SD11,Ind,writein,0
-Queens,29004,State Senate,SD11,Ind,writein,0
-Queens,29005,State Senate,SD11,Ind,writein,0
-Queens,29007,State Senate,SD11,Ind,writein,0
-Queens,29009,State Senate,SD11,Ind,writein,0
-Queens,29010,State Senate,SD11,Ind,writein,0
-Queens,29011,State Senate,SD11,Ind,writein,0
-Queens,32002,State Senate,SD11,Ind,writein,0
-Queens,32007,State Senate,SD11,Ind,writein,0
-Queens,32008,State Senate,SD11,Ind,writein,0
-Queens,32009,State Senate,SD11,Ind,writein,0
-Queens,32010,State Senate,SD11,Ind,writein,0
-Queens,33001,State Senate,SD11,Ind,writein,0
-Queens,33002,State Senate,SD11,Ind,writein,0
-Queens,33003,State Senate,SD11,Ind,writein,0
-Queens,33004,State Senate,SD11,Ind,writein,0
-Queens,33005,State Senate,SD11,Ind,writein,0
-Queens,33006,State Senate,SD11,Ind,writein,0
-Queens,33007,State Senate,SD11,Ind,writein,0
-Queens,33008,State Senate,SD11,Ind,writein,0
-Queens,33009,State Senate,SD11,Ind,writein,0
-Queens,33010,State Senate,SD11,Ind,writein,0
-Queens,33011,State Senate,SD11,Ind,writein,1
-Queens,33012,State Senate,SD11,Ind,writein,0
-Queens,33013,State Senate,SD11,Ind,writein,0
-Queens,33014,State Senate,SD11,Ind,writein,0
-Queens,33015,State Senate,SD11,Ind,writein,0
-Queens,40001,State Senate,SD11,Ind,writein,0
-Queens,40002,State Senate,SD11,Ind,writein,1
-Queens,40003,State Senate,SD11,Ind,writein,0
-Queens,40004,State Senate,SD11,Ind,writein,0
-Queens,40005,State Senate,SD11,Ind,writein,0
-Queens,40006,State Senate,SD11,Ind,writein,0
-Queens,40007,State Senate,SD11,Ind,writein,0
-Queens,40008,State Senate,SD11,Ind,writein,0
-Queens,40009,State Senate,SD11,Ind,writein,2
-Queens,40010,State Senate,SD11,Ind,writein,0
-Queens,40013,State Senate,SD11,Ind,writein,0
-Queens,40014,State Senate,SD11,Ind,writein,3
-Queens,40015,State Senate,SD11,Ind,writein,0
-Queens,40028,State Senate,SD11,Ind,writein,0
-Queens,40047,State Senate,SD11,Ind,writein,0
-Queens,40048,State Senate,SD11,Ind,writein,1
-Queens,40049,State Senate,SD11,Ind,writein,0
-Queens,40050,State Senate,SD11,Ind,writein,0
-Queens,40051,State Senate,SD11,Ind,writein,0
-Queens,23066,State Senate,SD12,Rep,Aurelio Arcabas,39
-Queens,23067,State Senate,SD12,Rep,Aurelio Arcabas,26
-Queens,30038,State Senate,SD12,Rep,Aurelio Arcabas,13
-Queens,30039,State Senate,SD12,Rep,Aurelio Arcabas,143
-Queens,30040,State Senate,SD12,Rep,Aurelio Arcabas,96
-Queens,30041,State Senate,SD12,Rep,Aurelio Arcabas,19
-Queens,30042,State Senate,SD12,Rep,Aurelio Arcabas,50
-Queens,30043,State Senate,SD12,Rep,Aurelio Arcabas,106
-Queens,30044,State Senate,SD12,Rep,Aurelio Arcabas,94
-Queens,30045,State Senate,SD12,Rep,Aurelio Arcabas,92
-Queens,30046,State Senate,SD12,Rep,Aurelio Arcabas,63
-Queens,30047,State Senate,SD12,Rep,Aurelio Arcabas,55
-Queens,30048,State Senate,SD12,Rep,Aurelio Arcabas,97
-Queens,30049,State Senate,SD12,Rep,Aurelio Arcabas,112
-Queens,30050,State Senate,SD12,Rep,Aurelio Arcabas,103
-Queens,30051,State Senate,SD12,Rep,Aurelio Arcabas,90
-Queens,30052,State Senate,SD12,Rep,Aurelio Arcabas,70
-Queens,30053,State Senate,SD12,Rep,Aurelio Arcabas,49
-Queens,30060,State Senate,SD12,Rep,Aurelio Arcabas,96
-Queens,30061,State Senate,SD12,Rep,Aurelio Arcabas,102
-Queens,30062,State Senate,SD12,Rep,Aurelio Arcabas,30
-Queens,30063,State Senate,SD12,Rep,Aurelio Arcabas,36
-Queens,30064,State Senate,SD12,Rep,Aurelio Arcabas,59
-Queens,30065,State Senate,SD12,Rep,Aurelio Arcabas,116
-Queens,30066,State Senate,SD12,Rep,Aurelio Arcabas,74
-Queens,30067,State Senate,SD12,Rep,Aurelio Arcabas,55
-Queens,30068,State Senate,SD12,Rep,Aurelio Arcabas,27
-Queens,30069,State Senate,SD12,Rep,Aurelio Arcabas,80
-Queens,30070,State Senate,SD12,Rep,Aurelio Arcabas,43
-Queens,30071,State Senate,SD12,Rep,Aurelio Arcabas,39
-Queens,34047,State Senate,SD12,Rep,Aurelio Arcabas,0
-Queens,34048,State Senate,SD12,Rep,Aurelio Arcabas,38
-Queens,34049,State Senate,SD12,Rep,Aurelio Arcabas,56
-Queens,34050,State Senate,SD12,Rep,Aurelio Arcabas,55
-Queens,34051,State Senate,SD12,Rep,Aurelio Arcabas,64
-Queens,34052,State Senate,SD12,Rep,Aurelio Arcabas,56
-Queens,34053,State Senate,SD12,Rep,Aurelio Arcabas,2
-Queens,34055,State Senate,SD12,Rep,Aurelio Arcabas,4
-Queens,34059,State Senate,SD12,Rep,Aurelio Arcabas,0
-Queens,34060,State Senate,SD12,Rep,Aurelio Arcabas,56
-Queens,36001,State Senate,SD12,Rep,Aurelio Arcabas,96
-Queens,36002,State Senate,SD12,Rep,Aurelio Arcabas,67
-Queens,36003,State Senate,SD12,Rep,Aurelio Arcabas,63
-Queens,36004,State Senate,SD12,Rep,Aurelio Arcabas,114
-Queens,36005,State Senate,SD12,Rep,Aurelio Arcabas,78
-Queens,36006,State Senate,SD12,Rep,Aurelio Arcabas,70
-Queens,36007,State Senate,SD12,Rep,Aurelio Arcabas,113
-Queens,36008,State Senate,SD12,Rep,Aurelio Arcabas,84
-Queens,36009,State Senate,SD12,Rep,Aurelio Arcabas,71
-Queens,36010,State Senate,SD12,Rep,Aurelio Arcabas,70
-Queens,36011,State Senate,SD12,Rep,Aurelio Arcabas,57
-Queens,36012,State Senate,SD12,Rep,Aurelio Arcabas,79
-Queens,36013,State Senate,SD12,Rep,Aurelio Arcabas,85
-Queens,36014,State Senate,SD12,Rep,Aurelio Arcabas,65
-Queens,36015,State Senate,SD12,Rep,Aurelio Arcabas,63
-Queens,36016,State Senate,SD12,Rep,Aurelio Arcabas,75
-Queens,36017,State Senate,SD12,Rep,Aurelio Arcabas,71
-Queens,36018,State Senate,SD12,Rep,Aurelio Arcabas,67
-Queens,36019,State Senate,SD12,Rep,Aurelio Arcabas,43
-Queens,36020,State Senate,SD12,Rep,Aurelio Arcabas,67
-Queens,36021,State Senate,SD12,Rep,Aurelio Arcabas,42
-Queens,36022,State Senate,SD12,Rep,Aurelio Arcabas,74
-Queens,36023,State Senate,SD12,Rep,Aurelio Arcabas,75
-Queens,36024,State Senate,SD12,Rep,Aurelio Arcabas,41
-Queens,36025,State Senate,SD12,Rep,Aurelio Arcabas,36
-Queens,36026,State Senate,SD12,Rep,Aurelio Arcabas,60
-Queens,36028,State Senate,SD12,Rep,Aurelio Arcabas,99
-Queens,36029,State Senate,SD12,Rep,Aurelio Arcabas,124
-Queens,36030,State Senate,SD12,Rep,Aurelio Arcabas,90
-Queens,36031,State Senate,SD12,Rep,Aurelio Arcabas,56
-Queens,36032,State Senate,SD12,Rep,Aurelio Arcabas,51
-Queens,36033,State Senate,SD12,Rep,Aurelio Arcabas,75
-Queens,36034,State Senate,SD12,Rep,Aurelio Arcabas,70
-Queens,36035,State Senate,SD12,Rep,Aurelio Arcabas,77
-Queens,36036,State Senate,SD12,Rep,Aurelio Arcabas,71
-Queens,36037,State Senate,SD12,Rep,Aurelio Arcabas,52
-Queens,36038,State Senate,SD12,Rep,Aurelio Arcabas,72
-Queens,36039,State Senate,SD12,Rep,Aurelio Arcabas,69
-Queens,36040,State Senate,SD12,Rep,Aurelio Arcabas,69
-Queens,36041,State Senate,SD12,Rep,Aurelio Arcabas,71
-Queens,36042,State Senate,SD12,Rep,Aurelio Arcabas,56
-Queens,36043,State Senate,SD12,Rep,Aurelio Arcabas,18
-Queens,36064,State Senate,SD12,Rep,Aurelio Arcabas,52
-Queens,36065,State Senate,SD12,Rep,Aurelio Arcabas,18
-Queens,37001,State Senate,SD12,Rep,Aurelio Arcabas,73
-Queens,37002,State Senate,SD12,Rep,Aurelio Arcabas,11
-Queens,37003,State Senate,SD12,Rep,Aurelio Arcabas,6
-Queens,37004,State Senate,SD12,Rep,Aurelio Arcabas,2
-Queens,37005,State Senate,SD12,Rep,Aurelio Arcabas,42
-Queens,37006,State Senate,SD12,Rep,Aurelio Arcabas,33
-Queens,37007,State Senate,SD12,Rep,Aurelio Arcabas,16
-Queens,37008,State Senate,SD12,Rep,Aurelio Arcabas,12
-Queens,37009,State Senate,SD12,Rep,Aurelio Arcabas,12
-Queens,37010,State Senate,SD12,Rep,Aurelio Arcabas,34
-Queens,37011,State Senate,SD12,Rep,Aurelio Arcabas,48
-Queens,37012,State Senate,SD12,Rep,Aurelio Arcabas,6
-Queens,37013,State Senate,SD12,Rep,Aurelio Arcabas,6
-Queens,37014,State Senate,SD12,Rep,Aurelio Arcabas,5
-Queens,37015,State Senate,SD12,Rep,Aurelio Arcabas,8
-Queens,37016,State Senate,SD12,Rep,Aurelio Arcabas,8
-Queens,37017,State Senate,SD12,Rep,Aurelio Arcabas,4
-Queens,37018,State Senate,SD12,Rep,Aurelio Arcabas,6
-Queens,37019,State Senate,SD12,Rep,Aurelio Arcabas,94
-Queens,37020,State Senate,SD12,Rep,Aurelio Arcabas,129
-Queens,37021,State Senate,SD12,Rep,Aurelio Arcabas,133
-Queens,37022,State Senate,SD12,Rep,Aurelio Arcabas,105
-Queens,37023,State Senate,SD12,Rep,Aurelio Arcabas,5
-Queens,37024,State Senate,SD12,Rep,Aurelio Arcabas,61
-Queens,37025,State Senate,SD12,Rep,Aurelio Arcabas,9
-Queens,37026,State Senate,SD12,Rep,Aurelio Arcabas,1
-Queens,37027,State Senate,SD12,Rep,Aurelio Arcabas,85
-Queens,37028,State Senate,SD12,Rep,Aurelio Arcabas,64
-Queens,37029,State Senate,SD12,Rep,Aurelio Arcabas,75
-Queens,37030,State Senate,SD12,Rep,Aurelio Arcabas,57
-Queens,37031,State Senate,SD12,Rep,Aurelio Arcabas,88
-Queens,37032,State Senate,SD12,Rep,Aurelio Arcabas,31
-Queens,37033,State Senate,SD12,Rep,Aurelio Arcabas,25
-Queens,37034,State Senate,SD12,Rep,Aurelio Arcabas,35
-Queens,37035,State Senate,SD12,Rep,Aurelio Arcabas,43
-Queens,37036,State Senate,SD12,Rep,Aurelio Arcabas,42
-Queens,37037,State Senate,SD12,Rep,Aurelio Arcabas,76
-Queens,37038,State Senate,SD12,Rep,Aurelio Arcabas,74
-Queens,37039,State Senate,SD12,Rep,Aurelio Arcabas,71
-Queens,37041,State Senate,SD12,Rep,Aurelio Arcabas,18
-Queens,37051,State Senate,SD12,Rep,Aurelio Arcabas,1
-Queens,37055,State Senate,SD12,Rep,Aurelio Arcabas,0
-Queens,37056,State Senate,SD12,Rep,Aurelio Arcabas,35
-Queens,37057,State Senate,SD12,Rep,Aurelio Arcabas,56
-Queens,37058,State Senate,SD12,Rep,Aurelio Arcabas,45
-Queens,37059,State Senate,SD12,Rep,Aurelio Arcabas,47
-Queens,37063,State Senate,SD12,Rep,Aurelio Arcabas,89
-Queens,37064,State Senate,SD12,Rep,Aurelio Arcabas,95
-Queens,37065,State Senate,SD12,Rep,Aurelio Arcabas,76
-Queens,37067,State Senate,SD12,Rep,Aurelio Arcabas,72
-Queens,37068,State Senate,SD12,Rep,Aurelio Arcabas,82
-Queens,38001,State Senate,SD12,Rep,Aurelio Arcabas,32
-Queens,38002,State Senate,SD12,Rep,Aurelio Arcabas,32
-Queens,38003,State Senate,SD12,Rep,Aurelio Arcabas,40
-Queens,38004,State Senate,SD12,Rep,Aurelio Arcabas,34
-Queens,38005,State Senate,SD12,Rep,Aurelio Arcabas,21
-Queens,38006,State Senate,SD12,Rep,Aurelio Arcabas,44
-Queens,38007,State Senate,SD12,Rep,Aurelio Arcabas,17
-Queens,38008,State Senate,SD12,Rep,Aurelio Arcabas,32
-Queens,38009,State Senate,SD12,Rep,Aurelio Arcabas,74
-Queens,38010,State Senate,SD12,Rep,Aurelio Arcabas,79
-Queens,38011,State Senate,SD12,Rep,Aurelio Arcabas,0
-Queens,38012,State Senate,SD12,Rep,Aurelio Arcabas,82
-Queens,38013,State Senate,SD12,Rep,Aurelio Arcabas,68
-Queens,38022,State Senate,SD12,Rep,Aurelio Arcabas,172
-Queens,38023,State Senate,SD12,Rep,Aurelio Arcabas,56
-Queens,38024,State Senate,SD12,Rep,Aurelio Arcabas,34
-Queens,38025,State Senate,SD12,Rep,Aurelio Arcabas,49
-Queens,38026,State Senate,SD12,Rep,Aurelio Arcabas,53
-Queens,38027,State Senate,SD12,Rep,Aurelio Arcabas,22
-Queens,38029,State Senate,SD12,Rep,Aurelio Arcabas,35
-Queens,38053,State Senate,SD12,Rep,Aurelio Arcabas,25
-Queens,39032,State Senate,SD12,Rep,Aurelio Arcabas,36
-Queens,39033,State Senate,SD12,Rep,Aurelio Arcabas,63
-Queens,23066,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,23067,State Senate,SD12,Con,Aurelio Arcabas,3
-Queens,30038,State Senate,SD12,Con,Aurelio Arcabas,2
-Queens,30039,State Senate,SD12,Con,Aurelio Arcabas,20
-Queens,30040,State Senate,SD12,Con,Aurelio Arcabas,14
-Queens,30041,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,30042,State Senate,SD12,Con,Aurelio Arcabas,10
-Queens,30043,State Senate,SD12,Con,Aurelio Arcabas,10
-Queens,30044,State Senate,SD12,Con,Aurelio Arcabas,8
-Queens,30045,State Senate,SD12,Con,Aurelio Arcabas,7
-Queens,30046,State Senate,SD12,Con,Aurelio Arcabas,6
-Queens,30047,State Senate,SD12,Con,Aurelio Arcabas,4
-Queens,30048,State Senate,SD12,Con,Aurelio Arcabas,17
-Queens,30049,State Senate,SD12,Con,Aurelio Arcabas,23
-Queens,30050,State Senate,SD12,Con,Aurelio Arcabas,14
-Queens,30051,State Senate,SD12,Con,Aurelio Arcabas,12
-Queens,30052,State Senate,SD12,Con,Aurelio Arcabas,7
-Queens,30053,State Senate,SD12,Con,Aurelio Arcabas,8
-Queens,30060,State Senate,SD12,Con,Aurelio Arcabas,9
-Queens,30061,State Senate,SD12,Con,Aurelio Arcabas,11
-Queens,30062,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,30063,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,30064,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,30065,State Senate,SD12,Con,Aurelio Arcabas,6
-Queens,30066,State Senate,SD12,Con,Aurelio Arcabas,6
-Queens,30067,State Senate,SD12,Con,Aurelio Arcabas,8
-Queens,30068,State Senate,SD12,Con,Aurelio Arcabas,4
-Queens,30069,State Senate,SD12,Con,Aurelio Arcabas,7
-Queens,30070,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,30071,State Senate,SD12,Con,Aurelio Arcabas,4
-Queens,34047,State Senate,SD12,Con,Aurelio Arcabas,0
-Queens,34048,State Senate,SD12,Con,Aurelio Arcabas,4
-Queens,34049,State Senate,SD12,Con,Aurelio Arcabas,4
-Queens,34050,State Senate,SD12,Con,Aurelio Arcabas,7
-Queens,34051,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,34052,State Senate,SD12,Con,Aurelio Arcabas,10
-Queens,34053,State Senate,SD12,Con,Aurelio Arcabas,1
-Queens,34055,State Senate,SD12,Con,Aurelio Arcabas,2
-Queens,34059,State Senate,SD12,Con,Aurelio Arcabas,0
-Queens,34060,State Senate,SD12,Con,Aurelio Arcabas,1
-Queens,36001,State Senate,SD12,Con,Aurelio Arcabas,9
-Queens,36002,State Senate,SD12,Con,Aurelio Arcabas,10
-Queens,36003,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,36004,State Senate,SD12,Con,Aurelio Arcabas,6
-Queens,36005,State Senate,SD12,Con,Aurelio Arcabas,8
-Queens,36006,State Senate,SD12,Con,Aurelio Arcabas,4
-Queens,36007,State Senate,SD12,Con,Aurelio Arcabas,12
-Queens,36008,State Senate,SD12,Con,Aurelio Arcabas,6
-Queens,36009,State Senate,SD12,Con,Aurelio Arcabas,4
-Queens,36010,State Senate,SD12,Con,Aurelio Arcabas,11
-Queens,36011,State Senate,SD12,Con,Aurelio Arcabas,6
-Queens,36012,State Senate,SD12,Con,Aurelio Arcabas,6
-Queens,36013,State Senate,SD12,Con,Aurelio Arcabas,11
-Queens,36014,State Senate,SD12,Con,Aurelio Arcabas,6
-Queens,36015,State Senate,SD12,Con,Aurelio Arcabas,10
-Queens,36016,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,36017,State Senate,SD12,Con,Aurelio Arcabas,6
-Queens,36018,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,36019,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,36020,State Senate,SD12,Con,Aurelio Arcabas,6
-Queens,36021,State Senate,SD12,Con,Aurelio Arcabas,1
-Queens,36022,State Senate,SD12,Con,Aurelio Arcabas,8
-Queens,36023,State Senate,SD12,Con,Aurelio Arcabas,9
-Queens,36024,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,36025,State Senate,SD12,Con,Aurelio Arcabas,8
-Queens,36026,State Senate,SD12,Con,Aurelio Arcabas,3
-Queens,36028,State Senate,SD12,Con,Aurelio Arcabas,15
-Queens,36029,State Senate,SD12,Con,Aurelio Arcabas,11
-Queens,36030,State Senate,SD12,Con,Aurelio Arcabas,4
-Queens,36031,State Senate,SD12,Con,Aurelio Arcabas,11
-Queens,36032,State Senate,SD12,Con,Aurelio Arcabas,7
-Queens,36033,State Senate,SD12,Con,Aurelio Arcabas,11
-Queens,36034,State Senate,SD12,Con,Aurelio Arcabas,4
-Queens,36035,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,36036,State Senate,SD12,Con,Aurelio Arcabas,6
-Queens,36037,State Senate,SD12,Con,Aurelio Arcabas,6
-Queens,36038,State Senate,SD12,Con,Aurelio Arcabas,7
-Queens,36039,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,36040,State Senate,SD12,Con,Aurelio Arcabas,4
-Queens,36041,State Senate,SD12,Con,Aurelio Arcabas,6
-Queens,36042,State Senate,SD12,Con,Aurelio Arcabas,9
-Queens,36043,State Senate,SD12,Con,Aurelio Arcabas,1
-Queens,36064,State Senate,SD12,Con,Aurelio Arcabas,2
-Queens,36065,State Senate,SD12,Con,Aurelio Arcabas,0
-Queens,37001,State Senate,SD12,Con,Aurelio Arcabas,15
-Queens,37002,State Senate,SD12,Con,Aurelio Arcabas,1
-Queens,37003,State Senate,SD12,Con,Aurelio Arcabas,1
-Queens,37004,State Senate,SD12,Con,Aurelio Arcabas,0
-Queens,37005,State Senate,SD12,Con,Aurelio Arcabas,7
-Queens,37006,State Senate,SD12,Con,Aurelio Arcabas,7
-Queens,37007,State Senate,SD12,Con,Aurelio Arcabas,0
-Queens,37008,State Senate,SD12,Con,Aurelio Arcabas,1
-Queens,37009,State Senate,SD12,Con,Aurelio Arcabas,3
-Queens,37010,State Senate,SD12,Con,Aurelio Arcabas,3
-Queens,37011,State Senate,SD12,Con,Aurelio Arcabas,9
-Queens,37012,State Senate,SD12,Con,Aurelio Arcabas,0
-Queens,37013,State Senate,SD12,Con,Aurelio Arcabas,2
-Queens,37014,State Senate,SD12,Con,Aurelio Arcabas,1
-Queens,37015,State Senate,SD12,Con,Aurelio Arcabas,1
-Queens,37016,State Senate,SD12,Con,Aurelio Arcabas,2
-Queens,37017,State Senate,SD12,Con,Aurelio Arcabas,0
-Queens,37018,State Senate,SD12,Con,Aurelio Arcabas,2
-Queens,37019,State Senate,SD12,Con,Aurelio Arcabas,7
-Queens,37020,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,37021,State Senate,SD12,Con,Aurelio Arcabas,10
-Queens,37022,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,37023,State Senate,SD12,Con,Aurelio Arcabas,0
-Queens,37024,State Senate,SD12,Con,Aurelio Arcabas,4
-Queens,37025,State Senate,SD12,Con,Aurelio Arcabas,1
-Queens,37026,State Senate,SD12,Con,Aurelio Arcabas,0
-Queens,37027,State Senate,SD12,Con,Aurelio Arcabas,8
-Queens,37028,State Senate,SD12,Con,Aurelio Arcabas,0
-Queens,37029,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,37030,State Senate,SD12,Con,Aurelio Arcabas,11
-Queens,37031,State Senate,SD12,Con,Aurelio Arcabas,6
-Queens,37032,State Senate,SD12,Con,Aurelio Arcabas,2
-Queens,37033,State Senate,SD12,Con,Aurelio Arcabas,6
-Queens,37034,State Senate,SD12,Con,Aurelio Arcabas,4
-Queens,37035,State Senate,SD12,Con,Aurelio Arcabas,7
-Queens,37036,State Senate,SD12,Con,Aurelio Arcabas,2
-Queens,37037,State Senate,SD12,Con,Aurelio Arcabas,11
-Queens,37038,State Senate,SD12,Con,Aurelio Arcabas,7
-Queens,37039,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,37041,State Senate,SD12,Con,Aurelio Arcabas,2
-Queens,37051,State Senate,SD12,Con,Aurelio Arcabas,0
-Queens,37055,State Senate,SD12,Con,Aurelio Arcabas,0
-Queens,37056,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,37057,State Senate,SD12,Con,Aurelio Arcabas,10
-Queens,37058,State Senate,SD12,Con,Aurelio Arcabas,10
-Queens,37059,State Senate,SD12,Con,Aurelio Arcabas,9
-Queens,37063,State Senate,SD12,Con,Aurelio Arcabas,11
-Queens,37064,State Senate,SD12,Con,Aurelio Arcabas,9
-Queens,37065,State Senate,SD12,Con,Aurelio Arcabas,7
-Queens,37067,State Senate,SD12,Con,Aurelio Arcabas,10
-Queens,37068,State Senate,SD12,Con,Aurelio Arcabas,8
-Queens,38001,State Senate,SD12,Con,Aurelio Arcabas,7
-Queens,38002,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,38003,State Senate,SD12,Con,Aurelio Arcabas,6
-Queens,38004,State Senate,SD12,Con,Aurelio Arcabas,10
-Queens,38005,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,38006,State Senate,SD12,Con,Aurelio Arcabas,12
-Queens,38007,State Senate,SD12,Con,Aurelio Arcabas,3
-Queens,38008,State Senate,SD12,Con,Aurelio Arcabas,9
-Queens,38009,State Senate,SD12,Con,Aurelio Arcabas,15
-Queens,38010,State Senate,SD12,Con,Aurelio Arcabas,14
-Queens,38011,State Senate,SD12,Con,Aurelio Arcabas,0
-Queens,38012,State Senate,SD12,Con,Aurelio Arcabas,10
-Queens,38013,State Senate,SD12,Con,Aurelio Arcabas,3
-Queens,38022,State Senate,SD12,Con,Aurelio Arcabas,28
-Queens,38023,State Senate,SD12,Con,Aurelio Arcabas,9
-Queens,38024,State Senate,SD12,Con,Aurelio Arcabas,9
-Queens,38025,State Senate,SD12,Con,Aurelio Arcabas,13
-Queens,38026,State Senate,SD12,Con,Aurelio Arcabas,8
-Queens,38027,State Senate,SD12,Con,Aurelio Arcabas,3
-Queens,38029,State Senate,SD12,Con,Aurelio Arcabas,5
-Queens,38053,State Senate,SD12,Con,Aurelio Arcabas,4
-Queens,39032,State Senate,SD12,Con,Aurelio Arcabas,0
-Queens,39033,State Senate,SD12,Con,Aurelio Arcabas,10
-Queens,23066,State Senate,SD12,Dem,Michael Gianaris,247
-Queens,23067,State Senate,SD12,Dem,Michael Gianaris,237
-Queens,30038,State Senate,SD12,Dem,Michael Gianaris,69
-Queens,30039,State Senate,SD12,Dem,Michael Gianaris,447
-Queens,30040,State Senate,SD12,Dem,Michael Gianaris,332
-Queens,30041,State Senate,SD12,Dem,Michael Gianaris,138
-Queens,30042,State Senate,SD12,Dem,Michael Gianaris,276
-Queens,30043,State Senate,SD12,Dem,Michael Gianaris,418
-Queens,30044,State Senate,SD12,Dem,Michael Gianaris,478
-Queens,30045,State Senate,SD12,Dem,Michael Gianaris,457
-Queens,30046,State Senate,SD12,Dem,Michael Gianaris,493
-Queens,30047,State Senate,SD12,Dem,Michael Gianaris,274
-Queens,30048,State Senate,SD12,Dem,Michael Gianaris,288
-Queens,30049,State Senate,SD12,Dem,Michael Gianaris,475
-Queens,30050,State Senate,SD12,Dem,Michael Gianaris,469
-Queens,30051,State Senate,SD12,Dem,Michael Gianaris,384
-Queens,30052,State Senate,SD12,Dem,Michael Gianaris,357
-Queens,30053,State Senate,SD12,Dem,Michael Gianaris,204
-Queens,30060,State Senate,SD12,Dem,Michael Gianaris,356
-Queens,30061,State Senate,SD12,Dem,Michael Gianaris,485
-Queens,30062,State Senate,SD12,Dem,Michael Gianaris,229
-Queens,30063,State Senate,SD12,Dem,Michael Gianaris,205
-Queens,30064,State Senate,SD12,Dem,Michael Gianaris,353
-Queens,30065,State Senate,SD12,Dem,Michael Gianaris,479
-Queens,30066,State Senate,SD12,Dem,Michael Gianaris,473
-Queens,30067,State Senate,SD12,Dem,Michael Gianaris,567
-Queens,30068,State Senate,SD12,Dem,Michael Gianaris,335
-Queens,30069,State Senate,SD12,Dem,Michael Gianaris,474
-Queens,30070,State Senate,SD12,Dem,Michael Gianaris,408
-Queens,30071,State Senate,SD12,Dem,Michael Gianaris,247
-Queens,34047,State Senate,SD12,Dem,Michael Gianaris,28
-Queens,34048,State Senate,SD12,Dem,Michael Gianaris,138
-Queens,34049,State Senate,SD12,Dem,Michael Gianaris,457
-Queens,34050,State Senate,SD12,Dem,Michael Gianaris,364
-Queens,34051,State Senate,SD12,Dem,Michael Gianaris,435
-Queens,34052,State Senate,SD12,Dem,Michael Gianaris,238
-Queens,34053,State Senate,SD12,Dem,Michael Gianaris,23
-Queens,34055,State Senate,SD12,Dem,Michael Gianaris,11
-Queens,34059,State Senate,SD12,Dem,Michael Gianaris,22
-Queens,34060,State Senate,SD12,Dem,Michael Gianaris,267
-Queens,36001,State Senate,SD12,Dem,Michael Gianaris,523
-Queens,36002,State Senate,SD12,Dem,Michael Gianaris,444
-Queens,36003,State Senate,SD12,Dem,Michael Gianaris,459
-Queens,36004,State Senate,SD12,Dem,Michael Gianaris,548
-Queens,36005,State Senate,SD12,Dem,Michael Gianaris,454
-Queens,36006,State Senate,SD12,Dem,Michael Gianaris,453
-Queens,36007,State Senate,SD12,Dem,Michael Gianaris,561
-Queens,36008,State Senate,SD12,Dem,Michael Gianaris,556
-Queens,36009,State Senate,SD12,Dem,Michael Gianaris,503
-Queens,36010,State Senate,SD12,Dem,Michael Gianaris,478
-Queens,36011,State Senate,SD12,Dem,Michael Gianaris,497
-Queens,36012,State Senate,SD12,Dem,Michael Gianaris,510
-Queens,36013,State Senate,SD12,Dem,Michael Gianaris,602
-Queens,36014,State Senate,SD12,Dem,Michael Gianaris,409
-Queens,36015,State Senate,SD12,Dem,Michael Gianaris,480
-Queens,36016,State Senate,SD12,Dem,Michael Gianaris,523
-Queens,36017,State Senate,SD12,Dem,Michael Gianaris,456
-Queens,36018,State Senate,SD12,Dem,Michael Gianaris,410
-Queens,36019,State Senate,SD12,Dem,Michael Gianaris,472
-Queens,36020,State Senate,SD12,Dem,Michael Gianaris,535
-Queens,36021,State Senate,SD12,Dem,Michael Gianaris,555
-Queens,36022,State Senate,SD12,Dem,Michael Gianaris,475
-Queens,36023,State Senate,SD12,Dem,Michael Gianaris,511
-Queens,36024,State Senate,SD12,Dem,Michael Gianaris,455
-Queens,36025,State Senate,SD12,Dem,Michael Gianaris,310
-Queens,36026,State Senate,SD12,Dem,Michael Gianaris,304
-Queens,36028,State Senate,SD12,Dem,Michael Gianaris,473
-Queens,36029,State Senate,SD12,Dem,Michael Gianaris,469
-Queens,36030,State Senate,SD12,Dem,Michael Gianaris,456
-Queens,36031,State Senate,SD12,Dem,Michael Gianaris,396
-Queens,36032,State Senate,SD12,Dem,Michael Gianaris,375
-Queens,36033,State Senate,SD12,Dem,Michael Gianaris,528
-Queens,36034,State Senate,SD12,Dem,Michael Gianaris,402
-Queens,36035,State Senate,SD12,Dem,Michael Gianaris,486
-Queens,36036,State Senate,SD12,Dem,Michael Gianaris,478
-Queens,36037,State Senate,SD12,Dem,Michael Gianaris,475
-Queens,36038,State Senate,SD12,Dem,Michael Gianaris,413
-Queens,36039,State Senate,SD12,Dem,Michael Gianaris,520
-Queens,36040,State Senate,SD12,Dem,Michael Gianaris,461
-Queens,36041,State Senate,SD12,Dem,Michael Gianaris,497
-Queens,36042,State Senate,SD12,Dem,Michael Gianaris,437
-Queens,36043,State Senate,SD12,Dem,Michael Gianaris,91
-Queens,36064,State Senate,SD12,Dem,Michael Gianaris,393
-Queens,36065,State Senate,SD12,Dem,Michael Gianaris,135
-Queens,37001,State Senate,SD12,Dem,Michael Gianaris,509
-Queens,37002,State Senate,SD12,Dem,Michael Gianaris,564
-Queens,37003,State Senate,SD12,Dem,Michael Gianaris,418
-Queens,37004,State Senate,SD12,Dem,Michael Gianaris,245
-Queens,37005,State Senate,SD12,Dem,Michael Gianaris,333
-Queens,37006,State Senate,SD12,Dem,Michael Gianaris,299
-Queens,37007,State Senate,SD12,Dem,Michael Gianaris,310
-Queens,37008,State Senate,SD12,Dem,Michael Gianaris,474
-Queens,37009,State Senate,SD12,Dem,Michael Gianaris,379
-Queens,37010,State Senate,SD12,Dem,Michael Gianaris,520
-Queens,37011,State Senate,SD12,Dem,Michael Gianaris,419
-Queens,37012,State Senate,SD12,Dem,Michael Gianaris,350
-Queens,37013,State Senate,SD12,Dem,Michael Gianaris,336
-Queens,37014,State Senate,SD12,Dem,Michael Gianaris,370
-Queens,37015,State Senate,SD12,Dem,Michael Gianaris,359
-Queens,37016,State Senate,SD12,Dem,Michael Gianaris,359
-Queens,37017,State Senate,SD12,Dem,Michael Gianaris,436
-Queens,37018,State Senate,SD12,Dem,Michael Gianaris,74
-Queens,37019,State Senate,SD12,Dem,Michael Gianaris,729
-Queens,37020,State Senate,SD12,Dem,Michael Gianaris,481
-Queens,37021,State Senate,SD12,Dem,Michael Gianaris,643
-Queens,37022,State Senate,SD12,Dem,Michael Gianaris,625
-Queens,37023,State Senate,SD12,Dem,Michael Gianaris,43
-Queens,37024,State Senate,SD12,Dem,Michael Gianaris,363
-Queens,37025,State Senate,SD12,Dem,Michael Gianaris,63
-Queens,37026,State Senate,SD12,Dem,Michael Gianaris,13
-Queens,37027,State Senate,SD12,Dem,Michael Gianaris,556
-Queens,37028,State Senate,SD12,Dem,Michael Gianaris,487
-Queens,37029,State Senate,SD12,Dem,Michael Gianaris,497
-Queens,37030,State Senate,SD12,Dem,Michael Gianaris,402
-Queens,37031,State Senate,SD12,Dem,Michael Gianaris,566
-Queens,37032,State Senate,SD12,Dem,Michael Gianaris,209
-Queens,37033,State Senate,SD12,Dem,Michael Gianaris,392
-Queens,37034,State Senate,SD12,Dem,Michael Gianaris,332
-Queens,37035,State Senate,SD12,Dem,Michael Gianaris,452
-Queens,37036,State Senate,SD12,Dem,Michael Gianaris,491
-Queens,37037,State Senate,SD12,Dem,Michael Gianaris,548
-Queens,37038,State Senate,SD12,Dem,Michael Gianaris,497
-Queens,37039,State Senate,SD12,Dem,Michael Gianaris,467
-Queens,37041,State Senate,SD12,Dem,Michael Gianaris,87
-Queens,37051,State Senate,SD12,Dem,Michael Gianaris,16
-Queens,37055,State Senate,SD12,Dem,Michael Gianaris,2
-Queens,37056,State Senate,SD12,Dem,Michael Gianaris,316
-Queens,37057,State Senate,SD12,Dem,Michael Gianaris,316
-Queens,37058,State Senate,SD12,Dem,Michael Gianaris,305
-Queens,37059,State Senate,SD12,Dem,Michael Gianaris,336
-Queens,37063,State Senate,SD12,Dem,Michael Gianaris,506
-Queens,37064,State Senate,SD12,Dem,Michael Gianaris,456
-Queens,37065,State Senate,SD12,Dem,Michael Gianaris,389
-Queens,37067,State Senate,SD12,Dem,Michael Gianaris,303
-Queens,37068,State Senate,SD12,Dem,Michael Gianaris,305
-Queens,38001,State Senate,SD12,Dem,Michael Gianaris,360
-Queens,38002,State Senate,SD12,Dem,Michael Gianaris,380
-Queens,38003,State Senate,SD12,Dem,Michael Gianaris,372
-Queens,38004,State Senate,SD12,Dem,Michael Gianaris,337
-Queens,38005,State Senate,SD12,Dem,Michael Gianaris,392
-Queens,38006,State Senate,SD12,Dem,Michael Gianaris,391
-Queens,38007,State Senate,SD12,Dem,Michael Gianaris,215
-Queens,38008,State Senate,SD12,Dem,Michael Gianaris,252
-Queens,38009,State Senate,SD12,Dem,Michael Gianaris,379
-Queens,38010,State Senate,SD12,Dem,Michael Gianaris,318
-Queens,38011,State Senate,SD12,Dem,Michael Gianaris,4
-Queens,38012,State Senate,SD12,Dem,Michael Gianaris,205
-Queens,38013,State Senate,SD12,Dem,Michael Gianaris,176
-Queens,38022,State Senate,SD12,Dem,Michael Gianaris,391
-Queens,38023,State Senate,SD12,Dem,Michael Gianaris,368
-Queens,38024,State Senate,SD12,Dem,Michael Gianaris,397
-Queens,38025,State Senate,SD12,Dem,Michael Gianaris,374
-Queens,38026,State Senate,SD12,Dem,Michael Gianaris,362
-Queens,38027,State Senate,SD12,Dem,Michael Gianaris,265
-Queens,38029,State Senate,SD12,Dem,Michael Gianaris,457
-Queens,38053,State Senate,SD12,Dem,Michael Gianaris,117
-Queens,39032,State Senate,SD12,Dem,Michael Gianaris,186
-Queens,39033,State Senate,SD12,Dem,Michael Gianaris,326
-Queens,23066,State Senate,SD12,WF,Michael Gianaris,0
-Queens,23067,State Senate,SD12,WF,Michael Gianaris,1
-Queens,30038,State Senate,SD12,WF,Michael Gianaris,2
-Queens,30039,State Senate,SD12,WF,Michael Gianaris,19
-Queens,30040,State Senate,SD12,WF,Michael Gianaris,12
-Queens,30041,State Senate,SD12,WF,Michael Gianaris,4
-Queens,30042,State Senate,SD12,WF,Michael Gianaris,14
-Queens,30043,State Senate,SD12,WF,Michael Gianaris,26
-Queens,30044,State Senate,SD12,WF,Michael Gianaris,26
-Queens,30045,State Senate,SD12,WF,Michael Gianaris,20
-Queens,30046,State Senate,SD12,WF,Michael Gianaris,39
-Queens,30047,State Senate,SD12,WF,Michael Gianaris,24
-Queens,30048,State Senate,SD12,WF,Michael Gianaris,18
-Queens,30049,State Senate,SD12,WF,Michael Gianaris,36
-Queens,30050,State Senate,SD12,WF,Michael Gianaris,39
-Queens,30051,State Senate,SD12,WF,Michael Gianaris,27
-Queens,30052,State Senate,SD12,WF,Michael Gianaris,6
-Queens,30053,State Senate,SD12,WF,Michael Gianaris,15
-Queens,30060,State Senate,SD12,WF,Michael Gianaris,29
-Queens,30061,State Senate,SD12,WF,Michael Gianaris,26
-Queens,30062,State Senate,SD12,WF,Michael Gianaris,21
-Queens,30063,State Senate,SD12,WF,Michael Gianaris,13
-Queens,30064,State Senate,SD12,WF,Michael Gianaris,28
-Queens,30065,State Senate,SD12,WF,Michael Gianaris,33
-Queens,30066,State Senate,SD12,WF,Michael Gianaris,37
-Queens,30067,State Senate,SD12,WF,Michael Gianaris,29
-Queens,30068,State Senate,SD12,WF,Michael Gianaris,21
-Queens,30069,State Senate,SD12,WF,Michael Gianaris,24
-Queens,30070,State Senate,SD12,WF,Michael Gianaris,13
-Queens,30071,State Senate,SD12,WF,Michael Gianaris,25
-Queens,34047,State Senate,SD12,WF,Michael Gianaris,1
-Queens,34048,State Senate,SD12,WF,Michael Gianaris,8
-Queens,34049,State Senate,SD12,WF,Michael Gianaris,19
-Queens,34050,State Senate,SD12,WF,Michael Gianaris,12
-Queens,34051,State Senate,SD12,WF,Michael Gianaris,10
-Queens,34052,State Senate,SD12,WF,Michael Gianaris,11
-Queens,34053,State Senate,SD12,WF,Michael Gianaris,1
-Queens,34055,State Senate,SD12,WF,Michael Gianaris,0
-Queens,34059,State Senate,SD12,WF,Michael Gianaris,1
-Queens,34060,State Senate,SD12,WF,Michael Gianaris,15
-Queens,36001,State Senate,SD12,WF,Michael Gianaris,57
-Queens,36002,State Senate,SD12,WF,Michael Gianaris,29
-Queens,36003,State Senate,SD12,WF,Michael Gianaris,29
-Queens,36004,State Senate,SD12,WF,Michael Gianaris,48
-Queens,36005,State Senate,SD12,WF,Michael Gianaris,31
-Queens,36006,State Senate,SD12,WF,Michael Gianaris,24
-Queens,36007,State Senate,SD12,WF,Michael Gianaris,39
-Queens,36008,State Senate,SD12,WF,Michael Gianaris,37
-Queens,36009,State Senate,SD12,WF,Michael Gianaris,15
-Queens,36010,State Senate,SD12,WF,Michael Gianaris,23
-Queens,36011,State Senate,SD12,WF,Michael Gianaris,32
-Queens,36012,State Senate,SD12,WF,Michael Gianaris,32
-Queens,36013,State Senate,SD12,WF,Michael Gianaris,34
-Queens,36014,State Senate,SD12,WF,Michael Gianaris,30
-Queens,36015,State Senate,SD12,WF,Michael Gianaris,32
-Queens,36016,State Senate,SD12,WF,Michael Gianaris,31
-Queens,36017,State Senate,SD12,WF,Michael Gianaris,31
-Queens,36018,State Senate,SD12,WF,Michael Gianaris,34
-Queens,36019,State Senate,SD12,WF,Michael Gianaris,34
-Queens,36020,State Senate,SD12,WF,Michael Gianaris,35
-Queens,36021,State Senate,SD12,WF,Michael Gianaris,32
-Queens,36022,State Senate,SD12,WF,Michael Gianaris,33
-Queens,36023,State Senate,SD12,WF,Michael Gianaris,32
-Queens,36024,State Senate,SD12,WF,Michael Gianaris,31
-Queens,36025,State Senate,SD12,WF,Michael Gianaris,19
-Queens,36026,State Senate,SD12,WF,Michael Gianaris,18
-Queens,36028,State Senate,SD12,WF,Michael Gianaris,28
-Queens,36029,State Senate,SD12,WF,Michael Gianaris,26
-Queens,36030,State Senate,SD12,WF,Michael Gianaris,20
-Queens,36031,State Senate,SD12,WF,Michael Gianaris,18
-Queens,36032,State Senate,SD12,WF,Michael Gianaris,24
-Queens,36033,State Senate,SD12,WF,Michael Gianaris,32
-Queens,36034,State Senate,SD12,WF,Michael Gianaris,17
-Queens,36035,State Senate,SD12,WF,Michael Gianaris,22
-Queens,36036,State Senate,SD12,WF,Michael Gianaris,36
-Queens,36037,State Senate,SD12,WF,Michael Gianaris,45
-Queens,36038,State Senate,SD12,WF,Michael Gianaris,31
-Queens,36039,State Senate,SD12,WF,Michael Gianaris,45
-Queens,36040,State Senate,SD12,WF,Michael Gianaris,39
-Queens,36041,State Senate,SD12,WF,Michael Gianaris,36
-Queens,36042,State Senate,SD12,WF,Michael Gianaris,23
-Queens,36043,State Senate,SD12,WF,Michael Gianaris,11
-Queens,36064,State Senate,SD12,WF,Michael Gianaris,20
-Queens,36065,State Senate,SD12,WF,Michael Gianaris,5
-Queens,37001,State Senate,SD12,WF,Michael Gianaris,15
-Queens,37002,State Senate,SD12,WF,Michael Gianaris,9
-Queens,37003,State Senate,SD12,WF,Michael Gianaris,5
-Queens,37004,State Senate,SD12,WF,Michael Gianaris,3
-Queens,37005,State Senate,SD12,WF,Michael Gianaris,18
-Queens,37006,State Senate,SD12,WF,Michael Gianaris,13
-Queens,37007,State Senate,SD12,WF,Michael Gianaris,3
-Queens,37008,State Senate,SD12,WF,Michael Gianaris,5
-Queens,37009,State Senate,SD12,WF,Michael Gianaris,6
-Queens,37010,State Senate,SD12,WF,Michael Gianaris,15
-Queens,37011,State Senate,SD12,WF,Michael Gianaris,23
-Queens,37012,State Senate,SD12,WF,Michael Gianaris,4
-Queens,37013,State Senate,SD12,WF,Michael Gianaris,4
-Queens,37014,State Senate,SD12,WF,Michael Gianaris,0
-Queens,37015,State Senate,SD12,WF,Michael Gianaris,8
-Queens,37016,State Senate,SD12,WF,Michael Gianaris,9
-Queens,37017,State Senate,SD12,WF,Michael Gianaris,5
-Queens,37018,State Senate,SD12,WF,Michael Gianaris,2
-Queens,37019,State Senate,SD12,WF,Michael Gianaris,52
-Queens,37020,State Senate,SD12,WF,Michael Gianaris,15
-Queens,37021,State Senate,SD12,WF,Michael Gianaris,29
-Queens,37022,State Senate,SD12,WF,Michael Gianaris,55
-Queens,37023,State Senate,SD12,WF,Michael Gianaris,7
-Queens,37024,State Senate,SD12,WF,Michael Gianaris,23
-Queens,37025,State Senate,SD12,WF,Michael Gianaris,3
-Queens,37026,State Senate,SD12,WF,Michael Gianaris,0
-Queens,37027,State Senate,SD12,WF,Michael Gianaris,70
-Queens,37028,State Senate,SD12,WF,Michael Gianaris,25
-Queens,37029,State Senate,SD12,WF,Michael Gianaris,31
-Queens,37030,State Senate,SD12,WF,Michael Gianaris,24
-Queens,37031,State Senate,SD12,WF,Michael Gianaris,32
-Queens,37032,State Senate,SD12,WF,Michael Gianaris,11
-Queens,37033,State Senate,SD12,WF,Michael Gianaris,14
-Queens,37034,State Senate,SD12,WF,Michael Gianaris,11
-Queens,37035,State Senate,SD12,WF,Michael Gianaris,29
-Queens,37036,State Senate,SD12,WF,Michael Gianaris,37
-Queens,37037,State Senate,SD12,WF,Michael Gianaris,44
-Queens,37038,State Senate,SD12,WF,Michael Gianaris,31
-Queens,37039,State Senate,SD12,WF,Michael Gianaris,24
-Queens,37041,State Senate,SD12,WF,Michael Gianaris,3
-Queens,37051,State Senate,SD12,WF,Michael Gianaris,0
-Queens,37055,State Senate,SD12,WF,Michael Gianaris,0
-Queens,37056,State Senate,SD12,WF,Michael Gianaris,21
-Queens,37057,State Senate,SD12,WF,Michael Gianaris,21
-Queens,37058,State Senate,SD12,WF,Michael Gianaris,34
-Queens,37059,State Senate,SD12,WF,Michael Gianaris,34
-Queens,37063,State Senate,SD12,WF,Michael Gianaris,23
-Queens,37064,State Senate,SD12,WF,Michael Gianaris,58
-Queens,37065,State Senate,SD12,WF,Michael Gianaris,22
-Queens,37067,State Senate,SD12,WF,Michael Gianaris,13
-Queens,37068,State Senate,SD12,WF,Michael Gianaris,24
-Queens,38001,State Senate,SD12,WF,Michael Gianaris,22
-Queens,38002,State Senate,SD12,WF,Michael Gianaris,14
-Queens,38003,State Senate,SD12,WF,Michael Gianaris,18
-Queens,38004,State Senate,SD12,WF,Michael Gianaris,23
-Queens,38005,State Senate,SD12,WF,Michael Gianaris,12
-Queens,38006,State Senate,SD12,WF,Michael Gianaris,25
-Queens,38007,State Senate,SD12,WF,Michael Gianaris,9
-Queens,38008,State Senate,SD12,WF,Michael Gianaris,8
-Queens,38009,State Senate,SD12,WF,Michael Gianaris,16
-Queens,38010,State Senate,SD12,WF,Michael Gianaris,8
-Queens,38011,State Senate,SD12,WF,Michael Gianaris,0
-Queens,38012,State Senate,SD12,WF,Michael Gianaris,9
-Queens,38013,State Senate,SD12,WF,Michael Gianaris,11
-Queens,38022,State Senate,SD12,WF,Michael Gianaris,26
-Queens,38023,State Senate,SD12,WF,Michael Gianaris,16
-Queens,38024,State Senate,SD12,WF,Michael Gianaris,14
-Queens,38025,State Senate,SD12,WF,Michael Gianaris,11
-Queens,38026,State Senate,SD12,WF,Michael Gianaris,10
-Queens,38027,State Senate,SD12,WF,Michael Gianaris,3
-Queens,38029,State Senate,SD12,WF,Michael Gianaris,15
-Queens,38053,State Senate,SD12,WF,Michael Gianaris,8
-Queens,39032,State Senate,SD12,WF,Michael Gianaris,6
-Queens,39033,State Senate,SD12,WF,Michael Gianaris,11
-Queens,23066,State Senate,SD12,Ind,writein,0
-Queens,23067,State Senate,SD12,Ind,writein,0
-Queens,30038,State Senate,SD12,Ind,writein,0
-Queens,30039,State Senate,SD12,Ind,writein,0
-Queens,30040,State Senate,SD12,Ind,writein,0
-Queens,30041,State Senate,SD12,Ind,writein,0
-Queens,30042,State Senate,SD12,Ind,writein,0
-Queens,30043,State Senate,SD12,Ind,writein,0
-Queens,30044,State Senate,SD12,Ind,writein,0
-Queens,30045,State Senate,SD12,Ind,writein,0
-Queens,30046,State Senate,SD12,Ind,writein,0
-Queens,30047,State Senate,SD12,Ind,writein,0
-Queens,30048,State Senate,SD12,Ind,writein,0
-Queens,30049,State Senate,SD12,Ind,writein,0
-Queens,30050,State Senate,SD12,Ind,writein,0
-Queens,30051,State Senate,SD12,Ind,writein,0
-Queens,30052,State Senate,SD12,Ind,writein,0
-Queens,30053,State Senate,SD12,Ind,writein,0
-Queens,30060,State Senate,SD12,Ind,writein,0
-Queens,30061,State Senate,SD12,Ind,writein,1
-Queens,30062,State Senate,SD12,Ind,writein,0
-Queens,30063,State Senate,SD12,Ind,writein,0
-Queens,30064,State Senate,SD12,Ind,writein,0
-Queens,30065,State Senate,SD12,Ind,writein,0
-Queens,30066,State Senate,SD12,Ind,writein,0
-Queens,30067,State Senate,SD12,Ind,writein,0
-Queens,30068,State Senate,SD12,Ind,writein,0
-Queens,30069,State Senate,SD12,Ind,writein,1
-Queens,30070,State Senate,SD12,Ind,writein,0
-Queens,30071,State Senate,SD12,Ind,writein,0
-Queens,34047,State Senate,SD12,Ind,writein,0
-Queens,34048,State Senate,SD12,Ind,writein,0
-Queens,34049,State Senate,SD12,Ind,writein,0
-Queens,34050,State Senate,SD12,Ind,writein,0
-Queens,34051,State Senate,SD12,Ind,writein,0
-Queens,34052,State Senate,SD12,Ind,writein,1
-Queens,34053,State Senate,SD12,Ind,writein,0
-Queens,34055,State Senate,SD12,Ind,writein,0
-Queens,34059,State Senate,SD12,Ind,writein,0
-Queens,34060,State Senate,SD12,Ind,writein,0
-Queens,36001,State Senate,SD12,Ind,writein,1
-Queens,36002,State Senate,SD12,Ind,writein,0
-Queens,36003,State Senate,SD12,Ind,writein,0
-Queens,36004,State Senate,SD12,Ind,writein,1
-Queens,36005,State Senate,SD12,Ind,writein,1
-Queens,36006,State Senate,SD12,Ind,writein,0
-Queens,36007,State Senate,SD12,Ind,writein,3
-Queens,36008,State Senate,SD12,Ind,writein,0
-Queens,36009,State Senate,SD12,Ind,writein,1
-Queens,36010,State Senate,SD12,Ind,writein,0
-Queens,36011,State Senate,SD12,Ind,writein,0
-Queens,36012,State Senate,SD12,Ind,writein,0
-Queens,36013,State Senate,SD12,Ind,writein,1
-Queens,36014,State Senate,SD12,Ind,writein,0
-Queens,36015,State Senate,SD12,Ind,writein,0
-Queens,36016,State Senate,SD12,Ind,writein,0
-Queens,36017,State Senate,SD12,Ind,writein,1
-Queens,36018,State Senate,SD12,Ind,writein,2
-Queens,36019,State Senate,SD12,Ind,writein,0
-Queens,36020,State Senate,SD12,Ind,writein,0
-Queens,36021,State Senate,SD12,Ind,writein,0
-Queens,36022,State Senate,SD12,Ind,writein,0
-Queens,36023,State Senate,SD12,Ind,writein,1
-Queens,36024,State Senate,SD12,Ind,writein,0
-Queens,36025,State Senate,SD12,Ind,writein,1
-Queens,36026,State Senate,SD12,Ind,writein,1
-Queens,36028,State Senate,SD12,Ind,writein,1
-Queens,36029,State Senate,SD12,Ind,writein,0
-Queens,36030,State Senate,SD12,Ind,writein,0
-Queens,36031,State Senate,SD12,Ind,writein,0
-Queens,36032,State Senate,SD12,Ind,writein,1
-Queens,36033,State Senate,SD12,Ind,writein,0
-Queens,36034,State Senate,SD12,Ind,writein,0
-Queens,36035,State Senate,SD12,Ind,writein,1
-Queens,36036,State Senate,SD12,Ind,writein,0
-Queens,36037,State Senate,SD12,Ind,writein,1
-Queens,36038,State Senate,SD12,Ind,writein,0
-Queens,36039,State Senate,SD12,Ind,writein,1
-Queens,36040,State Senate,SD12,Ind,writein,2
-Queens,36041,State Senate,SD12,Ind,writein,1
-Queens,36042,State Senate,SD12,Ind,writein,1
-Queens,36043,State Senate,SD12,Ind,writein,0
-Queens,36064,State Senate,SD12,Ind,writein,0
-Queens,36065,State Senate,SD12,Ind,writein,0
-Queens,37001,State Senate,SD12,Ind,writein,0
-Queens,37002,State Senate,SD12,Ind,writein,0
-Queens,37003,State Senate,SD12,Ind,writein,1
-Queens,37004,State Senate,SD12,Ind,writein,0
-Queens,37005,State Senate,SD12,Ind,writein,0
-Queens,37006,State Senate,SD12,Ind,writein,0
-Queens,37007,State Senate,SD12,Ind,writein,0
-Queens,37008,State Senate,SD12,Ind,writein,1
-Queens,37009,State Senate,SD12,Ind,writein,0
-Queens,37010,State Senate,SD12,Ind,writein,0
-Queens,37011,State Senate,SD12,Ind,writein,0
-Queens,37012,State Senate,SD12,Ind,writein,0
-Queens,37013,State Senate,SD12,Ind,writein,0
-Queens,37014,State Senate,SD12,Ind,writein,1
-Queens,37015,State Senate,SD12,Ind,writein,0
-Queens,37016,State Senate,SD12,Ind,writein,0
-Queens,37017,State Senate,SD12,Ind,writein,0
-Queens,37018,State Senate,SD12,Ind,writein,0
-Queens,37019,State Senate,SD12,Ind,writein,1
-Queens,37020,State Senate,SD12,Ind,writein,1
-Queens,37021,State Senate,SD12,Ind,writein,0
-Queens,37022,State Senate,SD12,Ind,writein,2
-Queens,37023,State Senate,SD12,Ind,writein,0
-Queens,37024,State Senate,SD12,Ind,writein,0
-Queens,37025,State Senate,SD12,Ind,writein,0
-Queens,37026,State Senate,SD12,Ind,writein,0
-Queens,37027,State Senate,SD12,Ind,writein,0
-Queens,37028,State Senate,SD12,Ind,writein,0
-Queens,37029,State Senate,SD12,Ind,writein,2
-Queens,37030,State Senate,SD12,Ind,writein,0
-Queens,37031,State Senate,SD12,Ind,writein,0
-Queens,37032,State Senate,SD12,Ind,writein,0
-Queens,37033,State Senate,SD12,Ind,writein,0
-Queens,37034,State Senate,SD12,Ind,writein,0
-Queens,37035,State Senate,SD12,Ind,writein,0
-Queens,37036,State Senate,SD12,Ind,writein,0
-Queens,37037,State Senate,SD12,Ind,writein,2
-Queens,37038,State Senate,SD12,Ind,writein,0
-Queens,37039,State Senate,SD12,Ind,writein,0
-Queens,37041,State Senate,SD12,Ind,writein,0
-Queens,37051,State Senate,SD12,Ind,writein,0
-Queens,37055,State Senate,SD12,Ind,writein,0
-Queens,37056,State Senate,SD12,Ind,writein,0
-Queens,37057,State Senate,SD12,Ind,writein,1
-Queens,37058,State Senate,SD12,Ind,writein,0
-Queens,37059,State Senate,SD12,Ind,writein,0
-Queens,37063,State Senate,SD12,Ind,writein,0
-Queens,37064,State Senate,SD12,Ind,writein,1
-Queens,37065,State Senate,SD12,Ind,writein,0
-Queens,37067,State Senate,SD12,Ind,writein,0
-Queens,37068,State Senate,SD12,Ind,writein,1
-Queens,38001,State Senate,SD12,Ind,writein,0
-Queens,38002,State Senate,SD12,Ind,writein,0
-Queens,38003,State Senate,SD12,Ind,writein,0
-Queens,38004,State Senate,SD12,Ind,writein,0
-Queens,38005,State Senate,SD12,Ind,writein,0
-Queens,38006,State Senate,SD12,Ind,writein,0
-Queens,38007,State Senate,SD12,Ind,writein,0
-Queens,38008,State Senate,SD12,Ind,writein,0
-Queens,38009,State Senate,SD12,Ind,writein,0
-Queens,38010,State Senate,SD12,Ind,writein,0
-Queens,38011,State Senate,SD12,Ind,writein,0
-Queens,38012,State Senate,SD12,Ind,writein,1
-Queens,38013,State Senate,SD12,Ind,writein,0
-Queens,38022,State Senate,SD12,Ind,writein,0
-Queens,38023,State Senate,SD12,Ind,writein,0
-Queens,38024,State Senate,SD12,Ind,writein,1
-Queens,38025,State Senate,SD12,Ind,writein,0
-Queens,38026,State Senate,SD12,Ind,writein,0
-Queens,38027,State Senate,SD12,Ind,writein,0
-Queens,38029,State Senate,SD12,Ind,writein,0
-Queens,38053,State Senate,SD12,Ind,writein,0
-Queens,39032,State Senate,SD12,Ind,writein,1
-Queens,39033,State Senate,SD12,Ind,writein,0
-Queens,30055,State Senate,SD13,Dem,Jose Peralta,183
-Queens,30056,State Senate,SD13,Dem,Jose Peralta,64
-Queens,30057,State Senate,SD13,Dem,Jose Peralta,484
-Queens,30058,State Senate,SD13,Dem,Jose Peralta,472
-Queens,30059,State Senate,SD13,Dem,Jose Peralta,315
-Queens,34001,State Senate,SD13,Dem,Jose Peralta,425
-Queens,34002,State Senate,SD13,Dem,Jose Peralta,254
-Queens,34003,State Senate,SD13,Dem,Jose Peralta,416
-Queens,34004,State Senate,SD13,Dem,Jose Peralta,498
-Queens,34005,State Senate,SD13,Dem,Jose Peralta,442
-Queens,34006,State Senate,SD13,Dem,Jose Peralta,347
-Queens,34007,State Senate,SD13,Dem,Jose Peralta,430
-Queens,34008,State Senate,SD13,Dem,Jose Peralta,395
-Queens,34009,State Senate,SD13,Dem,Jose Peralta,421
-Queens,34010,State Senate,SD13,Dem,Jose Peralta,444
-Queens,34011,State Senate,SD13,Dem,Jose Peralta,366
-Queens,34012,State Senate,SD13,Dem,Jose Peralta,288
-Queens,34013,State Senate,SD13,Dem,Jose Peralta,459
-Queens,34014,State Senate,SD13,Dem,Jose Peralta,480
-Queens,34015,State Senate,SD13,Dem,Jose Peralta,422
-Queens,34016,State Senate,SD13,Dem,Jose Peralta,429
-Queens,34017,State Senate,SD13,Dem,Jose Peralta,413
-Queens,34018,State Senate,SD13,Dem,Jose Peralta,506
-Queens,34019,State Senate,SD13,Dem,Jose Peralta,445
-Queens,34020,State Senate,SD13,Dem,Jose Peralta,459
-Queens,34021,State Senate,SD13,Dem,Jose Peralta,450
-Queens,34022,State Senate,SD13,Dem,Jose Peralta,509
-Queens,34023,State Senate,SD13,Dem,Jose Peralta,485
-Queens,34024,State Senate,SD13,Dem,Jose Peralta,496
-Queens,34025,State Senate,SD13,Dem,Jose Peralta,515
-Queens,34026,State Senate,SD13,Dem,Jose Peralta,536
-Queens,34027,State Senate,SD13,Dem,Jose Peralta,485
-Queens,34028,State Senate,SD13,Dem,Jose Peralta,490
-Queens,34029,State Senate,SD13,Dem,Jose Peralta,377
-Queens,34030,State Senate,SD13,Dem,Jose Peralta,16
-Queens,34035,State Senate,SD13,Dem,Jose Peralta,465
-Queens,34036,State Senate,SD13,Dem,Jose Peralta,422
-Queens,34037,State Senate,SD13,Dem,Jose Peralta,319
-Queens,34038,State Senate,SD13,Dem,Jose Peralta,364
-Queens,34039,State Senate,SD13,Dem,Jose Peralta,423
-Queens,34040,State Senate,SD13,Dem,Jose Peralta,394
-Queens,34041,State Senate,SD13,Dem,Jose Peralta,212
-Queens,34042,State Senate,SD13,Dem,Jose Peralta,243
-Queens,34043,State Senate,SD13,Dem,Jose Peralta,127
-Queens,34044,State Senate,SD13,Dem,Jose Peralta,123
-Queens,35011,State Senate,SD13,Dem,Jose Peralta,320
-Queens,35012,State Senate,SD13,Dem,Jose Peralta,348
-Queens,35014,State Senate,SD13,Dem,Jose Peralta,314
-Queens,35015,State Senate,SD13,Dem,Jose Peralta,557
-Queens,35016,State Senate,SD13,Dem,Jose Peralta,516
-Queens,35017,State Senate,SD13,Dem,Jose Peralta,553
-Queens,35018,State Senate,SD13,Dem,Jose Peralta,563
-Queens,35019,State Senate,SD13,Dem,Jose Peralta,452
-Queens,35020,State Senate,SD13,Dem,Jose Peralta,36
-Queens,35021,State Senate,SD13,Dem,Jose Peralta,547
-Queens,35022,State Senate,SD13,Dem,Jose Peralta,249
-Queens,35025,State Senate,SD13,Dem,Jose Peralta,675
-Queens,35032,State Senate,SD13,Dem,Jose Peralta,263
-Queens,35035,State Senate,SD13,Dem,Jose Peralta,177
-Queens,35037,State Senate,SD13,Dem,Jose Peralta,375
-Queens,35038,State Senate,SD13,Dem,Jose Peralta,655
-Queens,35039,State Senate,SD13,Dem,Jose Peralta,523
-Queens,35040,State Senate,SD13,Dem,Jose Peralta,425
-Queens,35041,State Senate,SD13,Dem,Jose Peralta,744
-Queens,35042,State Senate,SD13,Dem,Jose Peralta,328
-Queens,35043,State Senate,SD13,Dem,Jose Peralta,494
-Queens,35044,State Senate,SD13,Dem,Jose Peralta,379
-Queens,35045,State Senate,SD13,Dem,Jose Peralta,413
-Queens,35046,State Senate,SD13,Dem,Jose Peralta,344
-Queens,35047,State Senate,SD13,Dem,Jose Peralta,303
-Queens,35048,State Senate,SD13,Dem,Jose Peralta,103
-Queens,35049,State Senate,SD13,Dem,Jose Peralta,76
-Queens,35050,State Senate,SD13,Dem,Jose Peralta,483
-Queens,35051,State Senate,SD13,Dem,Jose Peralta,568
-Queens,35052,State Senate,SD13,Dem,Jose Peralta,565
-Queens,35053,State Senate,SD13,Dem,Jose Peralta,501
-Queens,35054,State Senate,SD13,Dem,Jose Peralta,594
-Queens,35055,State Senate,SD13,Dem,Jose Peralta,650
-Queens,35056,State Senate,SD13,Dem,Jose Peralta,32
-Queens,35057,State Senate,SD13,Dem,Jose Peralta,217
-Queens,36044,State Senate,SD13,Dem,Jose Peralta,53
-Queens,36045,State Senate,SD13,Dem,Jose Peralta,1
-Queens,36046,State Senate,SD13,Dem,Jose Peralta,281
-Queens,36047,State Senate,SD13,Dem,Jose Peralta,351
-Queens,36048,State Senate,SD13,Dem,Jose Peralta,332
-Queens,36050,State Senate,SD13,Dem,Jose Peralta,92
-Queens,36051,State Senate,SD13,Dem,Jose Peralta,48
-Queens,36052,State Senate,SD13,Dem,Jose Peralta,1
-Queens,36053,State Senate,SD13,Dem,Jose Peralta,387
-Queens,36054,State Senate,SD13,Dem,Jose Peralta,225
-Queens,36055,State Senate,SD13,Dem,Jose Peralta,428
-Queens,36056,State Senate,SD13,Dem,Jose Peralta,389
-Queens,36057,State Senate,SD13,Dem,Jose Peralta,432
-Queens,36058,State Senate,SD13,Dem,Jose Peralta,555
-Queens,36059,State Senate,SD13,Dem,Jose Peralta,457
-Queens,36060,State Senate,SD13,Dem,Jose Peralta,484
-Queens,36061,State Senate,SD13,Dem,Jose Peralta,432
-Queens,36062,State Senate,SD13,Dem,Jose Peralta,297
-Queens,36063,State Senate,SD13,Dem,Jose Peralta,366
-Queens,39001,State Senate,SD13,Dem,Jose Peralta,456
-Queens,39002,State Senate,SD13,Dem,Jose Peralta,412
-Queens,39003,State Senate,SD13,Dem,Jose Peralta,444
-Queens,39004,State Senate,SD13,Dem,Jose Peralta,437
-Queens,39005,State Senate,SD13,Dem,Jose Peralta,342
-Queens,39006,State Senate,SD13,Dem,Jose Peralta,250
-Queens,39007,State Senate,SD13,Dem,Jose Peralta,446
-Queens,39008,State Senate,SD13,Dem,Jose Peralta,282
-Queens,39009,State Senate,SD13,Dem,Jose Peralta,395
-Queens,39010,State Senate,SD13,Dem,Jose Peralta,435
-Queens,39011,State Senate,SD13,Dem,Jose Peralta,127
-Queens,39012,State Senate,SD13,Dem,Jose Peralta,363
-Queens,39013,State Senate,SD13,Dem,Jose Peralta,439
-Queens,39014,State Senate,SD13,Dem,Jose Peralta,334
-Queens,39015,State Senate,SD13,Dem,Jose Peralta,481
-Queens,39016,State Senate,SD13,Dem,Jose Peralta,372
-Queens,39017,State Senate,SD13,Dem,Jose Peralta,404
-Queens,39018,State Senate,SD13,Dem,Jose Peralta,273
-Queens,39019,State Senate,SD13,Dem,Jose Peralta,456
-Queens,39020,State Senate,SD13,Dem,Jose Peralta,32
-Queens,39021,State Senate,SD13,Dem,Jose Peralta,62
-Queens,39022,State Senate,SD13,Dem,Jose Peralta,73
-Queens,39025,State Senate,SD13,Dem,Jose Peralta,220
-Queens,39026,State Senate,SD13,Dem,Jose Peralta,217
-Queens,39028,State Senate,SD13,Dem,Jose Peralta,19
-Queens,39041,State Senate,SD13,Dem,Jose Peralta,336
-Queens,39043,State Senate,SD13,Dem,Jose Peralta,322
-Queens,39044,State Senate,SD13,Dem,Jose Peralta,456
-Queens,39045,State Senate,SD13,Dem,Jose Peralta,422
-Queens,39046,State Senate,SD13,Dem,Jose Peralta,497
-Queens,39047,State Senate,SD13,Dem,Jose Peralta,417
-Queens,39050,State Senate,SD13,Dem,Jose Peralta,113
-Queens,39051,State Senate,SD13,Dem,Jose Peralta,227
-Queens,39054,State Senate,SD13,Dem,Jose Peralta,33
-Queens,30055,State Senate,SD13,WF,Jose Peralta,9
-Queens,30056,State Senate,SD13,WF,Jose Peralta,8
-Queens,30057,State Senate,SD13,WF,Jose Peralta,8
-Queens,30058,State Senate,SD13,WF,Jose Peralta,16
-Queens,30059,State Senate,SD13,WF,Jose Peralta,3
-Queens,34001,State Senate,SD13,WF,Jose Peralta,5
-Queens,34002,State Senate,SD13,WF,Jose Peralta,7
-Queens,34003,State Senate,SD13,WF,Jose Peralta,13
-Queens,34004,State Senate,SD13,WF,Jose Peralta,9
-Queens,34005,State Senate,SD13,WF,Jose Peralta,12
-Queens,34006,State Senate,SD13,WF,Jose Peralta,9
-Queens,34007,State Senate,SD13,WF,Jose Peralta,8
-Queens,34008,State Senate,SD13,WF,Jose Peralta,17
-Queens,34009,State Senate,SD13,WF,Jose Peralta,16
-Queens,34010,State Senate,SD13,WF,Jose Peralta,19
-Queens,34011,State Senate,SD13,WF,Jose Peralta,14
-Queens,34012,State Senate,SD13,WF,Jose Peralta,6
-Queens,34013,State Senate,SD13,WF,Jose Peralta,15
-Queens,34014,State Senate,SD13,WF,Jose Peralta,15
-Queens,34015,State Senate,SD13,WF,Jose Peralta,27
-Queens,34016,State Senate,SD13,WF,Jose Peralta,40
-Queens,34017,State Senate,SD13,WF,Jose Peralta,41
-Queens,34018,State Senate,SD13,WF,Jose Peralta,23
-Queens,34019,State Senate,SD13,WF,Jose Peralta,24
-Queens,34020,State Senate,SD13,WF,Jose Peralta,21
-Queens,34021,State Senate,SD13,WF,Jose Peralta,16
-Queens,34022,State Senate,SD13,WF,Jose Peralta,43
-Queens,34023,State Senate,SD13,WF,Jose Peralta,37
-Queens,34024,State Senate,SD13,WF,Jose Peralta,49
-Queens,34025,State Senate,SD13,WF,Jose Peralta,46
-Queens,34026,State Senate,SD13,WF,Jose Peralta,34
-Queens,34027,State Senate,SD13,WF,Jose Peralta,30
-Queens,34028,State Senate,SD13,WF,Jose Peralta,49
-Queens,34029,State Senate,SD13,WF,Jose Peralta,17
-Queens,34030,State Senate,SD13,WF,Jose Peralta,0
-Queens,34035,State Senate,SD13,WF,Jose Peralta,12
-Queens,34036,State Senate,SD13,WF,Jose Peralta,20
-Queens,34037,State Senate,SD13,WF,Jose Peralta,22
-Queens,34038,State Senate,SD13,WF,Jose Peralta,11
-Queens,34039,State Senate,SD13,WF,Jose Peralta,17
-Queens,34040,State Senate,SD13,WF,Jose Peralta,20
-Queens,34041,State Senate,SD13,WF,Jose Peralta,9
-Queens,34042,State Senate,SD13,WF,Jose Peralta,10
-Queens,34043,State Senate,SD13,WF,Jose Peralta,9
-Queens,34044,State Senate,SD13,WF,Jose Peralta,6
-Queens,35011,State Senate,SD13,WF,Jose Peralta,20
-Queens,35012,State Senate,SD13,WF,Jose Peralta,16
-Queens,35014,State Senate,SD13,WF,Jose Peralta,12
-Queens,35015,State Senate,SD13,WF,Jose Peralta,14
-Queens,35016,State Senate,SD13,WF,Jose Peralta,9
-Queens,35017,State Senate,SD13,WF,Jose Peralta,13
-Queens,35018,State Senate,SD13,WF,Jose Peralta,14
-Queens,35019,State Senate,SD13,WF,Jose Peralta,6
-Queens,35020,State Senate,SD13,WF,Jose Peralta,3
-Queens,35021,State Senate,SD13,WF,Jose Peralta,20
-Queens,35022,State Senate,SD13,WF,Jose Peralta,8
-Queens,35025,State Senate,SD13,WF,Jose Peralta,9
-Queens,35032,State Senate,SD13,WF,Jose Peralta,12
-Queens,35035,State Senate,SD13,WF,Jose Peralta,7
-Queens,35037,State Senate,SD13,WF,Jose Peralta,6
-Queens,35038,State Senate,SD13,WF,Jose Peralta,14
-Queens,35039,State Senate,SD13,WF,Jose Peralta,7
-Queens,35040,State Senate,SD13,WF,Jose Peralta,4
-Queens,35041,State Senate,SD13,WF,Jose Peralta,7
-Queens,35042,State Senate,SD13,WF,Jose Peralta,4
-Queens,35043,State Senate,SD13,WF,Jose Peralta,15
-Queens,35044,State Senate,SD13,WF,Jose Peralta,8
-Queens,35045,State Senate,SD13,WF,Jose Peralta,4
-Queens,35046,State Senate,SD13,WF,Jose Peralta,9
-Queens,35047,State Senate,SD13,WF,Jose Peralta,2
-Queens,35048,State Senate,SD13,WF,Jose Peralta,2
-Queens,35049,State Senate,SD13,WF,Jose Peralta,2
-Queens,35050,State Senate,SD13,WF,Jose Peralta,14
-Queens,35051,State Senate,SD13,WF,Jose Peralta,7
-Queens,35052,State Senate,SD13,WF,Jose Peralta,15
-Queens,35053,State Senate,SD13,WF,Jose Peralta,14
-Queens,35054,State Senate,SD13,WF,Jose Peralta,13
-Queens,35055,State Senate,SD13,WF,Jose Peralta,7
-Queens,35056,State Senate,SD13,WF,Jose Peralta,1
-Queens,35057,State Senate,SD13,WF,Jose Peralta,6
-Queens,36044,State Senate,SD13,WF,Jose Peralta,0
-Queens,36045,State Senate,SD13,WF,Jose Peralta,0
-Queens,36046,State Senate,SD13,WF,Jose Peralta,21
-Queens,36047,State Senate,SD13,WF,Jose Peralta,23
-Queens,36048,State Senate,SD13,WF,Jose Peralta,25
-Queens,36050,State Senate,SD13,WF,Jose Peralta,6
-Queens,36051,State Senate,SD13,WF,Jose Peralta,1
-Queens,36052,State Senate,SD13,WF,Jose Peralta,0
-Queens,36053,State Senate,SD13,WF,Jose Peralta,22
-Queens,36054,State Senate,SD13,WF,Jose Peralta,18
-Queens,36055,State Senate,SD13,WF,Jose Peralta,30
-Queens,36056,State Senate,SD13,WF,Jose Peralta,20
-Queens,36057,State Senate,SD13,WF,Jose Peralta,37
-Queens,36058,State Senate,SD13,WF,Jose Peralta,31
-Queens,36059,State Senate,SD13,WF,Jose Peralta,28
-Queens,36060,State Senate,SD13,WF,Jose Peralta,44
-Queens,36061,State Senate,SD13,WF,Jose Peralta,22
-Queens,36062,State Senate,SD13,WF,Jose Peralta,18
-Queens,36063,State Senate,SD13,WF,Jose Peralta,7
-Queens,39001,State Senate,SD13,WF,Jose Peralta,18
-Queens,39002,State Senate,SD13,WF,Jose Peralta,11
-Queens,39003,State Senate,SD13,WF,Jose Peralta,16
-Queens,39004,State Senate,SD13,WF,Jose Peralta,18
-Queens,39005,State Senate,SD13,WF,Jose Peralta,12
-Queens,39006,State Senate,SD13,WF,Jose Peralta,4
-Queens,39007,State Senate,SD13,WF,Jose Peralta,20
-Queens,39008,State Senate,SD13,WF,Jose Peralta,13
-Queens,39009,State Senate,SD13,WF,Jose Peralta,10
-Queens,39010,State Senate,SD13,WF,Jose Peralta,5
-Queens,39011,State Senate,SD13,WF,Jose Peralta,10
-Queens,39012,State Senate,SD13,WF,Jose Peralta,13
-Queens,39013,State Senate,SD13,WF,Jose Peralta,6
-Queens,39014,State Senate,SD13,WF,Jose Peralta,17
-Queens,39015,State Senate,SD13,WF,Jose Peralta,19
-Queens,39016,State Senate,SD13,WF,Jose Peralta,5
-Queens,39017,State Senate,SD13,WF,Jose Peralta,16
-Queens,39018,State Senate,SD13,WF,Jose Peralta,21
-Queens,39019,State Senate,SD13,WF,Jose Peralta,23
-Queens,39020,State Senate,SD13,WF,Jose Peralta,1
-Queens,39021,State Senate,SD13,WF,Jose Peralta,2
-Queens,39022,State Senate,SD13,WF,Jose Peralta,5
-Queens,39025,State Senate,SD13,WF,Jose Peralta,7
-Queens,39026,State Senate,SD13,WF,Jose Peralta,17
-Queens,39028,State Senate,SD13,WF,Jose Peralta,0
-Queens,39041,State Senate,SD13,WF,Jose Peralta,8
-Queens,39043,State Senate,SD13,WF,Jose Peralta,11
-Queens,39044,State Senate,SD13,WF,Jose Peralta,32
-Queens,39045,State Senate,SD13,WF,Jose Peralta,49
-Queens,39046,State Senate,SD13,WF,Jose Peralta,61
-Queens,39047,State Senate,SD13,WF,Jose Peralta,37
-Queens,39050,State Senate,SD13,WF,Jose Peralta,6
-Queens,39051,State Senate,SD13,WF,Jose Peralta,25
-Queens,39054,State Senate,SD13,WF,Jose Peralta,1
-Queens,30055,State Senate,SD13,Ind,writein,1
-Queens,30056,State Senate,SD13,Ind,writein,0
-Queens,30057,State Senate,SD13,Ind,writein,1
-Queens,30058,State Senate,SD13,Ind,writein,1
-Queens,30059,State Senate,SD13,Ind,writein,0
-Queens,34001,State Senate,SD13,Ind,writein,1
-Queens,34002,State Senate,SD13,Ind,writein,1
-Queens,34003,State Senate,SD13,Ind,writein,0
-Queens,34004,State Senate,SD13,Ind,writein,1
-Queens,34005,State Senate,SD13,Ind,writein,0
-Queens,34006,State Senate,SD13,Ind,writein,2
-Queens,34007,State Senate,SD13,Ind,writein,0
-Queens,34008,State Senate,SD13,Ind,writein,0
-Queens,34009,State Senate,SD13,Ind,writein,1
-Queens,34010,State Senate,SD13,Ind,writein,1
-Queens,34011,State Senate,SD13,Ind,writein,0
-Queens,34012,State Senate,SD13,Ind,writein,0
-Queens,34013,State Senate,SD13,Ind,writein,1
-Queens,34014,State Senate,SD13,Ind,writein,1
-Queens,34015,State Senate,SD13,Ind,writein,1
-Queens,34016,State Senate,SD13,Ind,writein,3
-Queens,34017,State Senate,SD13,Ind,writein,1
-Queens,34018,State Senate,SD13,Ind,writein,0
-Queens,34019,State Senate,SD13,Ind,writein,0
-Queens,34020,State Senate,SD13,Ind,writein,0
-Queens,34021,State Senate,SD13,Ind,writein,0
-Queens,34022,State Senate,SD13,Ind,writein,2
-Queens,34023,State Senate,SD13,Ind,writein,1
-Queens,34024,State Senate,SD13,Ind,writein,1
-Queens,34025,State Senate,SD13,Ind,writein,0
-Queens,34026,State Senate,SD13,Ind,writein,2
-Queens,34027,State Senate,SD13,Ind,writein,0
-Queens,34028,State Senate,SD13,Ind,writein,0
-Queens,34029,State Senate,SD13,Ind,writein,1
-Queens,34030,State Senate,SD13,Ind,writein,0
-Queens,34035,State Senate,SD13,Ind,writein,0
-Queens,34036,State Senate,SD13,Ind,writein,0
-Queens,34037,State Senate,SD13,Ind,writein,0
-Queens,34038,State Senate,SD13,Ind,writein,0
-Queens,34039,State Senate,SD13,Ind,writein,1
-Queens,34040,State Senate,SD13,Ind,writein,1
-Queens,34041,State Senate,SD13,Ind,writein,0
-Queens,34042,State Senate,SD13,Ind,writein,0
-Queens,34043,State Senate,SD13,Ind,writein,0
-Queens,34044,State Senate,SD13,Ind,writein,0
-Queens,35011,State Senate,SD13,Ind,writein,0
-Queens,35012,State Senate,SD13,Ind,writein,0
-Queens,35014,State Senate,SD13,Ind,writein,0
-Queens,35015,State Senate,SD13,Ind,writein,0
-Queens,35016,State Senate,SD13,Ind,writein,0
-Queens,35017,State Senate,SD13,Ind,writein,1
-Queens,35018,State Senate,SD13,Ind,writein,1
-Queens,35019,State Senate,SD13,Ind,writein,0
-Queens,35020,State Senate,SD13,Ind,writein,0
-Queens,35021,State Senate,SD13,Ind,writein,0
-Queens,35022,State Senate,SD13,Ind,writein,1
-Queens,35025,State Senate,SD13,Ind,writein,0
-Queens,35032,State Senate,SD13,Ind,writein,0
-Queens,35035,State Senate,SD13,Ind,writein,0
-Queens,35037,State Senate,SD13,Ind,writein,0
-Queens,35038,State Senate,SD13,Ind,writein,0
-Queens,35039,State Senate,SD13,Ind,writein,0
-Queens,35040,State Senate,SD13,Ind,writein,0
-Queens,35041,State Senate,SD13,Ind,writein,1
-Queens,35042,State Senate,SD13,Ind,writein,0
-Queens,35043,State Senate,SD13,Ind,writein,0
-Queens,35044,State Senate,SD13,Ind,writein,0
-Queens,35045,State Senate,SD13,Ind,writein,0
-Queens,35046,State Senate,SD13,Ind,writein,0
-Queens,35047,State Senate,SD13,Ind,writein,0
-Queens,35048,State Senate,SD13,Ind,writein,0
-Queens,35049,State Senate,SD13,Ind,writein,0
-Queens,35050,State Senate,SD13,Ind,writein,3
-Queens,35051,State Senate,SD13,Ind,writein,0
-Queens,35052,State Senate,SD13,Ind,writein,3
-Queens,35053,State Senate,SD13,Ind,writein,1
-Queens,35054,State Senate,SD13,Ind,writein,0
-Queens,35055,State Senate,SD13,Ind,writein,0
-Queens,35056,State Senate,SD13,Ind,writein,0
-Queens,35057,State Senate,SD13,Ind,writein,0
-Queens,36044,State Senate,SD13,Ind,writein,0
-Queens,36045,State Senate,SD13,Ind,writein,0
-Queens,36046,State Senate,SD13,Ind,writein,3
-Queens,36047,State Senate,SD13,Ind,writein,1
-Queens,36048,State Senate,SD13,Ind,writein,0
-Queens,36050,State Senate,SD13,Ind,writein,0
-Queens,36051,State Senate,SD13,Ind,writein,0
-Queens,36052,State Senate,SD13,Ind,writein,0
-Queens,36053,State Senate,SD13,Ind,writein,1
-Queens,36054,State Senate,SD13,Ind,writein,1
-Queens,36055,State Senate,SD13,Ind,writein,1
-Queens,36056,State Senate,SD13,Ind,writein,2
-Queens,36057,State Senate,SD13,Ind,writein,2
-Queens,36058,State Senate,SD13,Ind,writein,0
-Queens,36059,State Senate,SD13,Ind,writein,4
-Queens,36060,State Senate,SD13,Ind,writein,1
-Queens,36061,State Senate,SD13,Ind,writein,3
-Queens,36062,State Senate,SD13,Ind,writein,0
-Queens,36063,State Senate,SD13,Ind,writein,1
-Queens,39001,State Senate,SD13,Ind,writein,2
-Queens,39002,State Senate,SD13,Ind,writein,0
-Queens,39003,State Senate,SD13,Ind,writein,0
-Queens,39004,State Senate,SD13,Ind,writein,0
-Queens,39005,State Senate,SD13,Ind,writein,0
-Queens,39006,State Senate,SD13,Ind,writein,0
-Queens,39007,State Senate,SD13,Ind,writein,0
-Queens,39008,State Senate,SD13,Ind,writein,1
-Queens,39009,State Senate,SD13,Ind,writein,2
-Queens,39010,State Senate,SD13,Ind,writein,0
-Queens,39011,State Senate,SD13,Ind,writein,1
-Queens,39012,State Senate,SD13,Ind,writein,1
-Queens,39013,State Senate,SD13,Ind,writein,2
-Queens,39014,State Senate,SD13,Ind,writein,1
-Queens,39015,State Senate,SD13,Ind,writein,0
-Queens,39016,State Senate,SD13,Ind,writein,1
-Queens,39017,State Senate,SD13,Ind,writein,2
-Queens,39018,State Senate,SD13,Ind,writein,2
-Queens,39019,State Senate,SD13,Ind,writein,2
-Queens,39020,State Senate,SD13,Ind,writein,0
-Queens,39021,State Senate,SD13,Ind,writein,0
-Queens,39022,State Senate,SD13,Ind,writein,0
-Queens,39025,State Senate,SD13,Ind,writein,0
-Queens,39026,State Senate,SD13,Ind,writein,1
-Queens,39028,State Senate,SD13,Ind,writein,0
-Queens,39041,State Senate,SD13,Ind,writein,1
-Queens,39043,State Senate,SD13,Ind,writein,0
-Queens,39044,State Senate,SD13,Ind,writein,0
-Queens,39045,State Senate,SD13,Ind,writein,1
-Queens,39046,State Senate,SD13,Ind,writein,5
-Queens,39047,State Senate,SD13,Ind,writein,1
-Queens,39050,State Senate,SD13,Ind,writein,0
-Queens,39051,State Senate,SD13,Ind,writein,0
-Queens,39054,State Senate,SD13,Ind,writein,0
-Queens,24008,State Senate,SD14,Dem,Malcolm Smith,130
-Queens,24009,State Senate,SD14,Dem,Malcolm Smith,3
-Queens,24013,State Senate,SD14,Dem,Malcolm Smith,345
-Queens,24014,State Senate,SD14,Dem,Malcolm Smith,238
-Queens,24027,State Senate,SD14,Dem,Malcolm Smith,599
-Queens,24029,State Senate,SD14,Dem,Malcolm Smith,519
-Queens,24030,State Senate,SD14,Dem,Malcolm Smith,541
-Queens,24031,State Senate,SD14,Dem,Malcolm Smith,264
-Queens,24037,State Senate,SD14,Dem,Malcolm Smith,467
-Queens,24039,State Senate,SD14,Dem,Malcolm Smith,77
-Queens,24040,State Senate,SD14,Dem,Malcolm Smith,424
-Queens,24041,State Senate,SD14,Dem,Malcolm Smith,86
-Queens,24043,State Senate,SD14,Dem,Malcolm Smith,533
-Queens,24044,State Senate,SD14,Dem,Malcolm Smith,587
-Queens,24045,State Senate,SD14,Dem,Malcolm Smith,376
-Queens,24046,State Senate,SD14,Dem,Malcolm Smith,477
-Queens,24047,State Senate,SD14,Dem,Malcolm Smith,521
-Queens,24048,State Senate,SD14,Dem,Malcolm Smith,104
-Queens,24049,State Senate,SD14,Dem,Malcolm Smith,470
-Queens,24056,State Senate,SD14,Dem,Malcolm Smith,27
-Queens,24058,State Senate,SD14,Dem,Malcolm Smith,82
-Queens,24059,State Senate,SD14,Dem,Malcolm Smith,306
-Queens,24060,State Senate,SD14,Dem,Malcolm Smith,101
-Queens,24065,State Senate,SD14,Dem,Malcolm Smith,373
-Queens,24066,State Senate,SD14,Dem,Malcolm Smith,480
-Queens,25002,State Senate,SD14,Dem,Malcolm Smith,37
-Queens,25003,State Senate,SD14,Dem,Malcolm Smith,373
-Queens,25004,State Senate,SD14,Dem,Malcolm Smith,109
-Queens,25005,State Senate,SD14,Dem,Malcolm Smith,74
-Queens,25006,State Senate,SD14,Dem,Malcolm Smith,420
-Queens,25007,State Senate,SD14,Dem,Malcolm Smith,509
-Queens,25008,State Senate,SD14,Dem,Malcolm Smith,259
-Queens,25009,State Senate,SD14,Dem,Malcolm Smith,80
-Queens,27002,State Senate,SD14,Dem,Malcolm Smith,370
-Queens,27003,State Senate,SD14,Dem,Malcolm Smith,360
-Queens,27004,State Senate,SD14,Dem,Malcolm Smith,383
-Queens,27005,State Senate,SD14,Dem,Malcolm Smith,346
-Queens,27006,State Senate,SD14,Dem,Malcolm Smith,360
-Queens,27007,State Senate,SD14,Dem,Malcolm Smith,531
-Queens,27008,State Senate,SD14,Dem,Malcolm Smith,444
-Queens,27009,State Senate,SD14,Dem,Malcolm Smith,487
-Queens,27011,State Senate,SD14,Dem,Malcolm Smith,220
-Queens,27012,State Senate,SD14,Dem,Malcolm Smith,404
-Queens,27013,State Senate,SD14,Dem,Malcolm Smith,456
-Queens,27014,State Senate,SD14,Dem,Malcolm Smith,477
-Queens,27015,State Senate,SD14,Dem,Malcolm Smith,433
-Queens,27016,State Senate,SD14,Dem,Malcolm Smith,171
-Queens,27017,State Senate,SD14,Dem,Malcolm Smith,429
-Queens,27020,State Senate,SD14,Dem,Malcolm Smith,376
-Queens,27021,State Senate,SD14,Dem,Malcolm Smith,417
-Queens,27031,State Senate,SD14,Dem,Malcolm Smith,65
-Queens,27032,State Senate,SD14,Dem,Malcolm Smith,54
-Queens,28006,State Senate,SD14,Dem,Malcolm Smith,37
-Queens,28007,State Senate,SD14,Dem,Malcolm Smith,85
-Queens,28011,State Senate,SD14,Dem,Malcolm Smith,242
-Queens,28025,State Senate,SD14,Dem,Malcolm Smith,440
-Queens,28026,State Senate,SD14,Dem,Malcolm Smith,184
-Queens,29001,State Senate,SD14,Dem,Malcolm Smith,345
-Queens,29002,State Senate,SD14,Dem,Malcolm Smith,379
-Queens,29003,State Senate,SD14,Dem,Malcolm Smith,377
-Queens,29006,State Senate,SD14,Dem,Malcolm Smith,349
-Queens,29008,State Senate,SD14,Dem,Malcolm Smith,252
-Queens,29012,State Senate,SD14,Dem,Malcolm Smith,605
-Queens,29013,State Senate,SD14,Dem,Malcolm Smith,340
-Queens,29014,State Senate,SD14,Dem,Malcolm Smith,422
-Queens,29015,State Senate,SD14,Dem,Malcolm Smith,560
-Queens,29016,State Senate,SD14,Dem,Malcolm Smith,337
-Queens,29017,State Senate,SD14,Dem,Malcolm Smith,451
-Queens,29018,State Senate,SD14,Dem,Malcolm Smith,525
-Queens,29019,State Senate,SD14,Dem,Malcolm Smith,529
-Queens,29020,State Senate,SD14,Dem,Malcolm Smith,618
-Queens,29021,State Senate,SD14,Dem,Malcolm Smith,629
-Queens,29022,State Senate,SD14,Dem,Malcolm Smith,590
-Queens,29023,State Senate,SD14,Dem,Malcolm Smith,712
-Queens,29024,State Senate,SD14,Dem,Malcolm Smith,660
-Queens,29025,State Senate,SD14,Dem,Malcolm Smith,604
-Queens,29026,State Senate,SD14,Dem,Malcolm Smith,655
-Queens,29027,State Senate,SD14,Dem,Malcolm Smith,572
-Queens,29028,State Senate,SD14,Dem,Malcolm Smith,597
-Queens,29029,State Senate,SD14,Dem,Malcolm Smith,645
-Queens,29030,State Senate,SD14,Dem,Malcolm Smith,535
-Queens,29031,State Senate,SD14,Dem,Malcolm Smith,691
-Queens,29032,State Senate,SD14,Dem,Malcolm Smith,668
-Queens,29033,State Senate,SD14,Dem,Malcolm Smith,650
-Queens,29034,State Senate,SD14,Dem,Malcolm Smith,607
-Queens,29036,State Senate,SD14,Dem,Malcolm Smith,497
-Queens,29037,State Senate,SD14,Dem,Malcolm Smith,516
-Queens,29038,State Senate,SD14,Dem,Malcolm Smith,554
-Queens,29039,State Senate,SD14,Dem,Malcolm Smith,270
-Queens,29050,State Senate,SD14,Dem,Malcolm Smith,768
-Queens,29051,State Senate,SD14,Dem,Malcolm Smith,724
-Queens,29052,State Senate,SD14,Dem,Malcolm Smith,652
-Queens,29053,State Senate,SD14,Dem,Malcolm Smith,466
-Queens,29054,State Senate,SD14,Dem,Malcolm Smith,661
-Queens,29055,State Senate,SD14,Dem,Malcolm Smith,671
-Queens,29056,State Senate,SD14,Dem,Malcolm Smith,650
-Queens,29057,State Senate,SD14,Dem,Malcolm Smith,646
-Queens,29058,State Senate,SD14,Dem,Malcolm Smith,538
-Queens,29059,State Senate,SD14,Dem,Malcolm Smith,717
-Queens,29060,State Senate,SD14,Dem,Malcolm Smith,727
-Queens,29061,State Senate,SD14,Dem,Malcolm Smith,665
-Queens,29062,State Senate,SD14,Dem,Malcolm Smith,661
-Queens,29063,State Senate,SD14,Dem,Malcolm Smith,564
-Queens,29064,State Senate,SD14,Dem,Malcolm Smith,506
-Queens,29065,State Senate,SD14,Dem,Malcolm Smith,494
-Queens,29066,State Senate,SD14,Dem,Malcolm Smith,553
-Queens,29067,State Senate,SD14,Dem,Malcolm Smith,588
-Queens,29068,State Senate,SD14,Dem,Malcolm Smith,600
-Queens,32001,State Senate,SD14,Dem,Malcolm Smith,455
-Queens,32003,State Senate,SD14,Dem,Malcolm Smith,484
-Queens,32004,State Senate,SD14,Dem,Malcolm Smith,487
-Queens,32005,State Senate,SD14,Dem,Malcolm Smith,509
-Queens,32006,State Senate,SD14,Dem,Malcolm Smith,483
-Queens,32011,State Senate,SD14,Dem,Malcolm Smith,202
-Queens,32014,State Senate,SD14,Dem,Malcolm Smith,20
-Queens,32015,State Senate,SD14,Dem,Malcolm Smith,468
-Queens,32016,State Senate,SD14,Dem,Malcolm Smith,491
-Queens,32023,State Senate,SD14,Dem,Malcolm Smith,380
-Queens,32024,State Senate,SD14,Dem,Malcolm Smith,298
-Queens,32040,State Senate,SD14,Dem,Malcolm Smith,550
-Queens,32041,State Senate,SD14,Dem,Malcolm Smith,542
-Queens,32042,State Senate,SD14,Dem,Malcolm Smith,590
-Queens,32043,State Senate,SD14,Dem,Malcolm Smith,744
-Queens,32044,State Senate,SD14,Dem,Malcolm Smith,308
-Queens,32045,State Senate,SD14,Dem,Malcolm Smith,421
-Queens,33016,State Senate,SD14,Dem,Malcolm Smith,97
-Queens,33017,State Senate,SD14,Dem,Malcolm Smith,502
-Queens,33018,State Senate,SD14,Dem,Malcolm Smith,453
-Queens,33019,State Senate,SD14,Dem,Malcolm Smith,421
-Queens,33020,State Senate,SD14,Dem,Malcolm Smith,432
-Queens,33021,State Senate,SD14,Dem,Malcolm Smith,543
-Queens,33022,State Senate,SD14,Dem,Malcolm Smith,504
-Queens,33023,State Senate,SD14,Dem,Malcolm Smith,561
-Queens,33024,State Senate,SD14,Dem,Malcolm Smith,526
-Queens,33025,State Senate,SD14,Dem,Malcolm Smith,500
-Queens,33026,State Senate,SD14,Dem,Malcolm Smith,388
-Queens,33027,State Senate,SD14,Dem,Malcolm Smith,426
-Queens,33028,State Senate,SD14,Dem,Malcolm Smith,454
-Queens,33029,State Senate,SD14,Dem,Malcolm Smith,546
-Queens,33030,State Senate,SD14,Dem,Malcolm Smith,576
-Queens,33031,State Senate,SD14,Dem,Malcolm Smith,645
-Queens,33032,State Senate,SD14,Dem,Malcolm Smith,596
-Queens,33033,State Senate,SD14,Dem,Malcolm Smith,640
-Queens,33034,State Senate,SD14,Dem,Malcolm Smith,634
-Queens,33035,State Senate,SD14,Dem,Malcolm Smith,529
-Queens,33036,State Senate,SD14,Dem,Malcolm Smith,451
-Queens,33037,State Senate,SD14,Dem,Malcolm Smith,531
-Queens,33038,State Senate,SD14,Dem,Malcolm Smith,520
-Queens,33039,State Senate,SD14,Dem,Malcolm Smith,637
-Queens,33040,State Senate,SD14,Dem,Malcolm Smith,645
-Queens,33041,State Senate,SD14,Dem,Malcolm Smith,621
-Queens,33042,State Senate,SD14,Dem,Malcolm Smith,531
-Queens,33043,State Senate,SD14,Dem,Malcolm Smith,547
-Queens,33044,State Senate,SD14,Dem,Malcolm Smith,598
-Queens,33045,State Senate,SD14,Dem,Malcolm Smith,570
-Queens,33046,State Senate,SD14,Dem,Malcolm Smith,566
-Queens,33047,State Senate,SD14,Dem,Malcolm Smith,507
-Queens,33048,State Senate,SD14,Dem,Malcolm Smith,644
-Queens,33049,State Senate,SD14,Dem,Malcolm Smith,608
-Queens,33050,State Senate,SD14,Dem,Malcolm Smith,622
-Queens,33051,State Senate,SD14,Dem,Malcolm Smith,521
-Queens,33052,State Senate,SD14,Dem,Malcolm Smith,542
-Queens,33053,State Senate,SD14,Dem,Malcolm Smith,481
-Queens,33054,State Senate,SD14,Dem,Malcolm Smith,556
-Queens,33055,State Senate,SD14,Dem,Malcolm Smith,575
-Queens,33056,State Senate,SD14,Dem,Malcolm Smith,591
-Queens,33057,State Senate,SD14,Dem,Malcolm Smith,642
-Queens,33058,State Senate,SD14,Dem,Malcolm Smith,621
-Queens,33059,State Senate,SD14,Dem,Malcolm Smith,632
-Queens,33060,State Senate,SD14,Dem,Malcolm Smith,579
-Queens,33061,State Senate,SD14,Dem,Malcolm Smith,551
-Queens,33062,State Senate,SD14,Dem,Malcolm Smith,636
-Queens,33063,State Senate,SD14,Dem,Malcolm Smith,634
-Queens,33064,State Senate,SD14,Dem,Malcolm Smith,622
-Queens,33065,State Senate,SD14,Dem,Malcolm Smith,674
-Queens,33066,State Senate,SD14,Dem,Malcolm Smith,604
-Queens,33067,State Senate,SD14,Dem,Malcolm Smith,600
-Queens,33068,State Senate,SD14,Dem,Malcolm Smith,666
-Queens,33069,State Senate,SD14,Dem,Malcolm Smith,484
-Queens,33070,State Senate,SD14,Dem,Malcolm Smith,483
-Queens,33071,State Senate,SD14,Dem,Malcolm Smith,470
-Queens,24008,State Senate,SD14,WF,Malcolm Smith,8
-Queens,24009,State Senate,SD14,WF,Malcolm Smith,0
-Queens,24013,State Senate,SD14,WF,Malcolm Smith,14
-Queens,24014,State Senate,SD14,WF,Malcolm Smith,12
-Queens,24027,State Senate,SD14,WF,Malcolm Smith,10
-Queens,24029,State Senate,SD14,WF,Malcolm Smith,15
-Queens,24030,State Senate,SD14,WF,Malcolm Smith,9
-Queens,24031,State Senate,SD14,WF,Malcolm Smith,12
-Queens,24037,State Senate,SD14,WF,Malcolm Smith,28
-Queens,24039,State Senate,SD14,WF,Malcolm Smith,3
-Queens,24040,State Senate,SD14,WF,Malcolm Smith,20
-Queens,24041,State Senate,SD14,WF,Malcolm Smith,11
-Queens,24043,State Senate,SD14,WF,Malcolm Smith,13
-Queens,24044,State Senate,SD14,WF,Malcolm Smith,12
-Queens,24045,State Senate,SD14,WF,Malcolm Smith,15
-Queens,24046,State Senate,SD14,WF,Malcolm Smith,12
-Queens,24047,State Senate,SD14,WF,Malcolm Smith,23
-Queens,24048,State Senate,SD14,WF,Malcolm Smith,2
-Queens,24049,State Senate,SD14,WF,Malcolm Smith,39
-Queens,24056,State Senate,SD14,WF,Malcolm Smith,0
-Queens,24058,State Senate,SD14,WF,Malcolm Smith,0
-Queens,24059,State Senate,SD14,WF,Malcolm Smith,11
-Queens,24060,State Senate,SD14,WF,Malcolm Smith,1
-Queens,24065,State Senate,SD14,WF,Malcolm Smith,7
-Queens,24066,State Senate,SD14,WF,Malcolm Smith,15
-Queens,25002,State Senate,SD14,WF,Malcolm Smith,1
-Queens,25003,State Senate,SD14,WF,Malcolm Smith,27
-Queens,25004,State Senate,SD14,WF,Malcolm Smith,3
-Queens,25005,State Senate,SD14,WF,Malcolm Smith,3
-Queens,25006,State Senate,SD14,WF,Malcolm Smith,20
-Queens,25007,State Senate,SD14,WF,Malcolm Smith,27
-Queens,25008,State Senate,SD14,WF,Malcolm Smith,15
-Queens,25009,State Senate,SD14,WF,Malcolm Smith,2
-Queens,27002,State Senate,SD14,WF,Malcolm Smith,9
-Queens,27003,State Senate,SD14,WF,Malcolm Smith,24
-Queens,27004,State Senate,SD14,WF,Malcolm Smith,22
-Queens,27005,State Senate,SD14,WF,Malcolm Smith,41
-Queens,27006,State Senate,SD14,WF,Malcolm Smith,16
-Queens,27007,State Senate,SD14,WF,Malcolm Smith,46
-Queens,27008,State Senate,SD14,WF,Malcolm Smith,16
-Queens,27009,State Senate,SD14,WF,Malcolm Smith,24
-Queens,27011,State Senate,SD14,WF,Malcolm Smith,6
-Queens,27012,State Senate,SD14,WF,Malcolm Smith,30
-Queens,27013,State Senate,SD14,WF,Malcolm Smith,15
-Queens,27014,State Senate,SD14,WF,Malcolm Smith,39
-Queens,27015,State Senate,SD14,WF,Malcolm Smith,27
-Queens,27016,State Senate,SD14,WF,Malcolm Smith,8
-Queens,27017,State Senate,SD14,WF,Malcolm Smith,13
-Queens,27020,State Senate,SD14,WF,Malcolm Smith,26
-Queens,27021,State Senate,SD14,WF,Malcolm Smith,15
-Queens,27031,State Senate,SD14,WF,Malcolm Smith,1
-Queens,27032,State Senate,SD14,WF,Malcolm Smith,5
-Queens,28006,State Senate,SD14,WF,Malcolm Smith,6
-Queens,28007,State Senate,SD14,WF,Malcolm Smith,5
-Queens,28011,State Senate,SD14,WF,Malcolm Smith,25
-Queens,28025,State Senate,SD14,WF,Malcolm Smith,33
-Queens,28026,State Senate,SD14,WF,Malcolm Smith,11
-Queens,29001,State Senate,SD14,WF,Malcolm Smith,9
-Queens,29002,State Senate,SD14,WF,Malcolm Smith,3
-Queens,29003,State Senate,SD14,WF,Malcolm Smith,3
-Queens,29006,State Senate,SD14,WF,Malcolm Smith,9
-Queens,29008,State Senate,SD14,WF,Malcolm Smith,8
-Queens,29012,State Senate,SD14,WF,Malcolm Smith,6
-Queens,29013,State Senate,SD14,WF,Malcolm Smith,14
-Queens,29014,State Senate,SD14,WF,Malcolm Smith,5
-Queens,29015,State Senate,SD14,WF,Malcolm Smith,11
-Queens,29016,State Senate,SD14,WF,Malcolm Smith,6
-Queens,29017,State Senate,SD14,WF,Malcolm Smith,3
-Queens,29018,State Senate,SD14,WF,Malcolm Smith,9
-Queens,29019,State Senate,SD14,WF,Malcolm Smith,9
-Queens,29020,State Senate,SD14,WF,Malcolm Smith,6
-Queens,29021,State Senate,SD14,WF,Malcolm Smith,12
-Queens,29022,State Senate,SD14,WF,Malcolm Smith,10
-Queens,29023,State Senate,SD14,WF,Malcolm Smith,16
-Queens,29024,State Senate,SD14,WF,Malcolm Smith,8
-Queens,29025,State Senate,SD14,WF,Malcolm Smith,8
-Queens,29026,State Senate,SD14,WF,Malcolm Smith,8
-Queens,29027,State Senate,SD14,WF,Malcolm Smith,8
-Queens,29028,State Senate,SD14,WF,Malcolm Smith,6
-Queens,29029,State Senate,SD14,WF,Malcolm Smith,5
-Queens,29030,State Senate,SD14,WF,Malcolm Smith,2
-Queens,29031,State Senate,SD14,WF,Malcolm Smith,9
-Queens,29032,State Senate,SD14,WF,Malcolm Smith,17
-Queens,29033,State Senate,SD14,WF,Malcolm Smith,9
-Queens,29034,State Senate,SD14,WF,Malcolm Smith,12
-Queens,29036,State Senate,SD14,WF,Malcolm Smith,13
-Queens,29037,State Senate,SD14,WF,Malcolm Smith,12
-Queens,29038,State Senate,SD14,WF,Malcolm Smith,7
-Queens,29039,State Senate,SD14,WF,Malcolm Smith,4
-Queens,29050,State Senate,SD14,WF,Malcolm Smith,5
-Queens,29051,State Senate,SD14,WF,Malcolm Smith,2
-Queens,29052,State Senate,SD14,WF,Malcolm Smith,10
-Queens,29053,State Senate,SD14,WF,Malcolm Smith,5
-Queens,29054,State Senate,SD14,WF,Malcolm Smith,12
-Queens,29055,State Senate,SD14,WF,Malcolm Smith,5
-Queens,29056,State Senate,SD14,WF,Malcolm Smith,10
-Queens,29057,State Senate,SD14,WF,Malcolm Smith,4
-Queens,29058,State Senate,SD14,WF,Malcolm Smith,6
-Queens,29059,State Senate,SD14,WF,Malcolm Smith,10
-Queens,29060,State Senate,SD14,WF,Malcolm Smith,13
-Queens,29061,State Senate,SD14,WF,Malcolm Smith,10
-Queens,29062,State Senate,SD14,WF,Malcolm Smith,7
-Queens,29063,State Senate,SD14,WF,Malcolm Smith,6
-Queens,29064,State Senate,SD14,WF,Malcolm Smith,8
-Queens,29065,State Senate,SD14,WF,Malcolm Smith,3
-Queens,29066,State Senate,SD14,WF,Malcolm Smith,3
-Queens,29067,State Senate,SD14,WF,Malcolm Smith,4
-Queens,29068,State Senate,SD14,WF,Malcolm Smith,7
-Queens,32001,State Senate,SD14,WF,Malcolm Smith,4
-Queens,32003,State Senate,SD14,WF,Malcolm Smith,6
-Queens,32004,State Senate,SD14,WF,Malcolm Smith,13
-Queens,32005,State Senate,SD14,WF,Malcolm Smith,7
-Queens,32006,State Senate,SD14,WF,Malcolm Smith,9
-Queens,32011,State Senate,SD14,WF,Malcolm Smith,6
-Queens,32014,State Senate,SD14,WF,Malcolm Smith,0
-Queens,32015,State Senate,SD14,WF,Malcolm Smith,7
-Queens,32016,State Senate,SD14,WF,Malcolm Smith,7
-Queens,32023,State Senate,SD14,WF,Malcolm Smith,2
-Queens,32024,State Senate,SD14,WF,Malcolm Smith,5
-Queens,32040,State Senate,SD14,WF,Malcolm Smith,4
-Queens,32041,State Senate,SD14,WF,Malcolm Smith,5
-Queens,32042,State Senate,SD14,WF,Malcolm Smith,1
-Queens,32043,State Senate,SD14,WF,Malcolm Smith,4
-Queens,32044,State Senate,SD14,WF,Malcolm Smith,1
-Queens,32045,State Senate,SD14,WF,Malcolm Smith,6
-Queens,33016,State Senate,SD14,WF,Malcolm Smith,1
-Queens,33017,State Senate,SD14,WF,Malcolm Smith,19
-Queens,33018,State Senate,SD14,WF,Malcolm Smith,24
-Queens,33019,State Senate,SD14,WF,Malcolm Smith,24
-Queens,33020,State Senate,SD14,WF,Malcolm Smith,22
-Queens,33021,State Senate,SD14,WF,Malcolm Smith,12
-Queens,33022,State Senate,SD14,WF,Malcolm Smith,12
-Queens,33023,State Senate,SD14,WF,Malcolm Smith,12
-Queens,33024,State Senate,SD14,WF,Malcolm Smith,5
-Queens,33025,State Senate,SD14,WF,Malcolm Smith,17
-Queens,33026,State Senate,SD14,WF,Malcolm Smith,9
-Queens,33027,State Senate,SD14,WF,Malcolm Smith,8
-Queens,33028,State Senate,SD14,WF,Malcolm Smith,7
-Queens,33029,State Senate,SD14,WF,Malcolm Smith,8
-Queens,33030,State Senate,SD14,WF,Malcolm Smith,6
-Queens,33031,State Senate,SD14,WF,Malcolm Smith,10
-Queens,33032,State Senate,SD14,WF,Malcolm Smith,9
-Queens,33033,State Senate,SD14,WF,Malcolm Smith,7
-Queens,33034,State Senate,SD14,WF,Malcolm Smith,7
-Queens,33035,State Senate,SD14,WF,Malcolm Smith,5
-Queens,33036,State Senate,SD14,WF,Malcolm Smith,6
-Queens,33037,State Senate,SD14,WF,Malcolm Smith,7
-Queens,33038,State Senate,SD14,WF,Malcolm Smith,9
-Queens,33039,State Senate,SD14,WF,Malcolm Smith,8
-Queens,33040,State Senate,SD14,WF,Malcolm Smith,6
-Queens,33041,State Senate,SD14,WF,Malcolm Smith,11
-Queens,33042,State Senate,SD14,WF,Malcolm Smith,7
-Queens,33043,State Senate,SD14,WF,Malcolm Smith,20
-Queens,33044,State Senate,SD14,WF,Malcolm Smith,10
-Queens,33045,State Senate,SD14,WF,Malcolm Smith,7
-Queens,33046,State Senate,SD14,WF,Malcolm Smith,6
-Queens,33047,State Senate,SD14,WF,Malcolm Smith,8
-Queens,33048,State Senate,SD14,WF,Malcolm Smith,10
-Queens,33049,State Senate,SD14,WF,Malcolm Smith,3
-Queens,33050,State Senate,SD14,WF,Malcolm Smith,8
-Queens,33051,State Senate,SD14,WF,Malcolm Smith,14
-Queens,33052,State Senate,SD14,WF,Malcolm Smith,12
-Queens,33053,State Senate,SD14,WF,Malcolm Smith,10
-Queens,33054,State Senate,SD14,WF,Malcolm Smith,7
-Queens,33055,State Senate,SD14,WF,Malcolm Smith,16
-Queens,33056,State Senate,SD14,WF,Malcolm Smith,10
-Queens,33057,State Senate,SD14,WF,Malcolm Smith,12
-Queens,33058,State Senate,SD14,WF,Malcolm Smith,17
-Queens,33059,State Senate,SD14,WF,Malcolm Smith,9
-Queens,33060,State Senate,SD14,WF,Malcolm Smith,6
-Queens,33061,State Senate,SD14,WF,Malcolm Smith,6
-Queens,33062,State Senate,SD14,WF,Malcolm Smith,16
-Queens,33063,State Senate,SD14,WF,Malcolm Smith,9
-Queens,33064,State Senate,SD14,WF,Malcolm Smith,11
-Queens,33065,State Senate,SD14,WF,Malcolm Smith,10
-Queens,33066,State Senate,SD14,WF,Malcolm Smith,8
-Queens,33067,State Senate,SD14,WF,Malcolm Smith,4
-Queens,33068,State Senate,SD14,WF,Malcolm Smith,6
-Queens,33069,State Senate,SD14,WF,Malcolm Smith,9
-Queens,33070,State Senate,SD14,WF,Malcolm Smith,6
-Queens,33071,State Senate,SD14,WF,Malcolm Smith,13
-Queens,24008,State Senate,SD14,Ind,writein,0
-Queens,24009,State Senate,SD14,Ind,writein,0
-Queens,24013,State Senate,SD14,Ind,writein,2
-Queens,24014,State Senate,SD14,Ind,writein,0
-Queens,24027,State Senate,SD14,Ind,writein,1
-Queens,24029,State Senate,SD14,Ind,writein,1
-Queens,24030,State Senate,SD14,Ind,writein,0
-Queens,24031,State Senate,SD14,Ind,writein,0
-Queens,24037,State Senate,SD14,Ind,writein,1
-Queens,24039,State Senate,SD14,Ind,writein,0
-Queens,24040,State Senate,SD14,Ind,writein,1
-Queens,24041,State Senate,SD14,Ind,writein,0
-Queens,24043,State Senate,SD14,Ind,writein,0
-Queens,24044,State Senate,SD14,Ind,writein,0
-Queens,24045,State Senate,SD14,Ind,writein,2
-Queens,24046,State Senate,SD14,Ind,writein,1
-Queens,24047,State Senate,SD14,Ind,writein,0
-Queens,24048,State Senate,SD14,Ind,writein,0
-Queens,24049,State Senate,SD14,Ind,writein,5
-Queens,24056,State Senate,SD14,Ind,writein,0
-Queens,24058,State Senate,SD14,Ind,writein,0
-Queens,24059,State Senate,SD14,Ind,writein,0
-Queens,24060,State Senate,SD14,Ind,writein,0
-Queens,24065,State Senate,SD14,Ind,writein,0
-Queens,24066,State Senate,SD14,Ind,writein,1
-Queens,25002,State Senate,SD14,Ind,writein,0
-Queens,25003,State Senate,SD14,Ind,writein,1
-Queens,25004,State Senate,SD14,Ind,writein,0
-Queens,25005,State Senate,SD14,Ind,writein,0
-Queens,25006,State Senate,SD14,Ind,writein,3
-Queens,25007,State Senate,SD14,Ind,writein,3
-Queens,25008,State Senate,SD14,Ind,writein,1
-Queens,25009,State Senate,SD14,Ind,writein,0
-Queens,27002,State Senate,SD14,Ind,writein,1
-Queens,27003,State Senate,SD14,Ind,writein,1
-Queens,27004,State Senate,SD14,Ind,writein,1
-Queens,27005,State Senate,SD14,Ind,writein,5
-Queens,27006,State Senate,SD14,Ind,writein,1
-Queens,27007,State Senate,SD14,Ind,writein,0
-Queens,27008,State Senate,SD14,Ind,writein,3
-Queens,27009,State Senate,SD14,Ind,writein,0
-Queens,27011,State Senate,SD14,Ind,writein,2
-Queens,27012,State Senate,SD14,Ind,writein,1
-Queens,27013,State Senate,SD14,Ind,writein,1
-Queens,27014,State Senate,SD14,Ind,writein,1
-Queens,27015,State Senate,SD14,Ind,writein,2
-Queens,27016,State Senate,SD14,Ind,writein,0
-Queens,27017,State Senate,SD14,Ind,writein,5
-Queens,27020,State Senate,SD14,Ind,writein,3
-Queens,27021,State Senate,SD14,Ind,writein,2
-Queens,27031,State Senate,SD14,Ind,writein,0
-Queens,27032,State Senate,SD14,Ind,writein,0
-Queens,28006,State Senate,SD14,Ind,writein,1
-Queens,28007,State Senate,SD14,Ind,writein,1
-Queens,28011,State Senate,SD14,Ind,writein,5
-Queens,28025,State Senate,SD14,Ind,writein,0
-Queens,28026,State Senate,SD14,Ind,writein,0
-Queens,29001,State Senate,SD14,Ind,writein,0
-Queens,29002,State Senate,SD14,Ind,writein,0
-Queens,29003,State Senate,SD14,Ind,writein,0
-Queens,29006,State Senate,SD14,Ind,writein,1
-Queens,29008,State Senate,SD14,Ind,writein,0
-Queens,29012,State Senate,SD14,Ind,writein,0
-Queens,29013,State Senate,SD14,Ind,writein,0
-Queens,29014,State Senate,SD14,Ind,writein,0
-Queens,29015,State Senate,SD14,Ind,writein,0
-Queens,29016,State Senate,SD14,Ind,writein,0
-Queens,29017,State Senate,SD14,Ind,writein,0
-Queens,29018,State Senate,SD14,Ind,writein,0
-Queens,29019,State Senate,SD14,Ind,writein,0
-Queens,29020,State Senate,SD14,Ind,writein,1
-Queens,29021,State Senate,SD14,Ind,writein,0
-Queens,29022,State Senate,SD14,Ind,writein,1
-Queens,29023,State Senate,SD14,Ind,writein,0
-Queens,29024,State Senate,SD14,Ind,writein,0
-Queens,29025,State Senate,SD14,Ind,writein,0
-Queens,29026,State Senate,SD14,Ind,writein,0
-Queens,29027,State Senate,SD14,Ind,writein,0
-Queens,29028,State Senate,SD14,Ind,writein,1
-Queens,29029,State Senate,SD14,Ind,writein,0
-Queens,29030,State Senate,SD14,Ind,writein,0
-Queens,29031,State Senate,SD14,Ind,writein,0
-Queens,29032,State Senate,SD14,Ind,writein,0
-Queens,29033,State Senate,SD14,Ind,writein,0
-Queens,29034,State Senate,SD14,Ind,writein,0
-Queens,29036,State Senate,SD14,Ind,writein,0
-Queens,29037,State Senate,SD14,Ind,writein,0
-Queens,29038,State Senate,SD14,Ind,writein,0
-Queens,29039,State Senate,SD14,Ind,writein,0
-Queens,29050,State Senate,SD14,Ind,writein,0
-Queens,29051,State Senate,SD14,Ind,writein,0
-Queens,29052,State Senate,SD14,Ind,writein,0
-Queens,29053,State Senate,SD14,Ind,writein,0
-Queens,29054,State Senate,SD14,Ind,writein,0
-Queens,29055,State Senate,SD14,Ind,writein,0
-Queens,29056,State Senate,SD14,Ind,writein,0
-Queens,29057,State Senate,SD14,Ind,writein,0
-Queens,29058,State Senate,SD14,Ind,writein,0
-Queens,29059,State Senate,SD14,Ind,writein,1
-Queens,29060,State Senate,SD14,Ind,writein,1
-Queens,29061,State Senate,SD14,Ind,writein,1
-Queens,29062,State Senate,SD14,Ind,writein,0
-Queens,29063,State Senate,SD14,Ind,writein,0
-Queens,29064,State Senate,SD14,Ind,writein,0
-Queens,29065,State Senate,SD14,Ind,writein,0
-Queens,29066,State Senate,SD14,Ind,writein,0
-Queens,29067,State Senate,SD14,Ind,writein,0
-Queens,29068,State Senate,SD14,Ind,writein,2
-Queens,32001,State Senate,SD14,Ind,writein,1
-Queens,32003,State Senate,SD14,Ind,writein,1
-Queens,32004,State Senate,SD14,Ind,writein,1
-Queens,32005,State Senate,SD14,Ind,writein,0
-Queens,32006,State Senate,SD14,Ind,writein,1
-Queens,32011,State Senate,SD14,Ind,writein,0
-Queens,32014,State Senate,SD14,Ind,writein,0
-Queens,32015,State Senate,SD14,Ind,writein,0
-Queens,32016,State Senate,SD14,Ind,writein,0
-Queens,32023,State Senate,SD14,Ind,writein,0
-Queens,32024,State Senate,SD14,Ind,writein,0
-Queens,32040,State Senate,SD14,Ind,writein,0
-Queens,32041,State Senate,SD14,Ind,writein,1
-Queens,32042,State Senate,SD14,Ind,writein,0
-Queens,32043,State Senate,SD14,Ind,writein,0
-Queens,32044,State Senate,SD14,Ind,writein,1
-Queens,32045,State Senate,SD14,Ind,writein,0
-Queens,33016,State Senate,SD14,Ind,writein,0
-Queens,33017,State Senate,SD14,Ind,writein,3
-Queens,33018,State Senate,SD14,Ind,writein,1
-Queens,33019,State Senate,SD14,Ind,writein,1
-Queens,33020,State Senate,SD14,Ind,writein,2
-Queens,33021,State Senate,SD14,Ind,writein,3
-Queens,33022,State Senate,SD14,Ind,writein,0
-Queens,33023,State Senate,SD14,Ind,writein,0
-Queens,33024,State Senate,SD14,Ind,writein,1
-Queens,33025,State Senate,SD14,Ind,writein,2
-Queens,33026,State Senate,SD14,Ind,writein,0
-Queens,33027,State Senate,SD14,Ind,writein,0
-Queens,33028,State Senate,SD14,Ind,writein,1
-Queens,33029,State Senate,SD14,Ind,writein,0
-Queens,33030,State Senate,SD14,Ind,writein,0
-Queens,33031,State Senate,SD14,Ind,writein,0
-Queens,33032,State Senate,SD14,Ind,writein,0
-Queens,33033,State Senate,SD14,Ind,writein,0
-Queens,33034,State Senate,SD14,Ind,writein,0
-Queens,33035,State Senate,SD14,Ind,writein,1
-Queens,33036,State Senate,SD14,Ind,writein,0
-Queens,33037,State Senate,SD14,Ind,writein,1
-Queens,33038,State Senate,SD14,Ind,writein,0
-Queens,33039,State Senate,SD14,Ind,writein,0
-Queens,33040,State Senate,SD14,Ind,writein,0
-Queens,33041,State Senate,SD14,Ind,writein,0
-Queens,33042,State Senate,SD14,Ind,writein,0
-Queens,33043,State Senate,SD14,Ind,writein,0
-Queens,33044,State Senate,SD14,Ind,writein,0
-Queens,33045,State Senate,SD14,Ind,writein,0
-Queens,33046,State Senate,SD14,Ind,writein,0
-Queens,33047,State Senate,SD14,Ind,writein,0
-Queens,33048,State Senate,SD14,Ind,writein,0
-Queens,33049,State Senate,SD14,Ind,writein,1
-Queens,33050,State Senate,SD14,Ind,writein,0
-Queens,33051,State Senate,SD14,Ind,writein,2
-Queens,33052,State Senate,SD14,Ind,writein,1
-Queens,33053,State Senate,SD14,Ind,writein,1
-Queens,33054,State Senate,SD14,Ind,writein,0
-Queens,33055,State Senate,SD14,Ind,writein,0
-Queens,33056,State Senate,SD14,Ind,writein,0
-Queens,33057,State Senate,SD14,Ind,writein,0
-Queens,33058,State Senate,SD14,Ind,writein,0
-Queens,33059,State Senate,SD14,Ind,writein,1
-Queens,33060,State Senate,SD14,Ind,writein,0
-Queens,33061,State Senate,SD14,Ind,writein,0
-Queens,33062,State Senate,SD14,Ind,writein,0
-Queens,33063,State Senate,SD14,Ind,writein,0
-Queens,33064,State Senate,SD14,Ind,writein,0
-Queens,33065,State Senate,SD14,Ind,writein,1
-Queens,33066,State Senate,SD14,Ind,writein,2
-Queens,33067,State Senate,SD14,Ind,writein,2
-Queens,33068,State Senate,SD14,Ind,writein,0
-Queens,33069,State Senate,SD14,Ind,writein,0
-Queens,33070,State Senate,SD14,Ind,writein,0
-Queens,33071,State Senate,SD14,Ind,writein,1
-Queens,23001,State Senate,SD15,Rep,Eric Ulrich,293
-Queens,23002,State Senate,SD15,Rep,Eric Ulrich,316
-Queens,23003,State Senate,SD15,Rep,Eric Ulrich,244
-Queens,23004,State Senate,SD15,Rep,Eric Ulrich,60
-Queens,23005,State Senate,SD15,Rep,Eric Ulrich,163
-Queens,23006,State Senate,SD15,Rep,Eric Ulrich,166
-Queens,23007,State Senate,SD15,Rep,Eric Ulrich,178
-Queens,23008,State Senate,SD15,Rep,Eric Ulrich,155
-Queens,23009,State Senate,SD15,Rep,Eric Ulrich,144
-Queens,23010,State Senate,SD15,Rep,Eric Ulrich,137
-Queens,23011,State Senate,SD15,Rep,Eric Ulrich,126
-Queens,23012,State Senate,SD15,Rep,Eric Ulrich,60
-Queens,23013,State Senate,SD15,Rep,Eric Ulrich,81
-Queens,23014,State Senate,SD15,Rep,Eric Ulrich,114
-Queens,23015,State Senate,SD15,Rep,Eric Ulrich,53
-Queens,23016,State Senate,SD15,Rep,Eric Ulrich,55
-Queens,23017,State Senate,SD15,Rep,Eric Ulrich,14
-Queens,23021,State Senate,SD15,Rep,Eric Ulrich,12
-Queens,23023,State Senate,SD15,Rep,Eric Ulrich,53
-Queens,23024,State Senate,SD15,Rep,Eric Ulrich,50
-Queens,23025,State Senate,SD15,Rep,Eric Ulrich,134
-Queens,23026,State Senate,SD15,Rep,Eric Ulrich,106
-Queens,23027,State Senate,SD15,Rep,Eric Ulrich,242
-Queens,23028,State Senate,SD15,Rep,Eric Ulrich,254
-Queens,23040,State Senate,SD15,Rep,Eric Ulrich,234
-Queens,23041,State Senate,SD15,Rep,Eric Ulrich,170
-Queens,23042,State Senate,SD15,Rep,Eric Ulrich,9
-Queens,23044,State Senate,SD15,Rep,Eric Ulrich,229
-Queens,23045,State Senate,SD15,Rep,Eric Ulrich,179
-Queens,23046,State Senate,SD15,Rep,Eric Ulrich,262
-Queens,23047,State Senate,SD15,Rep,Eric Ulrich,109
-Queens,23048,State Senate,SD15,Rep,Eric Ulrich,109
-Queens,23049,State Senate,SD15,Rep,Eric Ulrich,175
-Queens,23050,State Senate,SD15,Rep,Eric Ulrich,126
-Queens,23051,State Senate,SD15,Rep,Eric Ulrich,167
-Queens,23052,State Senate,SD15,Rep,Eric Ulrich,107
-Queens,23053,State Senate,SD15,Rep,Eric Ulrich,192
-Queens,23054,State Senate,SD15,Rep,Eric Ulrich,225
-Queens,23055,State Senate,SD15,Rep,Eric Ulrich,55
-Queens,23056,State Senate,SD15,Rep,Eric Ulrich,172
-Queens,23057,State Senate,SD15,Rep,Eric Ulrich,211
-Queens,23058,State Senate,SD15,Rep,Eric Ulrich,155
-Queens,23059,State Senate,SD15,Rep,Eric Ulrich,103
-Queens,23060,State Senate,SD15,Rep,Eric Ulrich,116
-Queens,23061,State Senate,SD15,Rep,Eric Ulrich,168
-Queens,23062,State Senate,SD15,Rep,Eric Ulrich,281
-Queens,23063,State Senate,SD15,Rep,Eric Ulrich,212
-Queens,23064,State Senate,SD15,Rep,Eric Ulrich,275
-Queens,23065,State Senate,SD15,Rep,Eric Ulrich,131
-Queens,23068,State Senate,SD15,Rep,Eric Ulrich,96
-Queens,23069,State Senate,SD15,Rep,Eric Ulrich,92
-Queens,23072,State Senate,SD15,Rep,Eric Ulrich,102
-Queens,25001,State Senate,SD15,Rep,Eric Ulrich,204
-Queens,27019,State Senate,SD15,Rep,Eric Ulrich,112
-Queens,27024,State Senate,SD15,Rep,Eric Ulrich,409
-Queens,27025,State Senate,SD15,Rep,Eric Ulrich,451
-Queens,27026,State Senate,SD15,Rep,Eric Ulrich,380
-Queens,27027,State Senate,SD15,Rep,Eric Ulrich,377
-Queens,27028,State Senate,SD15,Rep,Eric Ulrich,212
-Queens,27029,State Senate,SD15,Rep,Eric Ulrich,230
-Queens,27030,State Senate,SD15,Rep,Eric Ulrich,251
-Queens,27046,State Senate,SD15,Rep,Eric Ulrich,94
-Queens,27076,State Senate,SD15,Rep,Eric Ulrich,185
-Queens,27077,State Senate,SD15,Rep,Eric Ulrich,27
-Queens,28003,State Senate,SD15,Rep,Eric Ulrich,130
-Queens,28009,State Senate,SD15,Rep,Eric Ulrich,89
-Queens,28010,State Senate,SD15,Rep,Eric Ulrich,152
-Queens,28012,State Senate,SD15,Rep,Eric Ulrich,86
-Queens,28014,State Senate,SD15,Rep,Eric Ulrich,29
-Queens,28015,State Senate,SD15,Rep,Eric Ulrich,243
-Queens,28016,State Senate,SD15,Rep,Eric Ulrich,253
-Queens,28017,State Senate,SD15,Rep,Eric Ulrich,205
-Queens,28018,State Senate,SD15,Rep,Eric Ulrich,216
-Queens,28019,State Senate,SD15,Rep,Eric Ulrich,211
-Queens,28020,State Senate,SD15,Rep,Eric Ulrich,170
-Queens,28021,State Senate,SD15,Rep,Eric Ulrich,255
-Queens,28022,State Senate,SD15,Rep,Eric Ulrich,188
-Queens,28023,State Senate,SD15,Rep,Eric Ulrich,137
-Queens,28024,State Senate,SD15,Rep,Eric Ulrich,75
-Queens,28032,State Senate,SD15,Rep,Eric Ulrich,108
-Queens,28033,State Senate,SD15,Rep,Eric Ulrich,5
-Queens,28047,State Senate,SD15,Rep,Eric Ulrich,183
-Queens,28048,State Senate,SD15,Rep,Eric Ulrich,142
-Queens,28049,State Senate,SD15,Rep,Eric Ulrich,138
-Queens,28060,State Senate,SD15,Rep,Eric Ulrich,146
-Queens,28061,State Senate,SD15,Rep,Eric Ulrich,159
-Queens,28062,State Senate,SD15,Rep,Eric Ulrich,191
-Queens,28063,State Senate,SD15,Rep,Eric Ulrich,219
-Queens,28064,State Senate,SD15,Rep,Eric Ulrich,209
-Queens,28065,State Senate,SD15,Rep,Eric Ulrich,188
-Queens,28066,State Senate,SD15,Rep,Eric Ulrich,237
-Queens,28067,State Senate,SD15,Rep,Eric Ulrich,202
-Queens,28068,State Senate,SD15,Rep,Eric Ulrich,150
-Queens,28069,State Senate,SD15,Rep,Eric Ulrich,128
-Queens,28070,State Senate,SD15,Rep,Eric Ulrich,249
-Queens,28071,State Senate,SD15,Rep,Eric Ulrich,314
-Queens,28072,State Senate,SD15,Rep,Eric Ulrich,169
-Queens,28073,State Senate,SD15,Rep,Eric Ulrich,197
-Queens,28074,State Senate,SD15,Rep,Eric Ulrich,255
-Queens,28075,State Senate,SD15,Rep,Eric Ulrich,281
-Queens,28076,State Senate,SD15,Rep,Eric Ulrich,315
-Queens,28077,State Senate,SD15,Rep,Eric Ulrich,269
-Queens,28078,State Senate,SD15,Rep,Eric Ulrich,103
-Queens,28079,State Senate,SD15,Rep,Eric Ulrich,87
-Queens,28080,State Senate,SD15,Rep,Eric Ulrich,112
-Queens,30003,State Senate,SD15,Rep,Eric Ulrich,5
-Queens,30004,State Senate,SD15,Rep,Eric Ulrich,239
-Queens,30005,State Senate,SD15,Rep,Eric Ulrich,293
-Queens,30006,State Senate,SD15,Rep,Eric Ulrich,274
-Queens,30007,State Senate,SD15,Rep,Eric Ulrich,261
-Queens,30008,State Senate,SD15,Rep,Eric Ulrich,328
-Queens,30009,State Senate,SD15,Rep,Eric Ulrich,274
-Queens,30010,State Senate,SD15,Rep,Eric Ulrich,222
-Queens,30011,State Senate,SD15,Rep,Eric Ulrich,264
-Queens,30012,State Senate,SD15,Rep,Eric Ulrich,329
-Queens,30013,State Senate,SD15,Rep,Eric Ulrich,186
-Queens,30014,State Senate,SD15,Rep,Eric Ulrich,274
-Queens,30015,State Senate,SD15,Rep,Eric Ulrich,182
-Queens,30016,State Senate,SD15,Rep,Eric Ulrich,168
-Queens,30017,State Senate,SD15,Rep,Eric Ulrich,187
-Queens,30018,State Senate,SD15,Rep,Eric Ulrich,193
-Queens,30019,State Senate,SD15,Rep,Eric Ulrich,5
-Queens,30020,State Senate,SD15,Rep,Eric Ulrich,108
-Queens,30021,State Senate,SD15,Rep,Eric Ulrich,235
-Queens,30022,State Senate,SD15,Rep,Eric Ulrich,219
-Queens,30023,State Senate,SD15,Rep,Eric Ulrich,180
-Queens,30024,State Senate,SD15,Rep,Eric Ulrich,83
-Queens,30025,State Senate,SD15,Rep,Eric Ulrich,204
-Queens,30026,State Senate,SD15,Rep,Eric Ulrich,123
-Queens,30027,State Senate,SD15,Rep,Eric Ulrich,147
-Queens,30028,State Senate,SD15,Rep,Eric Ulrich,2
-Queens,30029,State Senate,SD15,Rep,Eric Ulrich,8
-Queens,30033,State Senate,SD15,Rep,Eric Ulrich,24
-Queens,30036,State Senate,SD15,Rep,Eric Ulrich,163
-Queens,30037,State Senate,SD15,Rep,Eric Ulrich,117
-Queens,31006,State Senate,SD15,Rep,Eric Ulrich,3
-Queens,31021,State Senate,SD15,Rep,Eric Ulrich,7
-Queens,31027,State Senate,SD15,Rep,Eric Ulrich,100
-Queens,31028,State Senate,SD15,Rep,Eric Ulrich,65
-Queens,34054,State Senate,SD15,Rep,Eric Ulrich,1
-Queens,34056,State Senate,SD15,Rep,Eric Ulrich,12
-Queens,34062,State Senate,SD15,Rep,Eric Ulrich,12
-Queens,34063,State Senate,SD15,Rep,Eric Ulrich,23
-Queens,37042,State Senate,SD15,Rep,Eric Ulrich,27
-Queens,37043,State Senate,SD15,Rep,Eric Ulrich,167
-Queens,37044,State Senate,SD15,Rep,Eric Ulrich,173
-Queens,37045,State Senate,SD15,Rep,Eric Ulrich,158
-Queens,37046,State Senate,SD15,Rep,Eric Ulrich,162
-Queens,37047,State Senate,SD15,Rep,Eric Ulrich,87
-Queens,37048,State Senate,SD15,Rep,Eric Ulrich,116
-Queens,37049,State Senate,SD15,Rep,Eric Ulrich,75
-Queens,37050,State Senate,SD15,Rep,Eric Ulrich,85
-Queens,37052,State Senate,SD15,Rep,Eric Ulrich,42
-Queens,37053,State Senate,SD15,Rep,Eric Ulrich,28
-Queens,37054,State Senate,SD15,Rep,Eric Ulrich,16
-Queens,37060,State Senate,SD15,Rep,Eric Ulrich,4
-Queens,37061,State Senate,SD15,Rep,Eric Ulrich,74
-Queens,37062,State Senate,SD15,Rep,Eric Ulrich,134
-Queens,37066,State Senate,SD15,Rep,Eric Ulrich,2
-Queens,37069,State Senate,SD15,Rep,Eric Ulrich,6
-Queens,38014,State Senate,SD15,Rep,Eric Ulrich,153
-Queens,38015,State Senate,SD15,Rep,Eric Ulrich,53
-Queens,38016,State Senate,SD15,Rep,Eric Ulrich,180
-Queens,38017,State Senate,SD15,Rep,Eric Ulrich,198
-Queens,38018,State Senate,SD15,Rep,Eric Ulrich,171
-Queens,38019,State Senate,SD15,Rep,Eric Ulrich,153
-Queens,38028,State Senate,SD15,Rep,Eric Ulrich,169
-Queens,38030,State Senate,SD15,Rep,Eric Ulrich,91
-Queens,38031,State Senate,SD15,Rep,Eric Ulrich,77
-Queens,38032,State Senate,SD15,Rep,Eric Ulrich,103
-Queens,38033,State Senate,SD15,Rep,Eric Ulrich,42
-Queens,38035,State Senate,SD15,Rep,Eric Ulrich,3
-Queens,38037,State Senate,SD15,Rep,Eric Ulrich,49
-Queens,38050,State Senate,SD15,Rep,Eric Ulrich,135
-Queens,38051,State Senate,SD15,Rep,Eric Ulrich,83
-Queens,38052,State Senate,SD15,Rep,Eric Ulrich,145
-Queens,38054,State Senate,SD15,Rep,Eric Ulrich,88
-Queens,38055,State Senate,SD15,Rep,Eric Ulrich,63
-Queens,38056,State Senate,SD15,Rep,Eric Ulrich,103
-Queens,38057,State Senate,SD15,Rep,Eric Ulrich,100
-Queens,38058,State Senate,SD15,Rep,Eric Ulrich,100
-Queens,39036,State Senate,SD15,Rep,Eric Ulrich,20
-Queens,23001,State Senate,SD15,Con,Eric Ulrich,62
-Queens,23002,State Senate,SD15,Con,Eric Ulrich,45
-Queens,23003,State Senate,SD15,Con,Eric Ulrich,38
-Queens,23004,State Senate,SD15,Con,Eric Ulrich,3
-Queens,23005,State Senate,SD15,Con,Eric Ulrich,16
-Queens,23006,State Senate,SD15,Con,Eric Ulrich,17
-Queens,23007,State Senate,SD15,Con,Eric Ulrich,9
-Queens,23008,State Senate,SD15,Con,Eric Ulrich,23
-Queens,23009,State Senate,SD15,Con,Eric Ulrich,15
-Queens,23010,State Senate,SD15,Con,Eric Ulrich,18
-Queens,23011,State Senate,SD15,Con,Eric Ulrich,11
-Queens,23012,State Senate,SD15,Con,Eric Ulrich,9
-Queens,23013,State Senate,SD15,Con,Eric Ulrich,14
-Queens,23014,State Senate,SD15,Con,Eric Ulrich,18
-Queens,23015,State Senate,SD15,Con,Eric Ulrich,8
-Queens,23016,State Senate,SD15,Con,Eric Ulrich,6
-Queens,23017,State Senate,SD15,Con,Eric Ulrich,1
-Queens,23021,State Senate,SD15,Con,Eric Ulrich,0
-Queens,23023,State Senate,SD15,Con,Eric Ulrich,2
-Queens,23024,State Senate,SD15,Con,Eric Ulrich,57
-Queens,23025,State Senate,SD15,Con,Eric Ulrich,32
-Queens,23026,State Senate,SD15,Con,Eric Ulrich,22
-Queens,23027,State Senate,SD15,Con,Eric Ulrich,53
-Queens,23028,State Senate,SD15,Con,Eric Ulrich,86
-Queens,23040,State Senate,SD15,Con,Eric Ulrich,17
-Queens,23041,State Senate,SD15,Con,Eric Ulrich,19
-Queens,23042,State Senate,SD15,Con,Eric Ulrich,2
-Queens,23044,State Senate,SD15,Con,Eric Ulrich,24
-Queens,23045,State Senate,SD15,Con,Eric Ulrich,16
-Queens,23046,State Senate,SD15,Con,Eric Ulrich,21
-Queens,23047,State Senate,SD15,Con,Eric Ulrich,9
-Queens,23048,State Senate,SD15,Con,Eric Ulrich,11
-Queens,23049,State Senate,SD15,Con,Eric Ulrich,18
-Queens,23050,State Senate,SD15,Con,Eric Ulrich,12
-Queens,23051,State Senate,SD15,Con,Eric Ulrich,28
-Queens,23052,State Senate,SD15,Con,Eric Ulrich,15
-Queens,23053,State Senate,SD15,Con,Eric Ulrich,13
-Queens,23054,State Senate,SD15,Con,Eric Ulrich,15
-Queens,23055,State Senate,SD15,Con,Eric Ulrich,3
-Queens,23056,State Senate,SD15,Con,Eric Ulrich,13
-Queens,23057,State Senate,SD15,Con,Eric Ulrich,20
-Queens,23058,State Senate,SD15,Con,Eric Ulrich,18
-Queens,23059,State Senate,SD15,Con,Eric Ulrich,8
-Queens,23060,State Senate,SD15,Con,Eric Ulrich,10
-Queens,23061,State Senate,SD15,Con,Eric Ulrich,16
-Queens,23062,State Senate,SD15,Con,Eric Ulrich,27
-Queens,23063,State Senate,SD15,Con,Eric Ulrich,28
-Queens,23064,State Senate,SD15,Con,Eric Ulrich,33
-Queens,23065,State Senate,SD15,Con,Eric Ulrich,14
-Queens,23068,State Senate,SD15,Con,Eric Ulrich,8
-Queens,23069,State Senate,SD15,Con,Eric Ulrich,13
-Queens,23072,State Senate,SD15,Con,Eric Ulrich,5
-Queens,25001,State Senate,SD15,Con,Eric Ulrich,13
-Queens,27019,State Senate,SD15,Con,Eric Ulrich,5
-Queens,27024,State Senate,SD15,Con,Eric Ulrich,24
-Queens,27025,State Senate,SD15,Con,Eric Ulrich,25
-Queens,27026,State Senate,SD15,Con,Eric Ulrich,33
-Queens,27027,State Senate,SD15,Con,Eric Ulrich,26
-Queens,27028,State Senate,SD15,Con,Eric Ulrich,10
-Queens,27029,State Senate,SD15,Con,Eric Ulrich,19
-Queens,27030,State Senate,SD15,Con,Eric Ulrich,43
-Queens,27046,State Senate,SD15,Con,Eric Ulrich,1
-Queens,27076,State Senate,SD15,Con,Eric Ulrich,10
-Queens,27077,State Senate,SD15,Con,Eric Ulrich,0
-Queens,28003,State Senate,SD15,Con,Eric Ulrich,22
-Queens,28009,State Senate,SD15,Con,Eric Ulrich,9
-Queens,28010,State Senate,SD15,Con,Eric Ulrich,9
-Queens,28012,State Senate,SD15,Con,Eric Ulrich,9
-Queens,28014,State Senate,SD15,Con,Eric Ulrich,8
-Queens,28015,State Senate,SD15,Con,Eric Ulrich,31
-Queens,28016,State Senate,SD15,Con,Eric Ulrich,30
-Queens,28017,State Senate,SD15,Con,Eric Ulrich,26
-Queens,28018,State Senate,SD15,Con,Eric Ulrich,17
-Queens,28019,State Senate,SD15,Con,Eric Ulrich,17
-Queens,28020,State Senate,SD15,Con,Eric Ulrich,11
-Queens,28021,State Senate,SD15,Con,Eric Ulrich,10
-Queens,28022,State Senate,SD15,Con,Eric Ulrich,9
-Queens,28023,State Senate,SD15,Con,Eric Ulrich,6
-Queens,28024,State Senate,SD15,Con,Eric Ulrich,6
-Queens,28032,State Senate,SD15,Con,Eric Ulrich,10
-Queens,28033,State Senate,SD15,Con,Eric Ulrich,0
-Queens,28047,State Senate,SD15,Con,Eric Ulrich,13
-Queens,28048,State Senate,SD15,Con,Eric Ulrich,6
-Queens,28049,State Senate,SD15,Con,Eric Ulrich,7
-Queens,28060,State Senate,SD15,Con,Eric Ulrich,12
-Queens,28061,State Senate,SD15,Con,Eric Ulrich,8
-Queens,28062,State Senate,SD15,Con,Eric Ulrich,11
-Queens,28063,State Senate,SD15,Con,Eric Ulrich,16
-Queens,28064,State Senate,SD15,Con,Eric Ulrich,25
-Queens,28065,State Senate,SD15,Con,Eric Ulrich,21
-Queens,28066,State Senate,SD15,Con,Eric Ulrich,17
-Queens,28067,State Senate,SD15,Con,Eric Ulrich,9
-Queens,28068,State Senate,SD15,Con,Eric Ulrich,17
-Queens,28069,State Senate,SD15,Con,Eric Ulrich,9
-Queens,28070,State Senate,SD15,Con,Eric Ulrich,31
-Queens,28071,State Senate,SD15,Con,Eric Ulrich,39
-Queens,28072,State Senate,SD15,Con,Eric Ulrich,19
-Queens,28073,State Senate,SD15,Con,Eric Ulrich,15
-Queens,28074,State Senate,SD15,Con,Eric Ulrich,26
-Queens,28075,State Senate,SD15,Con,Eric Ulrich,34
-Queens,28076,State Senate,SD15,Con,Eric Ulrich,29
-Queens,28077,State Senate,SD15,Con,Eric Ulrich,28
-Queens,28078,State Senate,SD15,Con,Eric Ulrich,11
-Queens,28079,State Senate,SD15,Con,Eric Ulrich,14
-Queens,28080,State Senate,SD15,Con,Eric Ulrich,16
-Queens,30003,State Senate,SD15,Con,Eric Ulrich,1
-Queens,30004,State Senate,SD15,Con,Eric Ulrich,25
-Queens,30005,State Senate,SD15,Con,Eric Ulrich,28
-Queens,30006,State Senate,SD15,Con,Eric Ulrich,25
-Queens,30007,State Senate,SD15,Con,Eric Ulrich,29
-Queens,30008,State Senate,SD15,Con,Eric Ulrich,21
-Queens,30009,State Senate,SD15,Con,Eric Ulrich,21
-Queens,30010,State Senate,SD15,Con,Eric Ulrich,22
-Queens,30011,State Senate,SD15,Con,Eric Ulrich,31
-Queens,30012,State Senate,SD15,Con,Eric Ulrich,46
-Queens,30013,State Senate,SD15,Con,Eric Ulrich,18
-Queens,30014,State Senate,SD15,Con,Eric Ulrich,27
-Queens,30015,State Senate,SD15,Con,Eric Ulrich,18
-Queens,30016,State Senate,SD15,Con,Eric Ulrich,23
-Queens,30017,State Senate,SD15,Con,Eric Ulrich,25
-Queens,30018,State Senate,SD15,Con,Eric Ulrich,16
-Queens,30019,State Senate,SD15,Con,Eric Ulrich,0
-Queens,30020,State Senate,SD15,Con,Eric Ulrich,17
-Queens,30021,State Senate,SD15,Con,Eric Ulrich,28
-Queens,30022,State Senate,SD15,Con,Eric Ulrich,21
-Queens,30023,State Senate,SD15,Con,Eric Ulrich,19
-Queens,30024,State Senate,SD15,Con,Eric Ulrich,8
-Queens,30025,State Senate,SD15,Con,Eric Ulrich,30
-Queens,30026,State Senate,SD15,Con,Eric Ulrich,10
-Queens,30027,State Senate,SD15,Con,Eric Ulrich,10
-Queens,30028,State Senate,SD15,Con,Eric Ulrich,0
-Queens,30029,State Senate,SD15,Con,Eric Ulrich,0
-Queens,30033,State Senate,SD15,Con,Eric Ulrich,0
-Queens,30036,State Senate,SD15,Con,Eric Ulrich,18
-Queens,30037,State Senate,SD15,Con,Eric Ulrich,14
-Queens,31006,State Senate,SD15,Con,Eric Ulrich,0
-Queens,31021,State Senate,SD15,Con,Eric Ulrich,0
-Queens,31027,State Senate,SD15,Con,Eric Ulrich,14
-Queens,31028,State Senate,SD15,Con,Eric Ulrich,4
-Queens,34054,State Senate,SD15,Con,Eric Ulrich,1
-Queens,34056,State Senate,SD15,Con,Eric Ulrich,2
-Queens,34062,State Senate,SD15,Con,Eric Ulrich,1
-Queens,34063,State Senate,SD15,Con,Eric Ulrich,1
-Queens,37042,State Senate,SD15,Con,Eric Ulrich,4
-Queens,37043,State Senate,SD15,Con,Eric Ulrich,23
-Queens,37044,State Senate,SD15,Con,Eric Ulrich,10
-Queens,37045,State Senate,SD15,Con,Eric Ulrich,14
-Queens,37046,State Senate,SD15,Con,Eric Ulrich,26
-Queens,37047,State Senate,SD15,Con,Eric Ulrich,13
-Queens,37048,State Senate,SD15,Con,Eric Ulrich,9
-Queens,37049,State Senate,SD15,Con,Eric Ulrich,4
-Queens,37050,State Senate,SD15,Con,Eric Ulrich,12
-Queens,37052,State Senate,SD15,Con,Eric Ulrich,3
-Queens,37053,State Senate,SD15,Con,Eric Ulrich,2
-Queens,37054,State Senate,SD15,Con,Eric Ulrich,2
-Queens,37060,State Senate,SD15,Con,Eric Ulrich,0
-Queens,37061,State Senate,SD15,Con,Eric Ulrich,8
-Queens,37062,State Senate,SD15,Con,Eric Ulrich,23
-Queens,37066,State Senate,SD15,Con,Eric Ulrich,1
-Queens,37069,State Senate,SD15,Con,Eric Ulrich,1
-Queens,38014,State Senate,SD15,Con,Eric Ulrich,18
-Queens,38015,State Senate,SD15,Con,Eric Ulrich,3
-Queens,38016,State Senate,SD15,Con,Eric Ulrich,27
-Queens,38017,State Senate,SD15,Con,Eric Ulrich,25
-Queens,38018,State Senate,SD15,Con,Eric Ulrich,32
-Queens,38019,State Senate,SD15,Con,Eric Ulrich,22
-Queens,38028,State Senate,SD15,Con,Eric Ulrich,15
-Queens,38030,State Senate,SD15,Con,Eric Ulrich,7
-Queens,38031,State Senate,SD15,Con,Eric Ulrich,17
-Queens,38032,State Senate,SD15,Con,Eric Ulrich,9
-Queens,38033,State Senate,SD15,Con,Eric Ulrich,12
-Queens,38035,State Senate,SD15,Con,Eric Ulrich,0
-Queens,38037,State Senate,SD15,Con,Eric Ulrich,5
-Queens,38050,State Senate,SD15,Con,Eric Ulrich,14
-Queens,38051,State Senate,SD15,Con,Eric Ulrich,16
-Queens,38052,State Senate,SD15,Con,Eric Ulrich,21
-Queens,38054,State Senate,SD15,Con,Eric Ulrich,10
-Queens,38055,State Senate,SD15,Con,Eric Ulrich,12
-Queens,38056,State Senate,SD15,Con,Eric Ulrich,22
-Queens,38057,State Senate,SD15,Con,Eric Ulrich,12
-Queens,38058,State Senate,SD15,Con,Eric Ulrich,15
-Queens,39036,State Senate,SD15,Con,Eric Ulrich,1
-Queens,23001,State Senate,SD15,Ind,Eric Ulrich,13
-Queens,23002,State Senate,SD15,Ind,Eric Ulrich,9
-Queens,23003,State Senate,SD15,Ind,Eric Ulrich,12
-Queens,23004,State Senate,SD15,Ind,Eric Ulrich,2
-Queens,23005,State Senate,SD15,Ind,Eric Ulrich,3
-Queens,23006,State Senate,SD15,Ind,Eric Ulrich,1
-Queens,23007,State Senate,SD15,Ind,Eric Ulrich,4
-Queens,23008,State Senate,SD15,Ind,Eric Ulrich,11
-Queens,23009,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,23010,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,23011,State Senate,SD15,Ind,Eric Ulrich,9
-Queens,23012,State Senate,SD15,Ind,Eric Ulrich,6
-Queens,23013,State Senate,SD15,Ind,Eric Ulrich,11
-Queens,23014,State Senate,SD15,Ind,Eric Ulrich,11
-Queens,23015,State Senate,SD15,Ind,Eric Ulrich,4
-Queens,23016,State Senate,SD15,Ind,Eric Ulrich,4
-Queens,23017,State Senate,SD15,Ind,Eric Ulrich,2
-Queens,23021,State Senate,SD15,Ind,Eric Ulrich,2
-Queens,23023,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,23024,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,23025,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,23026,State Senate,SD15,Ind,Eric Ulrich,1
-Queens,23027,State Senate,SD15,Ind,Eric Ulrich,2
-Queens,23028,State Senate,SD15,Ind,Eric Ulrich,13
-Queens,23040,State Senate,SD15,Ind,Eric Ulrich,12
-Queens,23041,State Senate,SD15,Ind,Eric Ulrich,13
-Queens,23042,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,23044,State Senate,SD15,Ind,Eric Ulrich,12
-Queens,23045,State Senate,SD15,Ind,Eric Ulrich,3
-Queens,23046,State Senate,SD15,Ind,Eric Ulrich,4
-Queens,23047,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,23048,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,23049,State Senate,SD15,Ind,Eric Ulrich,3
-Queens,23050,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,23051,State Senate,SD15,Ind,Eric Ulrich,4
-Queens,23052,State Senate,SD15,Ind,Eric Ulrich,4
-Queens,23053,State Senate,SD15,Ind,Eric Ulrich,17
-Queens,23054,State Senate,SD15,Ind,Eric Ulrich,17
-Queens,23055,State Senate,SD15,Ind,Eric Ulrich,4
-Queens,23056,State Senate,SD15,Ind,Eric Ulrich,11
-Queens,23057,State Senate,SD15,Ind,Eric Ulrich,19
-Queens,23058,State Senate,SD15,Ind,Eric Ulrich,10
-Queens,23059,State Senate,SD15,Ind,Eric Ulrich,8
-Queens,23060,State Senate,SD15,Ind,Eric Ulrich,9
-Queens,23061,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,23062,State Senate,SD15,Ind,Eric Ulrich,13
-Queens,23063,State Senate,SD15,Ind,Eric Ulrich,8
-Queens,23064,State Senate,SD15,Ind,Eric Ulrich,15
-Queens,23065,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,23068,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,23069,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,23072,State Senate,SD15,Ind,Eric Ulrich,2
-Queens,25001,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,27019,State Senate,SD15,Ind,Eric Ulrich,6
-Queens,27024,State Senate,SD15,Ind,Eric Ulrich,4
-Queens,27025,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,27026,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,27027,State Senate,SD15,Ind,Eric Ulrich,8
-Queens,27028,State Senate,SD15,Ind,Eric Ulrich,1
-Queens,27029,State Senate,SD15,Ind,Eric Ulrich,4
-Queens,27030,State Senate,SD15,Ind,Eric Ulrich,6
-Queens,27046,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,27076,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,27077,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,28003,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,28009,State Senate,SD15,Ind,Eric Ulrich,6
-Queens,28010,State Senate,SD15,Ind,Eric Ulrich,8
-Queens,28012,State Senate,SD15,Ind,Eric Ulrich,3
-Queens,28014,State Senate,SD15,Ind,Eric Ulrich,3
-Queens,28015,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,28016,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,28017,State Senate,SD15,Ind,Eric Ulrich,9
-Queens,28018,State Senate,SD15,Ind,Eric Ulrich,11
-Queens,28019,State Senate,SD15,Ind,Eric Ulrich,12
-Queens,28020,State Senate,SD15,Ind,Eric Ulrich,10
-Queens,28021,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,28022,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,28023,State Senate,SD15,Ind,Eric Ulrich,4
-Queens,28024,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,28032,State Senate,SD15,Ind,Eric Ulrich,3
-Queens,28033,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,28047,State Senate,SD15,Ind,Eric Ulrich,6
-Queens,28048,State Senate,SD15,Ind,Eric Ulrich,9
-Queens,28049,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,28060,State Senate,SD15,Ind,Eric Ulrich,8
-Queens,28061,State Senate,SD15,Ind,Eric Ulrich,9
-Queens,28062,State Senate,SD15,Ind,Eric Ulrich,9
-Queens,28063,State Senate,SD15,Ind,Eric Ulrich,3
-Queens,28064,State Senate,SD15,Ind,Eric Ulrich,11
-Queens,28065,State Senate,SD15,Ind,Eric Ulrich,12
-Queens,28066,State Senate,SD15,Ind,Eric Ulrich,16
-Queens,28067,State Senate,SD15,Ind,Eric Ulrich,9
-Queens,28068,State Senate,SD15,Ind,Eric Ulrich,9
-Queens,28069,State Senate,SD15,Ind,Eric Ulrich,4
-Queens,28070,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,28071,State Senate,SD15,Ind,Eric Ulrich,13
-Queens,28072,State Senate,SD15,Ind,Eric Ulrich,10
-Queens,28073,State Senate,SD15,Ind,Eric Ulrich,4
-Queens,28074,State Senate,SD15,Ind,Eric Ulrich,10
-Queens,28075,State Senate,SD15,Ind,Eric Ulrich,10
-Queens,28076,State Senate,SD15,Ind,Eric Ulrich,14
-Queens,28077,State Senate,SD15,Ind,Eric Ulrich,6
-Queens,28078,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,28079,State Senate,SD15,Ind,Eric Ulrich,2
-Queens,28080,State Senate,SD15,Ind,Eric Ulrich,9
-Queens,30003,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,30004,State Senate,SD15,Ind,Eric Ulrich,8
-Queens,30005,State Senate,SD15,Ind,Eric Ulrich,10
-Queens,30006,State Senate,SD15,Ind,Eric Ulrich,6
-Queens,30007,State Senate,SD15,Ind,Eric Ulrich,11
-Queens,30008,State Senate,SD15,Ind,Eric Ulrich,8
-Queens,30009,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,30010,State Senate,SD15,Ind,Eric Ulrich,12
-Queens,30011,State Senate,SD15,Ind,Eric Ulrich,9
-Queens,30012,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,30013,State Senate,SD15,Ind,Eric Ulrich,12
-Queens,30014,State Senate,SD15,Ind,Eric Ulrich,15
-Queens,30015,State Senate,SD15,Ind,Eric Ulrich,6
-Queens,30016,State Senate,SD15,Ind,Eric Ulrich,13
-Queens,30017,State Senate,SD15,Ind,Eric Ulrich,14
-Queens,30018,State Senate,SD15,Ind,Eric Ulrich,12
-Queens,30019,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,30020,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,30021,State Senate,SD15,Ind,Eric Ulrich,15
-Queens,30022,State Senate,SD15,Ind,Eric Ulrich,15
-Queens,30023,State Senate,SD15,Ind,Eric Ulrich,4
-Queens,30024,State Senate,SD15,Ind,Eric Ulrich,4
-Queens,30025,State Senate,SD15,Ind,Eric Ulrich,9
-Queens,30026,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,30027,State Senate,SD15,Ind,Eric Ulrich,6
-Queens,30028,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,30029,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,30033,State Senate,SD15,Ind,Eric Ulrich,3
-Queens,30036,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,30037,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,31006,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,31021,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,31027,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,31028,State Senate,SD15,Ind,Eric Ulrich,2
-Queens,34054,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,34056,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,34062,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,34063,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,37042,State Senate,SD15,Ind,Eric Ulrich,2
-Queens,37043,State Senate,SD15,Ind,Eric Ulrich,11
-Queens,37044,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,37045,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,37046,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,37047,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,37048,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,37049,State Senate,SD15,Ind,Eric Ulrich,1
-Queens,37050,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,37052,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,37053,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,37054,State Senate,SD15,Ind,Eric Ulrich,4
-Queens,37060,State Senate,SD15,Ind,Eric Ulrich,0
-Queens,37061,State Senate,SD15,Ind,Eric Ulrich,8
-Queens,37062,State Senate,SD15,Ind,Eric Ulrich,6
-Queens,37066,State Senate,SD15,Ind,Eric Ulrich,1
-Queens,37069,State Senate,SD15,Ind,Eric Ulrich,1
-Queens,38014,State Senate,SD15,Ind,Eric Ulrich,6
-Queens,38015,State Senate,SD15,Ind,Eric Ulrich,4
-Queens,38016,State Senate,SD15,Ind,Eric Ulrich,8
-Queens,38017,State Senate,SD15,Ind,Eric Ulrich,11
-Queens,38018,State Senate,SD15,Ind,Eric Ulrich,11
-Queens,38019,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,38028,State Senate,SD15,Ind,Eric Ulrich,9
-Queens,38030,State Senate,SD15,Ind,Eric Ulrich,8
-Queens,38031,State Senate,SD15,Ind,Eric Ulrich,4
-Queens,38032,State Senate,SD15,Ind,Eric Ulrich,9
-Queens,38033,State Senate,SD15,Ind,Eric Ulrich,3
-Queens,38035,State Senate,SD15,Ind,Eric Ulrich,1
-Queens,38037,State Senate,SD15,Ind,Eric Ulrich,2
-Queens,38050,State Senate,SD15,Ind,Eric Ulrich,7
-Queens,38051,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,38052,State Senate,SD15,Ind,Eric Ulrich,11
-Queens,38054,State Senate,SD15,Ind,Eric Ulrich,2
-Queens,38055,State Senate,SD15,Ind,Eric Ulrich,8
-Queens,38056,State Senate,SD15,Ind,Eric Ulrich,4
-Queens,38057,State Senate,SD15,Ind,Eric Ulrich,5
-Queens,38058,State Senate,SD15,Ind,Eric Ulrich,6
-Queens,39036,State Senate,SD15,Ind,Eric Ulrich,1
-Queens,23001,State Senate,SD15,Dem,Joseph Addabbo,46
-Queens,23002,State Senate,SD15,Dem,Joseph Addabbo,53
-Queens,23003,State Senate,SD15,Dem,Joseph Addabbo,55
-Queens,23004,State Senate,SD15,Dem,Joseph Addabbo,21
-Queens,23005,State Senate,SD15,Dem,Joseph Addabbo,78
-Queens,23006,State Senate,SD15,Dem,Joseph Addabbo,70
-Queens,23007,State Senate,SD15,Dem,Joseph Addabbo,57
-Queens,23008,State Senate,SD15,Dem,Joseph Addabbo,85
-Queens,23009,State Senate,SD15,Dem,Joseph Addabbo,81
-Queens,23010,State Senate,SD15,Dem,Joseph Addabbo,81
-Queens,23011,State Senate,SD15,Dem,Joseph Addabbo,102
-Queens,23012,State Senate,SD15,Dem,Joseph Addabbo,101
-Queens,23013,State Senate,SD15,Dem,Joseph Addabbo,93
-Queens,23014,State Senate,SD15,Dem,Joseph Addabbo,129
-Queens,23015,State Senate,SD15,Dem,Joseph Addabbo,160
-Queens,23016,State Senate,SD15,Dem,Joseph Addabbo,163
-Queens,23017,State Senate,SD15,Dem,Joseph Addabbo,98
-Queens,23021,State Senate,SD15,Dem,Joseph Addabbo,62
-Queens,23023,State Senate,SD15,Dem,Joseph Addabbo,48
-Queens,23024,State Senate,SD15,Dem,Joseph Addabbo,228
-Queens,23025,State Senate,SD15,Dem,Joseph Addabbo,201
-Queens,23026,State Senate,SD15,Dem,Joseph Addabbo,108
-Queens,23027,State Senate,SD15,Dem,Joseph Addabbo,102
-Queens,23028,State Senate,SD15,Dem,Joseph Addabbo,103
-Queens,23040,State Senate,SD15,Dem,Joseph Addabbo,61
-Queens,23041,State Senate,SD15,Dem,Joseph Addabbo,43
-Queens,23042,State Senate,SD15,Dem,Joseph Addabbo,7
-Queens,23044,State Senate,SD15,Dem,Joseph Addabbo,148
-Queens,23045,State Senate,SD15,Dem,Joseph Addabbo,142
-Queens,23046,State Senate,SD15,Dem,Joseph Addabbo,159
-Queens,23047,State Senate,SD15,Dem,Joseph Addabbo,96
-Queens,23048,State Senate,SD15,Dem,Joseph Addabbo,92
-Queens,23049,State Senate,SD15,Dem,Joseph Addabbo,141
-Queens,23050,State Senate,SD15,Dem,Joseph Addabbo,224
-Queens,23051,State Senate,SD15,Dem,Joseph Addabbo,168
-Queens,23052,State Senate,SD15,Dem,Joseph Addabbo,133
-Queens,23053,State Senate,SD15,Dem,Joseph Addabbo,296
-Queens,23054,State Senate,SD15,Dem,Joseph Addabbo,296
-Queens,23055,State Senate,SD15,Dem,Joseph Addabbo,171
-Queens,23056,State Senate,SD15,Dem,Joseph Addabbo,404
-Queens,23057,State Senate,SD15,Dem,Joseph Addabbo,365
-Queens,23058,State Senate,SD15,Dem,Joseph Addabbo,377
-Queens,23059,State Senate,SD15,Dem,Joseph Addabbo,339
-Queens,23060,State Senate,SD15,Dem,Joseph Addabbo,356
-Queens,23061,State Senate,SD15,Dem,Joseph Addabbo,309
-Queens,23062,State Senate,SD15,Dem,Joseph Addabbo,343
-Queens,23063,State Senate,SD15,Dem,Joseph Addabbo,419
-Queens,23064,State Senate,SD15,Dem,Joseph Addabbo,367
-Queens,23065,State Senate,SD15,Dem,Joseph Addabbo,314
-Queens,23068,State Senate,SD15,Dem,Joseph Addabbo,439
-Queens,23069,State Senate,SD15,Dem,Joseph Addabbo,247
-Queens,23072,State Senate,SD15,Dem,Joseph Addabbo,347
-Queens,25001,State Senate,SD15,Dem,Joseph Addabbo,271
-Queens,27019,State Senate,SD15,Dem,Joseph Addabbo,300
-Queens,27024,State Senate,SD15,Dem,Joseph Addabbo,219
-Queens,27025,State Senate,SD15,Dem,Joseph Addabbo,83
-Queens,27026,State Senate,SD15,Dem,Joseph Addabbo,137
-Queens,27027,State Senate,SD15,Dem,Joseph Addabbo,134
-Queens,27028,State Senate,SD15,Dem,Joseph Addabbo,364
-Queens,27029,State Senate,SD15,Dem,Joseph Addabbo,256
-Queens,27030,State Senate,SD15,Dem,Joseph Addabbo,128
-Queens,27046,State Senate,SD15,Dem,Joseph Addabbo,76
-Queens,27076,State Senate,SD15,Dem,Joseph Addabbo,207
-Queens,27077,State Senate,SD15,Dem,Joseph Addabbo,31
-Queens,28003,State Senate,SD15,Dem,Joseph Addabbo,308
-Queens,28009,State Senate,SD15,Dem,Joseph Addabbo,185
-Queens,28010,State Senate,SD15,Dem,Joseph Addabbo,239
-Queens,28012,State Senate,SD15,Dem,Joseph Addabbo,239
-Queens,28014,State Senate,SD15,Dem,Joseph Addabbo,44
-Queens,28015,State Senate,SD15,Dem,Joseph Addabbo,303
-Queens,28016,State Senate,SD15,Dem,Joseph Addabbo,214
-Queens,28017,State Senate,SD15,Dem,Joseph Addabbo,260
-Queens,28018,State Senate,SD15,Dem,Joseph Addabbo,345
-Queens,28019,State Senate,SD15,Dem,Joseph Addabbo,400
-Queens,28020,State Senate,SD15,Dem,Joseph Addabbo,419
-Queens,28021,State Senate,SD15,Dem,Joseph Addabbo,324
-Queens,28022,State Senate,SD15,Dem,Joseph Addabbo,401
-Queens,28023,State Senate,SD15,Dem,Joseph Addabbo,453
-Queens,28024,State Senate,SD15,Dem,Joseph Addabbo,261
-Queens,28032,State Senate,SD15,Dem,Joseph Addabbo,206
-Queens,28033,State Senate,SD15,Dem,Joseph Addabbo,6
-Queens,28047,State Senate,SD15,Dem,Joseph Addabbo,468
-Queens,28048,State Senate,SD15,Dem,Joseph Addabbo,391
-Queens,28049,State Senate,SD15,Dem,Joseph Addabbo,222
-Queens,28060,State Senate,SD15,Dem,Joseph Addabbo,346
-Queens,28061,State Senate,SD15,Dem,Joseph Addabbo,281
-Queens,28062,State Senate,SD15,Dem,Joseph Addabbo,285
-Queens,28063,State Senate,SD15,Dem,Joseph Addabbo,307
-Queens,28064,State Senate,SD15,Dem,Joseph Addabbo,289
-Queens,28065,State Senate,SD15,Dem,Joseph Addabbo,336
-Queens,28066,State Senate,SD15,Dem,Joseph Addabbo,326
-Queens,28067,State Senate,SD15,Dem,Joseph Addabbo,319
-Queens,28068,State Senate,SD15,Dem,Joseph Addabbo,321
-Queens,28069,State Senate,SD15,Dem,Joseph Addabbo,190
-Queens,28070,State Senate,SD15,Dem,Joseph Addabbo,328
-Queens,28071,State Senate,SD15,Dem,Joseph Addabbo,280
-Queens,28072,State Senate,SD15,Dem,Joseph Addabbo,238
-Queens,28073,State Senate,SD15,Dem,Joseph Addabbo,325
-Queens,28074,State Senate,SD15,Dem,Joseph Addabbo,305
-Queens,28075,State Senate,SD15,Dem,Joseph Addabbo,295
-Queens,28076,State Senate,SD15,Dem,Joseph Addabbo,233
-Queens,28077,State Senate,SD15,Dem,Joseph Addabbo,251
-Queens,28078,State Senate,SD15,Dem,Joseph Addabbo,242
-Queens,28079,State Senate,SD15,Dem,Joseph Addabbo,241
-Queens,28080,State Senate,SD15,Dem,Joseph Addabbo,190
-Queens,30003,State Senate,SD15,Dem,Joseph Addabbo,5
-Queens,30004,State Senate,SD15,Dem,Joseph Addabbo,273
-Queens,30005,State Senate,SD15,Dem,Joseph Addabbo,238
-Queens,30006,State Senate,SD15,Dem,Joseph Addabbo,228
-Queens,30007,State Senate,SD15,Dem,Joseph Addabbo,233
-Queens,30008,State Senate,SD15,Dem,Joseph Addabbo,255
-Queens,30009,State Senate,SD15,Dem,Joseph Addabbo,258
-Queens,30010,State Senate,SD15,Dem,Joseph Addabbo,296
-Queens,30011,State Senate,SD15,Dem,Joseph Addabbo,242
-Queens,30012,State Senate,SD15,Dem,Joseph Addabbo,230
-Queens,30013,State Senate,SD15,Dem,Joseph Addabbo,288
-Queens,30014,State Senate,SD15,Dem,Joseph Addabbo,237
-Queens,30015,State Senate,SD15,Dem,Joseph Addabbo,143
-Queens,30016,State Senate,SD15,Dem,Joseph Addabbo,277
-Queens,30017,State Senate,SD15,Dem,Joseph Addabbo,309
-Queens,30018,State Senate,SD15,Dem,Joseph Addabbo,327
-Queens,30019,State Senate,SD15,Dem,Joseph Addabbo,10
-Queens,30020,State Senate,SD15,Dem,Joseph Addabbo,169
-Queens,30021,State Senate,SD15,Dem,Joseph Addabbo,297
-Queens,30022,State Senate,SD15,Dem,Joseph Addabbo,339
-Queens,30023,State Senate,SD15,Dem,Joseph Addabbo,253
-Queens,30024,State Senate,SD15,Dem,Joseph Addabbo,154
-Queens,30025,State Senate,SD15,Dem,Joseph Addabbo,345
-Queens,30026,State Senate,SD15,Dem,Joseph Addabbo,240
-Queens,30027,State Senate,SD15,Dem,Joseph Addabbo,279
-Queens,30028,State Senate,SD15,Dem,Joseph Addabbo,0
-Queens,30029,State Senate,SD15,Dem,Joseph Addabbo,24
-Queens,30033,State Senate,SD15,Dem,Joseph Addabbo,67
-Queens,30036,State Senate,SD15,Dem,Joseph Addabbo,306
-Queens,30037,State Senate,SD15,Dem,Joseph Addabbo,317
-Queens,31006,State Senate,SD15,Dem,Joseph Addabbo,16
-Queens,31021,State Senate,SD15,Dem,Joseph Addabbo,20
-Queens,31027,State Senate,SD15,Dem,Joseph Addabbo,254
-Queens,31028,State Senate,SD15,Dem,Joseph Addabbo,216
-Queens,34054,State Senate,SD15,Dem,Joseph Addabbo,5
-Queens,34056,State Senate,SD15,Dem,Joseph Addabbo,46
-Queens,34062,State Senate,SD15,Dem,Joseph Addabbo,15
-Queens,34063,State Senate,SD15,Dem,Joseph Addabbo,45
-Queens,37042,State Senate,SD15,Dem,Joseph Addabbo,112
-Queens,37043,State Senate,SD15,Dem,Joseph Addabbo,319
-Queens,37044,State Senate,SD15,Dem,Joseph Addabbo,270
-Queens,37045,State Senate,SD15,Dem,Joseph Addabbo,277
-Queens,37046,State Senate,SD15,Dem,Joseph Addabbo,271
-Queens,37047,State Senate,SD15,Dem,Joseph Addabbo,344
-Queens,37048,State Senate,SD15,Dem,Joseph Addabbo,337
-Queens,37049,State Senate,SD15,Dem,Joseph Addabbo,288
-Queens,37050,State Senate,SD15,Dem,Joseph Addabbo,287
-Queens,37052,State Senate,SD15,Dem,Joseph Addabbo,88
-Queens,37053,State Senate,SD15,Dem,Joseph Addabbo,52
-Queens,37054,State Senate,SD15,Dem,Joseph Addabbo,114
-Queens,37060,State Senate,SD15,Dem,Joseph Addabbo,54
-Queens,37061,State Senate,SD15,Dem,Joseph Addabbo,210
-Queens,37062,State Senate,SD15,Dem,Joseph Addabbo,308
-Queens,37066,State Senate,SD15,Dem,Joseph Addabbo,12
-Queens,37069,State Senate,SD15,Dem,Joseph Addabbo,29
-Queens,38014,State Senate,SD15,Dem,Joseph Addabbo,344
-Queens,38015,State Senate,SD15,Dem,Joseph Addabbo,92
-Queens,38016,State Senate,SD15,Dem,Joseph Addabbo,331
-Queens,38017,State Senate,SD15,Dem,Joseph Addabbo,323
-Queens,38018,State Senate,SD15,Dem,Joseph Addabbo,306
-Queens,38019,State Senate,SD15,Dem,Joseph Addabbo,213
-Queens,38028,State Senate,SD15,Dem,Joseph Addabbo,277
-Queens,38030,State Senate,SD15,Dem,Joseph Addabbo,448
-Queens,38031,State Senate,SD15,Dem,Joseph Addabbo,281
-Queens,38032,State Senate,SD15,Dem,Joseph Addabbo,348
-Queens,38033,State Senate,SD15,Dem,Joseph Addabbo,179
-Queens,38035,State Senate,SD15,Dem,Joseph Addabbo,70
-Queens,38037,State Senate,SD15,Dem,Joseph Addabbo,215
-Queens,38050,State Senate,SD15,Dem,Joseph Addabbo,529
-Queens,38051,State Senate,SD15,Dem,Joseph Addabbo,442
-Queens,38052,State Senate,SD15,Dem,Joseph Addabbo,387
-Queens,38054,State Senate,SD15,Dem,Joseph Addabbo,415
-Queens,38055,State Senate,SD15,Dem,Joseph Addabbo,374
-Queens,38056,State Senate,SD15,Dem,Joseph Addabbo,401
-Queens,38057,State Senate,SD15,Dem,Joseph Addabbo,423
-Queens,38058,State Senate,SD15,Dem,Joseph Addabbo,458
-Queens,39036,State Senate,SD15,Dem,Joseph Addabbo,22
-Queens,23001,State Senate,SD15,WF,Joseph Addabbo,1
-Queens,23002,State Senate,SD15,WF,Joseph Addabbo,3
-Queens,23003,State Senate,SD15,WF,Joseph Addabbo,2
-Queens,23004,State Senate,SD15,WF,Joseph Addabbo,2
-Queens,23005,State Senate,SD15,WF,Joseph Addabbo,2
-Queens,23006,State Senate,SD15,WF,Joseph Addabbo,3
-Queens,23007,State Senate,SD15,WF,Joseph Addabbo,1
-Queens,23008,State Senate,SD15,WF,Joseph Addabbo,4
-Queens,23009,State Senate,SD15,WF,Joseph Addabbo,2
-Queens,23010,State Senate,SD15,WF,Joseph Addabbo,10
-Queens,23011,State Senate,SD15,WF,Joseph Addabbo,1
-Queens,23012,State Senate,SD15,WF,Joseph Addabbo,3
-Queens,23013,State Senate,SD15,WF,Joseph Addabbo,6
-Queens,23014,State Senate,SD15,WF,Joseph Addabbo,4
-Queens,23015,State Senate,SD15,WF,Joseph Addabbo,5
-Queens,23016,State Senate,SD15,WF,Joseph Addabbo,5
-Queens,23017,State Senate,SD15,WF,Joseph Addabbo,1
-Queens,23021,State Senate,SD15,WF,Joseph Addabbo,3
-Queens,23023,State Senate,SD15,WF,Joseph Addabbo,0
-Queens,23024,State Senate,SD15,WF,Joseph Addabbo,2
-Queens,23025,State Senate,SD15,WF,Joseph Addabbo,4
-Queens,23026,State Senate,SD15,WF,Joseph Addabbo,4
-Queens,23027,State Senate,SD15,WF,Joseph Addabbo,2
-Queens,23028,State Senate,SD15,WF,Joseph Addabbo,0
-Queens,23040,State Senate,SD15,WF,Joseph Addabbo,3
-Queens,23041,State Senate,SD15,WF,Joseph Addabbo,7
-Queens,23042,State Senate,SD15,WF,Joseph Addabbo,0
-Queens,23044,State Senate,SD15,WF,Joseph Addabbo,10
-Queens,23045,State Senate,SD15,WF,Joseph Addabbo,2
-Queens,23046,State Senate,SD15,WF,Joseph Addabbo,10
-Queens,23047,State Senate,SD15,WF,Joseph Addabbo,4
-Queens,23048,State Senate,SD15,WF,Joseph Addabbo,4
-Queens,23049,State Senate,SD15,WF,Joseph Addabbo,9
-Queens,23050,State Senate,SD15,WF,Joseph Addabbo,13
-Queens,23051,State Senate,SD15,WF,Joseph Addabbo,6
-Queens,23052,State Senate,SD15,WF,Joseph Addabbo,11
-Queens,23053,State Senate,SD15,WF,Joseph Addabbo,15
-Queens,23054,State Senate,SD15,WF,Joseph Addabbo,12
-Queens,23055,State Senate,SD15,WF,Joseph Addabbo,6
-Queens,23056,State Senate,SD15,WF,Joseph Addabbo,9
-Queens,23057,State Senate,SD15,WF,Joseph Addabbo,13
-Queens,23058,State Senate,SD15,WF,Joseph Addabbo,17
-Queens,23059,State Senate,SD15,WF,Joseph Addabbo,11
-Queens,23060,State Senate,SD15,WF,Joseph Addabbo,13
-Queens,23061,State Senate,SD15,WF,Joseph Addabbo,16
-Queens,23062,State Senate,SD15,WF,Joseph Addabbo,22
-Queens,23063,State Senate,SD15,WF,Joseph Addabbo,9
-Queens,23064,State Senate,SD15,WF,Joseph Addabbo,23
-Queens,23065,State Senate,SD15,WF,Joseph Addabbo,12
-Queens,23068,State Senate,SD15,WF,Joseph Addabbo,7
-Queens,23069,State Senate,SD15,WF,Joseph Addabbo,5
-Queens,23072,State Senate,SD15,WF,Joseph Addabbo,14
-Queens,25001,State Senate,SD15,WF,Joseph Addabbo,10
-Queens,27019,State Senate,SD15,WF,Joseph Addabbo,13
-Queens,27024,State Senate,SD15,WF,Joseph Addabbo,4
-Queens,27025,State Senate,SD15,WF,Joseph Addabbo,5
-Queens,27026,State Senate,SD15,WF,Joseph Addabbo,4
-Queens,27027,State Senate,SD15,WF,Joseph Addabbo,11
-Queens,27028,State Senate,SD15,WF,Joseph Addabbo,8
-Queens,27029,State Senate,SD15,WF,Joseph Addabbo,5
-Queens,27030,State Senate,SD15,WF,Joseph Addabbo,2
-Queens,27046,State Senate,SD15,WF,Joseph Addabbo,3
-Queens,27076,State Senate,SD15,WF,Joseph Addabbo,15
-Queens,27077,State Senate,SD15,WF,Joseph Addabbo,0
-Queens,28003,State Senate,SD15,WF,Joseph Addabbo,9
-Queens,28009,State Senate,SD15,WF,Joseph Addabbo,12
-Queens,28010,State Senate,SD15,WF,Joseph Addabbo,15
-Queens,28012,State Senate,SD15,WF,Joseph Addabbo,11
-Queens,28014,State Senate,SD15,WF,Joseph Addabbo,2
-Queens,28015,State Senate,SD15,WF,Joseph Addabbo,12
-Queens,28016,State Senate,SD15,WF,Joseph Addabbo,14
-Queens,28017,State Senate,SD15,WF,Joseph Addabbo,29
-Queens,28018,State Senate,SD15,WF,Joseph Addabbo,18
-Queens,28019,State Senate,SD15,WF,Joseph Addabbo,27
-Queens,28020,State Senate,SD15,WF,Joseph Addabbo,22
-Queens,28021,State Senate,SD15,WF,Joseph Addabbo,8
-Queens,28022,State Senate,SD15,WF,Joseph Addabbo,19
-Queens,28023,State Senate,SD15,WF,Joseph Addabbo,25
-Queens,28024,State Senate,SD15,WF,Joseph Addabbo,3
-Queens,28032,State Senate,SD15,WF,Joseph Addabbo,10
-Queens,28033,State Senate,SD15,WF,Joseph Addabbo,0
-Queens,28047,State Senate,SD15,WF,Joseph Addabbo,11
-Queens,28048,State Senate,SD15,WF,Joseph Addabbo,19
-Queens,28049,State Senate,SD15,WF,Joseph Addabbo,8
-Queens,28060,State Senate,SD15,WF,Joseph Addabbo,9
-Queens,28061,State Senate,SD15,WF,Joseph Addabbo,16
-Queens,28062,State Senate,SD15,WF,Joseph Addabbo,15
-Queens,28063,State Senate,SD15,WF,Joseph Addabbo,19
-Queens,28064,State Senate,SD15,WF,Joseph Addabbo,20
-Queens,28065,State Senate,SD15,WF,Joseph Addabbo,20
-Queens,28066,State Senate,SD15,WF,Joseph Addabbo,14
-Queens,28067,State Senate,SD15,WF,Joseph Addabbo,6
-Queens,28068,State Senate,SD15,WF,Joseph Addabbo,14
-Queens,28069,State Senate,SD15,WF,Joseph Addabbo,12
-Queens,28070,State Senate,SD15,WF,Joseph Addabbo,26
-Queens,28071,State Senate,SD15,WF,Joseph Addabbo,17
-Queens,28072,State Senate,SD15,WF,Joseph Addabbo,16
-Queens,28073,State Senate,SD15,WF,Joseph Addabbo,14
-Queens,28074,State Senate,SD15,WF,Joseph Addabbo,16
-Queens,28075,State Senate,SD15,WF,Joseph Addabbo,14
-Queens,28076,State Senate,SD15,WF,Joseph Addabbo,11
-Queens,28077,State Senate,SD15,WF,Joseph Addabbo,17
-Queens,28078,State Senate,SD15,WF,Joseph Addabbo,12
-Queens,28079,State Senate,SD15,WF,Joseph Addabbo,10
-Queens,28080,State Senate,SD15,WF,Joseph Addabbo,7
-Queens,30003,State Senate,SD15,WF,Joseph Addabbo,0
-Queens,30004,State Senate,SD15,WF,Joseph Addabbo,12
-Queens,30005,State Senate,SD15,WF,Joseph Addabbo,8
-Queens,30006,State Senate,SD15,WF,Joseph Addabbo,22
-Queens,30007,State Senate,SD15,WF,Joseph Addabbo,8
-Queens,30008,State Senate,SD15,WF,Joseph Addabbo,12
-Queens,30009,State Senate,SD15,WF,Joseph Addabbo,12
-Queens,30010,State Senate,SD15,WF,Joseph Addabbo,11
-Queens,30011,State Senate,SD15,WF,Joseph Addabbo,5
-Queens,30012,State Senate,SD15,WF,Joseph Addabbo,11
-Queens,30013,State Senate,SD15,WF,Joseph Addabbo,14
-Queens,30014,State Senate,SD15,WF,Joseph Addabbo,11
-Queens,30015,State Senate,SD15,WF,Joseph Addabbo,10
-Queens,30016,State Senate,SD15,WF,Joseph Addabbo,10
-Queens,30017,State Senate,SD15,WF,Joseph Addabbo,12
-Queens,30018,State Senate,SD15,WF,Joseph Addabbo,14
-Queens,30019,State Senate,SD15,WF,Joseph Addabbo,0
-Queens,30020,State Senate,SD15,WF,Joseph Addabbo,8
-Queens,30021,State Senate,SD15,WF,Joseph Addabbo,14
-Queens,30022,State Senate,SD15,WF,Joseph Addabbo,11
-Queens,30023,State Senate,SD15,WF,Joseph Addabbo,10
-Queens,30024,State Senate,SD15,WF,Joseph Addabbo,8
-Queens,30025,State Senate,SD15,WF,Joseph Addabbo,11
-Queens,30026,State Senate,SD15,WF,Joseph Addabbo,8
-Queens,30027,State Senate,SD15,WF,Joseph Addabbo,10
-Queens,30028,State Senate,SD15,WF,Joseph Addabbo,0
-Queens,30029,State Senate,SD15,WF,Joseph Addabbo,0
-Queens,30033,State Senate,SD15,WF,Joseph Addabbo,1
-Queens,30036,State Senate,SD15,WF,Joseph Addabbo,3
-Queens,30037,State Senate,SD15,WF,Joseph Addabbo,7
-Queens,31006,State Senate,SD15,WF,Joseph Addabbo,1
-Queens,31021,State Senate,SD15,WF,Joseph Addabbo,0
-Queens,31027,State Senate,SD15,WF,Joseph Addabbo,3
-Queens,31028,State Senate,SD15,WF,Joseph Addabbo,3
-Queens,34054,State Senate,SD15,WF,Joseph Addabbo,0
-Queens,34056,State Senate,SD15,WF,Joseph Addabbo,4
-Queens,34062,State Senate,SD15,WF,Joseph Addabbo,0
-Queens,34063,State Senate,SD15,WF,Joseph Addabbo,1
-Queens,37042,State Senate,SD15,WF,Joseph Addabbo,9
-Queens,37043,State Senate,SD15,WF,Joseph Addabbo,16
-Queens,37044,State Senate,SD15,WF,Joseph Addabbo,16
-Queens,37045,State Senate,SD15,WF,Joseph Addabbo,12
-Queens,37046,State Senate,SD15,WF,Joseph Addabbo,21
-Queens,37047,State Senate,SD15,WF,Joseph Addabbo,27
-Queens,37048,State Senate,SD15,WF,Joseph Addabbo,13
-Queens,37049,State Senate,SD15,WF,Joseph Addabbo,9
-Queens,37050,State Senate,SD15,WF,Joseph Addabbo,8
-Queens,37052,State Senate,SD15,WF,Joseph Addabbo,4
-Queens,37053,State Senate,SD15,WF,Joseph Addabbo,5
-Queens,37054,State Senate,SD15,WF,Joseph Addabbo,2
-Queens,37060,State Senate,SD15,WF,Joseph Addabbo,4
-Queens,37061,State Senate,SD15,WF,Joseph Addabbo,16
-Queens,37062,State Senate,SD15,WF,Joseph Addabbo,16
-Queens,37066,State Senate,SD15,WF,Joseph Addabbo,0
-Queens,37069,State Senate,SD15,WF,Joseph Addabbo,1
-Queens,38014,State Senate,SD15,WF,Joseph Addabbo,12
-Queens,38015,State Senate,SD15,WF,Joseph Addabbo,5
-Queens,38016,State Senate,SD15,WF,Joseph Addabbo,21
-Queens,38017,State Senate,SD15,WF,Joseph Addabbo,15
-Queens,38018,State Senate,SD15,WF,Joseph Addabbo,15
-Queens,38019,State Senate,SD15,WF,Joseph Addabbo,16
-Queens,38028,State Senate,SD15,WF,Joseph Addabbo,16
-Queens,38030,State Senate,SD15,WF,Joseph Addabbo,14
-Queens,38031,State Senate,SD15,WF,Joseph Addabbo,6
-Queens,38032,State Senate,SD15,WF,Joseph Addabbo,10
-Queens,38033,State Senate,SD15,WF,Joseph Addabbo,4
-Queens,38035,State Senate,SD15,WF,Joseph Addabbo,3
-Queens,38037,State Senate,SD15,WF,Joseph Addabbo,5
-Queens,38050,State Senate,SD15,WF,Joseph Addabbo,14
-Queens,38051,State Senate,SD15,WF,Joseph Addabbo,21
-Queens,38052,State Senate,SD15,WF,Joseph Addabbo,9
-Queens,38054,State Senate,SD15,WF,Joseph Addabbo,21
-Queens,38055,State Senate,SD15,WF,Joseph Addabbo,12
-Queens,38056,State Senate,SD15,WF,Joseph Addabbo,15
-Queens,38057,State Senate,SD15,WF,Joseph Addabbo,19
-Queens,38058,State Senate,SD15,WF,Joseph Addabbo,15
-Queens,39036,State Senate,SD15,WF,Joseph Addabbo,0
-Queens,23001,State Senate,SD15,Ind,writein,1
-Queens,23002,State Senate,SD15,Ind,writein,0
-Queens,23003,State Senate,SD15,Ind,writein,0
-Queens,23004,State Senate,SD15,Ind,writein,0
-Queens,23005,State Senate,SD15,Ind,writein,0
-Queens,23006,State Senate,SD15,Ind,writein,0
-Queens,23007,State Senate,SD15,Ind,writein,0
-Queens,23008,State Senate,SD15,Ind,writein,0
-Queens,23009,State Senate,SD15,Ind,writein,0
-Queens,23010,State Senate,SD15,Ind,writein,0
-Queens,23011,State Senate,SD15,Ind,writein,1
-Queens,23012,State Senate,SD15,Ind,writein,0
-Queens,23013,State Senate,SD15,Ind,writein,0
-Queens,23014,State Senate,SD15,Ind,writein,1
-Queens,23015,State Senate,SD15,Ind,writein,2
-Queens,23016,State Senate,SD15,Ind,writein,0
-Queens,23017,State Senate,SD15,Ind,writein,0
-Queens,23021,State Senate,SD15,Ind,writein,0
-Queens,23023,State Senate,SD15,Ind,writein,0
-Queens,23024,State Senate,SD15,Ind,writein,0
-Queens,23025,State Senate,SD15,Ind,writein,0
-Queens,23026,State Senate,SD15,Ind,writein,1
-Queens,23027,State Senate,SD15,Ind,writein,0
-Queens,23028,State Senate,SD15,Ind,writein,0
-Queens,23040,State Senate,SD15,Ind,writein,0
-Queens,23041,State Senate,SD15,Ind,writein,0
-Queens,23042,State Senate,SD15,Ind,writein,0
-Queens,23044,State Senate,SD15,Ind,writein,1
-Queens,23045,State Senate,SD15,Ind,writein,0
-Queens,23046,State Senate,SD15,Ind,writein,0
-Queens,23047,State Senate,SD15,Ind,writein,1
-Queens,23048,State Senate,SD15,Ind,writein,0
-Queens,23049,State Senate,SD15,Ind,writein,0
-Queens,23050,State Senate,SD15,Ind,writein,0
-Queens,23051,State Senate,SD15,Ind,writein,0
-Queens,23052,State Senate,SD15,Ind,writein,0
-Queens,23053,State Senate,SD15,Ind,writein,0
-Queens,23054,State Senate,SD15,Ind,writein,0
-Queens,23055,State Senate,SD15,Ind,writein,0
-Queens,23056,State Senate,SD15,Ind,writein,0
-Queens,23057,State Senate,SD15,Ind,writein,0
-Queens,23058,State Senate,SD15,Ind,writein,0
-Queens,23059,State Senate,SD15,Ind,writein,1
-Queens,23060,State Senate,SD15,Ind,writein,0
-Queens,23061,State Senate,SD15,Ind,writein,0
-Queens,23062,State Senate,SD15,Ind,writein,0
-Queens,23063,State Senate,SD15,Ind,writein,0
-Queens,23064,State Senate,SD15,Ind,writein,0
-Queens,23065,State Senate,SD15,Ind,writein,1
-Queens,23068,State Senate,SD15,Ind,writein,0
-Queens,23069,State Senate,SD15,Ind,writein,0
-Queens,23072,State Senate,SD15,Ind,writein,1
-Queens,25001,State Senate,SD15,Ind,writein,0
-Queens,27019,State Senate,SD15,Ind,writein,1
-Queens,27024,State Senate,SD15,Ind,writein,0
-Queens,27025,State Senate,SD15,Ind,writein,0
-Queens,27026,State Senate,SD15,Ind,writein,1
-Queens,27027,State Senate,SD15,Ind,writein,0
-Queens,27028,State Senate,SD15,Ind,writein,0
-Queens,27029,State Senate,SD15,Ind,writein,1
-Queens,27030,State Senate,SD15,Ind,writein,0
-Queens,27046,State Senate,SD15,Ind,writein,0
-Queens,27076,State Senate,SD15,Ind,writein,0
-Queens,27077,State Senate,SD15,Ind,writein,0
-Queens,28003,State Senate,SD15,Ind,writein,1
-Queens,28009,State Senate,SD15,Ind,writein,0
-Queens,28010,State Senate,SD15,Ind,writein,1
-Queens,28012,State Senate,SD15,Ind,writein,2
-Queens,28014,State Senate,SD15,Ind,writein,0
-Queens,28015,State Senate,SD15,Ind,writein,1
-Queens,28016,State Senate,SD15,Ind,writein,0
-Queens,28017,State Senate,SD15,Ind,writein,0
-Queens,28018,State Senate,SD15,Ind,writein,0
-Queens,28019,State Senate,SD15,Ind,writein,0
-Queens,28020,State Senate,SD15,Ind,writein,2
-Queens,28021,State Senate,SD15,Ind,writein,0
-Queens,28022,State Senate,SD15,Ind,writein,1
-Queens,28023,State Senate,SD15,Ind,writein,0
-Queens,28024,State Senate,SD15,Ind,writein,0
-Queens,28032,State Senate,SD15,Ind,writein,0
-Queens,28033,State Senate,SD15,Ind,writein,0
-Queens,28047,State Senate,SD15,Ind,writein,0
-Queens,28048,State Senate,SD15,Ind,writein,0
-Queens,28049,State Senate,SD15,Ind,writein,1
-Queens,28060,State Senate,SD15,Ind,writein,0
-Queens,28061,State Senate,SD15,Ind,writein,0
-Queens,28062,State Senate,SD15,Ind,writein,2
-Queens,28063,State Senate,SD15,Ind,writein,1
-Queens,28064,State Senate,SD15,Ind,writein,0
-Queens,28065,State Senate,SD15,Ind,writein,1
-Queens,28066,State Senate,SD15,Ind,writein,1
-Queens,28067,State Senate,SD15,Ind,writein,1
-Queens,28068,State Senate,SD15,Ind,writein,2
-Queens,28069,State Senate,SD15,Ind,writein,0
-Queens,28070,State Senate,SD15,Ind,writein,1
-Queens,28071,State Senate,SD15,Ind,writein,0
-Queens,28072,State Senate,SD15,Ind,writein,1
-Queens,28073,State Senate,SD15,Ind,writein,1
-Queens,28074,State Senate,SD15,Ind,writein,0
-Queens,28075,State Senate,SD15,Ind,writein,1
-Queens,28076,State Senate,SD15,Ind,writein,1
-Queens,28077,State Senate,SD15,Ind,writein,0
-Queens,28078,State Senate,SD15,Ind,writein,0
-Queens,28079,State Senate,SD15,Ind,writein,1
-Queens,28080,State Senate,SD15,Ind,writein,1
-Queens,30003,State Senate,SD15,Ind,writein,0
-Queens,30004,State Senate,SD15,Ind,writein,0
-Queens,30005,State Senate,SD15,Ind,writein,0
-Queens,30006,State Senate,SD15,Ind,writein,0
-Queens,30007,State Senate,SD15,Ind,writein,0
-Queens,30008,State Senate,SD15,Ind,writein,0
-Queens,30009,State Senate,SD15,Ind,writein,0
-Queens,30010,State Senate,SD15,Ind,writein,0
-Queens,30011,State Senate,SD15,Ind,writein,0
-Queens,30012,State Senate,SD15,Ind,writein,0
-Queens,30013,State Senate,SD15,Ind,writein,1
-Queens,30014,State Senate,SD15,Ind,writein,0
-Queens,30015,State Senate,SD15,Ind,writein,0
-Queens,30016,State Senate,SD15,Ind,writein,0
-Queens,30017,State Senate,SD15,Ind,writein,0
-Queens,30018,State Senate,SD15,Ind,writein,1
-Queens,30019,State Senate,SD15,Ind,writein,0
-Queens,30020,State Senate,SD15,Ind,writein,0
-Queens,30021,State Senate,SD15,Ind,writein,0
-Queens,30022,State Senate,SD15,Ind,writein,0
-Queens,30023,State Senate,SD15,Ind,writein,1
-Queens,30024,State Senate,SD15,Ind,writein,0
-Queens,30025,State Senate,SD15,Ind,writein,0
-Queens,30026,State Senate,SD15,Ind,writein,0
-Queens,30027,State Senate,SD15,Ind,writein,0
-Queens,30028,State Senate,SD15,Ind,writein,0
-Queens,30029,State Senate,SD15,Ind,writein,0
-Queens,30033,State Senate,SD15,Ind,writein,0
-Queens,30036,State Senate,SD15,Ind,writein,0
-Queens,30037,State Senate,SD15,Ind,writein,0
-Queens,31006,State Senate,SD15,Ind,writein,0
-Queens,31021,State Senate,SD15,Ind,writein,0
-Queens,31027,State Senate,SD15,Ind,writein,0
-Queens,31028,State Senate,SD15,Ind,writein,0
-Queens,34054,State Senate,SD15,Ind,writein,0
-Queens,34056,State Senate,SD15,Ind,writein,0
-Queens,34062,State Senate,SD15,Ind,writein,0
-Queens,34063,State Senate,SD15,Ind,writein,0
-Queens,37042,State Senate,SD15,Ind,writein,0
-Queens,37043,State Senate,SD15,Ind,writein,1
-Queens,37044,State Senate,SD15,Ind,writein,0
-Queens,37045,State Senate,SD15,Ind,writein,0
-Queens,37046,State Senate,SD15,Ind,writein,0
-Queens,37047,State Senate,SD15,Ind,writein,0
-Queens,37048,State Senate,SD15,Ind,writein,1
-Queens,37049,State Senate,SD15,Ind,writein,0
-Queens,37050,State Senate,SD15,Ind,writein,1
-Queens,37052,State Senate,SD15,Ind,writein,0
-Queens,37053,State Senate,SD15,Ind,writein,0
-Queens,37054,State Senate,SD15,Ind,writein,1
-Queens,37060,State Senate,SD15,Ind,writein,0
-Queens,37061,State Senate,SD15,Ind,writein,0
-Queens,37062,State Senate,SD15,Ind,writein,0
-Queens,37066,State Senate,SD15,Ind,writein,0
-Queens,37069,State Senate,SD15,Ind,writein,0
-Queens,38014,State Senate,SD15,Ind,writein,0
-Queens,38015,State Senate,SD15,Ind,writein,0
-Queens,38016,State Senate,SD15,Ind,writein,0
-Queens,38017,State Senate,SD15,Ind,writein,0
-Queens,38018,State Senate,SD15,Ind,writein,1
-Queens,38019,State Senate,SD15,Ind,writein,1
-Queens,38028,State Senate,SD15,Ind,writein,0
-Queens,38030,State Senate,SD15,Ind,writein,1
-Queens,38031,State Senate,SD15,Ind,writein,0
-Queens,38032,State Senate,SD15,Ind,writein,0
-Queens,38033,State Senate,SD15,Ind,writein,0
-Queens,38035,State Senate,SD15,Ind,writein,0
-Queens,38037,State Senate,SD15,Ind,writein,0
-Queens,38050,State Senate,SD15,Ind,writein,0
-Queens,38051,State Senate,SD15,Ind,writein,0
-Queens,38052,State Senate,SD15,Ind,writein,1
-Queens,38054,State Senate,SD15,Ind,writein,0
-Queens,38055,State Senate,SD15,Ind,writein,2
-Queens,38056,State Senate,SD15,Ind,writein,1
-Queens,38057,State Senate,SD15,Ind,writein,0
-Queens,38058,State Senate,SD15,Ind,writein,0
-Queens,39036,State Senate,SD15,Ind,writein,0
-Queens,24016,State Senate,SD16,Rep,J D Kim,66
-Queens,24023,State Senate,SD16,Rep,J D Kim,15
-Queens,25020,State Senate,SD16,Rep,J D Kim,77
-Queens,25021,State Senate,SD16,Rep,J D Kim,155
-Queens,25022,State Senate,SD16,Rep,J D Kim,110
-Queens,25023,State Senate,SD16,Rep,J D Kim,71
-Queens,25024,State Senate,SD16,Rep,J D Kim,165
-Queens,25034,State Senate,SD16,Rep,J D Kim,16
-Queens,25042,State Senate,SD16,Rep,J D Kim,149
-Queens,25043,State Senate,SD16,Rep,J D Kim,153
-Queens,25044,State Senate,SD16,Rep,J D Kim,107
-Queens,25045,State Senate,SD16,Rep,J D Kim,83
-Queens,25046,State Senate,SD16,Rep,J D Kim,68
-Queens,25047,State Senate,SD16,Rep,J D Kim,91
-Queens,25048,State Senate,SD16,Rep,J D Kim,89
-Queens,25049,State Senate,SD16,Rep,J D Kim,106
-Queens,25050,State Senate,SD16,Rep,J D Kim,61
-Queens,25051,State Senate,SD16,Rep,J D Kim,68
-Queens,25052,State Senate,SD16,Rep,J D Kim,78
-Queens,25053,State Senate,SD16,Rep,J D Kim,86
-Queens,25054,State Senate,SD16,Rep,J D Kim,52
-Queens,25055,State Senate,SD16,Rep,J D Kim,110
-Queens,25056,State Senate,SD16,Rep,J D Kim,105
-Queens,25057,State Senate,SD16,Rep,J D Kim,54
-Queens,25058,State Senate,SD16,Rep,J D Kim,15
-Queens,25059,State Senate,SD16,Rep,J D Kim,117
-Queens,25060,State Senate,SD16,Rep,J D Kim,73
-Queens,25061,State Senate,SD16,Rep,J D Kim,100
-Queens,25062,State Senate,SD16,Rep,J D Kim,68
-Queens,25063,State Senate,SD16,Rep,J D Kim,104
-Queens,25064,State Senate,SD16,Rep,J D Kim,24
-Queens,26039,State Senate,SD16,Rep,J D Kim,97
-Queens,26040,State Senate,SD16,Rep,J D Kim,27
-Queens,26041,State Senate,SD16,Rep,J D Kim,15
-Queens,26044,State Senate,SD16,Rep,J D Kim,193
-Queens,27034,State Senate,SD16,Rep,J D Kim,101
-Queens,27035,State Senate,SD16,Rep,J D Kim,72
-Queens,27036,State Senate,SD16,Rep,J D Kim,123
-Queens,27037,State Senate,SD16,Rep,J D Kim,47
-Queens,27038,State Senate,SD16,Rep,J D Kim,65
-Queens,27039,State Senate,SD16,Rep,J D Kim,26
-Queens,27040,State Senate,SD16,Rep,J D Kim,39
-Queens,27041,State Senate,SD16,Rep,J D Kim,23
-Queens,27042,State Senate,SD16,Rep,J D Kim,61
-Queens,27043,State Senate,SD16,Rep,J D Kim,71
-Queens,27044,State Senate,SD16,Rep,J D Kim,64
-Queens,27045,State Senate,SD16,Rep,J D Kim,57
-Queens,27047,State Senate,SD16,Rep,J D Kim,87
-Queens,27048,State Senate,SD16,Rep,J D Kim,131
-Queens,27049,State Senate,SD16,Rep,J D Kim,157
-Queens,27050,State Senate,SD16,Rep,J D Kim,100
-Queens,27052,State Senate,SD16,Rep,J D Kim,87
-Queens,27053,State Senate,SD16,Rep,J D Kim,95
-Queens,27054,State Senate,SD16,Rep,J D Kim,82
-Queens,27055,State Senate,SD16,Rep,J D Kim,63
-Queens,27056,State Senate,SD16,Rep,J D Kim,51
-Queens,28027,State Senate,SD16,Rep,J D Kim,52
-Queens,28028,State Senate,SD16,Rep,J D Kim,122
-Queens,28029,State Senate,SD16,Rep,J D Kim,95
-Queens,28030,State Senate,SD16,Rep,J D Kim,74
-Queens,28031,State Senate,SD16,Rep,J D Kim,108
-Queens,28034,State Senate,SD16,Rep,J D Kim,13
-Queens,28035,State Senate,SD16,Rep,J D Kim,126
-Queens,28036,State Senate,SD16,Rep,J D Kim,70
-Queens,28037,State Senate,SD16,Rep,J D Kim,101
-Queens,28038,State Senate,SD16,Rep,J D Kim,86
-Queens,28039,State Senate,SD16,Rep,J D Kim,117
-Queens,28040,State Senate,SD16,Rep,J D Kim,100
-Queens,28041,State Senate,SD16,Rep,J D Kim,145
-Queens,28042,State Senate,SD16,Rep,J D Kim,124
-Queens,28043,State Senate,SD16,Rep,J D Kim,114
-Queens,28044,State Senate,SD16,Rep,J D Kim,107
-Queens,28045,State Senate,SD16,Rep,J D Kim,133
-Queens,28046,State Senate,SD16,Rep,J D Kim,109
-Queens,28050,State Senate,SD16,Rep,J D Kim,100
-Queens,28051,State Senate,SD16,Rep,J D Kim,141
-Queens,28052,State Senate,SD16,Rep,J D Kim,72
-Queens,28053,State Senate,SD16,Rep,J D Kim,124
-Queens,28054,State Senate,SD16,Rep,J D Kim,33
-Queens,28055,State Senate,SD16,Rep,J D Kim,19
-Queens,28056,State Senate,SD16,Rep,J D Kim,78
-Queens,28057,State Senate,SD16,Rep,J D Kim,56
-Queens,28058,State Senate,SD16,Rep,J D Kim,66
-Queens,28059,State Senate,SD16,Rep,J D Kim,12
-Queens,30001,State Senate,SD16,Rep,J D Kim,38
-Queens,30002,State Senate,SD16,Rep,J D Kim,100
-Queens,30030,State Senate,SD16,Rep,J D Kim,81
-Queens,30031,State Senate,SD16,Rep,J D Kim,56
-Queens,30032,State Senate,SD16,Rep,J D Kim,11
-Queens,30034,State Senate,SD16,Rep,J D Kim,2
-Queens,30054,State Senate,SD16,Rep,J D Kim,4
-Queens,34031,State Senate,SD16,Rep,J D Kim,18
-Queens,34032,State Senate,SD16,Rep,J D Kim,12
-Queens,34033,State Senate,SD16,Rep,J D Kim,7
-Queens,34045,State Senate,SD16,Rep,J D Kim,92
-Queens,34046,State Senate,SD16,Rep,J D Kim,27
-Queens,34057,State Senate,SD16,Rep,J D Kim,13
-Queens,34058,State Senate,SD16,Rep,J D Kim,0
-Queens,34061,State Senate,SD16,Rep,J D Kim,5
-Queens,35001,State Senate,SD16,Rep,J D Kim,12
-Queens,35002,State Senate,SD16,Rep,J D Kim,105
-Queens,35003,State Senate,SD16,Rep,J D Kim,80
-Queens,35004,State Senate,SD16,Rep,J D Kim,51
-Queens,35005,State Senate,SD16,Rep,J D Kim,106
-Queens,35006,State Senate,SD16,Rep,J D Kim,83
-Queens,35007,State Senate,SD16,Rep,J D Kim,81
-Queens,35008,State Senate,SD16,Rep,J D Kim,93
-Queens,35009,State Senate,SD16,Rep,J D Kim,89
-Queens,35010,State Senate,SD16,Rep,J D Kim,81
-Queens,35023,State Senate,SD16,Rep,J D Kim,113
-Queens,35024,State Senate,SD16,Rep,J D Kim,63
-Queens,35026,State Senate,SD16,Rep,J D Kim,97
-Queens,35027,State Senate,SD16,Rep,J D Kim,128
-Queens,35028,State Senate,SD16,Rep,J D Kim,2
-Queens,35029,State Senate,SD16,Rep,J D Kim,0
-Queens,35030,State Senate,SD16,Rep,J D Kim,37
-Queens,35031,State Senate,SD16,Rep,J D Kim,0
-Queens,35034,State Senate,SD16,Rep,J D Kim,7
-Queens,39023,State Senate,SD16,Rep,J D Kim,67
-Queens,39024,State Senate,SD16,Rep,J D Kim,24
-Queens,39027,State Senate,SD16,Rep,J D Kim,7
-Queens,39029,State Senate,SD16,Rep,J D Kim,58
-Queens,39030,State Senate,SD16,Rep,J D Kim,96
-Queens,39031,State Senate,SD16,Rep,J D Kim,63
-Queens,39034,State Senate,SD16,Rep,J D Kim,93
-Queens,39035,State Senate,SD16,Rep,J D Kim,34
-Queens,39037,State Senate,SD16,Rep,J D Kim,50
-Queens,39038,State Senate,SD16,Rep,J D Kim,38
-Queens,39040,State Senate,SD16,Rep,J D Kim,22
-Queens,39042,State Senate,SD16,Rep,J D Kim,9
-Queens,39048,State Senate,SD16,Rep,J D Kim,30
-Queens,39049,State Senate,SD16,Rep,J D Kim,49
-Queens,39052,State Senate,SD16,Rep,J D Kim,2
-Queens,39053,State Senate,SD16,Rep,J D Kim,13
-Queens,40011,State Senate,SD16,Rep,J D Kim,20
-Queens,40012,State Senate,SD16,Rep,J D Kim,26
-Queens,40016,State Senate,SD16,Rep,J D Kim,86
-Queens,40017,State Senate,SD16,Rep,J D Kim,136
-Queens,40018,State Senate,SD16,Rep,J D Kim,106
-Queens,40019,State Senate,SD16,Rep,J D Kim,127
-Queens,40020,State Senate,SD16,Rep,J D Kim,153
-Queens,40021,State Senate,SD16,Rep,J D Kim,110
-Queens,40022,State Senate,SD16,Rep,J D Kim,134
-Queens,40023,State Senate,SD16,Rep,J D Kim,114
-Queens,40024,State Senate,SD16,Rep,J D Kim,101
-Queens,40025,State Senate,SD16,Rep,J D Kim,111
-Queens,40026,State Senate,SD16,Rep,J D Kim,128
-Queens,40027,State Senate,SD16,Rep,J D Kim,141
-Queens,40029,State Senate,SD16,Rep,J D Kim,98
-Queens,40030,State Senate,SD16,Rep,J D Kim,170
-Queens,40031,State Senate,SD16,Rep,J D Kim,111
-Queens,40032,State Senate,SD16,Rep,J D Kim,68
-Queens,40033,State Senate,SD16,Rep,J D Kim,82
-Queens,40034,State Senate,SD16,Rep,J D Kim,48
-Queens,40035,State Senate,SD16,Rep,J D Kim,77
-Queens,40036,State Senate,SD16,Rep,J D Kim,116
-Queens,40037,State Senate,SD16,Rep,J D Kim,82
-Queens,40038,State Senate,SD16,Rep,J D Kim,83
-Queens,40039,State Senate,SD16,Rep,J D Kim,120
-Queens,40040,State Senate,SD16,Rep,J D Kim,77
-Queens,40041,State Senate,SD16,Rep,J D Kim,94
-Queens,40042,State Senate,SD16,Rep,J D Kim,81
-Queens,40043,State Senate,SD16,Rep,J D Kim,91
-Queens,40044,State Senate,SD16,Rep,J D Kim,57
-Queens,40045,State Senate,SD16,Rep,J D Kim,38
-Queens,40046,State Senate,SD16,Rep,J D Kim,22
-Queens,24016,State Senate,SD16,Con,J D Kim,6
-Queens,24023,State Senate,SD16,Con,J D Kim,3
-Queens,25020,State Senate,SD16,Con,J D Kim,12
-Queens,25021,State Senate,SD16,Con,J D Kim,22
-Queens,25022,State Senate,SD16,Con,J D Kim,10
-Queens,25023,State Senate,SD16,Con,J D Kim,5
-Queens,25024,State Senate,SD16,Con,J D Kim,10
-Queens,25034,State Senate,SD16,Con,J D Kim,3
-Queens,25042,State Senate,SD16,Con,J D Kim,18
-Queens,25043,State Senate,SD16,Con,J D Kim,13
-Queens,25044,State Senate,SD16,Con,J D Kim,11
-Queens,25045,State Senate,SD16,Con,J D Kim,8
-Queens,25046,State Senate,SD16,Con,J D Kim,9
-Queens,25047,State Senate,SD16,Con,J D Kim,9
-Queens,25048,State Senate,SD16,Con,J D Kim,15
-Queens,25049,State Senate,SD16,Con,J D Kim,12
-Queens,25050,State Senate,SD16,Con,J D Kim,2
-Queens,25051,State Senate,SD16,Con,J D Kim,5
-Queens,25052,State Senate,SD16,Con,J D Kim,6
-Queens,25053,State Senate,SD16,Con,J D Kim,8
-Queens,25054,State Senate,SD16,Con,J D Kim,8
-Queens,25055,State Senate,SD16,Con,J D Kim,12
-Queens,25056,State Senate,SD16,Con,J D Kim,11
-Queens,25057,State Senate,SD16,Con,J D Kim,6
-Queens,25058,State Senate,SD16,Con,J D Kim,1
-Queens,25059,State Senate,SD16,Con,J D Kim,10
-Queens,25060,State Senate,SD16,Con,J D Kim,14
-Queens,25061,State Senate,SD16,Con,J D Kim,7
-Queens,25062,State Senate,SD16,Con,J D Kim,10
-Queens,25063,State Senate,SD16,Con,J D Kim,18
-Queens,25064,State Senate,SD16,Con,J D Kim,4
-Queens,26039,State Senate,SD16,Con,J D Kim,9
-Queens,26040,State Senate,SD16,Con,J D Kim,0
-Queens,26041,State Senate,SD16,Con,J D Kim,2
-Queens,26044,State Senate,SD16,Con,J D Kim,12
-Queens,27034,State Senate,SD16,Con,J D Kim,4
-Queens,27035,State Senate,SD16,Con,J D Kim,6
-Queens,27036,State Senate,SD16,Con,J D Kim,9
-Queens,27037,State Senate,SD16,Con,J D Kim,6
-Queens,27038,State Senate,SD16,Con,J D Kim,5
-Queens,27039,State Senate,SD16,Con,J D Kim,11
-Queens,27040,State Senate,SD16,Con,J D Kim,8
-Queens,27041,State Senate,SD16,Con,J D Kim,1
-Queens,27042,State Senate,SD16,Con,J D Kim,4
-Queens,27043,State Senate,SD16,Con,J D Kim,10
-Queens,27044,State Senate,SD16,Con,J D Kim,5
-Queens,27045,State Senate,SD16,Con,J D Kim,5
-Queens,27047,State Senate,SD16,Con,J D Kim,10
-Queens,27048,State Senate,SD16,Con,J D Kim,6
-Queens,27049,State Senate,SD16,Con,J D Kim,13
-Queens,27050,State Senate,SD16,Con,J D Kim,8
-Queens,27052,State Senate,SD16,Con,J D Kim,19
-Queens,27053,State Senate,SD16,Con,J D Kim,7
-Queens,27054,State Senate,SD16,Con,J D Kim,5
-Queens,27055,State Senate,SD16,Con,J D Kim,4
-Queens,27056,State Senate,SD16,Con,J D Kim,3
-Queens,28027,State Senate,SD16,Con,J D Kim,7
-Queens,28028,State Senate,SD16,Con,J D Kim,7
-Queens,28029,State Senate,SD16,Con,J D Kim,4
-Queens,28030,State Senate,SD16,Con,J D Kim,8
-Queens,28031,State Senate,SD16,Con,J D Kim,10
-Queens,28034,State Senate,SD16,Con,J D Kim,1
-Queens,28035,State Senate,SD16,Con,J D Kim,13
-Queens,28036,State Senate,SD16,Con,J D Kim,4
-Queens,28037,State Senate,SD16,Con,J D Kim,10
-Queens,28038,State Senate,SD16,Con,J D Kim,9
-Queens,28039,State Senate,SD16,Con,J D Kim,6
-Queens,28040,State Senate,SD16,Con,J D Kim,8
-Queens,28041,State Senate,SD16,Con,J D Kim,12
-Queens,28042,State Senate,SD16,Con,J D Kim,6
-Queens,28043,State Senate,SD16,Con,J D Kim,4
-Queens,28044,State Senate,SD16,Con,J D Kim,18
-Queens,28045,State Senate,SD16,Con,J D Kim,4
-Queens,28046,State Senate,SD16,Con,J D Kim,13
-Queens,28050,State Senate,SD16,Con,J D Kim,6
-Queens,28051,State Senate,SD16,Con,J D Kim,4
-Queens,28052,State Senate,SD16,Con,J D Kim,1
-Queens,28053,State Senate,SD16,Con,J D Kim,8
-Queens,28054,State Senate,SD16,Con,J D Kim,1
-Queens,28055,State Senate,SD16,Con,J D Kim,1
-Queens,28056,State Senate,SD16,Con,J D Kim,5
-Queens,28057,State Senate,SD16,Con,J D Kim,2
-Queens,28058,State Senate,SD16,Con,J D Kim,4
-Queens,28059,State Senate,SD16,Con,J D Kim,2
-Queens,30001,State Senate,SD16,Con,J D Kim,7
-Queens,30002,State Senate,SD16,Con,J D Kim,10
-Queens,30030,State Senate,SD16,Con,J D Kim,19
-Queens,30031,State Senate,SD16,Con,J D Kim,2
-Queens,30032,State Senate,SD16,Con,J D Kim,0
-Queens,30034,State Senate,SD16,Con,J D Kim,0
-Queens,30054,State Senate,SD16,Con,J D Kim,0
-Queens,34031,State Senate,SD16,Con,J D Kim,3
-Queens,34032,State Senate,SD16,Con,J D Kim,2
-Queens,34033,State Senate,SD16,Con,J D Kim,0
-Queens,34045,State Senate,SD16,Con,J D Kim,13
-Queens,34046,State Senate,SD16,Con,J D Kim,1
-Queens,34057,State Senate,SD16,Con,J D Kim,0
-Queens,34058,State Senate,SD16,Con,J D Kim,0
-Queens,34061,State Senate,SD16,Con,J D Kim,0
-Queens,35001,State Senate,SD16,Con,J D Kim,0
-Queens,35002,State Senate,SD16,Con,J D Kim,6
-Queens,35003,State Senate,SD16,Con,J D Kim,11
-Queens,35004,State Senate,SD16,Con,J D Kim,7
-Queens,35005,State Senate,SD16,Con,J D Kim,7
-Queens,35006,State Senate,SD16,Con,J D Kim,7
-Queens,35007,State Senate,SD16,Con,J D Kim,5
-Queens,35008,State Senate,SD16,Con,J D Kim,10
-Queens,35009,State Senate,SD16,Con,J D Kim,8
-Queens,35010,State Senate,SD16,Con,J D Kim,3
-Queens,35023,State Senate,SD16,Con,J D Kim,8
-Queens,35024,State Senate,SD16,Con,J D Kim,6
-Queens,35026,State Senate,SD16,Con,J D Kim,2
-Queens,35027,State Senate,SD16,Con,J D Kim,12
-Queens,35028,State Senate,SD16,Con,J D Kim,0
-Queens,35029,State Senate,SD16,Con,J D Kim,0
-Queens,35030,State Senate,SD16,Con,J D Kim,2
-Queens,35031,State Senate,SD16,Con,J D Kim,0
-Queens,35034,State Senate,SD16,Con,J D Kim,0
-Queens,39023,State Senate,SD16,Con,J D Kim,1
-Queens,39024,State Senate,SD16,Con,J D Kim,2
-Queens,39027,State Senate,SD16,Con,J D Kim,0
-Queens,39029,State Senate,SD16,Con,J D Kim,7
-Queens,39030,State Senate,SD16,Con,J D Kim,4
-Queens,39031,State Senate,SD16,Con,J D Kim,2
-Queens,39034,State Senate,SD16,Con,J D Kim,7
-Queens,39035,State Senate,SD16,Con,J D Kim,9
-Queens,39037,State Senate,SD16,Con,J D Kim,3
-Queens,39038,State Senate,SD16,Con,J D Kim,2
-Queens,39040,State Senate,SD16,Con,J D Kim,1
-Queens,39042,State Senate,SD16,Con,J D Kim,0
-Queens,39048,State Senate,SD16,Con,J D Kim,6
-Queens,39049,State Senate,SD16,Con,J D Kim,6
-Queens,39052,State Senate,SD16,Con,J D Kim,0
-Queens,39053,State Senate,SD16,Con,J D Kim,0
-Queens,40011,State Senate,SD16,Con,J D Kim,3
-Queens,40012,State Senate,SD16,Con,J D Kim,1
-Queens,40016,State Senate,SD16,Con,J D Kim,6
-Queens,40017,State Senate,SD16,Con,J D Kim,18
-Queens,40018,State Senate,SD16,Con,J D Kim,7
-Queens,40019,State Senate,SD16,Con,J D Kim,9
-Queens,40020,State Senate,SD16,Con,J D Kim,18
-Queens,40021,State Senate,SD16,Con,J D Kim,8
-Queens,40022,State Senate,SD16,Con,J D Kim,5
-Queens,40023,State Senate,SD16,Con,J D Kim,6
-Queens,40024,State Senate,SD16,Con,J D Kim,5
-Queens,40025,State Senate,SD16,Con,J D Kim,7
-Queens,40026,State Senate,SD16,Con,J D Kim,12
-Queens,40027,State Senate,SD16,Con,J D Kim,8
-Queens,40029,State Senate,SD16,Con,J D Kim,8
-Queens,40030,State Senate,SD16,Con,J D Kim,24
-Queens,40031,State Senate,SD16,Con,J D Kim,12
-Queens,40032,State Senate,SD16,Con,J D Kim,9
-Queens,40033,State Senate,SD16,Con,J D Kim,2
-Queens,40034,State Senate,SD16,Con,J D Kim,0
-Queens,40035,State Senate,SD16,Con,J D Kim,3
-Queens,40036,State Senate,SD16,Con,J D Kim,9
-Queens,40037,State Senate,SD16,Con,J D Kim,7
-Queens,40038,State Senate,SD16,Con,J D Kim,9
-Queens,40039,State Senate,SD16,Con,J D Kim,8
-Queens,40040,State Senate,SD16,Con,J D Kim,5
-Queens,40041,State Senate,SD16,Con,J D Kim,11
-Queens,40042,State Senate,SD16,Con,J D Kim,6
-Queens,40043,State Senate,SD16,Con,J D Kim,6
-Queens,40044,State Senate,SD16,Con,J D Kim,3
-Queens,40045,State Senate,SD16,Con,J D Kim,9
-Queens,40046,State Senate,SD16,Con,J D Kim,0
-Queens,24016,State Senate,SD16,Dem,Toby Ann Stavisky,157
-Queens,24023,State Senate,SD16,Dem,Toby Ann Stavisky,44
-Queens,25020,State Senate,SD16,Dem,Toby Ann Stavisky,379
-Queens,25021,State Senate,SD16,Dem,Toby Ann Stavisky,342
-Queens,25022,State Senate,SD16,Dem,Toby Ann Stavisky,344
-Queens,25023,State Senate,SD16,Dem,Toby Ann Stavisky,147
-Queens,25024,State Senate,SD16,Dem,Toby Ann Stavisky,320
-Queens,25034,State Senate,SD16,Dem,Toby Ann Stavisky,26
-Queens,25042,State Senate,SD16,Dem,Toby Ann Stavisky,259
-Queens,25043,State Senate,SD16,Dem,Toby Ann Stavisky,295
-Queens,25044,State Senate,SD16,Dem,Toby Ann Stavisky,343
-Queens,25045,State Senate,SD16,Dem,Toby Ann Stavisky,257
-Queens,25046,State Senate,SD16,Dem,Toby Ann Stavisky,239
-Queens,25047,State Senate,SD16,Dem,Toby Ann Stavisky,234
-Queens,25048,State Senate,SD16,Dem,Toby Ann Stavisky,297
-Queens,25049,State Senate,SD16,Dem,Toby Ann Stavisky,291
-Queens,25050,State Senate,SD16,Dem,Toby Ann Stavisky,272
-Queens,25051,State Senate,SD16,Dem,Toby Ann Stavisky,237
-Queens,25052,State Senate,SD16,Dem,Toby Ann Stavisky,212
-Queens,25053,State Senate,SD16,Dem,Toby Ann Stavisky,293
-Queens,25054,State Senate,SD16,Dem,Toby Ann Stavisky,432
-Queens,25055,State Senate,SD16,Dem,Toby Ann Stavisky,276
-Queens,25056,State Senate,SD16,Dem,Toby Ann Stavisky,254
-Queens,25057,State Senate,SD16,Dem,Toby Ann Stavisky,113
-Queens,25058,State Senate,SD16,Dem,Toby Ann Stavisky,8
-Queens,25059,State Senate,SD16,Dem,Toby Ann Stavisky,345
-Queens,25060,State Senate,SD16,Dem,Toby Ann Stavisky,158
-Queens,25061,State Senate,SD16,Dem,Toby Ann Stavisky,205
-Queens,25062,State Senate,SD16,Dem,Toby Ann Stavisky,271
-Queens,25063,State Senate,SD16,Dem,Toby Ann Stavisky,294
-Queens,25064,State Senate,SD16,Dem,Toby Ann Stavisky,87
-Queens,26039,State Senate,SD16,Dem,Toby Ann Stavisky,191
-Queens,26040,State Senate,SD16,Dem,Toby Ann Stavisky,46
-Queens,26041,State Senate,SD16,Dem,Toby Ann Stavisky,31
-Queens,26044,State Senate,SD16,Dem,Toby Ann Stavisky,244
-Queens,27034,State Senate,SD16,Dem,Toby Ann Stavisky,342
-Queens,27035,State Senate,SD16,Dem,Toby Ann Stavisky,502
-Queens,27036,State Senate,SD16,Dem,Toby Ann Stavisky,378
-Queens,27037,State Senate,SD16,Dem,Toby Ann Stavisky,510
-Queens,27038,State Senate,SD16,Dem,Toby Ann Stavisky,549
-Queens,27039,State Senate,SD16,Dem,Toby Ann Stavisky,486
-Queens,27040,State Senate,SD16,Dem,Toby Ann Stavisky,429
-Queens,27041,State Senate,SD16,Dem,Toby Ann Stavisky,487
-Queens,27042,State Senate,SD16,Dem,Toby Ann Stavisky,497
-Queens,27043,State Senate,SD16,Dem,Toby Ann Stavisky,207
-Queens,27044,State Senate,SD16,Dem,Toby Ann Stavisky,284
-Queens,27045,State Senate,SD16,Dem,Toby Ann Stavisky,452
-Queens,27047,State Senate,SD16,Dem,Toby Ann Stavisky,334
-Queens,27048,State Senate,SD16,Dem,Toby Ann Stavisky,284
-Queens,27049,State Senate,SD16,Dem,Toby Ann Stavisky,324
-Queens,27050,State Senate,SD16,Dem,Toby Ann Stavisky,216
-Queens,27052,State Senate,SD16,Dem,Toby Ann Stavisky,300
-Queens,27053,State Senate,SD16,Dem,Toby Ann Stavisky,230
-Queens,27054,State Senate,SD16,Dem,Toby Ann Stavisky,278
-Queens,27055,State Senate,SD16,Dem,Toby Ann Stavisky,244
-Queens,27056,State Senate,SD16,Dem,Toby Ann Stavisky,276
-Queens,28027,State Senate,SD16,Dem,Toby Ann Stavisky,199
-Queens,28028,State Senate,SD16,Dem,Toby Ann Stavisky,424
-Queens,28029,State Senate,SD16,Dem,Toby Ann Stavisky,334
-Queens,28030,State Senate,SD16,Dem,Toby Ann Stavisky,302
-Queens,28031,State Senate,SD16,Dem,Toby Ann Stavisky,467
-Queens,28034,State Senate,SD16,Dem,Toby Ann Stavisky,32
-Queens,28035,State Senate,SD16,Dem,Toby Ann Stavisky,440
-Queens,28036,State Senate,SD16,Dem,Toby Ann Stavisky,278
-Queens,28037,State Senate,SD16,Dem,Toby Ann Stavisky,451
-Queens,28038,State Senate,SD16,Dem,Toby Ann Stavisky,458
-Queens,28039,State Senate,SD16,Dem,Toby Ann Stavisky,448
-Queens,28040,State Senate,SD16,Dem,Toby Ann Stavisky,418
-Queens,28041,State Senate,SD16,Dem,Toby Ann Stavisky,385
-Queens,28042,State Senate,SD16,Dem,Toby Ann Stavisky,512
-Queens,28043,State Senate,SD16,Dem,Toby Ann Stavisky,326
-Queens,28044,State Senate,SD16,Dem,Toby Ann Stavisky,463
-Queens,28045,State Senate,SD16,Dem,Toby Ann Stavisky,347
-Queens,28046,State Senate,SD16,Dem,Toby Ann Stavisky,358
-Queens,28050,State Senate,SD16,Dem,Toby Ann Stavisky,333
-Queens,28051,State Senate,SD16,Dem,Toby Ann Stavisky,348
-Queens,28052,State Senate,SD16,Dem,Toby Ann Stavisky,148
-Queens,28053,State Senate,SD16,Dem,Toby Ann Stavisky,244
-Queens,28054,State Senate,SD16,Dem,Toby Ann Stavisky,116
-Queens,28055,State Senate,SD16,Dem,Toby Ann Stavisky,106
-Queens,28056,State Senate,SD16,Dem,Toby Ann Stavisky,265
-Queens,28057,State Senate,SD16,Dem,Toby Ann Stavisky,214
-Queens,28058,State Senate,SD16,Dem,Toby Ann Stavisky,237
-Queens,28059,State Senate,SD16,Dem,Toby Ann Stavisky,40
-Queens,30001,State Senate,SD16,Dem,Toby Ann Stavisky,109
-Queens,30002,State Senate,SD16,Dem,Toby Ann Stavisky,280
-Queens,30030,State Senate,SD16,Dem,Toby Ann Stavisky,219
-Queens,30031,State Senate,SD16,Dem,Toby Ann Stavisky,166
-Queens,30032,State Senate,SD16,Dem,Toby Ann Stavisky,62
-Queens,30034,State Senate,SD16,Dem,Toby Ann Stavisky,1
-Queens,30054,State Senate,SD16,Dem,Toby Ann Stavisky,32
-Queens,34031,State Senate,SD16,Dem,Toby Ann Stavisky,92
-Queens,34032,State Senate,SD16,Dem,Toby Ann Stavisky,36
-Queens,34033,State Senate,SD16,Dem,Toby Ann Stavisky,46
-Queens,34045,State Senate,SD16,Dem,Toby Ann Stavisky,425
-Queens,34046,State Senate,SD16,Dem,Toby Ann Stavisky,148
-Queens,34057,State Senate,SD16,Dem,Toby Ann Stavisky,64
-Queens,34058,State Senate,SD16,Dem,Toby Ann Stavisky,6
-Queens,34061,State Senate,SD16,Dem,Toby Ann Stavisky,24
-Queens,35001,State Senate,SD16,Dem,Toby Ann Stavisky,57
-Queens,35002,State Senate,SD16,Dem,Toby Ann Stavisky,292
-Queens,35003,State Senate,SD16,Dem,Toby Ann Stavisky,241
-Queens,35004,State Senate,SD16,Dem,Toby Ann Stavisky,172
-Queens,35005,State Senate,SD16,Dem,Toby Ann Stavisky,296
-Queens,35006,State Senate,SD16,Dem,Toby Ann Stavisky,402
-Queens,35007,State Senate,SD16,Dem,Toby Ann Stavisky,398
-Queens,35008,State Senate,SD16,Dem,Toby Ann Stavisky,344
-Queens,35009,State Senate,SD16,Dem,Toby Ann Stavisky,349
-Queens,35010,State Senate,SD16,Dem,Toby Ann Stavisky,426
-Queens,35023,State Senate,SD16,Dem,Toby Ann Stavisky,374
-Queens,35024,State Senate,SD16,Dem,Toby Ann Stavisky,330
-Queens,35026,State Senate,SD16,Dem,Toby Ann Stavisky,248
-Queens,35027,State Senate,SD16,Dem,Toby Ann Stavisky,294
-Queens,35028,State Senate,SD16,Dem,Toby Ann Stavisky,11
-Queens,35029,State Senate,SD16,Dem,Toby Ann Stavisky,2
-Queens,35030,State Senate,SD16,Dem,Toby Ann Stavisky,85
-Queens,35031,State Senate,SD16,Dem,Toby Ann Stavisky,2
-Queens,35034,State Senate,SD16,Dem,Toby Ann Stavisky,37
-Queens,39023,State Senate,SD16,Dem,Toby Ann Stavisky,263
-Queens,39024,State Senate,SD16,Dem,Toby Ann Stavisky,108
-Queens,39027,State Senate,SD16,Dem,Toby Ann Stavisky,67
-Queens,39029,State Senate,SD16,Dem,Toby Ann Stavisky,325
-Queens,39030,State Senate,SD16,Dem,Toby Ann Stavisky,421
-Queens,39031,State Senate,SD16,Dem,Toby Ann Stavisky,189
-Queens,39034,State Senate,SD16,Dem,Toby Ann Stavisky,334
-Queens,39035,State Senate,SD16,Dem,Toby Ann Stavisky,135
-Queens,39037,State Senate,SD16,Dem,Toby Ann Stavisky,267
-Queens,39038,State Senate,SD16,Dem,Toby Ann Stavisky,188
-Queens,39040,State Senate,SD16,Dem,Toby Ann Stavisky,60
-Queens,39042,State Senate,SD16,Dem,Toby Ann Stavisky,47
-Queens,39048,State Senate,SD16,Dem,Toby Ann Stavisky,206
-Queens,39049,State Senate,SD16,Dem,Toby Ann Stavisky,422
-Queens,39052,State Senate,SD16,Dem,Toby Ann Stavisky,6
-Queens,39053,State Senate,SD16,Dem,Toby Ann Stavisky,64
-Queens,40011,State Senate,SD16,Dem,Toby Ann Stavisky,43
-Queens,40012,State Senate,SD16,Dem,Toby Ann Stavisky,25
-Queens,40016,State Senate,SD16,Dem,Toby Ann Stavisky,261
-Queens,40017,State Senate,SD16,Dem,Toby Ann Stavisky,275
-Queens,40018,State Senate,SD16,Dem,Toby Ann Stavisky,313
-Queens,40019,State Senate,SD16,Dem,Toby Ann Stavisky,332
-Queens,40020,State Senate,SD16,Dem,Toby Ann Stavisky,286
-Queens,40021,State Senate,SD16,Dem,Toby Ann Stavisky,245
-Queens,40022,State Senate,SD16,Dem,Toby Ann Stavisky,254
-Queens,40023,State Senate,SD16,Dem,Toby Ann Stavisky,282
-Queens,40024,State Senate,SD16,Dem,Toby Ann Stavisky,296
-Queens,40025,State Senate,SD16,Dem,Toby Ann Stavisky,248
-Queens,40026,State Senate,SD16,Dem,Toby Ann Stavisky,272
-Queens,40027,State Senate,SD16,Dem,Toby Ann Stavisky,300
-Queens,40029,State Senate,SD16,Dem,Toby Ann Stavisky,293
-Queens,40030,State Senate,SD16,Dem,Toby Ann Stavisky,273
-Queens,40031,State Senate,SD16,Dem,Toby Ann Stavisky,248
-Queens,40032,State Senate,SD16,Dem,Toby Ann Stavisky,263
-Queens,40033,State Senate,SD16,Dem,Toby Ann Stavisky,310
-Queens,40034,State Senate,SD16,Dem,Toby Ann Stavisky,408
-Queens,40035,State Senate,SD16,Dem,Toby Ann Stavisky,380
-Queens,40036,State Senate,SD16,Dem,Toby Ann Stavisky,242
-Queens,40037,State Senate,SD16,Dem,Toby Ann Stavisky,353
-Queens,40038,State Senate,SD16,Dem,Toby Ann Stavisky,235
-Queens,40039,State Senate,SD16,Dem,Toby Ann Stavisky,357
-Queens,40040,State Senate,SD16,Dem,Toby Ann Stavisky,306
-Queens,40041,State Senate,SD16,Dem,Toby Ann Stavisky,257
-Queens,40042,State Senate,SD16,Dem,Toby Ann Stavisky,255
-Queens,40043,State Senate,SD16,Dem,Toby Ann Stavisky,219
-Queens,40044,State Senate,SD16,Dem,Toby Ann Stavisky,282
-Queens,40045,State Senate,SD16,Dem,Toby Ann Stavisky,201
-Queens,40046,State Senate,SD16,Dem,Toby Ann Stavisky,189
-Queens,24016,State Senate,SD16,WF,Toby Ann Stavisky,5
-Queens,24023,State Senate,SD16,WF,Toby Ann Stavisky,2
-Queens,25020,State Senate,SD16,WF,Toby Ann Stavisky,9
-Queens,25021,State Senate,SD16,WF,Toby Ann Stavisky,12
-Queens,25022,State Senate,SD16,WF,Toby Ann Stavisky,4
-Queens,25023,State Senate,SD16,WF,Toby Ann Stavisky,2
-Queens,25024,State Senate,SD16,WF,Toby Ann Stavisky,9
-Queens,25034,State Senate,SD16,WF,Toby Ann Stavisky,0
-Queens,25042,State Senate,SD16,WF,Toby Ann Stavisky,13
-Queens,25043,State Senate,SD16,WF,Toby Ann Stavisky,10
-Queens,25044,State Senate,SD16,WF,Toby Ann Stavisky,9
-Queens,25045,State Senate,SD16,WF,Toby Ann Stavisky,12
-Queens,25046,State Senate,SD16,WF,Toby Ann Stavisky,10
-Queens,25047,State Senate,SD16,WF,Toby Ann Stavisky,15
-Queens,25048,State Senate,SD16,WF,Toby Ann Stavisky,9
-Queens,25049,State Senate,SD16,WF,Toby Ann Stavisky,7
-Queens,25050,State Senate,SD16,WF,Toby Ann Stavisky,9
-Queens,25051,State Senate,SD16,WF,Toby Ann Stavisky,4
-Queens,25052,State Senate,SD16,WF,Toby Ann Stavisky,4
-Queens,25053,State Senate,SD16,WF,Toby Ann Stavisky,4
-Queens,25054,State Senate,SD16,WF,Toby Ann Stavisky,9
-Queens,25055,State Senate,SD16,WF,Toby Ann Stavisky,11
-Queens,25056,State Senate,SD16,WF,Toby Ann Stavisky,13
-Queens,25057,State Senate,SD16,WF,Toby Ann Stavisky,5
-Queens,25058,State Senate,SD16,WF,Toby Ann Stavisky,4
-Queens,25059,State Senate,SD16,WF,Toby Ann Stavisky,12
-Queens,25060,State Senate,SD16,WF,Toby Ann Stavisky,16
-Queens,25061,State Senate,SD16,WF,Toby Ann Stavisky,5
-Queens,25062,State Senate,SD16,WF,Toby Ann Stavisky,7
-Queens,25063,State Senate,SD16,WF,Toby Ann Stavisky,15
-Queens,25064,State Senate,SD16,WF,Toby Ann Stavisky,4
-Queens,26039,State Senate,SD16,WF,Toby Ann Stavisky,9
-Queens,26040,State Senate,SD16,WF,Toby Ann Stavisky,2
-Queens,26041,State Senate,SD16,WF,Toby Ann Stavisky,0
-Queens,26044,State Senate,SD16,WF,Toby Ann Stavisky,3
-Queens,27034,State Senate,SD16,WF,Toby Ann Stavisky,8
-Queens,27035,State Senate,SD16,WF,Toby Ann Stavisky,11
-Queens,27036,State Senate,SD16,WF,Toby Ann Stavisky,14
-Queens,27037,State Senate,SD16,WF,Toby Ann Stavisky,11
-Queens,27038,State Senate,SD16,WF,Toby Ann Stavisky,18
-Queens,27039,State Senate,SD16,WF,Toby Ann Stavisky,15
-Queens,27040,State Senate,SD16,WF,Toby Ann Stavisky,17
-Queens,27041,State Senate,SD16,WF,Toby Ann Stavisky,8
-Queens,27042,State Senate,SD16,WF,Toby Ann Stavisky,13
-Queens,27043,State Senate,SD16,WF,Toby Ann Stavisky,5
-Queens,27044,State Senate,SD16,WF,Toby Ann Stavisky,7
-Queens,27045,State Senate,SD16,WF,Toby Ann Stavisky,8
-Queens,27047,State Senate,SD16,WF,Toby Ann Stavisky,11
-Queens,27048,State Senate,SD16,WF,Toby Ann Stavisky,15
-Queens,27049,State Senate,SD16,WF,Toby Ann Stavisky,10
-Queens,27050,State Senate,SD16,WF,Toby Ann Stavisky,11
-Queens,27052,State Senate,SD16,WF,Toby Ann Stavisky,13
-Queens,27053,State Senate,SD16,WF,Toby Ann Stavisky,7
-Queens,27054,State Senate,SD16,WF,Toby Ann Stavisky,6
-Queens,27055,State Senate,SD16,WF,Toby Ann Stavisky,10
-Queens,27056,State Senate,SD16,WF,Toby Ann Stavisky,3
-Queens,28027,State Senate,SD16,WF,Toby Ann Stavisky,10
-Queens,28028,State Senate,SD16,WF,Toby Ann Stavisky,21
-Queens,28029,State Senate,SD16,WF,Toby Ann Stavisky,11
-Queens,28030,State Senate,SD16,WF,Toby Ann Stavisky,8
-Queens,28031,State Senate,SD16,WF,Toby Ann Stavisky,18
-Queens,28034,State Senate,SD16,WF,Toby Ann Stavisky,1
-Queens,28035,State Senate,SD16,WF,Toby Ann Stavisky,10
-Queens,28036,State Senate,SD16,WF,Toby Ann Stavisky,18
-Queens,28037,State Senate,SD16,WF,Toby Ann Stavisky,24
-Queens,28038,State Senate,SD16,WF,Toby Ann Stavisky,14
-Queens,28039,State Senate,SD16,WF,Toby Ann Stavisky,22
-Queens,28040,State Senate,SD16,WF,Toby Ann Stavisky,21
-Queens,28041,State Senate,SD16,WF,Toby Ann Stavisky,17
-Queens,28042,State Senate,SD16,WF,Toby Ann Stavisky,21
-Queens,28043,State Senate,SD16,WF,Toby Ann Stavisky,14
-Queens,28044,State Senate,SD16,WF,Toby Ann Stavisky,15
-Queens,28045,State Senate,SD16,WF,Toby Ann Stavisky,16
-Queens,28046,State Senate,SD16,WF,Toby Ann Stavisky,14
-Queens,28050,State Senate,SD16,WF,Toby Ann Stavisky,10
-Queens,28051,State Senate,SD16,WF,Toby Ann Stavisky,20
-Queens,28052,State Senate,SD16,WF,Toby Ann Stavisky,9
-Queens,28053,State Senate,SD16,WF,Toby Ann Stavisky,4
-Queens,28054,State Senate,SD16,WF,Toby Ann Stavisky,2
-Queens,28055,State Senate,SD16,WF,Toby Ann Stavisky,1
-Queens,28056,State Senate,SD16,WF,Toby Ann Stavisky,12
-Queens,28057,State Senate,SD16,WF,Toby Ann Stavisky,13
-Queens,28058,State Senate,SD16,WF,Toby Ann Stavisky,11
-Queens,28059,State Senate,SD16,WF,Toby Ann Stavisky,0
-Queens,30001,State Senate,SD16,WF,Toby Ann Stavisky,6
-Queens,30002,State Senate,SD16,WF,Toby Ann Stavisky,6
-Queens,30030,State Senate,SD16,WF,Toby Ann Stavisky,7
-Queens,30031,State Senate,SD16,WF,Toby Ann Stavisky,5
-Queens,30032,State Senate,SD16,WF,Toby Ann Stavisky,1
-Queens,30034,State Senate,SD16,WF,Toby Ann Stavisky,0
-Queens,30054,State Senate,SD16,WF,Toby Ann Stavisky,1
-Queens,34031,State Senate,SD16,WF,Toby Ann Stavisky,3
-Queens,34032,State Senate,SD16,WF,Toby Ann Stavisky,7
-Queens,34033,State Senate,SD16,WF,Toby Ann Stavisky,1
-Queens,34045,State Senate,SD16,WF,Toby Ann Stavisky,18
-Queens,34046,State Senate,SD16,WF,Toby Ann Stavisky,4
-Queens,34057,State Senate,SD16,WF,Toby Ann Stavisky,1
-Queens,34058,State Senate,SD16,WF,Toby Ann Stavisky,0
-Queens,34061,State Senate,SD16,WF,Toby Ann Stavisky,1
-Queens,35001,State Senate,SD16,WF,Toby Ann Stavisky,3
-Queens,35002,State Senate,SD16,WF,Toby Ann Stavisky,7
-Queens,35003,State Senate,SD16,WF,Toby Ann Stavisky,10
-Queens,35004,State Senate,SD16,WF,Toby Ann Stavisky,3
-Queens,35005,State Senate,SD16,WF,Toby Ann Stavisky,8
-Queens,35006,State Senate,SD16,WF,Toby Ann Stavisky,9
-Queens,35007,State Senate,SD16,WF,Toby Ann Stavisky,17
-Queens,35008,State Senate,SD16,WF,Toby Ann Stavisky,7
-Queens,35009,State Senate,SD16,WF,Toby Ann Stavisky,9
-Queens,35010,State Senate,SD16,WF,Toby Ann Stavisky,9
-Queens,35023,State Senate,SD16,WF,Toby Ann Stavisky,9
-Queens,35024,State Senate,SD16,WF,Toby Ann Stavisky,8
-Queens,35026,State Senate,SD16,WF,Toby Ann Stavisky,12
-Queens,35027,State Senate,SD16,WF,Toby Ann Stavisky,16
-Queens,35028,State Senate,SD16,WF,Toby Ann Stavisky,0
-Queens,35029,State Senate,SD16,WF,Toby Ann Stavisky,1
-Queens,35030,State Senate,SD16,WF,Toby Ann Stavisky,7
-Queens,35031,State Senate,SD16,WF,Toby Ann Stavisky,0
-Queens,35034,State Senate,SD16,WF,Toby Ann Stavisky,0
-Queens,39023,State Senate,SD16,WF,Toby Ann Stavisky,2
-Queens,39024,State Senate,SD16,WF,Toby Ann Stavisky,2
-Queens,39027,State Senate,SD16,WF,Toby Ann Stavisky,0
-Queens,39029,State Senate,SD16,WF,Toby Ann Stavisky,3
-Queens,39030,State Senate,SD16,WF,Toby Ann Stavisky,17
-Queens,39031,State Senate,SD16,WF,Toby Ann Stavisky,6
-Queens,39034,State Senate,SD16,WF,Toby Ann Stavisky,6
-Queens,39035,State Senate,SD16,WF,Toby Ann Stavisky,8
-Queens,39037,State Senate,SD16,WF,Toby Ann Stavisky,12
-Queens,39038,State Senate,SD16,WF,Toby Ann Stavisky,6
-Queens,39040,State Senate,SD16,WF,Toby Ann Stavisky,0
-Queens,39042,State Senate,SD16,WF,Toby Ann Stavisky,2
-Queens,39048,State Senate,SD16,WF,Toby Ann Stavisky,8
-Queens,39049,State Senate,SD16,WF,Toby Ann Stavisky,6
-Queens,39052,State Senate,SD16,WF,Toby Ann Stavisky,0
-Queens,39053,State Senate,SD16,WF,Toby Ann Stavisky,0
-Queens,40011,State Senate,SD16,WF,Toby Ann Stavisky,2
-Queens,40012,State Senate,SD16,WF,Toby Ann Stavisky,0
-Queens,40016,State Senate,SD16,WF,Toby Ann Stavisky,11
-Queens,40017,State Senate,SD16,WF,Toby Ann Stavisky,13
-Queens,40018,State Senate,SD16,WF,Toby Ann Stavisky,14
-Queens,40019,State Senate,SD16,WF,Toby Ann Stavisky,3
-Queens,40020,State Senate,SD16,WF,Toby Ann Stavisky,9
-Queens,40021,State Senate,SD16,WF,Toby Ann Stavisky,4
-Queens,40022,State Senate,SD16,WF,Toby Ann Stavisky,9
-Queens,40023,State Senate,SD16,WF,Toby Ann Stavisky,9
-Queens,40024,State Senate,SD16,WF,Toby Ann Stavisky,6
-Queens,40025,State Senate,SD16,WF,Toby Ann Stavisky,9
-Queens,40026,State Senate,SD16,WF,Toby Ann Stavisky,6
-Queens,40027,State Senate,SD16,WF,Toby Ann Stavisky,6
-Queens,40029,State Senate,SD16,WF,Toby Ann Stavisky,11
-Queens,40030,State Senate,SD16,WF,Toby Ann Stavisky,8
-Queens,40031,State Senate,SD16,WF,Toby Ann Stavisky,10
-Queens,40032,State Senate,SD16,WF,Toby Ann Stavisky,8
-Queens,40033,State Senate,SD16,WF,Toby Ann Stavisky,7
-Queens,40034,State Senate,SD16,WF,Toby Ann Stavisky,8
-Queens,40035,State Senate,SD16,WF,Toby Ann Stavisky,5
-Queens,40036,State Senate,SD16,WF,Toby Ann Stavisky,3
-Queens,40037,State Senate,SD16,WF,Toby Ann Stavisky,7
-Queens,40038,State Senate,SD16,WF,Toby Ann Stavisky,6
-Queens,40039,State Senate,SD16,WF,Toby Ann Stavisky,7
-Queens,40040,State Senate,SD16,WF,Toby Ann Stavisky,9
-Queens,40041,State Senate,SD16,WF,Toby Ann Stavisky,5
-Queens,40042,State Senate,SD16,WF,Toby Ann Stavisky,8
-Queens,40043,State Senate,SD16,WF,Toby Ann Stavisky,5
-Queens,40044,State Senate,SD16,WF,Toby Ann Stavisky,5
-Queens,40045,State Senate,SD16,WF,Toby Ann Stavisky,5
-Queens,40046,State Senate,SD16,WF,Toby Ann Stavisky,4
-Queens,24016,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,24023,State Senate,SD16,Ind,Toby Ann Stavisky,1
-Queens,25020,State Senate,SD16,Ind,Toby Ann Stavisky,5
-Queens,25021,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,25022,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,25023,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,25024,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,25034,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,25042,State Senate,SD16,Ind,Toby Ann Stavisky,5
-Queens,25043,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,25044,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,25045,State Senate,SD16,Ind,Toby Ann Stavisky,7
-Queens,25046,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,25047,State Senate,SD16,Ind,Toby Ann Stavisky,8
-Queens,25048,State Senate,SD16,Ind,Toby Ann Stavisky,10
-Queens,25049,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,25050,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,25051,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,25052,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,25053,State Senate,SD16,Ind,Toby Ann Stavisky,1
-Queens,25054,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,25055,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,25056,State Senate,SD16,Ind,Toby Ann Stavisky,7
-Queens,25057,State Senate,SD16,Ind,Toby Ann Stavisky,5
-Queens,25058,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,25059,State Senate,SD16,Ind,Toby Ann Stavisky,12
-Queens,25060,State Senate,SD16,Ind,Toby Ann Stavisky,24
-Queens,25061,State Senate,SD16,Ind,Toby Ann Stavisky,5
-Queens,25062,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,25063,State Senate,SD16,Ind,Toby Ann Stavisky,9
-Queens,25064,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,26039,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,26040,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,26041,State Senate,SD16,Ind,Toby Ann Stavisky,1
-Queens,26044,State Senate,SD16,Ind,Toby Ann Stavisky,10
-Queens,27034,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,27035,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,27036,State Senate,SD16,Ind,Toby Ann Stavisky,12
-Queens,27037,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,27038,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,27039,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,27040,State Senate,SD16,Ind,Toby Ann Stavisky,5
-Queens,27041,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,27042,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,27043,State Senate,SD16,Ind,Toby Ann Stavisky,5
-Queens,27044,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,27045,State Senate,SD16,Ind,Toby Ann Stavisky,10
-Queens,27047,State Senate,SD16,Ind,Toby Ann Stavisky,7
-Queens,27048,State Senate,SD16,Ind,Toby Ann Stavisky,5
-Queens,27049,State Senate,SD16,Ind,Toby Ann Stavisky,8
-Queens,27050,State Senate,SD16,Ind,Toby Ann Stavisky,5
-Queens,27052,State Senate,SD16,Ind,Toby Ann Stavisky,5
-Queens,27053,State Senate,SD16,Ind,Toby Ann Stavisky,1
-Queens,27054,State Senate,SD16,Ind,Toby Ann Stavisky,9
-Queens,27055,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,27056,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,28027,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,28028,State Senate,SD16,Ind,Toby Ann Stavisky,15
-Queens,28029,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,28030,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,28031,State Senate,SD16,Ind,Toby Ann Stavisky,8
-Queens,28034,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,28035,State Senate,SD16,Ind,Toby Ann Stavisky,10
-Queens,28036,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,28037,State Senate,SD16,Ind,Toby Ann Stavisky,13
-Queens,28038,State Senate,SD16,Ind,Toby Ann Stavisky,8
-Queens,28039,State Senate,SD16,Ind,Toby Ann Stavisky,15
-Queens,28040,State Senate,SD16,Ind,Toby Ann Stavisky,7
-Queens,28041,State Senate,SD16,Ind,Toby Ann Stavisky,9
-Queens,28042,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,28043,State Senate,SD16,Ind,Toby Ann Stavisky,12
-Queens,28044,State Senate,SD16,Ind,Toby Ann Stavisky,5
-Queens,28045,State Senate,SD16,Ind,Toby Ann Stavisky,9
-Queens,28046,State Senate,SD16,Ind,Toby Ann Stavisky,8
-Queens,28050,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,28051,State Senate,SD16,Ind,Toby Ann Stavisky,7
-Queens,28052,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,28053,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,28054,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,28055,State Senate,SD16,Ind,Toby Ann Stavisky,1
-Queens,28056,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,28057,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,28058,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,28059,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,30001,State Senate,SD16,Ind,Toby Ann Stavisky,1
-Queens,30002,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,30030,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,30031,State Senate,SD16,Ind,Toby Ann Stavisky,1
-Queens,30032,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,30034,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,30054,State Senate,SD16,Ind,Toby Ann Stavisky,1
-Queens,34031,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,34032,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,34033,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,34045,State Senate,SD16,Ind,Toby Ann Stavisky,7
-Queens,34046,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,34057,State Senate,SD16,Ind,Toby Ann Stavisky,1
-Queens,34058,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,34061,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,35001,State Senate,SD16,Ind,Toby Ann Stavisky,1
-Queens,35002,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,35003,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,35004,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,35005,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,35006,State Senate,SD16,Ind,Toby Ann Stavisky,7
-Queens,35007,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,35008,State Senate,SD16,Ind,Toby Ann Stavisky,12
-Queens,35009,State Senate,SD16,Ind,Toby Ann Stavisky,5
-Queens,35010,State Senate,SD16,Ind,Toby Ann Stavisky,7
-Queens,35023,State Senate,SD16,Ind,Toby Ann Stavisky,8
-Queens,35024,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,35026,State Senate,SD16,Ind,Toby Ann Stavisky,5
-Queens,35027,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,35028,State Senate,SD16,Ind,Toby Ann Stavisky,1
-Queens,35029,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,35030,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,35031,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,35034,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,39023,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,39024,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,39027,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,39029,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,39030,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,39031,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,39034,State Senate,SD16,Ind,Toby Ann Stavisky,5
-Queens,39035,State Senate,SD16,Ind,Toby Ann Stavisky,1
-Queens,39037,State Senate,SD16,Ind,Toby Ann Stavisky,11
-Queens,39038,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,39040,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,39042,State Senate,SD16,Ind,Toby Ann Stavisky,1
-Queens,39048,State Senate,SD16,Ind,Toby Ann Stavisky,5
-Queens,39049,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,39052,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,39053,State Senate,SD16,Ind,Toby Ann Stavisky,1
-Queens,40011,State Senate,SD16,Ind,Toby Ann Stavisky,1
-Queens,40012,State Senate,SD16,Ind,Toby Ann Stavisky,0
-Queens,40016,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,40017,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,40018,State Senate,SD16,Ind,Toby Ann Stavisky,7
-Queens,40019,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,40020,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,40021,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,40022,State Senate,SD16,Ind,Toby Ann Stavisky,5
-Queens,40023,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,40024,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,40025,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,40026,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,40027,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,40029,State Senate,SD16,Ind,Toby Ann Stavisky,9
-Queens,40030,State Senate,SD16,Ind,Toby Ann Stavisky,8
-Queens,40031,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,40032,State Senate,SD16,Ind,Toby Ann Stavisky,7
-Queens,40033,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,40034,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,40035,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,40036,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,40037,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,40038,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,40039,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,40040,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,40041,State Senate,SD16,Ind,Toby Ann Stavisky,6
-Queens,40042,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,40043,State Senate,SD16,Ind,Toby Ann Stavisky,3
-Queens,40044,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,40045,State Senate,SD16,Ind,Toby Ann Stavisky,2
-Queens,40046,State Senate,SD16,Ind,Toby Ann Stavisky,4
-Queens,24016,State Senate,SD16,Ind,writein,0
-Queens,24023,State Senate,SD16,Ind,writein,0
-Queens,25020,State Senate,SD16,Ind,writein,0
-Queens,25021,State Senate,SD16,Ind,writein,1
-Queens,25022,State Senate,SD16,Ind,writein,2
-Queens,25023,State Senate,SD16,Ind,writein,0
-Queens,25024,State Senate,SD16,Ind,writein,0
-Queens,25034,State Senate,SD16,Ind,writein,0
-Queens,25042,State Senate,SD16,Ind,writein,0
-Queens,25043,State Senate,SD16,Ind,writein,1
-Queens,25044,State Senate,SD16,Ind,writein,1
-Queens,25045,State Senate,SD16,Ind,writein,0
-Queens,25046,State Senate,SD16,Ind,writein,0
-Queens,25047,State Senate,SD16,Ind,writein,0
-Queens,25048,State Senate,SD16,Ind,writein,0
-Queens,25049,State Senate,SD16,Ind,writein,1
-Queens,25050,State Senate,SD16,Ind,writein,0
-Queens,25051,State Senate,SD16,Ind,writein,1
-Queens,25052,State Senate,SD16,Ind,writein,0
-Queens,25053,State Senate,SD16,Ind,writein,2
-Queens,25054,State Senate,SD16,Ind,writein,0
-Queens,25055,State Senate,SD16,Ind,writein,0
-Queens,25056,State Senate,SD16,Ind,writein,0
-Queens,25057,State Senate,SD16,Ind,writein,0
-Queens,25058,State Senate,SD16,Ind,writein,0
-Queens,25059,State Senate,SD16,Ind,writein,1
-Queens,25060,State Senate,SD16,Ind,writein,2
-Queens,25061,State Senate,SD16,Ind,writein,0
-Queens,25062,State Senate,SD16,Ind,writein,0
-Queens,25063,State Senate,SD16,Ind,writein,0
-Queens,25064,State Senate,SD16,Ind,writein,0
-Queens,26039,State Senate,SD16,Ind,writein,0
-Queens,26040,State Senate,SD16,Ind,writein,0
-Queens,26041,State Senate,SD16,Ind,writein,0
-Queens,26044,State Senate,SD16,Ind,writein,0
-Queens,27034,State Senate,SD16,Ind,writein,1
-Queens,27035,State Senate,SD16,Ind,writein,0
-Queens,27036,State Senate,SD16,Ind,writein,0
-Queens,27037,State Senate,SD16,Ind,writein,0
-Queens,27038,State Senate,SD16,Ind,writein,2
-Queens,27039,State Senate,SD16,Ind,writein,1
-Queens,27040,State Senate,SD16,Ind,writein,0
-Queens,27041,State Senate,SD16,Ind,writein,0
-Queens,27042,State Senate,SD16,Ind,writein,0
-Queens,27043,State Senate,SD16,Ind,writein,0
-Queens,27044,State Senate,SD16,Ind,writein,0
-Queens,27045,State Senate,SD16,Ind,writein,0
-Queens,27047,State Senate,SD16,Ind,writein,0
-Queens,27048,State Senate,SD16,Ind,writein,0
-Queens,27049,State Senate,SD16,Ind,writein,0
-Queens,27050,State Senate,SD16,Ind,writein,0
-Queens,27052,State Senate,SD16,Ind,writein,1
-Queens,27053,State Senate,SD16,Ind,writein,1
-Queens,27054,State Senate,SD16,Ind,writein,1
-Queens,27055,State Senate,SD16,Ind,writein,0
-Queens,27056,State Senate,SD16,Ind,writein,0
-Queens,28027,State Senate,SD16,Ind,writein,0
-Queens,28028,State Senate,SD16,Ind,writein,0
-Queens,28029,State Senate,SD16,Ind,writein,0
-Queens,28030,State Senate,SD16,Ind,writein,1
-Queens,28031,State Senate,SD16,Ind,writein,1
-Queens,28034,State Senate,SD16,Ind,writein,0
-Queens,28035,State Senate,SD16,Ind,writein,1
-Queens,28036,State Senate,SD16,Ind,writein,0
-Queens,28037,State Senate,SD16,Ind,writein,0
-Queens,28038,State Senate,SD16,Ind,writein,0
-Queens,28039,State Senate,SD16,Ind,writein,0
-Queens,28040,State Senate,SD16,Ind,writein,0
-Queens,28041,State Senate,SD16,Ind,writein,0
-Queens,28042,State Senate,SD16,Ind,writein,0
-Queens,28043,State Senate,SD16,Ind,writein,0
-Queens,28044,State Senate,SD16,Ind,writein,0
-Queens,28045,State Senate,SD16,Ind,writein,0
-Queens,28046,State Senate,SD16,Ind,writein,0
-Queens,28050,State Senate,SD16,Ind,writein,0
-Queens,28051,State Senate,SD16,Ind,writein,0
-Queens,28052,State Senate,SD16,Ind,writein,0
-Queens,28053,State Senate,SD16,Ind,writein,0
-Queens,28054,State Senate,SD16,Ind,writein,0
-Queens,28055,State Senate,SD16,Ind,writein,0
-Queens,28056,State Senate,SD16,Ind,writein,1
-Queens,28057,State Senate,SD16,Ind,writein,2
-Queens,28058,State Senate,SD16,Ind,writein,0
-Queens,28059,State Senate,SD16,Ind,writein,0
-Queens,30001,State Senate,SD16,Ind,writein,0
-Queens,30002,State Senate,SD16,Ind,writein,0
-Queens,30030,State Senate,SD16,Ind,writein,0
-Queens,30031,State Senate,SD16,Ind,writein,0
-Queens,30032,State Senate,SD16,Ind,writein,0
-Queens,30034,State Senate,SD16,Ind,writein,0
-Queens,30054,State Senate,SD16,Ind,writein,0
-Queens,34031,State Senate,SD16,Ind,writein,1
-Queens,34032,State Senate,SD16,Ind,writein,0
-Queens,34033,State Senate,SD16,Ind,writein,0
-Queens,34045,State Senate,SD16,Ind,writein,2
-Queens,34046,State Senate,SD16,Ind,writein,1
-Queens,34057,State Senate,SD16,Ind,writein,0
-Queens,34058,State Senate,SD16,Ind,writein,0
-Queens,34061,State Senate,SD16,Ind,writein,0
-Queens,35001,State Senate,SD16,Ind,writein,0
-Queens,35002,State Senate,SD16,Ind,writein,1
-Queens,35003,State Senate,SD16,Ind,writein,2
-Queens,35004,State Senate,SD16,Ind,writein,0
-Queens,35005,State Senate,SD16,Ind,writein,1
-Queens,35006,State Senate,SD16,Ind,writein,1
-Queens,35007,State Senate,SD16,Ind,writein,0
-Queens,35008,State Senate,SD16,Ind,writein,1
-Queens,35009,State Senate,SD16,Ind,writein,0
-Queens,35010,State Senate,SD16,Ind,writein,0
-Queens,35023,State Senate,SD16,Ind,writein,1
-Queens,35024,State Senate,SD16,Ind,writein,1
-Queens,35026,State Senate,SD16,Ind,writein,0
-Queens,35027,State Senate,SD16,Ind,writein,0
-Queens,35028,State Senate,SD16,Ind,writein,0
-Queens,35029,State Senate,SD16,Ind,writein,0
-Queens,35030,State Senate,SD16,Ind,writein,0
-Queens,35031,State Senate,SD16,Ind,writein,0
-Queens,35034,State Senate,SD16,Ind,writein,0
-Queens,39023,State Senate,SD16,Ind,writein,0
-Queens,39024,State Senate,SD16,Ind,writein,0
-Queens,39027,State Senate,SD16,Ind,writein,0
-Queens,39029,State Senate,SD16,Ind,writein,0
-Queens,39030,State Senate,SD16,Ind,writein,0
-Queens,39031,State Senate,SD16,Ind,writein,0
-Queens,39034,State Senate,SD16,Ind,writein,0
-Queens,39035,State Senate,SD16,Ind,writein,0
-Queens,39037,State Senate,SD16,Ind,writein,0
-Queens,39038,State Senate,SD16,Ind,writein,0
-Queens,39040,State Senate,SD16,Ind,writein,0
-Queens,39042,State Senate,SD16,Ind,writein,0
-Queens,39048,State Senate,SD16,Ind,writein,0
-Queens,39049,State Senate,SD16,Ind,writein,0
-Queens,39052,State Senate,SD16,Ind,writein,0
-Queens,39053,State Senate,SD16,Ind,writein,0
-Queens,40011,State Senate,SD16,Ind,writein,0
-Queens,40012,State Senate,SD16,Ind,writein,0
-Queens,40016,State Senate,SD16,Ind,writein,0
-Queens,40017,State Senate,SD16,Ind,writein,0
-Queens,40018,State Senate,SD16,Ind,writein,2
-Queens,40019,State Senate,SD16,Ind,writein,0
-Queens,40020,State Senate,SD16,Ind,writein,2
-Queens,40021,State Senate,SD16,Ind,writein,1
-Queens,40022,State Senate,SD16,Ind,writein,0
-Queens,40023,State Senate,SD16,Ind,writein,0
-Queens,40024,State Senate,SD16,Ind,writein,0
-Queens,40025,State Senate,SD16,Ind,writein,2
-Queens,40026,State Senate,SD16,Ind,writein,0
-Queens,40027,State Senate,SD16,Ind,writein,0
-Queens,40029,State Senate,SD16,Ind,writein,0
-Queens,40030,State Senate,SD16,Ind,writein,0
-Queens,40031,State Senate,SD16,Ind,writein,0
-Queens,40032,State Senate,SD16,Ind,writein,0
-Queens,40033,State Senate,SD16,Ind,writein,0
-Queens,40034,State Senate,SD16,Ind,writein,1
-Queens,40035,State Senate,SD16,Ind,writein,1
-Queens,40036,State Senate,SD16,Ind,writein,0
-Queens,40037,State Senate,SD16,Ind,writein,0
-Queens,40038,State Senate,SD16,Ind,writein,1
-Queens,40039,State Senate,SD16,Ind,writein,0
-Queens,40040,State Senate,SD16,Ind,writein,0
-Queens,40041,State Senate,SD16,Ind,writein,0
-Queens,40042,State Senate,SD16,Ind,writein,0
-Queens,40043,State Senate,SD16,Ind,writein,0
-Queens,40044,State Senate,SD16,Ind,writein,0
-Queens,40045,State Senate,SD16,Ind,writein,1
-Queens,40046,State Senate,SD16,Ind,writein,0
+Queens,23018,State Senate,10,Dem,James Sanders,199
+Queens,23019,State Senate,10,Dem,James Sanders,248
+Queens,23029,State Senate,10,Dem,James Sanders,370
+Queens,23030,State Senate,10,Dem,James Sanders,408
+Queens,23031,State Senate,10,Dem,James Sanders,329
+Queens,23032,State Senate,10,Dem,James Sanders,425
+Queens,23033,State Senate,10,Dem,James Sanders,293
+Queens,23034,State Senate,10,Dem,James Sanders,191
+Queens,23035,State Senate,10,Dem,James Sanders,411
+Queens,23036,State Senate,10,Dem,James Sanders,270
+Queens,23037,State Senate,10,Dem,James Sanders,254
+Queens,23038,State Senate,10,Dem,James Sanders,7
+Queens,23073,State Senate,10,Dem,James Sanders,4
+Queens,24063,State Senate,10,Dem,James Sanders,299
+Queens,24064,State Senate,10,Dem,James Sanders,234
+Queens,24068,State Senate,10,Dem,James Sanders,377
+Queens,24069,State Senate,10,Dem,James Sanders,408
+Queens,24070,State Senate,10,Dem,James Sanders,406
+Queens,24071,State Senate,10,Dem,James Sanders,506
+Queens,24072,State Senate,10,Dem,James Sanders,536
+Queens,24073,State Senate,10,Dem,James Sanders,467
+Queens,24074,State Senate,10,Dem,James Sanders,330
+Queens,24075,State Senate,10,Dem,James Sanders,276
+Queens,24076,State Senate,10,Dem,James Sanders,407
+Queens,24077,State Senate,10,Dem,James Sanders,250
+Queens,28001,State Senate,10,Dem,James Sanders,294
+Queens,28002,State Senate,10,Dem,James Sanders,183
+Queens,28004,State Senate,10,Dem,James Sanders,315
+Queens,28008,State Senate,10,Dem,James Sanders,73
+Queens,29035,State Senate,10,Dem,James Sanders,469
+Queens,29040,State Senate,10,Dem,James Sanders,386
+Queens,29041,State Senate,10,Dem,James Sanders,395
+Queens,29042,State Senate,10,Dem,James Sanders,641
+Queens,29043,State Senate,10,Dem,James Sanders,679
+Queens,29044,State Senate,10,Dem,James Sanders,674
+Queens,29045,State Senate,10,Dem,James Sanders,647
+Queens,29046,State Senate,10,Dem,James Sanders,698
+Queens,29047,State Senate,10,Dem,James Sanders,722
+Queens,29048,State Senate,10,Dem,James Sanders,258
+Queens,29049,State Senate,10,Dem,James Sanders,505
+Queens,31001,State Senate,10,Dem,James Sanders,387
+Queens,31002,State Senate,10,Dem,James Sanders,446
+Queens,31003,State Senate,10,Dem,James Sanders,411
+Queens,31004,State Senate,10,Dem,James Sanders,422
+Queens,31005,State Senate,10,Dem,James Sanders,408
+Queens,31007,State Senate,10,Dem,James Sanders,239
+Queens,31008,State Senate,10,Dem,James Sanders,247
+Queens,31009,State Senate,10,Dem,James Sanders,340
+Queens,31010,State Senate,10,Dem,James Sanders,398
+Queens,31011,State Senate,10,Dem,James Sanders,499
+Queens,31012,State Senate,10,Dem,James Sanders,398
+Queens,31013,State Senate,10,Dem,James Sanders,475
+Queens,31014,State Senate,10,Dem,James Sanders,510
+Queens,31015,State Senate,10,Dem,James Sanders,535
+Queens,31016,State Senate,10,Dem,James Sanders,223
+Queens,31017,State Senate,10,Dem,James Sanders,375
+Queens,31018,State Senate,10,Dem,James Sanders,575
+Queens,31019,State Senate,10,Dem,James Sanders,587
+Queens,31020,State Senate,10,Dem,James Sanders,147
+Queens,31022,State Senate,10,Dem,James Sanders,391
+Queens,31023,State Senate,10,Dem,James Sanders,117
+Queens,31024,State Senate,10,Dem,James Sanders,535
+Queens,31025,State Senate,10,Dem,James Sanders,524
+Queens,31026,State Senate,10,Dem,James Sanders,357
+Queens,31033,State Senate,10,Dem,James Sanders,207
+Queens,31034,State Senate,10,Dem,James Sanders,694
+Queens,31035,State Senate,10,Dem,James Sanders,603
+Queens,31036,State Senate,10,Dem,James Sanders,728
+Queens,31037,State Senate,10,Dem,James Sanders,344
+Queens,31038,State Senate,10,Dem,James Sanders,737
+Queens,31040,State Senate,10,Dem,James Sanders,667
+Queens,31041,State Senate,10,Dem,James Sanders,710
+Queens,31042,State Senate,10,Dem,James Sanders,722
+Queens,31043,State Senate,10,Dem,James Sanders,630
+Queens,31044,State Senate,10,Dem,James Sanders,705
+Queens,31045,State Senate,10,Dem,James Sanders,10
+Queens,31046,State Senate,10,Dem,James Sanders,614
+Queens,31047,State Senate,10,Dem,James Sanders,393
+Queens,31050,State Senate,10,Dem,James Sanders,425
+Queens,31051,State Senate,10,Dem,James Sanders,455
+Queens,31052,State Senate,10,Dem,James Sanders,435
+Queens,31053,State Senate,10,Dem,James Sanders,361
+Queens,31054,State Senate,10,Dem,James Sanders,359
+Queens,31055,State Senate,10,Dem,James Sanders,232
+Queens,31056,State Senate,10,Dem,James Sanders,287
+Queens,31058,State Senate,10,Dem,James Sanders,308
+Queens,31059,State Senate,10,Dem,James Sanders,238
+Queens,31061,State Senate,10,Dem,James Sanders,213
+Queens,31062,State Senate,10,Dem,James Sanders,198
+Queens,31063,State Senate,10,Dem,James Sanders,342
+Queens,31064,State Senate,10,Dem,James Sanders,296
+Queens,31066,State Senate,10,Dem,James Sanders,75
+Queens,31067,State Senate,10,Dem,James Sanders,235
+Queens,31068,State Senate,10,Dem,James Sanders,322
+Queens,31069,State Senate,10,Dem,James Sanders,235
+Queens,31070,State Senate,10,Dem,James Sanders,157
+Queens,31071,State Senate,10,Dem,James Sanders,180
+Queens,31072,State Senate,10,Dem,James Sanders,6
+Queens,31074,State Senate,10,Dem,James Sanders,2
+Queens,32012,State Senate,10,Dem,James Sanders,2
+Queens,32013,State Senate,10,Dem,James Sanders,59
+Queens,32017,State Senate,10,Dem,James Sanders,507
+Queens,32018,State Senate,10,Dem,James Sanders,364
+Queens,32019,State Senate,10,Dem,James Sanders,380
+Queens,32020,State Senate,10,Dem,James Sanders,425
+Queens,32021,State Senate,10,Dem,James Sanders,526
+Queens,32022,State Senate,10,Dem,James Sanders,553
+Queens,32025,State Senate,10,Dem,James Sanders,526
+Queens,32026,State Senate,10,Dem,James Sanders,517
+Queens,32027,State Senate,10,Dem,James Sanders,555
+Queens,32028,State Senate,10,Dem,James Sanders,526
+Queens,32029,State Senate,10,Dem,James Sanders,642
+Queens,32030,State Senate,10,Dem,James Sanders,425
+Queens,32031,State Senate,10,Dem,James Sanders,517
+Queens,32032,State Senate,10,Dem,James Sanders,345
+Queens,32033,State Senate,10,Dem,James Sanders,603
+Queens,32034,State Senate,10,Dem,James Sanders,576
+Queens,32035,State Senate,10,Dem,James Sanders,572
+Queens,32036,State Senate,10,Dem,James Sanders,578
+Queens,32037,State Senate,10,Dem,James Sanders,295
+Queens,32038,State Senate,10,Dem,James Sanders,554
+Queens,32039,State Senate,10,Dem,James Sanders,582
+Queens,32046,State Senate,10,Dem,James Sanders,750
+Queens,32047,State Senate,10,Dem,James Sanders,588
+Queens,32048,State Senate,10,Dem,James Sanders,474
+Queens,32049,State Senate,10,Dem,James Sanders,529
+Queens,32050,State Senate,10,Dem,James Sanders,572
+Queens,32051,State Senate,10,Dem,James Sanders,551
+Queens,32052,State Senate,10,Dem,James Sanders,409
+Queens,32053,State Senate,10,Dem,James Sanders,640
+Queens,32054,State Senate,10,Dem,James Sanders,301
+Queens,32055,State Senate,10,Dem,James Sanders,359
+Queens,32056,State Senate,10,Dem,James Sanders,204
+Queens,32057,State Senate,10,Dem,James Sanders,655
+Queens,32058,State Senate,10,Dem,James Sanders,661
+Queens,32059,State Senate,10,Dem,James Sanders,643
+Queens,32060,State Senate,10,Dem,James Sanders,697
+Queens,32061,State Senate,10,Dem,James Sanders,614
+Queens,32062,State Senate,10,Dem,James Sanders,612
+Queens,32063,State Senate,10,Dem,James Sanders,548
+Queens,32064,State Senate,10,Dem,James Sanders,526
+Queens,32065,State Senate,10,Dem,James Sanders,548
+Queens,32066,State Senate,10,Dem,James Sanders,543
+Queens,32067,State Senate,10,Dem,James Sanders,503
+Queens,32068,State Senate,10,Dem,James Sanders,511
+Queens,32069,State Senate,10,Dem,James Sanders,498
+Queens,32070,State Senate,10,Dem,James Sanders,499
+Queens,32071,State Senate,10,Dem,James Sanders,513
+Queens,32072,State Senate,10,Dem,James Sanders,541
+Queens,32073,State Senate,10,Dem,James Sanders,415
+Queens,32074,State Senate,10,Dem,James Sanders,343
+Queens,38034,State Senate,10,Dem,James Sanders,97
+Queens,38036,State Senate,10,Dem,James Sanders,94
+Queens,38038,State Senate,10,Dem,James Sanders,445
+Queens,38039,State Senate,10,Dem,James Sanders,453
+Queens,38040,State Senate,10,Dem,James Sanders,330
+Queens,38041,State Senate,10,Dem,James Sanders,401
+Queens,38042,State Senate,10,Dem,James Sanders,344
+Queens,38043,State Senate,10,Dem,James Sanders,336
+Queens,38044,State Senate,10,Dem,James Sanders,223
+Queens,38045,State Senate,10,Dem,James Sanders,79
+Queens,38046,State Senate,10,Dem,James Sanders,249
+Queens,38047,State Senate,10,Dem,James Sanders,251
+Queens,38048,State Senate,10,Dem,James Sanders,364
+Queens,38049,State Senate,10,Dem,James Sanders,417
+Queens,23018,State Senate,10,Ind,writein,0
+Queens,23019,State Senate,10,Ind,writein,3
+Queens,23029,State Senate,10,Ind,writein,5
+Queens,23030,State Senate,10,Ind,writein,5
+Queens,23031,State Senate,10,Ind,writein,0
+Queens,23032,State Senate,10,Ind,writein,1
+Queens,23033,State Senate,10,Ind,writein,0
+Queens,23034,State Senate,10,Ind,writein,0
+Queens,23035,State Senate,10,Ind,writein,0
+Queens,23036,State Senate,10,Ind,writein,0
+Queens,23037,State Senate,10,Ind,writein,0
+Queens,23038,State Senate,10,Ind,writein,0
+Queens,23073,State Senate,10,Ind,writein,0
+Queens,24063,State Senate,10,Ind,writein,0
+Queens,24064,State Senate,10,Ind,writein,0
+Queens,24068,State Senate,10,Ind,writein,3
+Queens,24069,State Senate,10,Ind,writein,0
+Queens,24070,State Senate,10,Ind,writein,3
+Queens,24071,State Senate,10,Ind,writein,1
+Queens,24072,State Senate,10,Ind,writein,1
+Queens,24073,State Senate,10,Ind,writein,0
+Queens,24074,State Senate,10,Ind,writein,1
+Queens,24075,State Senate,10,Ind,writein,0
+Queens,24076,State Senate,10,Ind,writein,0
+Queens,24077,State Senate,10,Ind,writein,0
+Queens,28001,State Senate,10,Ind,writein,1
+Queens,28002,State Senate,10,Ind,writein,1
+Queens,28004,State Senate,10,Ind,writein,0
+Queens,28008,State Senate,10,Ind,writein,2
+Queens,29035,State Senate,10,Ind,writein,0
+Queens,29040,State Senate,10,Ind,writein,2
+Queens,29041,State Senate,10,Ind,writein,1
+Queens,29042,State Senate,10,Ind,writein,0
+Queens,29043,State Senate,10,Ind,writein,0
+Queens,29044,State Senate,10,Ind,writein,0
+Queens,29045,State Senate,10,Ind,writein,0
+Queens,29046,State Senate,10,Ind,writein,0
+Queens,29047,State Senate,10,Ind,writein,0
+Queens,29048,State Senate,10,Ind,writein,0
+Queens,29049,State Senate,10,Ind,writein,0
+Queens,31001,State Senate,10,Ind,writein,0
+Queens,31002,State Senate,10,Ind,writein,1
+Queens,31003,State Senate,10,Ind,writein,0
+Queens,31004,State Senate,10,Ind,writein,1
+Queens,31005,State Senate,10,Ind,writein,0
+Queens,31007,State Senate,10,Ind,writein,0
+Queens,31008,State Senate,10,Ind,writein,0
+Queens,31009,State Senate,10,Ind,writein,0
+Queens,31010,State Senate,10,Ind,writein,1
+Queens,31011,State Senate,10,Ind,writein,0
+Queens,31012,State Senate,10,Ind,writein,0
+Queens,31013,State Senate,10,Ind,writein,0
+Queens,31014,State Senate,10,Ind,writein,1
+Queens,31015,State Senate,10,Ind,writein,0
+Queens,31016,State Senate,10,Ind,writein,0
+Queens,31017,State Senate,10,Ind,writein,0
+Queens,31018,State Senate,10,Ind,writein,1
+Queens,31019,State Senate,10,Ind,writein,2
+Queens,31020,State Senate,10,Ind,writein,0
+Queens,31022,State Senate,10,Ind,writein,2
+Queens,31023,State Senate,10,Ind,writein,2
+Queens,31024,State Senate,10,Ind,writein,1
+Queens,31025,State Senate,10,Ind,writein,1
+Queens,31026,State Senate,10,Ind,writein,2
+Queens,31033,State Senate,10,Ind,writein,0
+Queens,31034,State Senate,10,Ind,writein,1
+Queens,31035,State Senate,10,Ind,writein,0
+Queens,31036,State Senate,10,Ind,writein,1
+Queens,31037,State Senate,10,Ind,writein,0
+Queens,31038,State Senate,10,Ind,writein,0
+Queens,31040,State Senate,10,Ind,writein,0
+Queens,31041,State Senate,10,Ind,writein,0
+Queens,31042,State Senate,10,Ind,writein,0
+Queens,31043,State Senate,10,Ind,writein,0
+Queens,31044,State Senate,10,Ind,writein,0
+Queens,31045,State Senate,10,Ind,writein,0
+Queens,31046,State Senate,10,Ind,writein,1
+Queens,31047,State Senate,10,Ind,writein,0
+Queens,31050,State Senate,10,Ind,writein,0
+Queens,31051,State Senate,10,Ind,writein,1
+Queens,31052,State Senate,10,Ind,writein,0
+Queens,31053,State Senate,10,Ind,writein,0
+Queens,31054,State Senate,10,Ind,writein,0
+Queens,31055,State Senate,10,Ind,writein,0
+Queens,31056,State Senate,10,Ind,writein,0
+Queens,31058,State Senate,10,Ind,writein,0
+Queens,31059,State Senate,10,Ind,writein,0
+Queens,31061,State Senate,10,Ind,writein,0
+Queens,31062,State Senate,10,Ind,writein,1
+Queens,31063,State Senate,10,Ind,writein,0
+Queens,31064,State Senate,10,Ind,writein,0
+Queens,31066,State Senate,10,Ind,writein,1
+Queens,31067,State Senate,10,Ind,writein,1
+Queens,31068,State Senate,10,Ind,writein,5
+Queens,31069,State Senate,10,Ind,writein,0
+Queens,31070,State Senate,10,Ind,writein,1
+Queens,31071,State Senate,10,Ind,writein,1
+Queens,31072,State Senate,10,Ind,writein,0
+Queens,31074,State Senate,10,Ind,writein,0
+Queens,32012,State Senate,10,Ind,writein,0
+Queens,32013,State Senate,10,Ind,writein,0
+Queens,32017,State Senate,10,Ind,writein,0
+Queens,32018,State Senate,10,Ind,writein,0
+Queens,32019,State Senate,10,Ind,writein,0
+Queens,32020,State Senate,10,Ind,writein,1
+Queens,32021,State Senate,10,Ind,writein,0
+Queens,32022,State Senate,10,Ind,writein,0
+Queens,32025,State Senate,10,Ind,writein,1
+Queens,32026,State Senate,10,Ind,writein,0
+Queens,32027,State Senate,10,Ind,writein,1
+Queens,32028,State Senate,10,Ind,writein,1
+Queens,32029,State Senate,10,Ind,writein,0
+Queens,32030,State Senate,10,Ind,writein,1
+Queens,32031,State Senate,10,Ind,writein,0
+Queens,32032,State Senate,10,Ind,writein,0
+Queens,32033,State Senate,10,Ind,writein,0
+Queens,32034,State Senate,10,Ind,writein,2
+Queens,32035,State Senate,10,Ind,writein,0
+Queens,32036,State Senate,10,Ind,writein,0
+Queens,32037,State Senate,10,Ind,writein,0
+Queens,32038,State Senate,10,Ind,writein,5
+Queens,32039,State Senate,10,Ind,writein,0
+Queens,32046,State Senate,10,Ind,writein,0
+Queens,32047,State Senate,10,Ind,writein,0
+Queens,32048,State Senate,10,Ind,writein,0
+Queens,32049,State Senate,10,Ind,writein,0
+Queens,32050,State Senate,10,Ind,writein,0
+Queens,32051,State Senate,10,Ind,writein,1
+Queens,32052,State Senate,10,Ind,writein,0
+Queens,32053,State Senate,10,Ind,writein,0
+Queens,32054,State Senate,10,Ind,writein,0
+Queens,32055,State Senate,10,Ind,writein,0
+Queens,32056,State Senate,10,Ind,writein,0
+Queens,32057,State Senate,10,Ind,writein,1
+Queens,32058,State Senate,10,Ind,writein,0
+Queens,32059,State Senate,10,Ind,writein,0
+Queens,32060,State Senate,10,Ind,writein,0
+Queens,32061,State Senate,10,Ind,writein,0
+Queens,32062,State Senate,10,Ind,writein,1
+Queens,32063,State Senate,10,Ind,writein,0
+Queens,32064,State Senate,10,Ind,writein,0
+Queens,32065,State Senate,10,Ind,writein,1
+Queens,32066,State Senate,10,Ind,writein,0
+Queens,32067,State Senate,10,Ind,writein,0
+Queens,32068,State Senate,10,Ind,writein,1
+Queens,32069,State Senate,10,Ind,writein,1
+Queens,32070,State Senate,10,Ind,writein,0
+Queens,32071,State Senate,10,Ind,writein,0
+Queens,32072,State Senate,10,Ind,writein,0
+Queens,32073,State Senate,10,Ind,writein,0
+Queens,32074,State Senate,10,Ind,writein,0
+Queens,38034,State Senate,10,Ind,writein,1
+Queens,38036,State Senate,10,Ind,writein,0
+Queens,38038,State Senate,10,Ind,writein,0
+Queens,38039,State Senate,10,Ind,writein,1
+Queens,38040,State Senate,10,Ind,writein,2
+Queens,38041,State Senate,10,Ind,writein,0
+Queens,38042,State Senate,10,Ind,writein,0
+Queens,38043,State Senate,10,Ind,writein,1
+Queens,38044,State Senate,10,Ind,writein,1
+Queens,38045,State Senate,10,Ind,writein,1
+Queens,38046,State Senate,10,Ind,writein,0
+Queens,38047,State Senate,10,Ind,writein,1
+Queens,38048,State Senate,10,Ind,writein,4
+Queens,38049,State Senate,10,Ind,writein,4
+Queens,24001,State Senate,11,Rep,Joseph Concannon,111
+Queens,24002,State Senate,11,Rep,Joseph Concannon,113
+Queens,24003,State Senate,11,Rep,Joseph Concannon,96
+Queens,24004,State Senate,11,Rep,Joseph Concannon,66
+Queens,24005,State Senate,11,Rep,Joseph Concannon,97
+Queens,24006,State Senate,11,Rep,Joseph Concannon,137
+Queens,24007,State Senate,11,Rep,Joseph Concannon,66
+Queens,24010,State Senate,11,Rep,Joseph Concannon,42
+Queens,24011,State Senate,11,Rep,Joseph Concannon,118
+Queens,24012,State Senate,11,Rep,Joseph Concannon,11
+Queens,24017,State Senate,11,Rep,Joseph Concannon,89
+Queens,24018,State Senate,11,Rep,Joseph Concannon,145
+Queens,24019,State Senate,11,Rep,Joseph Concannon,162
+Queens,24020,State Senate,11,Rep,Joseph Concannon,126
+Queens,24021,State Senate,11,Rep,Joseph Concannon,144
+Queens,24022,State Senate,11,Rep,Joseph Concannon,80
+Queens,24024,State Senate,11,Rep,Joseph Concannon,166
+Queens,24025,State Senate,11,Rep,Joseph Concannon,164
+Queens,24028,State Senate,11,Rep,Joseph Concannon,159
+Queens,24032,State Senate,11,Rep,Joseph Concannon,103
+Queens,24033,State Senate,11,Rep,Joseph Concannon,218
+Queens,24034,State Senate,11,Rep,Joseph Concannon,134
+Queens,24035,State Senate,11,Rep,Joseph Concannon,102
+Queens,24036,State Senate,11,Rep,Joseph Concannon,13
+Queens,24038,State Senate,11,Rep,Joseph Concannon,4
+Queens,24042,State Senate,11,Rep,Joseph Concannon,39
+Queens,24050,State Senate,11,Rep,Joseph Concannon,92
+Queens,24051,State Senate,11,Rep,Joseph Concannon,47
+Queens,24052,State Senate,11,Rep,Joseph Concannon,59
+Queens,24053,State Senate,11,Rep,Joseph Concannon,87
+Queens,24054,State Senate,11,Rep,Joseph Concannon,31
+Queens,24055,State Senate,11,Rep,Joseph Concannon,15
+Queens,24057,State Senate,11,Rep,Joseph Concannon,17
+Queens,24067,State Senate,11,Rep,Joseph Concannon,47
+Queens,25010,State Senate,11,Rep,Joseph Concannon,183
+Queens,25011,State Senate,11,Rep,Joseph Concannon,169
+Queens,25012,State Senate,11,Rep,Joseph Concannon,222
+Queens,25013,State Senate,11,Rep,Joseph Concannon,118
+Queens,25014,State Senate,11,Rep,Joseph Concannon,132
+Queens,25015,State Senate,11,Rep,Joseph Concannon,85
+Queens,25016,State Senate,11,Rep,Joseph Concannon,134
+Queens,25017,State Senate,11,Rep,Joseph Concannon,118
+Queens,25018,State Senate,11,Rep,Joseph Concannon,86
+Queens,25019,State Senate,11,Rep,Joseph Concannon,69
+Queens,25026,State Senate,11,Rep,Joseph Concannon,8
+Queens,25027,State Senate,11,Rep,Joseph Concannon,130
+Queens,25028,State Senate,11,Rep,Joseph Concannon,50
+Queens,25029,State Senate,11,Rep,Joseph Concannon,147
+Queens,25030,State Senate,11,Rep,Joseph Concannon,130
+Queens,25031,State Senate,11,Rep,Joseph Concannon,45
+Queens,25032,State Senate,11,Rep,Joseph Concannon,55
+Queens,25033,State Senate,11,Rep,Joseph Concannon,89
+Queens,25035,State Senate,11,Rep,Joseph Concannon,99
+Queens,25036,State Senate,11,Rep,Joseph Concannon,75
+Queens,25037,State Senate,11,Rep,Joseph Concannon,125
+Queens,25038,State Senate,11,Rep,Joseph Concannon,148
+Queens,25039,State Senate,11,Rep,Joseph Concannon,165
+Queens,25040,State Senate,11,Rep,Joseph Concannon,166
+Queens,25041,State Senate,11,Rep,Joseph Concannon,32
+Queens,25065,State Senate,11,Rep,Joseph Concannon,58
+Queens,25066,State Senate,11,Rep,Joseph Concannon,8
+Queens,25067,State Senate,11,Rep,Joseph Concannon,135
+Queens,25068,State Senate,11,Rep,Joseph Concannon,107
+Queens,26001,State Senate,11,Rep,Joseph Concannon,71
+Queens,26002,State Senate,11,Rep,Joseph Concannon,23
+Queens,26003,State Senate,11,Rep,Joseph Concannon,165
+Queens,26004,State Senate,11,Rep,Joseph Concannon,145
+Queens,26005,State Senate,11,Rep,Joseph Concannon,154
+Queens,26006,State Senate,11,Rep,Joseph Concannon,128
+Queens,26007,State Senate,11,Rep,Joseph Concannon,107
+Queens,26008,State Senate,11,Rep,Joseph Concannon,177
+Queens,26009,State Senate,11,Rep,Joseph Concannon,140
+Queens,26010,State Senate,11,Rep,Joseph Concannon,146
+Queens,26011,State Senate,11,Rep,Joseph Concannon,148
+Queens,26012,State Senate,11,Rep,Joseph Concannon,160
+Queens,26013,State Senate,11,Rep,Joseph Concannon,164
+Queens,26014,State Senate,11,Rep,Joseph Concannon,193
+Queens,26015,State Senate,11,Rep,Joseph Concannon,120
+Queens,26016,State Senate,11,Rep,Joseph Concannon,188
+Queens,26017,State Senate,11,Rep,Joseph Concannon,190
+Queens,26018,State Senate,11,Rep,Joseph Concannon,212
+Queens,26019,State Senate,11,Rep,Joseph Concannon,148
+Queens,26020,State Senate,11,Rep,Joseph Concannon,159
+Queens,26021,State Senate,11,Rep,Joseph Concannon,93
+Queens,26022,State Senate,11,Rep,Joseph Concannon,123
+Queens,26023,State Senate,11,Rep,Joseph Concannon,113
+Queens,26024,State Senate,11,Rep,Joseph Concannon,86
+Queens,26025,State Senate,11,Rep,Joseph Concannon,125
+Queens,26026,State Senate,11,Rep,Joseph Concannon,43
+Queens,26027,State Senate,11,Rep,Joseph Concannon,154
+Queens,26028,State Senate,11,Rep,Joseph Concannon,176
+Queens,26029,State Senate,11,Rep,Joseph Concannon,218
+Queens,26030,State Senate,11,Rep,Joseph Concannon,219
+Queens,26031,State Senate,11,Rep,Joseph Concannon,244
+Queens,26032,State Senate,11,Rep,Joseph Concannon,143
+Queens,26033,State Senate,11,Rep,Joseph Concannon,202
+Queens,26034,State Senate,11,Rep,Joseph Concannon,98
+Queens,26035,State Senate,11,Rep,Joseph Concannon,165
+Queens,26036,State Senate,11,Rep,Joseph Concannon,125
+Queens,26037,State Senate,11,Rep,Joseph Concannon,158
+Queens,26042,State Senate,11,Rep,Joseph Concannon,89
+Queens,26043,State Senate,11,Rep,Joseph Concannon,88
+Queens,26045,State Senate,11,Rep,Joseph Concannon,112
+Queens,26046,State Senate,11,Rep,Joseph Concannon,129
+Queens,26047,State Senate,11,Rep,Joseph Concannon,114
+Queens,26048,State Senate,11,Rep,Joseph Concannon,104
+Queens,26049,State Senate,11,Rep,Joseph Concannon,82
+Queens,26050,State Senate,11,Rep,Joseph Concannon,102
+Queens,26051,State Senate,11,Rep,Joseph Concannon,60
+Queens,26052,State Senate,11,Rep,Joseph Concannon,78
+Queens,26053,State Senate,11,Rep,Joseph Concannon,153
+Queens,26054,State Senate,11,Rep,Joseph Concannon,142
+Queens,26055,State Senate,11,Rep,Joseph Concannon,98
+Queens,26056,State Senate,11,Rep,Joseph Concannon,69
+Queens,26057,State Senate,11,Rep,Joseph Concannon,125
+Queens,26058,State Senate,11,Rep,Joseph Concannon,127
+Queens,26059,State Senate,11,Rep,Joseph Concannon,172
+Queens,26060,State Senate,11,Rep,Joseph Concannon,187
+Queens,26061,State Senate,11,Rep,Joseph Concannon,159
+Queens,26062,State Senate,11,Rep,Joseph Concannon,146
+Queens,26063,State Senate,11,Rep,Joseph Concannon,163
+Queens,26064,State Senate,11,Rep,Joseph Concannon,138
+Queens,26065,State Senate,11,Rep,Joseph Concannon,139
+Queens,26066,State Senate,11,Rep,Joseph Concannon,204
+Queens,26067,State Senate,11,Rep,Joseph Concannon,184
+Queens,26068,State Senate,11,Rep,Joseph Concannon,206
+Queens,26069,State Senate,11,Rep,Joseph Concannon,210
+Queens,26070,State Senate,11,Rep,Joseph Concannon,100
+Queens,26071,State Senate,11,Rep,Joseph Concannon,76
+Queens,26072,State Senate,11,Rep,Joseph Concannon,134
+Queens,26073,State Senate,11,Rep,Joseph Concannon,74
+Queens,26074,State Senate,11,Rep,Joseph Concannon,126
+Queens,26076,State Senate,11,Rep,Joseph Concannon,91
+Queens,26077,State Senate,11,Rep,Joseph Concannon,134
+Queens,27010,State Senate,11,Rep,Joseph Concannon,6
+Queens,27033,State Senate,11,Rep,Joseph Concannon,13
+Queens,27060,State Senate,11,Rep,Joseph Concannon,104
+Queens,27061,State Senate,11,Rep,Joseph Concannon,102
+Queens,27062,State Senate,11,Rep,Joseph Concannon,93
+Queens,27063,State Senate,11,Rep,Joseph Concannon,69
+Queens,27064,State Senate,11,Rep,Joseph Concannon,78
+Queens,27065,State Senate,11,Rep,Joseph Concannon,114
+Queens,27066,State Senate,11,Rep,Joseph Concannon,127
+Queens,27067,State Senate,11,Rep,Joseph Concannon,98
+Queens,27068,State Senate,11,Rep,Joseph Concannon,82
+Queens,27069,State Senate,11,Rep,Joseph Concannon,101
+Queens,27070,State Senate,11,Rep,Joseph Concannon,150
+Queens,27071,State Senate,11,Rep,Joseph Concannon,234
+Queens,27072,State Senate,11,Rep,Joseph Concannon,157
+Queens,29004,State Senate,11,Rep,Joseph Concannon,24
+Queens,29005,State Senate,11,Rep,Joseph Concannon,4
+Queens,29007,State Senate,11,Rep,Joseph Concannon,11
+Queens,29009,State Senate,11,Rep,Joseph Concannon,57
+Queens,29010,State Senate,11,Rep,Joseph Concannon,63
+Queens,29011,State Senate,11,Rep,Joseph Concannon,31
+Queens,32002,State Senate,11,Rep,Joseph Concannon,0
+Queens,32007,State Senate,11,Rep,Joseph Concannon,7
+Queens,32008,State Senate,11,Rep,Joseph Concannon,5
+Queens,32009,State Senate,11,Rep,Joseph Concannon,3
+Queens,32010,State Senate,11,Rep,Joseph Concannon,2
+Queens,33001,State Senate,11,Rep,Joseph Concannon,123
+Queens,33002,State Senate,11,Rep,Joseph Concannon,167
+Queens,33003,State Senate,11,Rep,Joseph Concannon,125
+Queens,33004,State Senate,11,Rep,Joseph Concannon,106
+Queens,33005,State Senate,11,Rep,Joseph Concannon,139
+Queens,33006,State Senate,11,Rep,Joseph Concannon,163
+Queens,33007,State Senate,11,Rep,Joseph Concannon,162
+Queens,33008,State Senate,11,Rep,Joseph Concannon,83
+Queens,33009,State Senate,11,Rep,Joseph Concannon,145
+Queens,33010,State Senate,11,Rep,Joseph Concannon,80
+Queens,33011,State Senate,11,Rep,Joseph Concannon,146
+Queens,33012,State Senate,11,Rep,Joseph Concannon,149
+Queens,33013,State Senate,11,Rep,Joseph Concannon,119
+Queens,33014,State Senate,11,Rep,Joseph Concannon,80
+Queens,33015,State Senate,11,Rep,Joseph Concannon,74
+Queens,40001,State Senate,11,Rep,Joseph Concannon,166
+Queens,40002,State Senate,11,Rep,Joseph Concannon,121
+Queens,40003,State Senate,11,Rep,Joseph Concannon,3
+Queens,40004,State Senate,11,Rep,Joseph Concannon,96
+Queens,40005,State Senate,11,Rep,Joseph Concannon,189
+Queens,40006,State Senate,11,Rep,Joseph Concannon,189
+Queens,40007,State Senate,11,Rep,Joseph Concannon,185
+Queens,40008,State Senate,11,Rep,Joseph Concannon,76
+Queens,40009,State Senate,11,Rep,Joseph Concannon,160
+Queens,40010,State Senate,11,Rep,Joseph Concannon,0
+Queens,40013,State Senate,11,Rep,Joseph Concannon,85
+Queens,40014,State Senate,11,Rep,Joseph Concannon,105
+Queens,40015,State Senate,11,Rep,Joseph Concannon,73
+Queens,40028,State Senate,11,Rep,Joseph Concannon,29
+Queens,40047,State Senate,11,Rep,Joseph Concannon,75
+Queens,40048,State Senate,11,Rep,Joseph Concannon,78
+Queens,40049,State Senate,11,Rep,Joseph Concannon,45
+Queens,40050,State Senate,11,Rep,Joseph Concannon,14
+Queens,40051,State Senate,11,Rep,Joseph Concannon,16
+Queens,24001,State Senate,11,Con,Joseph Concannon,15
+Queens,24002,State Senate,11,Con,Joseph Concannon,11
+Queens,24003,State Senate,11,Con,Joseph Concannon,19
+Queens,24004,State Senate,11,Con,Joseph Concannon,6
+Queens,24005,State Senate,11,Con,Joseph Concannon,15
+Queens,24006,State Senate,11,Con,Joseph Concannon,13
+Queens,24007,State Senate,11,Con,Joseph Concannon,16
+Queens,24010,State Senate,11,Con,Joseph Concannon,6
+Queens,24011,State Senate,11,Con,Joseph Concannon,11
+Queens,24012,State Senate,11,Con,Joseph Concannon,2
+Queens,24017,State Senate,11,Con,Joseph Concannon,10
+Queens,24018,State Senate,11,Con,Joseph Concannon,16
+Queens,24019,State Senate,11,Con,Joseph Concannon,17
+Queens,24020,State Senate,11,Con,Joseph Concannon,8
+Queens,24021,State Senate,11,Con,Joseph Concannon,16
+Queens,24022,State Senate,11,Con,Joseph Concannon,7
+Queens,24024,State Senate,11,Con,Joseph Concannon,17
+Queens,24025,State Senate,11,Con,Joseph Concannon,13
+Queens,24028,State Senate,11,Con,Joseph Concannon,5
+Queens,24032,State Senate,11,Con,Joseph Concannon,6
+Queens,24033,State Senate,11,Con,Joseph Concannon,13
+Queens,24034,State Senate,11,Con,Joseph Concannon,4
+Queens,24035,State Senate,11,Con,Joseph Concannon,6
+Queens,24036,State Senate,11,Con,Joseph Concannon,0
+Queens,24038,State Senate,11,Con,Joseph Concannon,0
+Queens,24042,State Senate,11,Con,Joseph Concannon,4
+Queens,24050,State Senate,11,Con,Joseph Concannon,7
+Queens,24051,State Senate,11,Con,Joseph Concannon,12
+Queens,24052,State Senate,11,Con,Joseph Concannon,3
+Queens,24053,State Senate,11,Con,Joseph Concannon,10
+Queens,24054,State Senate,11,Con,Joseph Concannon,1
+Queens,24055,State Senate,11,Con,Joseph Concannon,1
+Queens,24057,State Senate,11,Con,Joseph Concannon,0
+Queens,24067,State Senate,11,Con,Joseph Concannon,2
+Queens,25010,State Senate,11,Con,Joseph Concannon,6
+Queens,25011,State Senate,11,Con,Joseph Concannon,12
+Queens,25012,State Senate,11,Con,Joseph Concannon,14
+Queens,25013,State Senate,11,Con,Joseph Concannon,12
+Queens,25014,State Senate,11,Con,Joseph Concannon,9
+Queens,25015,State Senate,11,Con,Joseph Concannon,15
+Queens,25016,State Senate,11,Con,Joseph Concannon,18
+Queens,25017,State Senate,11,Con,Joseph Concannon,10
+Queens,25018,State Senate,11,Con,Joseph Concannon,8
+Queens,25019,State Senate,11,Con,Joseph Concannon,12
+Queens,25026,State Senate,11,Con,Joseph Concannon,1
+Queens,25027,State Senate,11,Con,Joseph Concannon,20
+Queens,25028,State Senate,11,Con,Joseph Concannon,7
+Queens,25029,State Senate,11,Con,Joseph Concannon,20
+Queens,25030,State Senate,11,Con,Joseph Concannon,10
+Queens,25031,State Senate,11,Con,Joseph Concannon,9
+Queens,25032,State Senate,11,Con,Joseph Concannon,2
+Queens,25033,State Senate,11,Con,Joseph Concannon,15
+Queens,25035,State Senate,11,Con,Joseph Concannon,16
+Queens,25036,State Senate,11,Con,Joseph Concannon,11
+Queens,25037,State Senate,11,Con,Joseph Concannon,12
+Queens,25038,State Senate,11,Con,Joseph Concannon,13
+Queens,25039,State Senate,11,Con,Joseph Concannon,25
+Queens,25040,State Senate,11,Con,Joseph Concannon,23
+Queens,25041,State Senate,11,Con,Joseph Concannon,0
+Queens,25065,State Senate,11,Con,Joseph Concannon,9
+Queens,25066,State Senate,11,Con,Joseph Concannon,1
+Queens,25067,State Senate,11,Con,Joseph Concannon,10
+Queens,25068,State Senate,11,Con,Joseph Concannon,15
+Queens,26001,State Senate,11,Con,Joseph Concannon,6
+Queens,26002,State Senate,11,Con,Joseph Concannon,1
+Queens,26003,State Senate,11,Con,Joseph Concannon,14
+Queens,26004,State Senate,11,Con,Joseph Concannon,11
+Queens,26005,State Senate,11,Con,Joseph Concannon,26
+Queens,26006,State Senate,11,Con,Joseph Concannon,15
+Queens,26007,State Senate,11,Con,Joseph Concannon,5
+Queens,26008,State Senate,11,Con,Joseph Concannon,20
+Queens,26009,State Senate,11,Con,Joseph Concannon,16
+Queens,26010,State Senate,11,Con,Joseph Concannon,14
+Queens,26011,State Senate,11,Con,Joseph Concannon,24
+Queens,26012,State Senate,11,Con,Joseph Concannon,19
+Queens,26013,State Senate,11,Con,Joseph Concannon,19
+Queens,26014,State Senate,11,Con,Joseph Concannon,20
+Queens,26015,State Senate,11,Con,Joseph Concannon,15
+Queens,26016,State Senate,11,Con,Joseph Concannon,17
+Queens,26017,State Senate,11,Con,Joseph Concannon,14
+Queens,26018,State Senate,11,Con,Joseph Concannon,18
+Queens,26019,State Senate,11,Con,Joseph Concannon,11
+Queens,26020,State Senate,11,Con,Joseph Concannon,12
+Queens,26021,State Senate,11,Con,Joseph Concannon,8
+Queens,26022,State Senate,11,Con,Joseph Concannon,8
+Queens,26023,State Senate,11,Con,Joseph Concannon,9
+Queens,26024,State Senate,11,Con,Joseph Concannon,9
+Queens,26025,State Senate,11,Con,Joseph Concannon,5
+Queens,26026,State Senate,11,Con,Joseph Concannon,3
+Queens,26027,State Senate,11,Con,Joseph Concannon,14
+Queens,26028,State Senate,11,Con,Joseph Concannon,18
+Queens,26029,State Senate,11,Con,Joseph Concannon,14
+Queens,26030,State Senate,11,Con,Joseph Concannon,28
+Queens,26031,State Senate,11,Con,Joseph Concannon,22
+Queens,26032,State Senate,11,Con,Joseph Concannon,16
+Queens,26033,State Senate,11,Con,Joseph Concannon,37
+Queens,26034,State Senate,11,Con,Joseph Concannon,15
+Queens,26035,State Senate,11,Con,Joseph Concannon,15
+Queens,26036,State Senate,11,Con,Joseph Concannon,17
+Queens,26037,State Senate,11,Con,Joseph Concannon,16
+Queens,26042,State Senate,11,Con,Joseph Concannon,16
+Queens,26043,State Senate,11,Con,Joseph Concannon,2
+Queens,26045,State Senate,11,Con,Joseph Concannon,16
+Queens,26046,State Senate,11,Con,Joseph Concannon,10
+Queens,26047,State Senate,11,Con,Joseph Concannon,12
+Queens,26048,State Senate,11,Con,Joseph Concannon,6
+Queens,26049,State Senate,11,Con,Joseph Concannon,12
+Queens,26050,State Senate,11,Con,Joseph Concannon,8
+Queens,26051,State Senate,11,Con,Joseph Concannon,9
+Queens,26052,State Senate,11,Con,Joseph Concannon,9
+Queens,26053,State Senate,11,Con,Joseph Concannon,13
+Queens,26054,State Senate,11,Con,Joseph Concannon,25
+Queens,26055,State Senate,11,Con,Joseph Concannon,16
+Queens,26056,State Senate,11,Con,Joseph Concannon,15
+Queens,26057,State Senate,11,Con,Joseph Concannon,19
+Queens,26058,State Senate,11,Con,Joseph Concannon,16
+Queens,26059,State Senate,11,Con,Joseph Concannon,34
+Queens,26060,State Senate,11,Con,Joseph Concannon,28
+Queens,26061,State Senate,11,Con,Joseph Concannon,12
+Queens,26062,State Senate,11,Con,Joseph Concannon,15
+Queens,26063,State Senate,11,Con,Joseph Concannon,19
+Queens,26064,State Senate,11,Con,Joseph Concannon,18
+Queens,26065,State Senate,11,Con,Joseph Concannon,22
+Queens,26066,State Senate,11,Con,Joseph Concannon,34
+Queens,26067,State Senate,11,Con,Joseph Concannon,18
+Queens,26068,State Senate,11,Con,Joseph Concannon,13
+Queens,26069,State Senate,11,Con,Joseph Concannon,21
+Queens,26070,State Senate,11,Con,Joseph Concannon,22
+Queens,26071,State Senate,11,Con,Joseph Concannon,2
+Queens,26072,State Senate,11,Con,Joseph Concannon,9
+Queens,26073,State Senate,11,Con,Joseph Concannon,4
+Queens,26074,State Senate,11,Con,Joseph Concannon,12
+Queens,26076,State Senate,11,Con,Joseph Concannon,7
+Queens,26077,State Senate,11,Con,Joseph Concannon,17
+Queens,27010,State Senate,11,Con,Joseph Concannon,0
+Queens,27033,State Senate,11,Con,Joseph Concannon,0
+Queens,27060,State Senate,11,Con,Joseph Concannon,4
+Queens,27061,State Senate,11,Con,Joseph Concannon,8
+Queens,27062,State Senate,11,Con,Joseph Concannon,14
+Queens,27063,State Senate,11,Con,Joseph Concannon,10
+Queens,27064,State Senate,11,Con,Joseph Concannon,16
+Queens,27065,State Senate,11,Con,Joseph Concannon,8
+Queens,27066,State Senate,11,Con,Joseph Concannon,15
+Queens,27067,State Senate,11,Con,Joseph Concannon,17
+Queens,27068,State Senate,11,Con,Joseph Concannon,9
+Queens,27069,State Senate,11,Con,Joseph Concannon,9
+Queens,27070,State Senate,11,Con,Joseph Concannon,6
+Queens,27071,State Senate,11,Con,Joseph Concannon,19
+Queens,27072,State Senate,11,Con,Joseph Concannon,18
+Queens,29004,State Senate,11,Con,Joseph Concannon,2
+Queens,29005,State Senate,11,Con,Joseph Concannon,0
+Queens,29007,State Senate,11,Con,Joseph Concannon,1
+Queens,29009,State Senate,11,Con,Joseph Concannon,1
+Queens,29010,State Senate,11,Con,Joseph Concannon,4
+Queens,29011,State Senate,11,Con,Joseph Concannon,0
+Queens,32002,State Senate,11,Con,Joseph Concannon,0
+Queens,32007,State Senate,11,Con,Joseph Concannon,1
+Queens,32008,State Senate,11,Con,Joseph Concannon,0
+Queens,32009,State Senate,11,Con,Joseph Concannon,0
+Queens,32010,State Senate,11,Con,Joseph Concannon,1
+Queens,33001,State Senate,11,Con,Joseph Concannon,14
+Queens,33002,State Senate,11,Con,Joseph Concannon,15
+Queens,33003,State Senate,11,Con,Joseph Concannon,13
+Queens,33004,State Senate,11,Con,Joseph Concannon,17
+Queens,33005,State Senate,11,Con,Joseph Concannon,16
+Queens,33006,State Senate,11,Con,Joseph Concannon,39
+Queens,33007,State Senate,11,Con,Joseph Concannon,23
+Queens,33008,State Senate,11,Con,Joseph Concannon,13
+Queens,33009,State Senate,11,Con,Joseph Concannon,37
+Queens,33010,State Senate,11,Con,Joseph Concannon,13
+Queens,33011,State Senate,11,Con,Joseph Concannon,19
+Queens,33012,State Senate,11,Con,Joseph Concannon,27
+Queens,33013,State Senate,11,Con,Joseph Concannon,7
+Queens,33014,State Senate,11,Con,Joseph Concannon,3
+Queens,33015,State Senate,11,Con,Joseph Concannon,14
+Queens,40001,State Senate,11,Con,Joseph Concannon,16
+Queens,40002,State Senate,11,Con,Joseph Concannon,15
+Queens,40003,State Senate,11,Con,Joseph Concannon,1
+Queens,40004,State Senate,11,Con,Joseph Concannon,13
+Queens,40005,State Senate,11,Con,Joseph Concannon,17
+Queens,40006,State Senate,11,Con,Joseph Concannon,22
+Queens,40007,State Senate,11,Con,Joseph Concannon,22
+Queens,40008,State Senate,11,Con,Joseph Concannon,10
+Queens,40009,State Senate,11,Con,Joseph Concannon,19
+Queens,40010,State Senate,11,Con,Joseph Concannon,0
+Queens,40013,State Senate,11,Con,Joseph Concannon,13
+Queens,40014,State Senate,11,Con,Joseph Concannon,6
+Queens,40015,State Senate,11,Con,Joseph Concannon,5
+Queens,40028,State Senate,11,Con,Joseph Concannon,2
+Queens,40047,State Senate,11,Con,Joseph Concannon,21
+Queens,40048,State Senate,11,Con,Joseph Concannon,9
+Queens,40049,State Senate,11,Con,Joseph Concannon,7
+Queens,40050,State Senate,11,Con,Joseph Concannon,1
+Queens,40051,State Senate,11,Con,Joseph Concannon,2
+Queens,24001,State Senate,11,Dem,Tony Avella,504
+Queens,24002,State Senate,11,Dem,Tony Avella,481
+Queens,24003,State Senate,11,Dem,Tony Avella,377
+Queens,24004,State Senate,11,Dem,Tony Avella,212
+Queens,24005,State Senate,11,Dem,Tony Avella,418
+Queens,24006,State Senate,11,Dem,Tony Avella,354
+Queens,24007,State Senate,11,Dem,Tony Avella,311
+Queens,24010,State Senate,11,Dem,Tony Avella,190
+Queens,24011,State Senate,11,Dem,Tony Avella,507
+Queens,24012,State Senate,11,Dem,Tony Avella,59
+Queens,24017,State Senate,11,Dem,Tony Avella,387
+Queens,24018,State Senate,11,Dem,Tony Avella,482
+Queens,24019,State Senate,11,Dem,Tony Avella,397
+Queens,24020,State Senate,11,Dem,Tony Avella,466
+Queens,24021,State Senate,11,Dem,Tony Avella,478
+Queens,24022,State Senate,11,Dem,Tony Avella,182
+Queens,24024,State Senate,11,Dem,Tony Avella,424
+Queens,24025,State Senate,11,Dem,Tony Avella,454
+Queens,24028,State Senate,11,Dem,Tony Avella,303
+Queens,24032,State Senate,11,Dem,Tony Avella,172
+Queens,24033,State Senate,11,Dem,Tony Avella,264
+Queens,24034,State Senate,11,Dem,Tony Avella,177
+Queens,24035,State Senate,11,Dem,Tony Avella,338
+Queens,24036,State Senate,11,Dem,Tony Avella,174
+Queens,24038,State Senate,11,Dem,Tony Avella,10
+Queens,24042,State Senate,11,Dem,Tony Avella,188
+Queens,24050,State Senate,11,Dem,Tony Avella,393
+Queens,24051,State Senate,11,Dem,Tony Avella,426
+Queens,24052,State Senate,11,Dem,Tony Avella,390
+Queens,24053,State Senate,11,Dem,Tony Avella,489
+Queens,24054,State Senate,11,Dem,Tony Avella,402
+Queens,24055,State Senate,11,Dem,Tony Avella,292
+Queens,24057,State Senate,11,Dem,Tony Avella,156
+Queens,24067,State Senate,11,Dem,Tony Avella,300
+Queens,25010,State Senate,11,Dem,Tony Avella,291
+Queens,25011,State Senate,11,Dem,Tony Avella,251
+Queens,25012,State Senate,11,Dem,Tony Avella,286
+Queens,25013,State Senate,11,Dem,Tony Avella,229
+Queens,25014,State Senate,11,Dem,Tony Avella,210
+Queens,25015,State Senate,11,Dem,Tony Avella,245
+Queens,25016,State Senate,11,Dem,Tony Avella,371
+Queens,25017,State Senate,11,Dem,Tony Avella,409
+Queens,25018,State Senate,11,Dem,Tony Avella,502
+Queens,25019,State Senate,11,Dem,Tony Avella,513
+Queens,25026,State Senate,11,Dem,Tony Avella,47
+Queens,25027,State Senate,11,Dem,Tony Avella,295
+Queens,25028,State Senate,11,Dem,Tony Avella,155
+Queens,25029,State Senate,11,Dem,Tony Avella,346
+Queens,25030,State Senate,11,Dem,Tony Avella,426
+Queens,25031,State Senate,11,Dem,Tony Avella,422
+Queens,25032,State Senate,11,Dem,Tony Avella,296
+Queens,25033,State Senate,11,Dem,Tony Avella,374
+Queens,25035,State Senate,11,Dem,Tony Avella,219
+Queens,25036,State Senate,11,Dem,Tony Avella,229
+Queens,25037,State Senate,11,Dem,Tony Avella,340
+Queens,25038,State Senate,11,Dem,Tony Avella,280
+Queens,25039,State Senate,11,Dem,Tony Avella,381
+Queens,25040,State Senate,11,Dem,Tony Avella,370
+Queens,25041,State Senate,11,Dem,Tony Avella,98
+Queens,25065,State Senate,11,Dem,Tony Avella,290
+Queens,25066,State Senate,11,Dem,Tony Avella,40
+Queens,25067,State Senate,11,Dem,Tony Avella,407
+Queens,25068,State Senate,11,Dem,Tony Avella,233
+Queens,26001,State Senate,11,Dem,Tony Avella,132
+Queens,26002,State Senate,11,Dem,Tony Avella,75
+Queens,26003,State Senate,11,Dem,Tony Avella,399
+Queens,26004,State Senate,11,Dem,Tony Avella,334
+Queens,26005,State Senate,11,Dem,Tony Avella,363
+Queens,26006,State Senate,11,Dem,Tony Avella,334
+Queens,26007,State Senate,11,Dem,Tony Avella,264
+Queens,26008,State Senate,11,Dem,Tony Avella,445
+Queens,26009,State Senate,11,Dem,Tony Avella,404
+Queens,26010,State Senate,11,Dem,Tony Avella,421
+Queens,26011,State Senate,11,Dem,Tony Avella,269
+Queens,26012,State Senate,11,Dem,Tony Avella,214
+Queens,26013,State Senate,11,Dem,Tony Avella,369
+Queens,26014,State Senate,11,Dem,Tony Avella,311
+Queens,26015,State Senate,11,Dem,Tony Avella,349
+Queens,26016,State Senate,11,Dem,Tony Avella,412
+Queens,26017,State Senate,11,Dem,Tony Avella,402
+Queens,26018,State Senate,11,Dem,Tony Avella,200
+Queens,26019,State Senate,11,Dem,Tony Avella,433
+Queens,26020,State Senate,11,Dem,Tony Avella,500
+Queens,26021,State Senate,11,Dem,Tony Avella,334
+Queens,26022,State Senate,11,Dem,Tony Avella,546
+Queens,26023,State Senate,11,Dem,Tony Avella,459
+Queens,26024,State Senate,11,Dem,Tony Avella,418
+Queens,26025,State Senate,11,Dem,Tony Avella,343
+Queens,26026,State Senate,11,Dem,Tony Avella,232
+Queens,26027,State Senate,11,Dem,Tony Avella,478
+Queens,26028,State Senate,11,Dem,Tony Avella,354
+Queens,26029,State Senate,11,Dem,Tony Avella,349
+Queens,26030,State Senate,11,Dem,Tony Avella,384
+Queens,26031,State Senate,11,Dem,Tony Avella,372
+Queens,26032,State Senate,11,Dem,Tony Avella,376
+Queens,26033,State Senate,11,Dem,Tony Avella,384
+Queens,26034,State Senate,11,Dem,Tony Avella,169
+Queens,26035,State Senate,11,Dem,Tony Avella,352
+Queens,26036,State Senate,11,Dem,Tony Avella,382
+Queens,26037,State Senate,11,Dem,Tony Avella,386
+Queens,26042,State Senate,11,Dem,Tony Avella,274
+Queens,26043,State Senate,11,Dem,Tony Avella,124
+Queens,26045,State Senate,11,Dem,Tony Avella,450
+Queens,26046,State Senate,11,Dem,Tony Avella,447
+Queens,26047,State Senate,11,Dem,Tony Avella,510
+Queens,26048,State Senate,11,Dem,Tony Avella,242
+Queens,26049,State Senate,11,Dem,Tony Avella,224
+Queens,26050,State Senate,11,Dem,Tony Avella,333
+Queens,26051,State Senate,11,Dem,Tony Avella,228
+Queens,26052,State Senate,11,Dem,Tony Avella,298
+Queens,26053,State Senate,11,Dem,Tony Avella,430
+Queens,26054,State Senate,11,Dem,Tony Avella,340
+Queens,26055,State Senate,11,Dem,Tony Avella,304
+Queens,26056,State Senate,11,Dem,Tony Avella,171
+Queens,26057,State Senate,11,Dem,Tony Avella,379
+Queens,26058,State Senate,11,Dem,Tony Avella,391
+Queens,26059,State Senate,11,Dem,Tony Avella,374
+Queens,26060,State Senate,11,Dem,Tony Avella,389
+Queens,26061,State Senate,11,Dem,Tony Avella,370
+Queens,26062,State Senate,11,Dem,Tony Avella,380
+Queens,26063,State Senate,11,Dem,Tony Avella,410
+Queens,26064,State Senate,11,Dem,Tony Avella,319
+Queens,26065,State Senate,11,Dem,Tony Avella,417
+Queens,26066,State Senate,11,Dem,Tony Avella,409
+Queens,26067,State Senate,11,Dem,Tony Avella,321
+Queens,26068,State Senate,11,Dem,Tony Avella,283
+Queens,26069,State Senate,11,Dem,Tony Avella,407
+Queens,26070,State Senate,11,Dem,Tony Avella,403
+Queens,26071,State Senate,11,Dem,Tony Avella,351
+Queens,26072,State Senate,11,Dem,Tony Avella,562
+Queens,26073,State Senate,11,Dem,Tony Avella,352
+Queens,26074,State Senate,11,Dem,Tony Avella,433
+Queens,26076,State Senate,11,Dem,Tony Avella,290
+Queens,26077,State Senate,11,Dem,Tony Avella,366
+Queens,27010,State Senate,11,Dem,Tony Avella,27
+Queens,27033,State Senate,11,Dem,Tony Avella,45
+Queens,27060,State Senate,11,Dem,Tony Avella,365
+Queens,27061,State Senate,11,Dem,Tony Avella,382
+Queens,27062,State Senate,11,Dem,Tony Avella,388
+Queens,27063,State Senate,11,Dem,Tony Avella,293
+Queens,27064,State Senate,11,Dem,Tony Avella,399
+Queens,27065,State Senate,11,Dem,Tony Avella,337
+Queens,27066,State Senate,11,Dem,Tony Avella,382
+Queens,27067,State Senate,11,Dem,Tony Avella,369
+Queens,27068,State Senate,11,Dem,Tony Avella,309
+Queens,27069,State Senate,11,Dem,Tony Avella,270
+Queens,27070,State Senate,11,Dem,Tony Avella,133
+Queens,27071,State Senate,11,Dem,Tony Avella,342
+Queens,27072,State Senate,11,Dem,Tony Avella,296
+Queens,29004,State Senate,11,Dem,Tony Avella,453
+Queens,29005,State Senate,11,Dem,Tony Avella,87
+Queens,29007,State Senate,11,Dem,Tony Avella,32
+Queens,29009,State Senate,11,Dem,Tony Avella,417
+Queens,29010,State Senate,11,Dem,Tony Avella,420
+Queens,29011,State Senate,11,Dem,Tony Avella,178
+Queens,32002,State Senate,11,Dem,Tony Avella,13
+Queens,32007,State Senate,11,Dem,Tony Avella,78
+Queens,32008,State Senate,11,Dem,Tony Avella,72
+Queens,32009,State Senate,11,Dem,Tony Avella,91
+Queens,32010,State Senate,11,Dem,Tony Avella,29
+Queens,33001,State Senate,11,Dem,Tony Avella,351
+Queens,33002,State Senate,11,Dem,Tony Avella,364
+Queens,33003,State Senate,11,Dem,Tony Avella,387
+Queens,33004,State Senate,11,Dem,Tony Avella,437
+Queens,33005,State Senate,11,Dem,Tony Avella,418
+Queens,33006,State Senate,11,Dem,Tony Avella,395
+Queens,33007,State Senate,11,Dem,Tony Avella,410
+Queens,33008,State Senate,11,Dem,Tony Avella,233
+Queens,33009,State Senate,11,Dem,Tony Avella,333
+Queens,33010,State Senate,11,Dem,Tony Avella,235
+Queens,33011,State Senate,11,Dem,Tony Avella,258
+Queens,33012,State Senate,11,Dem,Tony Avella,391
+Queens,33013,State Senate,11,Dem,Tony Avella,447
+Queens,33014,State Senate,11,Dem,Tony Avella,389
+Queens,33015,State Senate,11,Dem,Tony Avella,278
+Queens,40001,State Senate,11,Dem,Tony Avella,240
+Queens,40002,State Senate,11,Dem,Tony Avella,229
+Queens,40003,State Senate,11,Dem,Tony Avella,22
+Queens,40004,State Senate,11,Dem,Tony Avella,206
+Queens,40005,State Senate,11,Dem,Tony Avella,324
+Queens,40006,State Senate,11,Dem,Tony Avella,289
+Queens,40007,State Senate,11,Dem,Tony Avella,400
+Queens,40008,State Senate,11,Dem,Tony Avella,257
+Queens,40009,State Senate,11,Dem,Tony Avella,277
+Queens,40010,State Senate,11,Dem,Tony Avella,2
+Queens,40013,State Senate,11,Dem,Tony Avella,221
+Queens,40014,State Senate,11,Dem,Tony Avella,369
+Queens,40015,State Senate,11,Dem,Tony Avella,298
+Queens,40028,State Senate,11,Dem,Tony Avella,152
+Queens,40047,State Senate,11,Dem,Tony Avella,341
+Queens,40048,State Senate,11,Dem,Tony Avella,386
+Queens,40049,State Senate,11,Dem,Tony Avella,182
+Queens,40050,State Senate,11,Dem,Tony Avella,316
+Queens,40051,State Senate,11,Dem,Tony Avella,322
+Queens,24001,State Senate,11,WF,Tony Avella,13
+Queens,24002,State Senate,11,WF,Tony Avella,25
+Queens,24003,State Senate,11,WF,Tony Avella,12
+Queens,24004,State Senate,11,WF,Tony Avella,10
+Queens,24005,State Senate,11,WF,Tony Avella,19
+Queens,24006,State Senate,11,WF,Tony Avella,13
+Queens,24007,State Senate,11,WF,Tony Avella,10
+Queens,24010,State Senate,11,WF,Tony Avella,4
+Queens,24011,State Senate,11,WF,Tony Avella,14
+Queens,24012,State Senate,11,WF,Tony Avella,3
+Queens,24017,State Senate,11,WF,Tony Avella,10
+Queens,24018,State Senate,11,WF,Tony Avella,19
+Queens,24019,State Senate,11,WF,Tony Avella,13
+Queens,24020,State Senate,11,WF,Tony Avella,12
+Queens,24021,State Senate,11,WF,Tony Avella,21
+Queens,24022,State Senate,11,WF,Tony Avella,12
+Queens,24024,State Senate,11,WF,Tony Avella,20
+Queens,24025,State Senate,11,WF,Tony Avella,10
+Queens,24028,State Senate,11,WF,Tony Avella,12
+Queens,24032,State Senate,11,WF,Tony Avella,4
+Queens,24033,State Senate,11,WF,Tony Avella,14
+Queens,24034,State Senate,11,WF,Tony Avella,10
+Queens,24035,State Senate,11,WF,Tony Avella,9
+Queens,24036,State Senate,11,WF,Tony Avella,0
+Queens,24038,State Senate,11,WF,Tony Avella,1
+Queens,24042,State Senate,11,WF,Tony Avella,10
+Queens,24050,State Senate,11,WF,Tony Avella,12
+Queens,24051,State Senate,11,WF,Tony Avella,6
+Queens,24052,State Senate,11,WF,Tony Avella,4
+Queens,24053,State Senate,11,WF,Tony Avella,12
+Queens,24054,State Senate,11,WF,Tony Avella,7
+Queens,24055,State Senate,11,WF,Tony Avella,3
+Queens,24057,State Senate,11,WF,Tony Avella,2
+Queens,24067,State Senate,11,WF,Tony Avella,5
+Queens,25010,State Senate,11,WF,Tony Avella,9
+Queens,25011,State Senate,11,WF,Tony Avella,10
+Queens,25012,State Senate,11,WF,Tony Avella,10
+Queens,25013,State Senate,11,WF,Tony Avella,19
+Queens,25014,State Senate,11,WF,Tony Avella,9
+Queens,25015,State Senate,11,WF,Tony Avella,10
+Queens,25016,State Senate,11,WF,Tony Avella,16
+Queens,25017,State Senate,11,WF,Tony Avella,9
+Queens,25018,State Senate,11,WF,Tony Avella,17
+Queens,25019,State Senate,11,WF,Tony Avella,8
+Queens,25026,State Senate,11,WF,Tony Avella,2
+Queens,25027,State Senate,11,WF,Tony Avella,15
+Queens,25028,State Senate,11,WF,Tony Avella,10
+Queens,25029,State Senate,11,WF,Tony Avella,19
+Queens,25030,State Senate,11,WF,Tony Avella,11
+Queens,25031,State Senate,11,WF,Tony Avella,18
+Queens,25032,State Senate,11,WF,Tony Avella,8
+Queens,25033,State Senate,11,WF,Tony Avella,15
+Queens,25035,State Senate,11,WF,Tony Avella,1
+Queens,25036,State Senate,11,WF,Tony Avella,16
+Queens,25037,State Senate,11,WF,Tony Avella,19
+Queens,25038,State Senate,11,WF,Tony Avella,11
+Queens,25039,State Senate,11,WF,Tony Avella,16
+Queens,25040,State Senate,11,WF,Tony Avella,17
+Queens,25041,State Senate,11,WF,Tony Avella,3
+Queens,25065,State Senate,11,WF,Tony Avella,14
+Queens,25066,State Senate,11,WF,Tony Avella,1
+Queens,25067,State Senate,11,WF,Tony Avella,10
+Queens,25068,State Senate,11,WF,Tony Avella,4
+Queens,26001,State Senate,11,WF,Tony Avella,4
+Queens,26002,State Senate,11,WF,Tony Avella,2
+Queens,26003,State Senate,11,WF,Tony Avella,16
+Queens,26004,State Senate,11,WF,Tony Avella,31
+Queens,26005,State Senate,11,WF,Tony Avella,22
+Queens,26006,State Senate,11,WF,Tony Avella,13
+Queens,26007,State Senate,11,WF,Tony Avella,13
+Queens,26008,State Senate,11,WF,Tony Avella,13
+Queens,26009,State Senate,11,WF,Tony Avella,26
+Queens,26010,State Senate,11,WF,Tony Avella,19
+Queens,26011,State Senate,11,WF,Tony Avella,14
+Queens,26012,State Senate,11,WF,Tony Avella,10
+Queens,26013,State Senate,11,WF,Tony Avella,13
+Queens,26014,State Senate,11,WF,Tony Avella,12
+Queens,26015,State Senate,11,WF,Tony Avella,7
+Queens,26016,State Senate,11,WF,Tony Avella,7
+Queens,26017,State Senate,11,WF,Tony Avella,22
+Queens,26018,State Senate,11,WF,Tony Avella,12
+Queens,26019,State Senate,11,WF,Tony Avella,9
+Queens,26020,State Senate,11,WF,Tony Avella,9
+Queens,26021,State Senate,11,WF,Tony Avella,8
+Queens,26022,State Senate,11,WF,Tony Avella,19
+Queens,26023,State Senate,11,WF,Tony Avella,13
+Queens,26024,State Senate,11,WF,Tony Avella,9
+Queens,26025,State Senate,11,WF,Tony Avella,3
+Queens,26026,State Senate,11,WF,Tony Avella,5
+Queens,26027,State Senate,11,WF,Tony Avella,15
+Queens,26028,State Senate,11,WF,Tony Avella,11
+Queens,26029,State Senate,11,WF,Tony Avella,21
+Queens,26030,State Senate,11,WF,Tony Avella,13
+Queens,26031,State Senate,11,WF,Tony Avella,12
+Queens,26032,State Senate,11,WF,Tony Avella,15
+Queens,26033,State Senate,11,WF,Tony Avella,20
+Queens,26034,State Senate,11,WF,Tony Avella,14
+Queens,26035,State Senate,11,WF,Tony Avella,16
+Queens,26036,State Senate,11,WF,Tony Avella,16
+Queens,26037,State Senate,11,WF,Tony Avella,21
+Queens,26042,State Senate,11,WF,Tony Avella,11
+Queens,26043,State Senate,11,WF,Tony Avella,2
+Queens,26045,State Senate,11,WF,Tony Avella,14
+Queens,26046,State Senate,11,WF,Tony Avella,13
+Queens,26047,State Senate,11,WF,Tony Avella,20
+Queens,26048,State Senate,11,WF,Tony Avella,2
+Queens,26049,State Senate,11,WF,Tony Avella,10
+Queens,26050,State Senate,11,WF,Tony Avella,12
+Queens,26051,State Senate,11,WF,Tony Avella,10
+Queens,26052,State Senate,11,WF,Tony Avella,17
+Queens,26053,State Senate,11,WF,Tony Avella,19
+Queens,26054,State Senate,11,WF,Tony Avella,10
+Queens,26055,State Senate,11,WF,Tony Avella,8
+Queens,26056,State Senate,11,WF,Tony Avella,11
+Queens,26057,State Senate,11,WF,Tony Avella,19
+Queens,26058,State Senate,11,WF,Tony Avella,9
+Queens,26059,State Senate,11,WF,Tony Avella,18
+Queens,26060,State Senate,11,WF,Tony Avella,21
+Queens,26061,State Senate,11,WF,Tony Avella,18
+Queens,26062,State Senate,11,WF,Tony Avella,18
+Queens,26063,State Senate,11,WF,Tony Avella,27
+Queens,26064,State Senate,11,WF,Tony Avella,23
+Queens,26065,State Senate,11,WF,Tony Avella,17
+Queens,26066,State Senate,11,WF,Tony Avella,28
+Queens,26067,State Senate,11,WF,Tony Avella,10
+Queens,26068,State Senate,11,WF,Tony Avella,23
+Queens,26069,State Senate,11,WF,Tony Avella,29
+Queens,26070,State Senate,11,WF,Tony Avella,12
+Queens,26071,State Senate,11,WF,Tony Avella,5
+Queens,26072,State Senate,11,WF,Tony Avella,16
+Queens,26073,State Senate,11,WF,Tony Avella,3
+Queens,26074,State Senate,11,WF,Tony Avella,18
+Queens,26076,State Senate,11,WF,Tony Avella,11
+Queens,26077,State Senate,11,WF,Tony Avella,11
+Queens,27010,State Senate,11,WF,Tony Avella,0
+Queens,27033,State Senate,11,WF,Tony Avella,0
+Queens,27060,State Senate,11,WF,Tony Avella,6
+Queens,27061,State Senate,11,WF,Tony Avella,15
+Queens,27062,State Senate,11,WF,Tony Avella,23
+Queens,27063,State Senate,11,WF,Tony Avella,12
+Queens,27064,State Senate,11,WF,Tony Avella,29
+Queens,27065,State Senate,11,WF,Tony Avella,19
+Queens,27066,State Senate,11,WF,Tony Avella,21
+Queens,27067,State Senate,11,WF,Tony Avella,23
+Queens,27068,State Senate,11,WF,Tony Avella,16
+Queens,27069,State Senate,11,WF,Tony Avella,7
+Queens,27070,State Senate,11,WF,Tony Avella,8
+Queens,27071,State Senate,11,WF,Tony Avella,15
+Queens,27072,State Senate,11,WF,Tony Avella,15
+Queens,29004,State Senate,11,WF,Tony Avella,4
+Queens,29005,State Senate,11,WF,Tony Avella,1
+Queens,29007,State Senate,11,WF,Tony Avella,2
+Queens,29009,State Senate,11,WF,Tony Avella,6
+Queens,29010,State Senate,11,WF,Tony Avella,8
+Queens,29011,State Senate,11,WF,Tony Avella,7
+Queens,32002,State Senate,11,WF,Tony Avella,0
+Queens,32007,State Senate,11,WF,Tony Avella,3
+Queens,32008,State Senate,11,WF,Tony Avella,3
+Queens,32009,State Senate,11,WF,Tony Avella,0
+Queens,32010,State Senate,11,WF,Tony Avella,0
+Queens,33001,State Senate,11,WF,Tony Avella,15
+Queens,33002,State Senate,11,WF,Tony Avella,11
+Queens,33003,State Senate,11,WF,Tony Avella,10
+Queens,33004,State Senate,11,WF,Tony Avella,7
+Queens,33005,State Senate,11,WF,Tony Avella,11
+Queens,33006,State Senate,11,WF,Tony Avella,17
+Queens,33007,State Senate,11,WF,Tony Avella,11
+Queens,33008,State Senate,11,WF,Tony Avella,11
+Queens,33009,State Senate,11,WF,Tony Avella,18
+Queens,33010,State Senate,11,WF,Tony Avella,6
+Queens,33011,State Senate,11,WF,Tony Avella,15
+Queens,33012,State Senate,11,WF,Tony Avella,17
+Queens,33013,State Senate,11,WF,Tony Avella,9
+Queens,33014,State Senate,11,WF,Tony Avella,8
+Queens,33015,State Senate,11,WF,Tony Avella,5
+Queens,40001,State Senate,11,WF,Tony Avella,17
+Queens,40002,State Senate,11,WF,Tony Avella,19
+Queens,40003,State Senate,11,WF,Tony Avella,0
+Queens,40004,State Senate,11,WF,Tony Avella,10
+Queens,40005,State Senate,11,WF,Tony Avella,13
+Queens,40006,State Senate,11,WF,Tony Avella,12
+Queens,40007,State Senate,11,WF,Tony Avella,9
+Queens,40008,State Senate,11,WF,Tony Avella,12
+Queens,40009,State Senate,11,WF,Tony Avella,10
+Queens,40010,State Senate,11,WF,Tony Avella,0
+Queens,40013,State Senate,11,WF,Tony Avella,17
+Queens,40014,State Senate,11,WF,Tony Avella,17
+Queens,40015,State Senate,11,WF,Tony Avella,15
+Queens,40028,State Senate,11,WF,Tony Avella,8
+Queens,40047,State Senate,11,WF,Tony Avella,8
+Queens,40048,State Senate,11,WF,Tony Avella,20
+Queens,40049,State Senate,11,WF,Tony Avella,2
+Queens,40050,State Senate,11,WF,Tony Avella,8
+Queens,40051,State Senate,11,WF,Tony Avella,9
+Queens,24001,State Senate,11,Ind,Tony Avella,14
+Queens,24002,State Senate,11,Ind,Tony Avella,9
+Queens,24003,State Senate,11,Ind,Tony Avella,6
+Queens,24004,State Senate,11,Ind,Tony Avella,4
+Queens,24005,State Senate,11,Ind,Tony Avella,8
+Queens,24006,State Senate,11,Ind,Tony Avella,5
+Queens,24007,State Senate,11,Ind,Tony Avella,6
+Queens,24010,State Senate,11,Ind,Tony Avella,5
+Queens,24011,State Senate,11,Ind,Tony Avella,8
+Queens,24012,State Senate,11,Ind,Tony Avella,3
+Queens,24017,State Senate,11,Ind,Tony Avella,6
+Queens,24018,State Senate,11,Ind,Tony Avella,11
+Queens,24019,State Senate,11,Ind,Tony Avella,8
+Queens,24020,State Senate,11,Ind,Tony Avella,10
+Queens,24021,State Senate,11,Ind,Tony Avella,10
+Queens,24022,State Senate,11,Ind,Tony Avella,3
+Queens,24024,State Senate,11,Ind,Tony Avella,11
+Queens,24025,State Senate,11,Ind,Tony Avella,8
+Queens,24028,State Senate,11,Ind,Tony Avella,10
+Queens,24032,State Senate,11,Ind,Tony Avella,4
+Queens,24033,State Senate,11,Ind,Tony Avella,8
+Queens,24034,State Senate,11,Ind,Tony Avella,6
+Queens,24035,State Senate,11,Ind,Tony Avella,6
+Queens,24036,State Senate,11,Ind,Tony Avella,4
+Queens,24038,State Senate,11,Ind,Tony Avella,1
+Queens,24042,State Senate,11,Ind,Tony Avella,6
+Queens,24050,State Senate,11,Ind,Tony Avella,6
+Queens,24051,State Senate,11,Ind,Tony Avella,7
+Queens,24052,State Senate,11,Ind,Tony Avella,1
+Queens,24053,State Senate,11,Ind,Tony Avella,8
+Queens,24054,State Senate,11,Ind,Tony Avella,4
+Queens,24055,State Senate,11,Ind,Tony Avella,2
+Queens,24057,State Senate,11,Ind,Tony Avella,2
+Queens,24067,State Senate,11,Ind,Tony Avella,1
+Queens,25010,State Senate,11,Ind,Tony Avella,0
+Queens,25011,State Senate,11,Ind,Tony Avella,1
+Queens,25012,State Senate,11,Ind,Tony Avella,6
+Queens,25013,State Senate,11,Ind,Tony Avella,11
+Queens,25014,State Senate,11,Ind,Tony Avella,7
+Queens,25015,State Senate,11,Ind,Tony Avella,6
+Queens,25016,State Senate,11,Ind,Tony Avella,6
+Queens,25017,State Senate,11,Ind,Tony Avella,8
+Queens,25018,State Senate,11,Ind,Tony Avella,6
+Queens,25019,State Senate,11,Ind,Tony Avella,12
+Queens,25026,State Senate,11,Ind,Tony Avella,1
+Queens,25027,State Senate,11,Ind,Tony Avella,16
+Queens,25028,State Senate,11,Ind,Tony Avella,3
+Queens,25029,State Senate,11,Ind,Tony Avella,26
+Queens,25030,State Senate,11,Ind,Tony Avella,5
+Queens,25031,State Senate,11,Ind,Tony Avella,10
+Queens,25032,State Senate,11,Ind,Tony Avella,2
+Queens,25033,State Senate,11,Ind,Tony Avella,7
+Queens,25035,State Senate,11,Ind,Tony Avella,7
+Queens,25036,State Senate,11,Ind,Tony Avella,10
+Queens,25037,State Senate,11,Ind,Tony Avella,9
+Queens,25038,State Senate,11,Ind,Tony Avella,6
+Queens,25039,State Senate,11,Ind,Tony Avella,15
+Queens,25040,State Senate,11,Ind,Tony Avella,7
+Queens,25041,State Senate,11,Ind,Tony Avella,1
+Queens,25065,State Senate,11,Ind,Tony Avella,8
+Queens,25066,State Senate,11,Ind,Tony Avella,2
+Queens,25067,State Senate,11,Ind,Tony Avella,10
+Queens,25068,State Senate,11,Ind,Tony Avella,6
+Queens,26001,State Senate,11,Ind,Tony Avella,7
+Queens,26002,State Senate,11,Ind,Tony Avella,2
+Queens,26003,State Senate,11,Ind,Tony Avella,14
+Queens,26004,State Senate,11,Ind,Tony Avella,15
+Queens,26005,State Senate,11,Ind,Tony Avella,14
+Queens,26006,State Senate,11,Ind,Tony Avella,6
+Queens,26007,State Senate,11,Ind,Tony Avella,2
+Queens,26008,State Senate,11,Ind,Tony Avella,10
+Queens,26009,State Senate,11,Ind,Tony Avella,14
+Queens,26010,State Senate,11,Ind,Tony Avella,8
+Queens,26011,State Senate,11,Ind,Tony Avella,10
+Queens,26012,State Senate,11,Ind,Tony Avella,6
+Queens,26013,State Senate,11,Ind,Tony Avella,6
+Queens,26014,State Senate,11,Ind,Tony Avella,8
+Queens,26015,State Senate,11,Ind,Tony Avella,2
+Queens,26016,State Senate,11,Ind,Tony Avella,7
+Queens,26017,State Senate,11,Ind,Tony Avella,16
+Queens,26018,State Senate,11,Ind,Tony Avella,12
+Queens,26019,State Senate,11,Ind,Tony Avella,4
+Queens,26020,State Senate,11,Ind,Tony Avella,13
+Queens,26021,State Senate,11,Ind,Tony Avella,8
+Queens,26022,State Senate,11,Ind,Tony Avella,11
+Queens,26023,State Senate,11,Ind,Tony Avella,10
+Queens,26024,State Senate,11,Ind,Tony Avella,4
+Queens,26025,State Senate,11,Ind,Tony Avella,5
+Queens,26026,State Senate,11,Ind,Tony Avella,1
+Queens,26027,State Senate,11,Ind,Tony Avella,8
+Queens,26028,State Senate,11,Ind,Tony Avella,11
+Queens,26029,State Senate,11,Ind,Tony Avella,24
+Queens,26030,State Senate,11,Ind,Tony Avella,16
+Queens,26031,State Senate,11,Ind,Tony Avella,17
+Queens,26032,State Senate,11,Ind,Tony Avella,18
+Queens,26033,State Senate,11,Ind,Tony Avella,7
+Queens,26034,State Senate,11,Ind,Tony Avella,12
+Queens,26035,State Senate,11,Ind,Tony Avella,18
+Queens,26036,State Senate,11,Ind,Tony Avella,10
+Queens,26037,State Senate,11,Ind,Tony Avella,16
+Queens,26042,State Senate,11,Ind,Tony Avella,7
+Queens,26043,State Senate,11,Ind,Tony Avella,7
+Queens,26045,State Senate,11,Ind,Tony Avella,15
+Queens,26046,State Senate,11,Ind,Tony Avella,11
+Queens,26047,State Senate,11,Ind,Tony Avella,7
+Queens,26048,State Senate,11,Ind,Tony Avella,6
+Queens,26049,State Senate,11,Ind,Tony Avella,7
+Queens,26050,State Senate,11,Ind,Tony Avella,9
+Queens,26051,State Senate,11,Ind,Tony Avella,10
+Queens,26052,State Senate,11,Ind,Tony Avella,7
+Queens,26053,State Senate,11,Ind,Tony Avella,7
+Queens,26054,State Senate,11,Ind,Tony Avella,7
+Queens,26055,State Senate,11,Ind,Tony Avella,8
+Queens,26056,State Senate,11,Ind,Tony Avella,8
+Queens,26057,State Senate,11,Ind,Tony Avella,10
+Queens,26058,State Senate,11,Ind,Tony Avella,17
+Queens,26059,State Senate,11,Ind,Tony Avella,7
+Queens,26060,State Senate,11,Ind,Tony Avella,12
+Queens,26061,State Senate,11,Ind,Tony Avella,13
+Queens,26062,State Senate,11,Ind,Tony Avella,9
+Queens,26063,State Senate,11,Ind,Tony Avella,9
+Queens,26064,State Senate,11,Ind,Tony Avella,8
+Queens,26065,State Senate,11,Ind,Tony Avella,12
+Queens,26066,State Senate,11,Ind,Tony Avella,16
+Queens,26067,State Senate,11,Ind,Tony Avella,10
+Queens,26068,State Senate,11,Ind,Tony Avella,12
+Queens,26069,State Senate,11,Ind,Tony Avella,16
+Queens,26070,State Senate,11,Ind,Tony Avella,9
+Queens,26071,State Senate,11,Ind,Tony Avella,3
+Queens,26072,State Senate,11,Ind,Tony Avella,10
+Queens,26073,State Senate,11,Ind,Tony Avella,8
+Queens,26074,State Senate,11,Ind,Tony Avella,9
+Queens,26076,State Senate,11,Ind,Tony Avella,6
+Queens,26077,State Senate,11,Ind,Tony Avella,9
+Queens,27010,State Senate,11,Ind,Tony Avella,0
+Queens,27033,State Senate,11,Ind,Tony Avella,1
+Queens,27060,State Senate,11,Ind,Tony Avella,11
+Queens,27061,State Senate,11,Ind,Tony Avella,16
+Queens,27062,State Senate,11,Ind,Tony Avella,6
+Queens,27063,State Senate,11,Ind,Tony Avella,5
+Queens,27064,State Senate,11,Ind,Tony Avella,9
+Queens,27065,State Senate,11,Ind,Tony Avella,11
+Queens,27066,State Senate,11,Ind,Tony Avella,9
+Queens,27067,State Senate,11,Ind,Tony Avella,10
+Queens,27068,State Senate,11,Ind,Tony Avella,5
+Queens,27069,State Senate,11,Ind,Tony Avella,8
+Queens,27070,State Senate,11,Ind,Tony Avella,2
+Queens,27071,State Senate,11,Ind,Tony Avella,15
+Queens,27072,State Senate,11,Ind,Tony Avella,18
+Queens,29004,State Senate,11,Ind,Tony Avella,1
+Queens,29005,State Senate,11,Ind,Tony Avella,0
+Queens,29007,State Senate,11,Ind,Tony Avella,1
+Queens,29009,State Senate,11,Ind,Tony Avella,2
+Queens,29010,State Senate,11,Ind,Tony Avella,0
+Queens,29011,State Senate,11,Ind,Tony Avella,1
+Queens,32002,State Senate,11,Ind,Tony Avella,0
+Queens,32007,State Senate,11,Ind,Tony Avella,1
+Queens,32008,State Senate,11,Ind,Tony Avella,0
+Queens,32009,State Senate,11,Ind,Tony Avella,0
+Queens,32010,State Senate,11,Ind,Tony Avella,0
+Queens,33001,State Senate,11,Ind,Tony Avella,14
+Queens,33002,State Senate,11,Ind,Tony Avella,10
+Queens,33003,State Senate,11,Ind,Tony Avella,11
+Queens,33004,State Senate,11,Ind,Tony Avella,10
+Queens,33005,State Senate,11,Ind,Tony Avella,5
+Queens,33006,State Senate,11,Ind,Tony Avella,14
+Queens,33007,State Senate,11,Ind,Tony Avella,17
+Queens,33008,State Senate,11,Ind,Tony Avella,5
+Queens,33009,State Senate,11,Ind,Tony Avella,9
+Queens,33010,State Senate,11,Ind,Tony Avella,3
+Queens,33011,State Senate,11,Ind,Tony Avella,4
+Queens,33012,State Senate,11,Ind,Tony Avella,7
+Queens,33013,State Senate,11,Ind,Tony Avella,4
+Queens,33014,State Senate,11,Ind,Tony Avella,5
+Queens,33015,State Senate,11,Ind,Tony Avella,3
+Queens,40001,State Senate,11,Ind,Tony Avella,4
+Queens,40002,State Senate,11,Ind,Tony Avella,11
+Queens,40003,State Senate,11,Ind,Tony Avella,3
+Queens,40004,State Senate,11,Ind,Tony Avella,9
+Queens,40005,State Senate,11,Ind,Tony Avella,4
+Queens,40006,State Senate,11,Ind,Tony Avella,6
+Queens,40007,State Senate,11,Ind,Tony Avella,11
+Queens,40008,State Senate,11,Ind,Tony Avella,11
+Queens,40009,State Senate,11,Ind,Tony Avella,5
+Queens,40010,State Senate,11,Ind,Tony Avella,0
+Queens,40013,State Senate,11,Ind,Tony Avella,3
+Queens,40014,State Senate,11,Ind,Tony Avella,9
+Queens,40015,State Senate,11,Ind,Tony Avella,2
+Queens,40028,State Senate,11,Ind,Tony Avella,2
+Queens,40047,State Senate,11,Ind,Tony Avella,10
+Queens,40048,State Senate,11,Ind,Tony Avella,3
+Queens,40049,State Senate,11,Ind,Tony Avella,2
+Queens,40050,State Senate,11,Ind,Tony Avella,1
+Queens,40051,State Senate,11,Ind,Tony Avella,4
+Queens,24001,State Senate,11,Ind,writein,0
+Queens,24002,State Senate,11,Ind,writein,1
+Queens,24003,State Senate,11,Ind,writein,0
+Queens,24004,State Senate,11,Ind,writein,0
+Queens,24005,State Senate,11,Ind,writein,1
+Queens,24006,State Senate,11,Ind,writein,0
+Queens,24007,State Senate,11,Ind,writein,0
+Queens,24010,State Senate,11,Ind,writein,0
+Queens,24011,State Senate,11,Ind,writein,0
+Queens,24012,State Senate,11,Ind,writein,0
+Queens,24017,State Senate,11,Ind,writein,1
+Queens,24018,State Senate,11,Ind,writein,0
+Queens,24019,State Senate,11,Ind,writein,0
+Queens,24020,State Senate,11,Ind,writein,0
+Queens,24021,State Senate,11,Ind,writein,1
+Queens,24022,State Senate,11,Ind,writein,1
+Queens,24024,State Senate,11,Ind,writein,0
+Queens,24025,State Senate,11,Ind,writein,0
+Queens,24028,State Senate,11,Ind,writein,0
+Queens,24032,State Senate,11,Ind,writein,0
+Queens,24033,State Senate,11,Ind,writein,0
+Queens,24034,State Senate,11,Ind,writein,0
+Queens,24035,State Senate,11,Ind,writein,0
+Queens,24036,State Senate,11,Ind,writein,0
+Queens,24038,State Senate,11,Ind,writein,0
+Queens,24042,State Senate,11,Ind,writein,0
+Queens,24050,State Senate,11,Ind,writein,0
+Queens,24051,State Senate,11,Ind,writein,1
+Queens,24052,State Senate,11,Ind,writein,0
+Queens,24053,State Senate,11,Ind,writein,2
+Queens,24054,State Senate,11,Ind,writein,0
+Queens,24055,State Senate,11,Ind,writein,0
+Queens,24057,State Senate,11,Ind,writein,0
+Queens,24067,State Senate,11,Ind,writein,0
+Queens,25010,State Senate,11,Ind,writein,0
+Queens,25011,State Senate,11,Ind,writein,0
+Queens,25012,State Senate,11,Ind,writein,0
+Queens,25013,State Senate,11,Ind,writein,3
+Queens,25014,State Senate,11,Ind,writein,1
+Queens,25015,State Senate,11,Ind,writein,0
+Queens,25016,State Senate,11,Ind,writein,0
+Queens,25017,State Senate,11,Ind,writein,0
+Queens,25018,State Senate,11,Ind,writein,0
+Queens,25019,State Senate,11,Ind,writein,1
+Queens,25026,State Senate,11,Ind,writein,0
+Queens,25027,State Senate,11,Ind,writein,1
+Queens,25028,State Senate,11,Ind,writein,0
+Queens,25029,State Senate,11,Ind,writein,1
+Queens,25030,State Senate,11,Ind,writein,1
+Queens,25031,State Senate,11,Ind,writein,1
+Queens,25032,State Senate,11,Ind,writein,0
+Queens,25033,State Senate,11,Ind,writein,0
+Queens,25035,State Senate,11,Ind,writein,0
+Queens,25036,State Senate,11,Ind,writein,0
+Queens,25037,State Senate,11,Ind,writein,0
+Queens,25038,State Senate,11,Ind,writein,0
+Queens,25039,State Senate,11,Ind,writein,0
+Queens,25040,State Senate,11,Ind,writein,0
+Queens,25041,State Senate,11,Ind,writein,1
+Queens,25065,State Senate,11,Ind,writein,0
+Queens,25066,State Senate,11,Ind,writein,0
+Queens,25067,State Senate,11,Ind,writein,0
+Queens,25068,State Senate,11,Ind,writein,0
+Queens,26001,State Senate,11,Ind,writein,0
+Queens,26002,State Senate,11,Ind,writein,0
+Queens,26003,State Senate,11,Ind,writein,0
+Queens,26004,State Senate,11,Ind,writein,1
+Queens,26005,State Senate,11,Ind,writein,0
+Queens,26006,State Senate,11,Ind,writein,0
+Queens,26007,State Senate,11,Ind,writein,0
+Queens,26008,State Senate,11,Ind,writein,0
+Queens,26009,State Senate,11,Ind,writein,0
+Queens,26010,State Senate,11,Ind,writein,2
+Queens,26011,State Senate,11,Ind,writein,0
+Queens,26012,State Senate,11,Ind,writein,0
+Queens,26013,State Senate,11,Ind,writein,0
+Queens,26014,State Senate,11,Ind,writein,0
+Queens,26015,State Senate,11,Ind,writein,0
+Queens,26016,State Senate,11,Ind,writein,1
+Queens,26017,State Senate,11,Ind,writein,0
+Queens,26018,State Senate,11,Ind,writein,0
+Queens,26019,State Senate,11,Ind,writein,0
+Queens,26020,State Senate,11,Ind,writein,0
+Queens,26021,State Senate,11,Ind,writein,0
+Queens,26022,State Senate,11,Ind,writein,0
+Queens,26023,State Senate,11,Ind,writein,0
+Queens,26024,State Senate,11,Ind,writein,0
+Queens,26025,State Senate,11,Ind,writein,0
+Queens,26026,State Senate,11,Ind,writein,0
+Queens,26027,State Senate,11,Ind,writein,0
+Queens,26028,State Senate,11,Ind,writein,1
+Queens,26029,State Senate,11,Ind,writein,0
+Queens,26030,State Senate,11,Ind,writein,0
+Queens,26031,State Senate,11,Ind,writein,0
+Queens,26032,State Senate,11,Ind,writein,0
+Queens,26033,State Senate,11,Ind,writein,1
+Queens,26034,State Senate,11,Ind,writein,0
+Queens,26035,State Senate,11,Ind,writein,0
+Queens,26036,State Senate,11,Ind,writein,0
+Queens,26037,State Senate,11,Ind,writein,1
+Queens,26042,State Senate,11,Ind,writein,0
+Queens,26043,State Senate,11,Ind,writein,0
+Queens,26045,State Senate,11,Ind,writein,1
+Queens,26046,State Senate,11,Ind,writein,0
+Queens,26047,State Senate,11,Ind,writein,0
+Queens,26048,State Senate,11,Ind,writein,0
+Queens,26049,State Senate,11,Ind,writein,0
+Queens,26050,State Senate,11,Ind,writein,0
+Queens,26051,State Senate,11,Ind,writein,1
+Queens,26052,State Senate,11,Ind,writein,0
+Queens,26053,State Senate,11,Ind,writein,1
+Queens,26054,State Senate,11,Ind,writein,0
+Queens,26055,State Senate,11,Ind,writein,2
+Queens,26056,State Senate,11,Ind,writein,0
+Queens,26057,State Senate,11,Ind,writein,1
+Queens,26058,State Senate,11,Ind,writein,0
+Queens,26059,State Senate,11,Ind,writein,0
+Queens,26060,State Senate,11,Ind,writein,0
+Queens,26061,State Senate,11,Ind,writein,0
+Queens,26062,State Senate,11,Ind,writein,0
+Queens,26063,State Senate,11,Ind,writein,0
+Queens,26064,State Senate,11,Ind,writein,0
+Queens,26065,State Senate,11,Ind,writein,0
+Queens,26066,State Senate,11,Ind,writein,1
+Queens,26067,State Senate,11,Ind,writein,0
+Queens,26068,State Senate,11,Ind,writein,0
+Queens,26069,State Senate,11,Ind,writein,0
+Queens,26070,State Senate,11,Ind,writein,1
+Queens,26071,State Senate,11,Ind,writein,0
+Queens,26072,State Senate,11,Ind,writein,0
+Queens,26073,State Senate,11,Ind,writein,0
+Queens,26074,State Senate,11,Ind,writein,0
+Queens,26076,State Senate,11,Ind,writein,0
+Queens,26077,State Senate,11,Ind,writein,0
+Queens,27010,State Senate,11,Ind,writein,0
+Queens,27033,State Senate,11,Ind,writein,0
+Queens,27060,State Senate,11,Ind,writein,0
+Queens,27061,State Senate,11,Ind,writein,1
+Queens,27062,State Senate,11,Ind,writein,0
+Queens,27063,State Senate,11,Ind,writein,1
+Queens,27064,State Senate,11,Ind,writein,0
+Queens,27065,State Senate,11,Ind,writein,1
+Queens,27066,State Senate,11,Ind,writein,0
+Queens,27067,State Senate,11,Ind,writein,0
+Queens,27068,State Senate,11,Ind,writein,0
+Queens,27069,State Senate,11,Ind,writein,0
+Queens,27070,State Senate,11,Ind,writein,1
+Queens,27071,State Senate,11,Ind,writein,1
+Queens,27072,State Senate,11,Ind,writein,0
+Queens,29004,State Senate,11,Ind,writein,0
+Queens,29005,State Senate,11,Ind,writein,0
+Queens,29007,State Senate,11,Ind,writein,0
+Queens,29009,State Senate,11,Ind,writein,0
+Queens,29010,State Senate,11,Ind,writein,0
+Queens,29011,State Senate,11,Ind,writein,0
+Queens,32002,State Senate,11,Ind,writein,0
+Queens,32007,State Senate,11,Ind,writein,0
+Queens,32008,State Senate,11,Ind,writein,0
+Queens,32009,State Senate,11,Ind,writein,0
+Queens,32010,State Senate,11,Ind,writein,0
+Queens,33001,State Senate,11,Ind,writein,0
+Queens,33002,State Senate,11,Ind,writein,0
+Queens,33003,State Senate,11,Ind,writein,0
+Queens,33004,State Senate,11,Ind,writein,0
+Queens,33005,State Senate,11,Ind,writein,0
+Queens,33006,State Senate,11,Ind,writein,0
+Queens,33007,State Senate,11,Ind,writein,0
+Queens,33008,State Senate,11,Ind,writein,0
+Queens,33009,State Senate,11,Ind,writein,0
+Queens,33010,State Senate,11,Ind,writein,0
+Queens,33011,State Senate,11,Ind,writein,1
+Queens,33012,State Senate,11,Ind,writein,0
+Queens,33013,State Senate,11,Ind,writein,0
+Queens,33014,State Senate,11,Ind,writein,0
+Queens,33015,State Senate,11,Ind,writein,0
+Queens,40001,State Senate,11,Ind,writein,0
+Queens,40002,State Senate,11,Ind,writein,1
+Queens,40003,State Senate,11,Ind,writein,0
+Queens,40004,State Senate,11,Ind,writein,0
+Queens,40005,State Senate,11,Ind,writein,0
+Queens,40006,State Senate,11,Ind,writein,0
+Queens,40007,State Senate,11,Ind,writein,0
+Queens,40008,State Senate,11,Ind,writein,0
+Queens,40009,State Senate,11,Ind,writein,2
+Queens,40010,State Senate,11,Ind,writein,0
+Queens,40013,State Senate,11,Ind,writein,0
+Queens,40014,State Senate,11,Ind,writein,3
+Queens,40015,State Senate,11,Ind,writein,0
+Queens,40028,State Senate,11,Ind,writein,0
+Queens,40047,State Senate,11,Ind,writein,0
+Queens,40048,State Senate,11,Ind,writein,1
+Queens,40049,State Senate,11,Ind,writein,0
+Queens,40050,State Senate,11,Ind,writein,0
+Queens,40051,State Senate,11,Ind,writein,0
+Queens,23066,State Senate,12,Rep,Aurelio Arcabas,39
+Queens,23067,State Senate,12,Rep,Aurelio Arcabas,26
+Queens,30038,State Senate,12,Rep,Aurelio Arcabas,13
+Queens,30039,State Senate,12,Rep,Aurelio Arcabas,143
+Queens,30040,State Senate,12,Rep,Aurelio Arcabas,96
+Queens,30041,State Senate,12,Rep,Aurelio Arcabas,19
+Queens,30042,State Senate,12,Rep,Aurelio Arcabas,50
+Queens,30043,State Senate,12,Rep,Aurelio Arcabas,106
+Queens,30044,State Senate,12,Rep,Aurelio Arcabas,94
+Queens,30045,State Senate,12,Rep,Aurelio Arcabas,92
+Queens,30046,State Senate,12,Rep,Aurelio Arcabas,63
+Queens,30047,State Senate,12,Rep,Aurelio Arcabas,55
+Queens,30048,State Senate,12,Rep,Aurelio Arcabas,97
+Queens,30049,State Senate,12,Rep,Aurelio Arcabas,112
+Queens,30050,State Senate,12,Rep,Aurelio Arcabas,103
+Queens,30051,State Senate,12,Rep,Aurelio Arcabas,90
+Queens,30052,State Senate,12,Rep,Aurelio Arcabas,70
+Queens,30053,State Senate,12,Rep,Aurelio Arcabas,49
+Queens,30060,State Senate,12,Rep,Aurelio Arcabas,96
+Queens,30061,State Senate,12,Rep,Aurelio Arcabas,102
+Queens,30062,State Senate,12,Rep,Aurelio Arcabas,30
+Queens,30063,State Senate,12,Rep,Aurelio Arcabas,36
+Queens,30064,State Senate,12,Rep,Aurelio Arcabas,59
+Queens,30065,State Senate,12,Rep,Aurelio Arcabas,116
+Queens,30066,State Senate,12,Rep,Aurelio Arcabas,74
+Queens,30067,State Senate,12,Rep,Aurelio Arcabas,55
+Queens,30068,State Senate,12,Rep,Aurelio Arcabas,27
+Queens,30069,State Senate,12,Rep,Aurelio Arcabas,80
+Queens,30070,State Senate,12,Rep,Aurelio Arcabas,43
+Queens,30071,State Senate,12,Rep,Aurelio Arcabas,39
+Queens,34047,State Senate,12,Rep,Aurelio Arcabas,0
+Queens,34048,State Senate,12,Rep,Aurelio Arcabas,38
+Queens,34049,State Senate,12,Rep,Aurelio Arcabas,56
+Queens,34050,State Senate,12,Rep,Aurelio Arcabas,55
+Queens,34051,State Senate,12,Rep,Aurelio Arcabas,64
+Queens,34052,State Senate,12,Rep,Aurelio Arcabas,56
+Queens,34053,State Senate,12,Rep,Aurelio Arcabas,2
+Queens,34055,State Senate,12,Rep,Aurelio Arcabas,4
+Queens,34059,State Senate,12,Rep,Aurelio Arcabas,0
+Queens,34060,State Senate,12,Rep,Aurelio Arcabas,56
+Queens,36001,State Senate,12,Rep,Aurelio Arcabas,96
+Queens,36002,State Senate,12,Rep,Aurelio Arcabas,67
+Queens,36003,State Senate,12,Rep,Aurelio Arcabas,63
+Queens,36004,State Senate,12,Rep,Aurelio Arcabas,114
+Queens,36005,State Senate,12,Rep,Aurelio Arcabas,78
+Queens,36006,State Senate,12,Rep,Aurelio Arcabas,70
+Queens,36007,State Senate,12,Rep,Aurelio Arcabas,113
+Queens,36008,State Senate,12,Rep,Aurelio Arcabas,84
+Queens,36009,State Senate,12,Rep,Aurelio Arcabas,71
+Queens,36010,State Senate,12,Rep,Aurelio Arcabas,70
+Queens,36011,State Senate,12,Rep,Aurelio Arcabas,57
+Queens,36012,State Senate,12,Rep,Aurelio Arcabas,79
+Queens,36013,State Senate,12,Rep,Aurelio Arcabas,85
+Queens,36014,State Senate,12,Rep,Aurelio Arcabas,65
+Queens,36015,State Senate,12,Rep,Aurelio Arcabas,63
+Queens,36016,State Senate,12,Rep,Aurelio Arcabas,75
+Queens,36017,State Senate,12,Rep,Aurelio Arcabas,71
+Queens,36018,State Senate,12,Rep,Aurelio Arcabas,67
+Queens,36019,State Senate,12,Rep,Aurelio Arcabas,43
+Queens,36020,State Senate,12,Rep,Aurelio Arcabas,67
+Queens,36021,State Senate,12,Rep,Aurelio Arcabas,42
+Queens,36022,State Senate,12,Rep,Aurelio Arcabas,74
+Queens,36023,State Senate,12,Rep,Aurelio Arcabas,75
+Queens,36024,State Senate,12,Rep,Aurelio Arcabas,41
+Queens,36025,State Senate,12,Rep,Aurelio Arcabas,36
+Queens,36026,State Senate,12,Rep,Aurelio Arcabas,60
+Queens,36028,State Senate,12,Rep,Aurelio Arcabas,99
+Queens,36029,State Senate,12,Rep,Aurelio Arcabas,124
+Queens,36030,State Senate,12,Rep,Aurelio Arcabas,90
+Queens,36031,State Senate,12,Rep,Aurelio Arcabas,56
+Queens,36032,State Senate,12,Rep,Aurelio Arcabas,51
+Queens,36033,State Senate,12,Rep,Aurelio Arcabas,75
+Queens,36034,State Senate,12,Rep,Aurelio Arcabas,70
+Queens,36035,State Senate,12,Rep,Aurelio Arcabas,77
+Queens,36036,State Senate,12,Rep,Aurelio Arcabas,71
+Queens,36037,State Senate,12,Rep,Aurelio Arcabas,52
+Queens,36038,State Senate,12,Rep,Aurelio Arcabas,72
+Queens,36039,State Senate,12,Rep,Aurelio Arcabas,69
+Queens,36040,State Senate,12,Rep,Aurelio Arcabas,69
+Queens,36041,State Senate,12,Rep,Aurelio Arcabas,71
+Queens,36042,State Senate,12,Rep,Aurelio Arcabas,56
+Queens,36043,State Senate,12,Rep,Aurelio Arcabas,18
+Queens,36064,State Senate,12,Rep,Aurelio Arcabas,52
+Queens,36065,State Senate,12,Rep,Aurelio Arcabas,18
+Queens,37001,State Senate,12,Rep,Aurelio Arcabas,73
+Queens,37002,State Senate,12,Rep,Aurelio Arcabas,11
+Queens,37003,State Senate,12,Rep,Aurelio Arcabas,6
+Queens,37004,State Senate,12,Rep,Aurelio Arcabas,2
+Queens,37005,State Senate,12,Rep,Aurelio Arcabas,42
+Queens,37006,State Senate,12,Rep,Aurelio Arcabas,33
+Queens,37007,State Senate,12,Rep,Aurelio Arcabas,16
+Queens,37008,State Senate,12,Rep,Aurelio Arcabas,12
+Queens,37009,State Senate,12,Rep,Aurelio Arcabas,12
+Queens,37010,State Senate,12,Rep,Aurelio Arcabas,34
+Queens,37011,State Senate,12,Rep,Aurelio Arcabas,48
+Queens,37012,State Senate,12,Rep,Aurelio Arcabas,6
+Queens,37013,State Senate,12,Rep,Aurelio Arcabas,6
+Queens,37014,State Senate,12,Rep,Aurelio Arcabas,5
+Queens,37015,State Senate,12,Rep,Aurelio Arcabas,8
+Queens,37016,State Senate,12,Rep,Aurelio Arcabas,8
+Queens,37017,State Senate,12,Rep,Aurelio Arcabas,4
+Queens,37018,State Senate,12,Rep,Aurelio Arcabas,6
+Queens,37019,State Senate,12,Rep,Aurelio Arcabas,94
+Queens,37020,State Senate,12,Rep,Aurelio Arcabas,129
+Queens,37021,State Senate,12,Rep,Aurelio Arcabas,133
+Queens,37022,State Senate,12,Rep,Aurelio Arcabas,105
+Queens,37023,State Senate,12,Rep,Aurelio Arcabas,5
+Queens,37024,State Senate,12,Rep,Aurelio Arcabas,61
+Queens,37025,State Senate,12,Rep,Aurelio Arcabas,9
+Queens,37026,State Senate,12,Rep,Aurelio Arcabas,1
+Queens,37027,State Senate,12,Rep,Aurelio Arcabas,85
+Queens,37028,State Senate,12,Rep,Aurelio Arcabas,64
+Queens,37029,State Senate,12,Rep,Aurelio Arcabas,75
+Queens,37030,State Senate,12,Rep,Aurelio Arcabas,57
+Queens,37031,State Senate,12,Rep,Aurelio Arcabas,88
+Queens,37032,State Senate,12,Rep,Aurelio Arcabas,31
+Queens,37033,State Senate,12,Rep,Aurelio Arcabas,25
+Queens,37034,State Senate,12,Rep,Aurelio Arcabas,35
+Queens,37035,State Senate,12,Rep,Aurelio Arcabas,43
+Queens,37036,State Senate,12,Rep,Aurelio Arcabas,42
+Queens,37037,State Senate,12,Rep,Aurelio Arcabas,76
+Queens,37038,State Senate,12,Rep,Aurelio Arcabas,74
+Queens,37039,State Senate,12,Rep,Aurelio Arcabas,71
+Queens,37041,State Senate,12,Rep,Aurelio Arcabas,18
+Queens,37051,State Senate,12,Rep,Aurelio Arcabas,1
+Queens,37055,State Senate,12,Rep,Aurelio Arcabas,0
+Queens,37056,State Senate,12,Rep,Aurelio Arcabas,35
+Queens,37057,State Senate,12,Rep,Aurelio Arcabas,56
+Queens,37058,State Senate,12,Rep,Aurelio Arcabas,45
+Queens,37059,State Senate,12,Rep,Aurelio Arcabas,47
+Queens,37063,State Senate,12,Rep,Aurelio Arcabas,89
+Queens,37064,State Senate,12,Rep,Aurelio Arcabas,95
+Queens,37065,State Senate,12,Rep,Aurelio Arcabas,76
+Queens,37067,State Senate,12,Rep,Aurelio Arcabas,72
+Queens,37068,State Senate,12,Rep,Aurelio Arcabas,82
+Queens,38001,State Senate,12,Rep,Aurelio Arcabas,32
+Queens,38002,State Senate,12,Rep,Aurelio Arcabas,32
+Queens,38003,State Senate,12,Rep,Aurelio Arcabas,40
+Queens,38004,State Senate,12,Rep,Aurelio Arcabas,34
+Queens,38005,State Senate,12,Rep,Aurelio Arcabas,21
+Queens,38006,State Senate,12,Rep,Aurelio Arcabas,44
+Queens,38007,State Senate,12,Rep,Aurelio Arcabas,17
+Queens,38008,State Senate,12,Rep,Aurelio Arcabas,32
+Queens,38009,State Senate,12,Rep,Aurelio Arcabas,74
+Queens,38010,State Senate,12,Rep,Aurelio Arcabas,79
+Queens,38011,State Senate,12,Rep,Aurelio Arcabas,0
+Queens,38012,State Senate,12,Rep,Aurelio Arcabas,82
+Queens,38013,State Senate,12,Rep,Aurelio Arcabas,68
+Queens,38022,State Senate,12,Rep,Aurelio Arcabas,172
+Queens,38023,State Senate,12,Rep,Aurelio Arcabas,56
+Queens,38024,State Senate,12,Rep,Aurelio Arcabas,34
+Queens,38025,State Senate,12,Rep,Aurelio Arcabas,49
+Queens,38026,State Senate,12,Rep,Aurelio Arcabas,53
+Queens,38027,State Senate,12,Rep,Aurelio Arcabas,22
+Queens,38029,State Senate,12,Rep,Aurelio Arcabas,35
+Queens,38053,State Senate,12,Rep,Aurelio Arcabas,25
+Queens,39032,State Senate,12,Rep,Aurelio Arcabas,36
+Queens,39033,State Senate,12,Rep,Aurelio Arcabas,63
+Queens,23066,State Senate,12,Con,Aurelio Arcabas,5
+Queens,23067,State Senate,12,Con,Aurelio Arcabas,3
+Queens,30038,State Senate,12,Con,Aurelio Arcabas,2
+Queens,30039,State Senate,12,Con,Aurelio Arcabas,20
+Queens,30040,State Senate,12,Con,Aurelio Arcabas,14
+Queens,30041,State Senate,12,Con,Aurelio Arcabas,5
+Queens,30042,State Senate,12,Con,Aurelio Arcabas,10
+Queens,30043,State Senate,12,Con,Aurelio Arcabas,10
+Queens,30044,State Senate,12,Con,Aurelio Arcabas,8
+Queens,30045,State Senate,12,Con,Aurelio Arcabas,7
+Queens,30046,State Senate,12,Con,Aurelio Arcabas,6
+Queens,30047,State Senate,12,Con,Aurelio Arcabas,4
+Queens,30048,State Senate,12,Con,Aurelio Arcabas,17
+Queens,30049,State Senate,12,Con,Aurelio Arcabas,23
+Queens,30050,State Senate,12,Con,Aurelio Arcabas,14
+Queens,30051,State Senate,12,Con,Aurelio Arcabas,12
+Queens,30052,State Senate,12,Con,Aurelio Arcabas,7
+Queens,30053,State Senate,12,Con,Aurelio Arcabas,8
+Queens,30060,State Senate,12,Con,Aurelio Arcabas,9
+Queens,30061,State Senate,12,Con,Aurelio Arcabas,11
+Queens,30062,State Senate,12,Con,Aurelio Arcabas,5
+Queens,30063,State Senate,12,Con,Aurelio Arcabas,5
+Queens,30064,State Senate,12,Con,Aurelio Arcabas,5
+Queens,30065,State Senate,12,Con,Aurelio Arcabas,6
+Queens,30066,State Senate,12,Con,Aurelio Arcabas,6
+Queens,30067,State Senate,12,Con,Aurelio Arcabas,8
+Queens,30068,State Senate,12,Con,Aurelio Arcabas,4
+Queens,30069,State Senate,12,Con,Aurelio Arcabas,7
+Queens,30070,State Senate,12,Con,Aurelio Arcabas,5
+Queens,30071,State Senate,12,Con,Aurelio Arcabas,4
+Queens,34047,State Senate,12,Con,Aurelio Arcabas,0
+Queens,34048,State Senate,12,Con,Aurelio Arcabas,4
+Queens,34049,State Senate,12,Con,Aurelio Arcabas,4
+Queens,34050,State Senate,12,Con,Aurelio Arcabas,7
+Queens,34051,State Senate,12,Con,Aurelio Arcabas,5
+Queens,34052,State Senate,12,Con,Aurelio Arcabas,10
+Queens,34053,State Senate,12,Con,Aurelio Arcabas,1
+Queens,34055,State Senate,12,Con,Aurelio Arcabas,2
+Queens,34059,State Senate,12,Con,Aurelio Arcabas,0
+Queens,34060,State Senate,12,Con,Aurelio Arcabas,1
+Queens,36001,State Senate,12,Con,Aurelio Arcabas,9
+Queens,36002,State Senate,12,Con,Aurelio Arcabas,10
+Queens,36003,State Senate,12,Con,Aurelio Arcabas,5
+Queens,36004,State Senate,12,Con,Aurelio Arcabas,6
+Queens,36005,State Senate,12,Con,Aurelio Arcabas,8
+Queens,36006,State Senate,12,Con,Aurelio Arcabas,4
+Queens,36007,State Senate,12,Con,Aurelio Arcabas,12
+Queens,36008,State Senate,12,Con,Aurelio Arcabas,6
+Queens,36009,State Senate,12,Con,Aurelio Arcabas,4
+Queens,36010,State Senate,12,Con,Aurelio Arcabas,11
+Queens,36011,State Senate,12,Con,Aurelio Arcabas,6
+Queens,36012,State Senate,12,Con,Aurelio Arcabas,6
+Queens,36013,State Senate,12,Con,Aurelio Arcabas,11
+Queens,36014,State Senate,12,Con,Aurelio Arcabas,6
+Queens,36015,State Senate,12,Con,Aurelio Arcabas,10
+Queens,36016,State Senate,12,Con,Aurelio Arcabas,5
+Queens,36017,State Senate,12,Con,Aurelio Arcabas,6
+Queens,36018,State Senate,12,Con,Aurelio Arcabas,5
+Queens,36019,State Senate,12,Con,Aurelio Arcabas,5
+Queens,36020,State Senate,12,Con,Aurelio Arcabas,6
+Queens,36021,State Senate,12,Con,Aurelio Arcabas,1
+Queens,36022,State Senate,12,Con,Aurelio Arcabas,8
+Queens,36023,State Senate,12,Con,Aurelio Arcabas,9
+Queens,36024,State Senate,12,Con,Aurelio Arcabas,5
+Queens,36025,State Senate,12,Con,Aurelio Arcabas,8
+Queens,36026,State Senate,12,Con,Aurelio Arcabas,3
+Queens,36028,State Senate,12,Con,Aurelio Arcabas,15
+Queens,36029,State Senate,12,Con,Aurelio Arcabas,11
+Queens,36030,State Senate,12,Con,Aurelio Arcabas,4
+Queens,36031,State Senate,12,Con,Aurelio Arcabas,11
+Queens,36032,State Senate,12,Con,Aurelio Arcabas,7
+Queens,36033,State Senate,12,Con,Aurelio Arcabas,11
+Queens,36034,State Senate,12,Con,Aurelio Arcabas,4
+Queens,36035,State Senate,12,Con,Aurelio Arcabas,5
+Queens,36036,State Senate,12,Con,Aurelio Arcabas,6
+Queens,36037,State Senate,12,Con,Aurelio Arcabas,6
+Queens,36038,State Senate,12,Con,Aurelio Arcabas,7
+Queens,36039,State Senate,12,Con,Aurelio Arcabas,5
+Queens,36040,State Senate,12,Con,Aurelio Arcabas,4
+Queens,36041,State Senate,12,Con,Aurelio Arcabas,6
+Queens,36042,State Senate,12,Con,Aurelio Arcabas,9
+Queens,36043,State Senate,12,Con,Aurelio Arcabas,1
+Queens,36064,State Senate,12,Con,Aurelio Arcabas,2
+Queens,36065,State Senate,12,Con,Aurelio Arcabas,0
+Queens,37001,State Senate,12,Con,Aurelio Arcabas,15
+Queens,37002,State Senate,12,Con,Aurelio Arcabas,1
+Queens,37003,State Senate,12,Con,Aurelio Arcabas,1
+Queens,37004,State Senate,12,Con,Aurelio Arcabas,0
+Queens,37005,State Senate,12,Con,Aurelio Arcabas,7
+Queens,37006,State Senate,12,Con,Aurelio Arcabas,7
+Queens,37007,State Senate,12,Con,Aurelio Arcabas,0
+Queens,37008,State Senate,12,Con,Aurelio Arcabas,1
+Queens,37009,State Senate,12,Con,Aurelio Arcabas,3
+Queens,37010,State Senate,12,Con,Aurelio Arcabas,3
+Queens,37011,State Senate,12,Con,Aurelio Arcabas,9
+Queens,37012,State Senate,12,Con,Aurelio Arcabas,0
+Queens,37013,State Senate,12,Con,Aurelio Arcabas,2
+Queens,37014,State Senate,12,Con,Aurelio Arcabas,1
+Queens,37015,State Senate,12,Con,Aurelio Arcabas,1
+Queens,37016,State Senate,12,Con,Aurelio Arcabas,2
+Queens,37017,State Senate,12,Con,Aurelio Arcabas,0
+Queens,37018,State Senate,12,Con,Aurelio Arcabas,2
+Queens,37019,State Senate,12,Con,Aurelio Arcabas,7
+Queens,37020,State Senate,12,Con,Aurelio Arcabas,5
+Queens,37021,State Senate,12,Con,Aurelio Arcabas,10
+Queens,37022,State Senate,12,Con,Aurelio Arcabas,5
+Queens,37023,State Senate,12,Con,Aurelio Arcabas,0
+Queens,37024,State Senate,12,Con,Aurelio Arcabas,4
+Queens,37025,State Senate,12,Con,Aurelio Arcabas,1
+Queens,37026,State Senate,12,Con,Aurelio Arcabas,0
+Queens,37027,State Senate,12,Con,Aurelio Arcabas,8
+Queens,37028,State Senate,12,Con,Aurelio Arcabas,0
+Queens,37029,State Senate,12,Con,Aurelio Arcabas,5
+Queens,37030,State Senate,12,Con,Aurelio Arcabas,11
+Queens,37031,State Senate,12,Con,Aurelio Arcabas,6
+Queens,37032,State Senate,12,Con,Aurelio Arcabas,2
+Queens,37033,State Senate,12,Con,Aurelio Arcabas,6
+Queens,37034,State Senate,12,Con,Aurelio Arcabas,4
+Queens,37035,State Senate,12,Con,Aurelio Arcabas,7
+Queens,37036,State Senate,12,Con,Aurelio Arcabas,2
+Queens,37037,State Senate,12,Con,Aurelio Arcabas,11
+Queens,37038,State Senate,12,Con,Aurelio Arcabas,7
+Queens,37039,State Senate,12,Con,Aurelio Arcabas,5
+Queens,37041,State Senate,12,Con,Aurelio Arcabas,2
+Queens,37051,State Senate,12,Con,Aurelio Arcabas,0
+Queens,37055,State Senate,12,Con,Aurelio Arcabas,0
+Queens,37056,State Senate,12,Con,Aurelio Arcabas,5
+Queens,37057,State Senate,12,Con,Aurelio Arcabas,10
+Queens,37058,State Senate,12,Con,Aurelio Arcabas,10
+Queens,37059,State Senate,12,Con,Aurelio Arcabas,9
+Queens,37063,State Senate,12,Con,Aurelio Arcabas,11
+Queens,37064,State Senate,12,Con,Aurelio Arcabas,9
+Queens,37065,State Senate,12,Con,Aurelio Arcabas,7
+Queens,37067,State Senate,12,Con,Aurelio Arcabas,10
+Queens,37068,State Senate,12,Con,Aurelio Arcabas,8
+Queens,38001,State Senate,12,Con,Aurelio Arcabas,7
+Queens,38002,State Senate,12,Con,Aurelio Arcabas,5
+Queens,38003,State Senate,12,Con,Aurelio Arcabas,6
+Queens,38004,State Senate,12,Con,Aurelio Arcabas,10
+Queens,38005,State Senate,12,Con,Aurelio Arcabas,5
+Queens,38006,State Senate,12,Con,Aurelio Arcabas,12
+Queens,38007,State Senate,12,Con,Aurelio Arcabas,3
+Queens,38008,State Senate,12,Con,Aurelio Arcabas,9
+Queens,38009,State Senate,12,Con,Aurelio Arcabas,15
+Queens,38010,State Senate,12,Con,Aurelio Arcabas,14
+Queens,38011,State Senate,12,Con,Aurelio Arcabas,0
+Queens,38012,State Senate,12,Con,Aurelio Arcabas,10
+Queens,38013,State Senate,12,Con,Aurelio Arcabas,3
+Queens,38022,State Senate,12,Con,Aurelio Arcabas,28
+Queens,38023,State Senate,12,Con,Aurelio Arcabas,9
+Queens,38024,State Senate,12,Con,Aurelio Arcabas,9
+Queens,38025,State Senate,12,Con,Aurelio Arcabas,13
+Queens,38026,State Senate,12,Con,Aurelio Arcabas,8
+Queens,38027,State Senate,12,Con,Aurelio Arcabas,3
+Queens,38029,State Senate,12,Con,Aurelio Arcabas,5
+Queens,38053,State Senate,12,Con,Aurelio Arcabas,4
+Queens,39032,State Senate,12,Con,Aurelio Arcabas,0
+Queens,39033,State Senate,12,Con,Aurelio Arcabas,10
+Queens,23066,State Senate,12,Dem,Michael Gianaris,247
+Queens,23067,State Senate,12,Dem,Michael Gianaris,237
+Queens,30038,State Senate,12,Dem,Michael Gianaris,69
+Queens,30039,State Senate,12,Dem,Michael Gianaris,447
+Queens,30040,State Senate,12,Dem,Michael Gianaris,332
+Queens,30041,State Senate,12,Dem,Michael Gianaris,138
+Queens,30042,State Senate,12,Dem,Michael Gianaris,276
+Queens,30043,State Senate,12,Dem,Michael Gianaris,418
+Queens,30044,State Senate,12,Dem,Michael Gianaris,478
+Queens,30045,State Senate,12,Dem,Michael Gianaris,457
+Queens,30046,State Senate,12,Dem,Michael Gianaris,493
+Queens,30047,State Senate,12,Dem,Michael Gianaris,274
+Queens,30048,State Senate,12,Dem,Michael Gianaris,288
+Queens,30049,State Senate,12,Dem,Michael Gianaris,475
+Queens,30050,State Senate,12,Dem,Michael Gianaris,469
+Queens,30051,State Senate,12,Dem,Michael Gianaris,384
+Queens,30052,State Senate,12,Dem,Michael Gianaris,357
+Queens,30053,State Senate,12,Dem,Michael Gianaris,204
+Queens,30060,State Senate,12,Dem,Michael Gianaris,356
+Queens,30061,State Senate,12,Dem,Michael Gianaris,485
+Queens,30062,State Senate,12,Dem,Michael Gianaris,229
+Queens,30063,State Senate,12,Dem,Michael Gianaris,205
+Queens,30064,State Senate,12,Dem,Michael Gianaris,353
+Queens,30065,State Senate,12,Dem,Michael Gianaris,479
+Queens,30066,State Senate,12,Dem,Michael Gianaris,473
+Queens,30067,State Senate,12,Dem,Michael Gianaris,567
+Queens,30068,State Senate,12,Dem,Michael Gianaris,335
+Queens,30069,State Senate,12,Dem,Michael Gianaris,474
+Queens,30070,State Senate,12,Dem,Michael Gianaris,408
+Queens,30071,State Senate,12,Dem,Michael Gianaris,247
+Queens,34047,State Senate,12,Dem,Michael Gianaris,28
+Queens,34048,State Senate,12,Dem,Michael Gianaris,138
+Queens,34049,State Senate,12,Dem,Michael Gianaris,457
+Queens,34050,State Senate,12,Dem,Michael Gianaris,364
+Queens,34051,State Senate,12,Dem,Michael Gianaris,435
+Queens,34052,State Senate,12,Dem,Michael Gianaris,238
+Queens,34053,State Senate,12,Dem,Michael Gianaris,23
+Queens,34055,State Senate,12,Dem,Michael Gianaris,11
+Queens,34059,State Senate,12,Dem,Michael Gianaris,22
+Queens,34060,State Senate,12,Dem,Michael Gianaris,267
+Queens,36001,State Senate,12,Dem,Michael Gianaris,523
+Queens,36002,State Senate,12,Dem,Michael Gianaris,444
+Queens,36003,State Senate,12,Dem,Michael Gianaris,459
+Queens,36004,State Senate,12,Dem,Michael Gianaris,548
+Queens,36005,State Senate,12,Dem,Michael Gianaris,454
+Queens,36006,State Senate,12,Dem,Michael Gianaris,453
+Queens,36007,State Senate,12,Dem,Michael Gianaris,561
+Queens,36008,State Senate,12,Dem,Michael Gianaris,556
+Queens,36009,State Senate,12,Dem,Michael Gianaris,503
+Queens,36010,State Senate,12,Dem,Michael Gianaris,478
+Queens,36011,State Senate,12,Dem,Michael Gianaris,497
+Queens,36012,State Senate,12,Dem,Michael Gianaris,510
+Queens,36013,State Senate,12,Dem,Michael Gianaris,602
+Queens,36014,State Senate,12,Dem,Michael Gianaris,409
+Queens,36015,State Senate,12,Dem,Michael Gianaris,480
+Queens,36016,State Senate,12,Dem,Michael Gianaris,523
+Queens,36017,State Senate,12,Dem,Michael Gianaris,456
+Queens,36018,State Senate,12,Dem,Michael Gianaris,410
+Queens,36019,State Senate,12,Dem,Michael Gianaris,472
+Queens,36020,State Senate,12,Dem,Michael Gianaris,535
+Queens,36021,State Senate,12,Dem,Michael Gianaris,555
+Queens,36022,State Senate,12,Dem,Michael Gianaris,475
+Queens,36023,State Senate,12,Dem,Michael Gianaris,511
+Queens,36024,State Senate,12,Dem,Michael Gianaris,455
+Queens,36025,State Senate,12,Dem,Michael Gianaris,310
+Queens,36026,State Senate,12,Dem,Michael Gianaris,304
+Queens,36028,State Senate,12,Dem,Michael Gianaris,473
+Queens,36029,State Senate,12,Dem,Michael Gianaris,469
+Queens,36030,State Senate,12,Dem,Michael Gianaris,456
+Queens,36031,State Senate,12,Dem,Michael Gianaris,396
+Queens,36032,State Senate,12,Dem,Michael Gianaris,375
+Queens,36033,State Senate,12,Dem,Michael Gianaris,528
+Queens,36034,State Senate,12,Dem,Michael Gianaris,402
+Queens,36035,State Senate,12,Dem,Michael Gianaris,486
+Queens,36036,State Senate,12,Dem,Michael Gianaris,478
+Queens,36037,State Senate,12,Dem,Michael Gianaris,475
+Queens,36038,State Senate,12,Dem,Michael Gianaris,413
+Queens,36039,State Senate,12,Dem,Michael Gianaris,520
+Queens,36040,State Senate,12,Dem,Michael Gianaris,461
+Queens,36041,State Senate,12,Dem,Michael Gianaris,497
+Queens,36042,State Senate,12,Dem,Michael Gianaris,437
+Queens,36043,State Senate,12,Dem,Michael Gianaris,91
+Queens,36064,State Senate,12,Dem,Michael Gianaris,393
+Queens,36065,State Senate,12,Dem,Michael Gianaris,135
+Queens,37001,State Senate,12,Dem,Michael Gianaris,509
+Queens,37002,State Senate,12,Dem,Michael Gianaris,564
+Queens,37003,State Senate,12,Dem,Michael Gianaris,418
+Queens,37004,State Senate,12,Dem,Michael Gianaris,245
+Queens,37005,State Senate,12,Dem,Michael Gianaris,333
+Queens,37006,State Senate,12,Dem,Michael Gianaris,299
+Queens,37007,State Senate,12,Dem,Michael Gianaris,310
+Queens,37008,State Senate,12,Dem,Michael Gianaris,474
+Queens,37009,State Senate,12,Dem,Michael Gianaris,379
+Queens,37010,State Senate,12,Dem,Michael Gianaris,520
+Queens,37011,State Senate,12,Dem,Michael Gianaris,419
+Queens,37012,State Senate,12,Dem,Michael Gianaris,350
+Queens,37013,State Senate,12,Dem,Michael Gianaris,336
+Queens,37014,State Senate,12,Dem,Michael Gianaris,370
+Queens,37015,State Senate,12,Dem,Michael Gianaris,359
+Queens,37016,State Senate,12,Dem,Michael Gianaris,359
+Queens,37017,State Senate,12,Dem,Michael Gianaris,436
+Queens,37018,State Senate,12,Dem,Michael Gianaris,74
+Queens,37019,State Senate,12,Dem,Michael Gianaris,729
+Queens,37020,State Senate,12,Dem,Michael Gianaris,481
+Queens,37021,State Senate,12,Dem,Michael Gianaris,643
+Queens,37022,State Senate,12,Dem,Michael Gianaris,625
+Queens,37023,State Senate,12,Dem,Michael Gianaris,43
+Queens,37024,State Senate,12,Dem,Michael Gianaris,363
+Queens,37025,State Senate,12,Dem,Michael Gianaris,63
+Queens,37026,State Senate,12,Dem,Michael Gianaris,13
+Queens,37027,State Senate,12,Dem,Michael Gianaris,556
+Queens,37028,State Senate,12,Dem,Michael Gianaris,487
+Queens,37029,State Senate,12,Dem,Michael Gianaris,497
+Queens,37030,State Senate,12,Dem,Michael Gianaris,402
+Queens,37031,State Senate,12,Dem,Michael Gianaris,566
+Queens,37032,State Senate,12,Dem,Michael Gianaris,209
+Queens,37033,State Senate,12,Dem,Michael Gianaris,392
+Queens,37034,State Senate,12,Dem,Michael Gianaris,332
+Queens,37035,State Senate,12,Dem,Michael Gianaris,452
+Queens,37036,State Senate,12,Dem,Michael Gianaris,491
+Queens,37037,State Senate,12,Dem,Michael Gianaris,548
+Queens,37038,State Senate,12,Dem,Michael Gianaris,497
+Queens,37039,State Senate,12,Dem,Michael Gianaris,467
+Queens,37041,State Senate,12,Dem,Michael Gianaris,87
+Queens,37051,State Senate,12,Dem,Michael Gianaris,16
+Queens,37055,State Senate,12,Dem,Michael Gianaris,2
+Queens,37056,State Senate,12,Dem,Michael Gianaris,316
+Queens,37057,State Senate,12,Dem,Michael Gianaris,316
+Queens,37058,State Senate,12,Dem,Michael Gianaris,305
+Queens,37059,State Senate,12,Dem,Michael Gianaris,336
+Queens,37063,State Senate,12,Dem,Michael Gianaris,506
+Queens,37064,State Senate,12,Dem,Michael Gianaris,456
+Queens,37065,State Senate,12,Dem,Michael Gianaris,389
+Queens,37067,State Senate,12,Dem,Michael Gianaris,303
+Queens,37068,State Senate,12,Dem,Michael Gianaris,305
+Queens,38001,State Senate,12,Dem,Michael Gianaris,360
+Queens,38002,State Senate,12,Dem,Michael Gianaris,380
+Queens,38003,State Senate,12,Dem,Michael Gianaris,372
+Queens,38004,State Senate,12,Dem,Michael Gianaris,337
+Queens,38005,State Senate,12,Dem,Michael Gianaris,392
+Queens,38006,State Senate,12,Dem,Michael Gianaris,391
+Queens,38007,State Senate,12,Dem,Michael Gianaris,215
+Queens,38008,State Senate,12,Dem,Michael Gianaris,252
+Queens,38009,State Senate,12,Dem,Michael Gianaris,379
+Queens,38010,State Senate,12,Dem,Michael Gianaris,318
+Queens,38011,State Senate,12,Dem,Michael Gianaris,4
+Queens,38012,State Senate,12,Dem,Michael Gianaris,205
+Queens,38013,State Senate,12,Dem,Michael Gianaris,176
+Queens,38022,State Senate,12,Dem,Michael Gianaris,391
+Queens,38023,State Senate,12,Dem,Michael Gianaris,368
+Queens,38024,State Senate,12,Dem,Michael Gianaris,397
+Queens,38025,State Senate,12,Dem,Michael Gianaris,374
+Queens,38026,State Senate,12,Dem,Michael Gianaris,362
+Queens,38027,State Senate,12,Dem,Michael Gianaris,265
+Queens,38029,State Senate,12,Dem,Michael Gianaris,457
+Queens,38053,State Senate,12,Dem,Michael Gianaris,117
+Queens,39032,State Senate,12,Dem,Michael Gianaris,186
+Queens,39033,State Senate,12,Dem,Michael Gianaris,326
+Queens,23066,State Senate,12,WF,Michael Gianaris,0
+Queens,23067,State Senate,12,WF,Michael Gianaris,1
+Queens,30038,State Senate,12,WF,Michael Gianaris,2
+Queens,30039,State Senate,12,WF,Michael Gianaris,19
+Queens,30040,State Senate,12,WF,Michael Gianaris,12
+Queens,30041,State Senate,12,WF,Michael Gianaris,4
+Queens,30042,State Senate,12,WF,Michael Gianaris,14
+Queens,30043,State Senate,12,WF,Michael Gianaris,26
+Queens,30044,State Senate,12,WF,Michael Gianaris,26
+Queens,30045,State Senate,12,WF,Michael Gianaris,20
+Queens,30046,State Senate,12,WF,Michael Gianaris,39
+Queens,30047,State Senate,12,WF,Michael Gianaris,24
+Queens,30048,State Senate,12,WF,Michael Gianaris,18
+Queens,30049,State Senate,12,WF,Michael Gianaris,36
+Queens,30050,State Senate,12,WF,Michael Gianaris,39
+Queens,30051,State Senate,12,WF,Michael Gianaris,27
+Queens,30052,State Senate,12,WF,Michael Gianaris,6
+Queens,30053,State Senate,12,WF,Michael Gianaris,15
+Queens,30060,State Senate,12,WF,Michael Gianaris,29
+Queens,30061,State Senate,12,WF,Michael Gianaris,26
+Queens,30062,State Senate,12,WF,Michael Gianaris,21
+Queens,30063,State Senate,12,WF,Michael Gianaris,13
+Queens,30064,State Senate,12,WF,Michael Gianaris,28
+Queens,30065,State Senate,12,WF,Michael Gianaris,33
+Queens,30066,State Senate,12,WF,Michael Gianaris,37
+Queens,30067,State Senate,12,WF,Michael Gianaris,29
+Queens,30068,State Senate,12,WF,Michael Gianaris,21
+Queens,30069,State Senate,12,WF,Michael Gianaris,24
+Queens,30070,State Senate,12,WF,Michael Gianaris,13
+Queens,30071,State Senate,12,WF,Michael Gianaris,25
+Queens,34047,State Senate,12,WF,Michael Gianaris,1
+Queens,34048,State Senate,12,WF,Michael Gianaris,8
+Queens,34049,State Senate,12,WF,Michael Gianaris,19
+Queens,34050,State Senate,12,WF,Michael Gianaris,12
+Queens,34051,State Senate,12,WF,Michael Gianaris,10
+Queens,34052,State Senate,12,WF,Michael Gianaris,11
+Queens,34053,State Senate,12,WF,Michael Gianaris,1
+Queens,34055,State Senate,12,WF,Michael Gianaris,0
+Queens,34059,State Senate,12,WF,Michael Gianaris,1
+Queens,34060,State Senate,12,WF,Michael Gianaris,15
+Queens,36001,State Senate,12,WF,Michael Gianaris,57
+Queens,36002,State Senate,12,WF,Michael Gianaris,29
+Queens,36003,State Senate,12,WF,Michael Gianaris,29
+Queens,36004,State Senate,12,WF,Michael Gianaris,48
+Queens,36005,State Senate,12,WF,Michael Gianaris,31
+Queens,36006,State Senate,12,WF,Michael Gianaris,24
+Queens,36007,State Senate,12,WF,Michael Gianaris,39
+Queens,36008,State Senate,12,WF,Michael Gianaris,37
+Queens,36009,State Senate,12,WF,Michael Gianaris,15
+Queens,36010,State Senate,12,WF,Michael Gianaris,23
+Queens,36011,State Senate,12,WF,Michael Gianaris,32
+Queens,36012,State Senate,12,WF,Michael Gianaris,32
+Queens,36013,State Senate,12,WF,Michael Gianaris,34
+Queens,36014,State Senate,12,WF,Michael Gianaris,30
+Queens,36015,State Senate,12,WF,Michael Gianaris,32
+Queens,36016,State Senate,12,WF,Michael Gianaris,31
+Queens,36017,State Senate,12,WF,Michael Gianaris,31
+Queens,36018,State Senate,12,WF,Michael Gianaris,34
+Queens,36019,State Senate,12,WF,Michael Gianaris,34
+Queens,36020,State Senate,12,WF,Michael Gianaris,35
+Queens,36021,State Senate,12,WF,Michael Gianaris,32
+Queens,36022,State Senate,12,WF,Michael Gianaris,33
+Queens,36023,State Senate,12,WF,Michael Gianaris,32
+Queens,36024,State Senate,12,WF,Michael Gianaris,31
+Queens,36025,State Senate,12,WF,Michael Gianaris,19
+Queens,36026,State Senate,12,WF,Michael Gianaris,18
+Queens,36028,State Senate,12,WF,Michael Gianaris,28
+Queens,36029,State Senate,12,WF,Michael Gianaris,26
+Queens,36030,State Senate,12,WF,Michael Gianaris,20
+Queens,36031,State Senate,12,WF,Michael Gianaris,18
+Queens,36032,State Senate,12,WF,Michael Gianaris,24
+Queens,36033,State Senate,12,WF,Michael Gianaris,32
+Queens,36034,State Senate,12,WF,Michael Gianaris,17
+Queens,36035,State Senate,12,WF,Michael Gianaris,22
+Queens,36036,State Senate,12,WF,Michael Gianaris,36
+Queens,36037,State Senate,12,WF,Michael Gianaris,45
+Queens,36038,State Senate,12,WF,Michael Gianaris,31
+Queens,36039,State Senate,12,WF,Michael Gianaris,45
+Queens,36040,State Senate,12,WF,Michael Gianaris,39
+Queens,36041,State Senate,12,WF,Michael Gianaris,36
+Queens,36042,State Senate,12,WF,Michael Gianaris,23
+Queens,36043,State Senate,12,WF,Michael Gianaris,11
+Queens,36064,State Senate,12,WF,Michael Gianaris,20
+Queens,36065,State Senate,12,WF,Michael Gianaris,5
+Queens,37001,State Senate,12,WF,Michael Gianaris,15
+Queens,37002,State Senate,12,WF,Michael Gianaris,9
+Queens,37003,State Senate,12,WF,Michael Gianaris,5
+Queens,37004,State Senate,12,WF,Michael Gianaris,3
+Queens,37005,State Senate,12,WF,Michael Gianaris,18
+Queens,37006,State Senate,12,WF,Michael Gianaris,13
+Queens,37007,State Senate,12,WF,Michael Gianaris,3
+Queens,37008,State Senate,12,WF,Michael Gianaris,5
+Queens,37009,State Senate,12,WF,Michael Gianaris,6
+Queens,37010,State Senate,12,WF,Michael Gianaris,15
+Queens,37011,State Senate,12,WF,Michael Gianaris,23
+Queens,37012,State Senate,12,WF,Michael Gianaris,4
+Queens,37013,State Senate,12,WF,Michael Gianaris,4
+Queens,37014,State Senate,12,WF,Michael Gianaris,0
+Queens,37015,State Senate,12,WF,Michael Gianaris,8
+Queens,37016,State Senate,12,WF,Michael Gianaris,9
+Queens,37017,State Senate,12,WF,Michael Gianaris,5
+Queens,37018,State Senate,12,WF,Michael Gianaris,2
+Queens,37019,State Senate,12,WF,Michael Gianaris,52
+Queens,37020,State Senate,12,WF,Michael Gianaris,15
+Queens,37021,State Senate,12,WF,Michael Gianaris,29
+Queens,37022,State Senate,12,WF,Michael Gianaris,55
+Queens,37023,State Senate,12,WF,Michael Gianaris,7
+Queens,37024,State Senate,12,WF,Michael Gianaris,23
+Queens,37025,State Senate,12,WF,Michael Gianaris,3
+Queens,37026,State Senate,12,WF,Michael Gianaris,0
+Queens,37027,State Senate,12,WF,Michael Gianaris,70
+Queens,37028,State Senate,12,WF,Michael Gianaris,25
+Queens,37029,State Senate,12,WF,Michael Gianaris,31
+Queens,37030,State Senate,12,WF,Michael Gianaris,24
+Queens,37031,State Senate,12,WF,Michael Gianaris,32
+Queens,37032,State Senate,12,WF,Michael Gianaris,11
+Queens,37033,State Senate,12,WF,Michael Gianaris,14
+Queens,37034,State Senate,12,WF,Michael Gianaris,11
+Queens,37035,State Senate,12,WF,Michael Gianaris,29
+Queens,37036,State Senate,12,WF,Michael Gianaris,37
+Queens,37037,State Senate,12,WF,Michael Gianaris,44
+Queens,37038,State Senate,12,WF,Michael Gianaris,31
+Queens,37039,State Senate,12,WF,Michael Gianaris,24
+Queens,37041,State Senate,12,WF,Michael Gianaris,3
+Queens,37051,State Senate,12,WF,Michael Gianaris,0
+Queens,37055,State Senate,12,WF,Michael Gianaris,0
+Queens,37056,State Senate,12,WF,Michael Gianaris,21
+Queens,37057,State Senate,12,WF,Michael Gianaris,21
+Queens,37058,State Senate,12,WF,Michael Gianaris,34
+Queens,37059,State Senate,12,WF,Michael Gianaris,34
+Queens,37063,State Senate,12,WF,Michael Gianaris,23
+Queens,37064,State Senate,12,WF,Michael Gianaris,58
+Queens,37065,State Senate,12,WF,Michael Gianaris,22
+Queens,37067,State Senate,12,WF,Michael Gianaris,13
+Queens,37068,State Senate,12,WF,Michael Gianaris,24
+Queens,38001,State Senate,12,WF,Michael Gianaris,22
+Queens,38002,State Senate,12,WF,Michael Gianaris,14
+Queens,38003,State Senate,12,WF,Michael Gianaris,18
+Queens,38004,State Senate,12,WF,Michael Gianaris,23
+Queens,38005,State Senate,12,WF,Michael Gianaris,12
+Queens,38006,State Senate,12,WF,Michael Gianaris,25
+Queens,38007,State Senate,12,WF,Michael Gianaris,9
+Queens,38008,State Senate,12,WF,Michael Gianaris,8
+Queens,38009,State Senate,12,WF,Michael Gianaris,16
+Queens,38010,State Senate,12,WF,Michael Gianaris,8
+Queens,38011,State Senate,12,WF,Michael Gianaris,0
+Queens,38012,State Senate,12,WF,Michael Gianaris,9
+Queens,38013,State Senate,12,WF,Michael Gianaris,11
+Queens,38022,State Senate,12,WF,Michael Gianaris,26
+Queens,38023,State Senate,12,WF,Michael Gianaris,16
+Queens,38024,State Senate,12,WF,Michael Gianaris,14
+Queens,38025,State Senate,12,WF,Michael Gianaris,11
+Queens,38026,State Senate,12,WF,Michael Gianaris,10
+Queens,38027,State Senate,12,WF,Michael Gianaris,3
+Queens,38029,State Senate,12,WF,Michael Gianaris,15
+Queens,38053,State Senate,12,WF,Michael Gianaris,8
+Queens,39032,State Senate,12,WF,Michael Gianaris,6
+Queens,39033,State Senate,12,WF,Michael Gianaris,11
+Queens,23066,State Senate,12,Ind,writein,0
+Queens,23067,State Senate,12,Ind,writein,0
+Queens,30038,State Senate,12,Ind,writein,0
+Queens,30039,State Senate,12,Ind,writein,0
+Queens,30040,State Senate,12,Ind,writein,0
+Queens,30041,State Senate,12,Ind,writein,0
+Queens,30042,State Senate,12,Ind,writein,0
+Queens,30043,State Senate,12,Ind,writein,0
+Queens,30044,State Senate,12,Ind,writein,0
+Queens,30045,State Senate,12,Ind,writein,0
+Queens,30046,State Senate,12,Ind,writein,0
+Queens,30047,State Senate,12,Ind,writein,0
+Queens,30048,State Senate,12,Ind,writein,0
+Queens,30049,State Senate,12,Ind,writein,0
+Queens,30050,State Senate,12,Ind,writein,0
+Queens,30051,State Senate,12,Ind,writein,0
+Queens,30052,State Senate,12,Ind,writein,0
+Queens,30053,State Senate,12,Ind,writein,0
+Queens,30060,State Senate,12,Ind,writein,0
+Queens,30061,State Senate,12,Ind,writein,1
+Queens,30062,State Senate,12,Ind,writein,0
+Queens,30063,State Senate,12,Ind,writein,0
+Queens,30064,State Senate,12,Ind,writein,0
+Queens,30065,State Senate,12,Ind,writein,0
+Queens,30066,State Senate,12,Ind,writein,0
+Queens,30067,State Senate,12,Ind,writein,0
+Queens,30068,State Senate,12,Ind,writein,0
+Queens,30069,State Senate,12,Ind,writein,1
+Queens,30070,State Senate,12,Ind,writein,0
+Queens,30071,State Senate,12,Ind,writein,0
+Queens,34047,State Senate,12,Ind,writein,0
+Queens,34048,State Senate,12,Ind,writein,0
+Queens,34049,State Senate,12,Ind,writein,0
+Queens,34050,State Senate,12,Ind,writein,0
+Queens,34051,State Senate,12,Ind,writein,0
+Queens,34052,State Senate,12,Ind,writein,1
+Queens,34053,State Senate,12,Ind,writein,0
+Queens,34055,State Senate,12,Ind,writein,0
+Queens,34059,State Senate,12,Ind,writein,0
+Queens,34060,State Senate,12,Ind,writein,0
+Queens,36001,State Senate,12,Ind,writein,1
+Queens,36002,State Senate,12,Ind,writein,0
+Queens,36003,State Senate,12,Ind,writein,0
+Queens,36004,State Senate,12,Ind,writein,1
+Queens,36005,State Senate,12,Ind,writein,1
+Queens,36006,State Senate,12,Ind,writein,0
+Queens,36007,State Senate,12,Ind,writein,3
+Queens,36008,State Senate,12,Ind,writein,0
+Queens,36009,State Senate,12,Ind,writein,1
+Queens,36010,State Senate,12,Ind,writein,0
+Queens,36011,State Senate,12,Ind,writein,0
+Queens,36012,State Senate,12,Ind,writein,0
+Queens,36013,State Senate,12,Ind,writein,1
+Queens,36014,State Senate,12,Ind,writein,0
+Queens,36015,State Senate,12,Ind,writein,0
+Queens,36016,State Senate,12,Ind,writein,0
+Queens,36017,State Senate,12,Ind,writein,1
+Queens,36018,State Senate,12,Ind,writein,2
+Queens,36019,State Senate,12,Ind,writein,0
+Queens,36020,State Senate,12,Ind,writein,0
+Queens,36021,State Senate,12,Ind,writein,0
+Queens,36022,State Senate,12,Ind,writein,0
+Queens,36023,State Senate,12,Ind,writein,1
+Queens,36024,State Senate,12,Ind,writein,0
+Queens,36025,State Senate,12,Ind,writein,1
+Queens,36026,State Senate,12,Ind,writein,1
+Queens,36028,State Senate,12,Ind,writein,1
+Queens,36029,State Senate,12,Ind,writein,0
+Queens,36030,State Senate,12,Ind,writein,0
+Queens,36031,State Senate,12,Ind,writein,0
+Queens,36032,State Senate,12,Ind,writein,1
+Queens,36033,State Senate,12,Ind,writein,0
+Queens,36034,State Senate,12,Ind,writein,0
+Queens,36035,State Senate,12,Ind,writein,1
+Queens,36036,State Senate,12,Ind,writein,0
+Queens,36037,State Senate,12,Ind,writein,1
+Queens,36038,State Senate,12,Ind,writein,0
+Queens,36039,State Senate,12,Ind,writein,1
+Queens,36040,State Senate,12,Ind,writein,2
+Queens,36041,State Senate,12,Ind,writein,1
+Queens,36042,State Senate,12,Ind,writein,1
+Queens,36043,State Senate,12,Ind,writein,0
+Queens,36064,State Senate,12,Ind,writein,0
+Queens,36065,State Senate,12,Ind,writein,0
+Queens,37001,State Senate,12,Ind,writein,0
+Queens,37002,State Senate,12,Ind,writein,0
+Queens,37003,State Senate,12,Ind,writein,1
+Queens,37004,State Senate,12,Ind,writein,0
+Queens,37005,State Senate,12,Ind,writein,0
+Queens,37006,State Senate,12,Ind,writein,0
+Queens,37007,State Senate,12,Ind,writein,0
+Queens,37008,State Senate,12,Ind,writein,1
+Queens,37009,State Senate,12,Ind,writein,0
+Queens,37010,State Senate,12,Ind,writein,0
+Queens,37011,State Senate,12,Ind,writein,0
+Queens,37012,State Senate,12,Ind,writein,0
+Queens,37013,State Senate,12,Ind,writein,0
+Queens,37014,State Senate,12,Ind,writein,1
+Queens,37015,State Senate,12,Ind,writein,0
+Queens,37016,State Senate,12,Ind,writein,0
+Queens,37017,State Senate,12,Ind,writein,0
+Queens,37018,State Senate,12,Ind,writein,0
+Queens,37019,State Senate,12,Ind,writein,1
+Queens,37020,State Senate,12,Ind,writein,1
+Queens,37021,State Senate,12,Ind,writein,0
+Queens,37022,State Senate,12,Ind,writein,2
+Queens,37023,State Senate,12,Ind,writein,0
+Queens,37024,State Senate,12,Ind,writein,0
+Queens,37025,State Senate,12,Ind,writein,0
+Queens,37026,State Senate,12,Ind,writein,0
+Queens,37027,State Senate,12,Ind,writein,0
+Queens,37028,State Senate,12,Ind,writein,0
+Queens,37029,State Senate,12,Ind,writein,2
+Queens,37030,State Senate,12,Ind,writein,0
+Queens,37031,State Senate,12,Ind,writein,0
+Queens,37032,State Senate,12,Ind,writein,0
+Queens,37033,State Senate,12,Ind,writein,0
+Queens,37034,State Senate,12,Ind,writein,0
+Queens,37035,State Senate,12,Ind,writein,0
+Queens,37036,State Senate,12,Ind,writein,0
+Queens,37037,State Senate,12,Ind,writein,2
+Queens,37038,State Senate,12,Ind,writein,0
+Queens,37039,State Senate,12,Ind,writein,0
+Queens,37041,State Senate,12,Ind,writein,0
+Queens,37051,State Senate,12,Ind,writein,0
+Queens,37055,State Senate,12,Ind,writein,0
+Queens,37056,State Senate,12,Ind,writein,0
+Queens,37057,State Senate,12,Ind,writein,1
+Queens,37058,State Senate,12,Ind,writein,0
+Queens,37059,State Senate,12,Ind,writein,0
+Queens,37063,State Senate,12,Ind,writein,0
+Queens,37064,State Senate,12,Ind,writein,1
+Queens,37065,State Senate,12,Ind,writein,0
+Queens,37067,State Senate,12,Ind,writein,0
+Queens,37068,State Senate,12,Ind,writein,1
+Queens,38001,State Senate,12,Ind,writein,0
+Queens,38002,State Senate,12,Ind,writein,0
+Queens,38003,State Senate,12,Ind,writein,0
+Queens,38004,State Senate,12,Ind,writein,0
+Queens,38005,State Senate,12,Ind,writein,0
+Queens,38006,State Senate,12,Ind,writein,0
+Queens,38007,State Senate,12,Ind,writein,0
+Queens,38008,State Senate,12,Ind,writein,0
+Queens,38009,State Senate,12,Ind,writein,0
+Queens,38010,State Senate,12,Ind,writein,0
+Queens,38011,State Senate,12,Ind,writein,0
+Queens,38012,State Senate,12,Ind,writein,1
+Queens,38013,State Senate,12,Ind,writein,0
+Queens,38022,State Senate,12,Ind,writein,0
+Queens,38023,State Senate,12,Ind,writein,0
+Queens,38024,State Senate,12,Ind,writein,1
+Queens,38025,State Senate,12,Ind,writein,0
+Queens,38026,State Senate,12,Ind,writein,0
+Queens,38027,State Senate,12,Ind,writein,0
+Queens,38029,State Senate,12,Ind,writein,0
+Queens,38053,State Senate,12,Ind,writein,0
+Queens,39032,State Senate,12,Ind,writein,1
+Queens,39033,State Senate,12,Ind,writein,0
+Queens,30055,State Senate,13,Dem,Jose Peralta,183
+Queens,30056,State Senate,13,Dem,Jose Peralta,64
+Queens,30057,State Senate,13,Dem,Jose Peralta,484
+Queens,30058,State Senate,13,Dem,Jose Peralta,472
+Queens,30059,State Senate,13,Dem,Jose Peralta,315
+Queens,34001,State Senate,13,Dem,Jose Peralta,425
+Queens,34002,State Senate,13,Dem,Jose Peralta,254
+Queens,34003,State Senate,13,Dem,Jose Peralta,416
+Queens,34004,State Senate,13,Dem,Jose Peralta,498
+Queens,34005,State Senate,13,Dem,Jose Peralta,442
+Queens,34006,State Senate,13,Dem,Jose Peralta,347
+Queens,34007,State Senate,13,Dem,Jose Peralta,430
+Queens,34008,State Senate,13,Dem,Jose Peralta,395
+Queens,34009,State Senate,13,Dem,Jose Peralta,421
+Queens,34010,State Senate,13,Dem,Jose Peralta,444
+Queens,34011,State Senate,13,Dem,Jose Peralta,366
+Queens,34012,State Senate,13,Dem,Jose Peralta,288
+Queens,34013,State Senate,13,Dem,Jose Peralta,459
+Queens,34014,State Senate,13,Dem,Jose Peralta,480
+Queens,34015,State Senate,13,Dem,Jose Peralta,422
+Queens,34016,State Senate,13,Dem,Jose Peralta,429
+Queens,34017,State Senate,13,Dem,Jose Peralta,413
+Queens,34018,State Senate,13,Dem,Jose Peralta,506
+Queens,34019,State Senate,13,Dem,Jose Peralta,445
+Queens,34020,State Senate,13,Dem,Jose Peralta,459
+Queens,34021,State Senate,13,Dem,Jose Peralta,450
+Queens,34022,State Senate,13,Dem,Jose Peralta,509
+Queens,34023,State Senate,13,Dem,Jose Peralta,485
+Queens,34024,State Senate,13,Dem,Jose Peralta,496
+Queens,34025,State Senate,13,Dem,Jose Peralta,515
+Queens,34026,State Senate,13,Dem,Jose Peralta,536
+Queens,34027,State Senate,13,Dem,Jose Peralta,485
+Queens,34028,State Senate,13,Dem,Jose Peralta,490
+Queens,34029,State Senate,13,Dem,Jose Peralta,377
+Queens,34030,State Senate,13,Dem,Jose Peralta,16
+Queens,34035,State Senate,13,Dem,Jose Peralta,465
+Queens,34036,State Senate,13,Dem,Jose Peralta,422
+Queens,34037,State Senate,13,Dem,Jose Peralta,319
+Queens,34038,State Senate,13,Dem,Jose Peralta,364
+Queens,34039,State Senate,13,Dem,Jose Peralta,423
+Queens,34040,State Senate,13,Dem,Jose Peralta,394
+Queens,34041,State Senate,13,Dem,Jose Peralta,212
+Queens,34042,State Senate,13,Dem,Jose Peralta,243
+Queens,34043,State Senate,13,Dem,Jose Peralta,127
+Queens,34044,State Senate,13,Dem,Jose Peralta,123
+Queens,35011,State Senate,13,Dem,Jose Peralta,320
+Queens,35012,State Senate,13,Dem,Jose Peralta,348
+Queens,35014,State Senate,13,Dem,Jose Peralta,314
+Queens,35015,State Senate,13,Dem,Jose Peralta,557
+Queens,35016,State Senate,13,Dem,Jose Peralta,516
+Queens,35017,State Senate,13,Dem,Jose Peralta,553
+Queens,35018,State Senate,13,Dem,Jose Peralta,563
+Queens,35019,State Senate,13,Dem,Jose Peralta,452
+Queens,35020,State Senate,13,Dem,Jose Peralta,36
+Queens,35021,State Senate,13,Dem,Jose Peralta,547
+Queens,35022,State Senate,13,Dem,Jose Peralta,249
+Queens,35025,State Senate,13,Dem,Jose Peralta,675
+Queens,35032,State Senate,13,Dem,Jose Peralta,263
+Queens,35035,State Senate,13,Dem,Jose Peralta,177
+Queens,35037,State Senate,13,Dem,Jose Peralta,375
+Queens,35038,State Senate,13,Dem,Jose Peralta,655
+Queens,35039,State Senate,13,Dem,Jose Peralta,523
+Queens,35040,State Senate,13,Dem,Jose Peralta,425
+Queens,35041,State Senate,13,Dem,Jose Peralta,744
+Queens,35042,State Senate,13,Dem,Jose Peralta,328
+Queens,35043,State Senate,13,Dem,Jose Peralta,494
+Queens,35044,State Senate,13,Dem,Jose Peralta,379
+Queens,35045,State Senate,13,Dem,Jose Peralta,413
+Queens,35046,State Senate,13,Dem,Jose Peralta,344
+Queens,35047,State Senate,13,Dem,Jose Peralta,303
+Queens,35048,State Senate,13,Dem,Jose Peralta,103
+Queens,35049,State Senate,13,Dem,Jose Peralta,76
+Queens,35050,State Senate,13,Dem,Jose Peralta,483
+Queens,35051,State Senate,13,Dem,Jose Peralta,568
+Queens,35052,State Senate,13,Dem,Jose Peralta,565
+Queens,35053,State Senate,13,Dem,Jose Peralta,501
+Queens,35054,State Senate,13,Dem,Jose Peralta,594
+Queens,35055,State Senate,13,Dem,Jose Peralta,650
+Queens,35056,State Senate,13,Dem,Jose Peralta,32
+Queens,35057,State Senate,13,Dem,Jose Peralta,217
+Queens,36044,State Senate,13,Dem,Jose Peralta,53
+Queens,36045,State Senate,13,Dem,Jose Peralta,1
+Queens,36046,State Senate,13,Dem,Jose Peralta,281
+Queens,36047,State Senate,13,Dem,Jose Peralta,351
+Queens,36048,State Senate,13,Dem,Jose Peralta,332
+Queens,36050,State Senate,13,Dem,Jose Peralta,92
+Queens,36051,State Senate,13,Dem,Jose Peralta,48
+Queens,36052,State Senate,13,Dem,Jose Peralta,1
+Queens,36053,State Senate,13,Dem,Jose Peralta,387
+Queens,36054,State Senate,13,Dem,Jose Peralta,225
+Queens,36055,State Senate,13,Dem,Jose Peralta,428
+Queens,36056,State Senate,13,Dem,Jose Peralta,389
+Queens,36057,State Senate,13,Dem,Jose Peralta,432
+Queens,36058,State Senate,13,Dem,Jose Peralta,555
+Queens,36059,State Senate,13,Dem,Jose Peralta,457
+Queens,36060,State Senate,13,Dem,Jose Peralta,484
+Queens,36061,State Senate,13,Dem,Jose Peralta,432
+Queens,36062,State Senate,13,Dem,Jose Peralta,297
+Queens,36063,State Senate,13,Dem,Jose Peralta,366
+Queens,39001,State Senate,13,Dem,Jose Peralta,456
+Queens,39002,State Senate,13,Dem,Jose Peralta,412
+Queens,39003,State Senate,13,Dem,Jose Peralta,444
+Queens,39004,State Senate,13,Dem,Jose Peralta,437
+Queens,39005,State Senate,13,Dem,Jose Peralta,342
+Queens,39006,State Senate,13,Dem,Jose Peralta,250
+Queens,39007,State Senate,13,Dem,Jose Peralta,446
+Queens,39008,State Senate,13,Dem,Jose Peralta,282
+Queens,39009,State Senate,13,Dem,Jose Peralta,395
+Queens,39010,State Senate,13,Dem,Jose Peralta,435
+Queens,39011,State Senate,13,Dem,Jose Peralta,127
+Queens,39012,State Senate,13,Dem,Jose Peralta,363
+Queens,39013,State Senate,13,Dem,Jose Peralta,439
+Queens,39014,State Senate,13,Dem,Jose Peralta,334
+Queens,39015,State Senate,13,Dem,Jose Peralta,481
+Queens,39016,State Senate,13,Dem,Jose Peralta,372
+Queens,39017,State Senate,13,Dem,Jose Peralta,404
+Queens,39018,State Senate,13,Dem,Jose Peralta,273
+Queens,39019,State Senate,13,Dem,Jose Peralta,456
+Queens,39020,State Senate,13,Dem,Jose Peralta,32
+Queens,39021,State Senate,13,Dem,Jose Peralta,62
+Queens,39022,State Senate,13,Dem,Jose Peralta,73
+Queens,39025,State Senate,13,Dem,Jose Peralta,220
+Queens,39026,State Senate,13,Dem,Jose Peralta,217
+Queens,39028,State Senate,13,Dem,Jose Peralta,19
+Queens,39041,State Senate,13,Dem,Jose Peralta,336
+Queens,39043,State Senate,13,Dem,Jose Peralta,322
+Queens,39044,State Senate,13,Dem,Jose Peralta,456
+Queens,39045,State Senate,13,Dem,Jose Peralta,422
+Queens,39046,State Senate,13,Dem,Jose Peralta,497
+Queens,39047,State Senate,13,Dem,Jose Peralta,417
+Queens,39050,State Senate,13,Dem,Jose Peralta,113
+Queens,39051,State Senate,13,Dem,Jose Peralta,227
+Queens,39054,State Senate,13,Dem,Jose Peralta,33
+Queens,30055,State Senate,13,WF,Jose Peralta,9
+Queens,30056,State Senate,13,WF,Jose Peralta,8
+Queens,30057,State Senate,13,WF,Jose Peralta,8
+Queens,30058,State Senate,13,WF,Jose Peralta,16
+Queens,30059,State Senate,13,WF,Jose Peralta,3
+Queens,34001,State Senate,13,WF,Jose Peralta,5
+Queens,34002,State Senate,13,WF,Jose Peralta,7
+Queens,34003,State Senate,13,WF,Jose Peralta,13
+Queens,34004,State Senate,13,WF,Jose Peralta,9
+Queens,34005,State Senate,13,WF,Jose Peralta,12
+Queens,34006,State Senate,13,WF,Jose Peralta,9
+Queens,34007,State Senate,13,WF,Jose Peralta,8
+Queens,34008,State Senate,13,WF,Jose Peralta,17
+Queens,34009,State Senate,13,WF,Jose Peralta,16
+Queens,34010,State Senate,13,WF,Jose Peralta,19
+Queens,34011,State Senate,13,WF,Jose Peralta,14
+Queens,34012,State Senate,13,WF,Jose Peralta,6
+Queens,34013,State Senate,13,WF,Jose Peralta,15
+Queens,34014,State Senate,13,WF,Jose Peralta,15
+Queens,34015,State Senate,13,WF,Jose Peralta,27
+Queens,34016,State Senate,13,WF,Jose Peralta,40
+Queens,34017,State Senate,13,WF,Jose Peralta,41
+Queens,34018,State Senate,13,WF,Jose Peralta,23
+Queens,34019,State Senate,13,WF,Jose Peralta,24
+Queens,34020,State Senate,13,WF,Jose Peralta,21
+Queens,34021,State Senate,13,WF,Jose Peralta,16
+Queens,34022,State Senate,13,WF,Jose Peralta,43
+Queens,34023,State Senate,13,WF,Jose Peralta,37
+Queens,34024,State Senate,13,WF,Jose Peralta,49
+Queens,34025,State Senate,13,WF,Jose Peralta,46
+Queens,34026,State Senate,13,WF,Jose Peralta,34
+Queens,34027,State Senate,13,WF,Jose Peralta,30
+Queens,34028,State Senate,13,WF,Jose Peralta,49
+Queens,34029,State Senate,13,WF,Jose Peralta,17
+Queens,34030,State Senate,13,WF,Jose Peralta,0
+Queens,34035,State Senate,13,WF,Jose Peralta,12
+Queens,34036,State Senate,13,WF,Jose Peralta,20
+Queens,34037,State Senate,13,WF,Jose Peralta,22
+Queens,34038,State Senate,13,WF,Jose Peralta,11
+Queens,34039,State Senate,13,WF,Jose Peralta,17
+Queens,34040,State Senate,13,WF,Jose Peralta,20
+Queens,34041,State Senate,13,WF,Jose Peralta,9
+Queens,34042,State Senate,13,WF,Jose Peralta,10
+Queens,34043,State Senate,13,WF,Jose Peralta,9
+Queens,34044,State Senate,13,WF,Jose Peralta,6
+Queens,35011,State Senate,13,WF,Jose Peralta,20
+Queens,35012,State Senate,13,WF,Jose Peralta,16
+Queens,35014,State Senate,13,WF,Jose Peralta,12
+Queens,35015,State Senate,13,WF,Jose Peralta,14
+Queens,35016,State Senate,13,WF,Jose Peralta,9
+Queens,35017,State Senate,13,WF,Jose Peralta,13
+Queens,35018,State Senate,13,WF,Jose Peralta,14
+Queens,35019,State Senate,13,WF,Jose Peralta,6
+Queens,35020,State Senate,13,WF,Jose Peralta,3
+Queens,35021,State Senate,13,WF,Jose Peralta,20
+Queens,35022,State Senate,13,WF,Jose Peralta,8
+Queens,35025,State Senate,13,WF,Jose Peralta,9
+Queens,35032,State Senate,13,WF,Jose Peralta,12
+Queens,35035,State Senate,13,WF,Jose Peralta,7
+Queens,35037,State Senate,13,WF,Jose Peralta,6
+Queens,35038,State Senate,13,WF,Jose Peralta,14
+Queens,35039,State Senate,13,WF,Jose Peralta,7
+Queens,35040,State Senate,13,WF,Jose Peralta,4
+Queens,35041,State Senate,13,WF,Jose Peralta,7
+Queens,35042,State Senate,13,WF,Jose Peralta,4
+Queens,35043,State Senate,13,WF,Jose Peralta,15
+Queens,35044,State Senate,13,WF,Jose Peralta,8
+Queens,35045,State Senate,13,WF,Jose Peralta,4
+Queens,35046,State Senate,13,WF,Jose Peralta,9
+Queens,35047,State Senate,13,WF,Jose Peralta,2
+Queens,35048,State Senate,13,WF,Jose Peralta,2
+Queens,35049,State Senate,13,WF,Jose Peralta,2
+Queens,35050,State Senate,13,WF,Jose Peralta,14
+Queens,35051,State Senate,13,WF,Jose Peralta,7
+Queens,35052,State Senate,13,WF,Jose Peralta,15
+Queens,35053,State Senate,13,WF,Jose Peralta,14
+Queens,35054,State Senate,13,WF,Jose Peralta,13
+Queens,35055,State Senate,13,WF,Jose Peralta,7
+Queens,35056,State Senate,13,WF,Jose Peralta,1
+Queens,35057,State Senate,13,WF,Jose Peralta,6
+Queens,36044,State Senate,13,WF,Jose Peralta,0
+Queens,36045,State Senate,13,WF,Jose Peralta,0
+Queens,36046,State Senate,13,WF,Jose Peralta,21
+Queens,36047,State Senate,13,WF,Jose Peralta,23
+Queens,36048,State Senate,13,WF,Jose Peralta,25
+Queens,36050,State Senate,13,WF,Jose Peralta,6
+Queens,36051,State Senate,13,WF,Jose Peralta,1
+Queens,36052,State Senate,13,WF,Jose Peralta,0
+Queens,36053,State Senate,13,WF,Jose Peralta,22
+Queens,36054,State Senate,13,WF,Jose Peralta,18
+Queens,36055,State Senate,13,WF,Jose Peralta,30
+Queens,36056,State Senate,13,WF,Jose Peralta,20
+Queens,36057,State Senate,13,WF,Jose Peralta,37
+Queens,36058,State Senate,13,WF,Jose Peralta,31
+Queens,36059,State Senate,13,WF,Jose Peralta,28
+Queens,36060,State Senate,13,WF,Jose Peralta,44
+Queens,36061,State Senate,13,WF,Jose Peralta,22
+Queens,36062,State Senate,13,WF,Jose Peralta,18
+Queens,36063,State Senate,13,WF,Jose Peralta,7
+Queens,39001,State Senate,13,WF,Jose Peralta,18
+Queens,39002,State Senate,13,WF,Jose Peralta,11
+Queens,39003,State Senate,13,WF,Jose Peralta,16
+Queens,39004,State Senate,13,WF,Jose Peralta,18
+Queens,39005,State Senate,13,WF,Jose Peralta,12
+Queens,39006,State Senate,13,WF,Jose Peralta,4
+Queens,39007,State Senate,13,WF,Jose Peralta,20
+Queens,39008,State Senate,13,WF,Jose Peralta,13
+Queens,39009,State Senate,13,WF,Jose Peralta,10
+Queens,39010,State Senate,13,WF,Jose Peralta,5
+Queens,39011,State Senate,13,WF,Jose Peralta,10
+Queens,39012,State Senate,13,WF,Jose Peralta,13
+Queens,39013,State Senate,13,WF,Jose Peralta,6
+Queens,39014,State Senate,13,WF,Jose Peralta,17
+Queens,39015,State Senate,13,WF,Jose Peralta,19
+Queens,39016,State Senate,13,WF,Jose Peralta,5
+Queens,39017,State Senate,13,WF,Jose Peralta,16
+Queens,39018,State Senate,13,WF,Jose Peralta,21
+Queens,39019,State Senate,13,WF,Jose Peralta,23
+Queens,39020,State Senate,13,WF,Jose Peralta,1
+Queens,39021,State Senate,13,WF,Jose Peralta,2
+Queens,39022,State Senate,13,WF,Jose Peralta,5
+Queens,39025,State Senate,13,WF,Jose Peralta,7
+Queens,39026,State Senate,13,WF,Jose Peralta,17
+Queens,39028,State Senate,13,WF,Jose Peralta,0
+Queens,39041,State Senate,13,WF,Jose Peralta,8
+Queens,39043,State Senate,13,WF,Jose Peralta,11
+Queens,39044,State Senate,13,WF,Jose Peralta,32
+Queens,39045,State Senate,13,WF,Jose Peralta,49
+Queens,39046,State Senate,13,WF,Jose Peralta,61
+Queens,39047,State Senate,13,WF,Jose Peralta,37
+Queens,39050,State Senate,13,WF,Jose Peralta,6
+Queens,39051,State Senate,13,WF,Jose Peralta,25
+Queens,39054,State Senate,13,WF,Jose Peralta,1
+Queens,30055,State Senate,13,Ind,writein,1
+Queens,30056,State Senate,13,Ind,writein,0
+Queens,30057,State Senate,13,Ind,writein,1
+Queens,30058,State Senate,13,Ind,writein,1
+Queens,30059,State Senate,13,Ind,writein,0
+Queens,34001,State Senate,13,Ind,writein,1
+Queens,34002,State Senate,13,Ind,writein,1
+Queens,34003,State Senate,13,Ind,writein,0
+Queens,34004,State Senate,13,Ind,writein,1
+Queens,34005,State Senate,13,Ind,writein,0
+Queens,34006,State Senate,13,Ind,writein,2
+Queens,34007,State Senate,13,Ind,writein,0
+Queens,34008,State Senate,13,Ind,writein,0
+Queens,34009,State Senate,13,Ind,writein,1
+Queens,34010,State Senate,13,Ind,writein,1
+Queens,34011,State Senate,13,Ind,writein,0
+Queens,34012,State Senate,13,Ind,writein,0
+Queens,34013,State Senate,13,Ind,writein,1
+Queens,34014,State Senate,13,Ind,writein,1
+Queens,34015,State Senate,13,Ind,writein,1
+Queens,34016,State Senate,13,Ind,writein,3
+Queens,34017,State Senate,13,Ind,writein,1
+Queens,34018,State Senate,13,Ind,writein,0
+Queens,34019,State Senate,13,Ind,writein,0
+Queens,34020,State Senate,13,Ind,writein,0
+Queens,34021,State Senate,13,Ind,writein,0
+Queens,34022,State Senate,13,Ind,writein,2
+Queens,34023,State Senate,13,Ind,writein,1
+Queens,34024,State Senate,13,Ind,writein,1
+Queens,34025,State Senate,13,Ind,writein,0
+Queens,34026,State Senate,13,Ind,writein,2
+Queens,34027,State Senate,13,Ind,writein,0
+Queens,34028,State Senate,13,Ind,writein,0
+Queens,34029,State Senate,13,Ind,writein,1
+Queens,34030,State Senate,13,Ind,writein,0
+Queens,34035,State Senate,13,Ind,writein,0
+Queens,34036,State Senate,13,Ind,writein,0
+Queens,34037,State Senate,13,Ind,writein,0
+Queens,34038,State Senate,13,Ind,writein,0
+Queens,34039,State Senate,13,Ind,writein,1
+Queens,34040,State Senate,13,Ind,writein,1
+Queens,34041,State Senate,13,Ind,writein,0
+Queens,34042,State Senate,13,Ind,writein,0
+Queens,34043,State Senate,13,Ind,writein,0
+Queens,34044,State Senate,13,Ind,writein,0
+Queens,35011,State Senate,13,Ind,writein,0
+Queens,35012,State Senate,13,Ind,writein,0
+Queens,35014,State Senate,13,Ind,writein,0
+Queens,35015,State Senate,13,Ind,writein,0
+Queens,35016,State Senate,13,Ind,writein,0
+Queens,35017,State Senate,13,Ind,writein,1
+Queens,35018,State Senate,13,Ind,writein,1
+Queens,35019,State Senate,13,Ind,writein,0
+Queens,35020,State Senate,13,Ind,writein,0
+Queens,35021,State Senate,13,Ind,writein,0
+Queens,35022,State Senate,13,Ind,writein,1
+Queens,35025,State Senate,13,Ind,writein,0
+Queens,35032,State Senate,13,Ind,writein,0
+Queens,35035,State Senate,13,Ind,writein,0
+Queens,35037,State Senate,13,Ind,writein,0
+Queens,35038,State Senate,13,Ind,writein,0
+Queens,35039,State Senate,13,Ind,writein,0
+Queens,35040,State Senate,13,Ind,writein,0
+Queens,35041,State Senate,13,Ind,writein,1
+Queens,35042,State Senate,13,Ind,writein,0
+Queens,35043,State Senate,13,Ind,writein,0
+Queens,35044,State Senate,13,Ind,writein,0
+Queens,35045,State Senate,13,Ind,writein,0
+Queens,35046,State Senate,13,Ind,writein,0
+Queens,35047,State Senate,13,Ind,writein,0
+Queens,35048,State Senate,13,Ind,writein,0
+Queens,35049,State Senate,13,Ind,writein,0
+Queens,35050,State Senate,13,Ind,writein,3
+Queens,35051,State Senate,13,Ind,writein,0
+Queens,35052,State Senate,13,Ind,writein,3
+Queens,35053,State Senate,13,Ind,writein,1
+Queens,35054,State Senate,13,Ind,writein,0
+Queens,35055,State Senate,13,Ind,writein,0
+Queens,35056,State Senate,13,Ind,writein,0
+Queens,35057,State Senate,13,Ind,writein,0
+Queens,36044,State Senate,13,Ind,writein,0
+Queens,36045,State Senate,13,Ind,writein,0
+Queens,36046,State Senate,13,Ind,writein,3
+Queens,36047,State Senate,13,Ind,writein,1
+Queens,36048,State Senate,13,Ind,writein,0
+Queens,36050,State Senate,13,Ind,writein,0
+Queens,36051,State Senate,13,Ind,writein,0
+Queens,36052,State Senate,13,Ind,writein,0
+Queens,36053,State Senate,13,Ind,writein,1
+Queens,36054,State Senate,13,Ind,writein,1
+Queens,36055,State Senate,13,Ind,writein,1
+Queens,36056,State Senate,13,Ind,writein,2
+Queens,36057,State Senate,13,Ind,writein,2
+Queens,36058,State Senate,13,Ind,writein,0
+Queens,36059,State Senate,13,Ind,writein,4
+Queens,36060,State Senate,13,Ind,writein,1
+Queens,36061,State Senate,13,Ind,writein,3
+Queens,36062,State Senate,13,Ind,writein,0
+Queens,36063,State Senate,13,Ind,writein,1
+Queens,39001,State Senate,13,Ind,writein,2
+Queens,39002,State Senate,13,Ind,writein,0
+Queens,39003,State Senate,13,Ind,writein,0
+Queens,39004,State Senate,13,Ind,writein,0
+Queens,39005,State Senate,13,Ind,writein,0
+Queens,39006,State Senate,13,Ind,writein,0
+Queens,39007,State Senate,13,Ind,writein,0
+Queens,39008,State Senate,13,Ind,writein,1
+Queens,39009,State Senate,13,Ind,writein,2
+Queens,39010,State Senate,13,Ind,writein,0
+Queens,39011,State Senate,13,Ind,writein,1
+Queens,39012,State Senate,13,Ind,writein,1
+Queens,39013,State Senate,13,Ind,writein,2
+Queens,39014,State Senate,13,Ind,writein,1
+Queens,39015,State Senate,13,Ind,writein,0
+Queens,39016,State Senate,13,Ind,writein,1
+Queens,39017,State Senate,13,Ind,writein,2
+Queens,39018,State Senate,13,Ind,writein,2
+Queens,39019,State Senate,13,Ind,writein,2
+Queens,39020,State Senate,13,Ind,writein,0
+Queens,39021,State Senate,13,Ind,writein,0
+Queens,39022,State Senate,13,Ind,writein,0
+Queens,39025,State Senate,13,Ind,writein,0
+Queens,39026,State Senate,13,Ind,writein,1
+Queens,39028,State Senate,13,Ind,writein,0
+Queens,39041,State Senate,13,Ind,writein,1
+Queens,39043,State Senate,13,Ind,writein,0
+Queens,39044,State Senate,13,Ind,writein,0
+Queens,39045,State Senate,13,Ind,writein,1
+Queens,39046,State Senate,13,Ind,writein,5
+Queens,39047,State Senate,13,Ind,writein,1
+Queens,39050,State Senate,13,Ind,writein,0
+Queens,39051,State Senate,13,Ind,writein,0
+Queens,39054,State Senate,13,Ind,writein,0
+Queens,24008,State Senate,14,Dem,Malcolm Smith,130
+Queens,24009,State Senate,14,Dem,Malcolm Smith,3
+Queens,24013,State Senate,14,Dem,Malcolm Smith,345
+Queens,24014,State Senate,14,Dem,Malcolm Smith,238
+Queens,24027,State Senate,14,Dem,Malcolm Smith,599
+Queens,24029,State Senate,14,Dem,Malcolm Smith,519
+Queens,24030,State Senate,14,Dem,Malcolm Smith,541
+Queens,24031,State Senate,14,Dem,Malcolm Smith,264
+Queens,24037,State Senate,14,Dem,Malcolm Smith,467
+Queens,24039,State Senate,14,Dem,Malcolm Smith,77
+Queens,24040,State Senate,14,Dem,Malcolm Smith,424
+Queens,24041,State Senate,14,Dem,Malcolm Smith,86
+Queens,24043,State Senate,14,Dem,Malcolm Smith,533
+Queens,24044,State Senate,14,Dem,Malcolm Smith,587
+Queens,24045,State Senate,14,Dem,Malcolm Smith,376
+Queens,24046,State Senate,14,Dem,Malcolm Smith,477
+Queens,24047,State Senate,14,Dem,Malcolm Smith,521
+Queens,24048,State Senate,14,Dem,Malcolm Smith,104
+Queens,24049,State Senate,14,Dem,Malcolm Smith,470
+Queens,24056,State Senate,14,Dem,Malcolm Smith,27
+Queens,24058,State Senate,14,Dem,Malcolm Smith,82
+Queens,24059,State Senate,14,Dem,Malcolm Smith,306
+Queens,24060,State Senate,14,Dem,Malcolm Smith,101
+Queens,24065,State Senate,14,Dem,Malcolm Smith,373
+Queens,24066,State Senate,14,Dem,Malcolm Smith,480
+Queens,25002,State Senate,14,Dem,Malcolm Smith,37
+Queens,25003,State Senate,14,Dem,Malcolm Smith,373
+Queens,25004,State Senate,14,Dem,Malcolm Smith,109
+Queens,25005,State Senate,14,Dem,Malcolm Smith,74
+Queens,25006,State Senate,14,Dem,Malcolm Smith,420
+Queens,25007,State Senate,14,Dem,Malcolm Smith,509
+Queens,25008,State Senate,14,Dem,Malcolm Smith,259
+Queens,25009,State Senate,14,Dem,Malcolm Smith,80
+Queens,27002,State Senate,14,Dem,Malcolm Smith,370
+Queens,27003,State Senate,14,Dem,Malcolm Smith,360
+Queens,27004,State Senate,14,Dem,Malcolm Smith,383
+Queens,27005,State Senate,14,Dem,Malcolm Smith,346
+Queens,27006,State Senate,14,Dem,Malcolm Smith,360
+Queens,27007,State Senate,14,Dem,Malcolm Smith,531
+Queens,27008,State Senate,14,Dem,Malcolm Smith,444
+Queens,27009,State Senate,14,Dem,Malcolm Smith,487
+Queens,27011,State Senate,14,Dem,Malcolm Smith,220
+Queens,27012,State Senate,14,Dem,Malcolm Smith,404
+Queens,27013,State Senate,14,Dem,Malcolm Smith,456
+Queens,27014,State Senate,14,Dem,Malcolm Smith,477
+Queens,27015,State Senate,14,Dem,Malcolm Smith,433
+Queens,27016,State Senate,14,Dem,Malcolm Smith,171
+Queens,27017,State Senate,14,Dem,Malcolm Smith,429
+Queens,27020,State Senate,14,Dem,Malcolm Smith,376
+Queens,27021,State Senate,14,Dem,Malcolm Smith,417
+Queens,27031,State Senate,14,Dem,Malcolm Smith,65
+Queens,27032,State Senate,14,Dem,Malcolm Smith,54
+Queens,28006,State Senate,14,Dem,Malcolm Smith,37
+Queens,28007,State Senate,14,Dem,Malcolm Smith,85
+Queens,28011,State Senate,14,Dem,Malcolm Smith,242
+Queens,28025,State Senate,14,Dem,Malcolm Smith,440
+Queens,28026,State Senate,14,Dem,Malcolm Smith,184
+Queens,29001,State Senate,14,Dem,Malcolm Smith,345
+Queens,29002,State Senate,14,Dem,Malcolm Smith,379
+Queens,29003,State Senate,14,Dem,Malcolm Smith,377
+Queens,29006,State Senate,14,Dem,Malcolm Smith,349
+Queens,29008,State Senate,14,Dem,Malcolm Smith,252
+Queens,29012,State Senate,14,Dem,Malcolm Smith,605
+Queens,29013,State Senate,14,Dem,Malcolm Smith,340
+Queens,29014,State Senate,14,Dem,Malcolm Smith,422
+Queens,29015,State Senate,14,Dem,Malcolm Smith,560
+Queens,29016,State Senate,14,Dem,Malcolm Smith,337
+Queens,29017,State Senate,14,Dem,Malcolm Smith,451
+Queens,29018,State Senate,14,Dem,Malcolm Smith,525
+Queens,29019,State Senate,14,Dem,Malcolm Smith,529
+Queens,29020,State Senate,14,Dem,Malcolm Smith,618
+Queens,29021,State Senate,14,Dem,Malcolm Smith,629
+Queens,29022,State Senate,14,Dem,Malcolm Smith,590
+Queens,29023,State Senate,14,Dem,Malcolm Smith,712
+Queens,29024,State Senate,14,Dem,Malcolm Smith,660
+Queens,29025,State Senate,14,Dem,Malcolm Smith,604
+Queens,29026,State Senate,14,Dem,Malcolm Smith,655
+Queens,29027,State Senate,14,Dem,Malcolm Smith,572
+Queens,29028,State Senate,14,Dem,Malcolm Smith,597
+Queens,29029,State Senate,14,Dem,Malcolm Smith,645
+Queens,29030,State Senate,14,Dem,Malcolm Smith,535
+Queens,29031,State Senate,14,Dem,Malcolm Smith,691
+Queens,29032,State Senate,14,Dem,Malcolm Smith,668
+Queens,29033,State Senate,14,Dem,Malcolm Smith,650
+Queens,29034,State Senate,14,Dem,Malcolm Smith,607
+Queens,29036,State Senate,14,Dem,Malcolm Smith,497
+Queens,29037,State Senate,14,Dem,Malcolm Smith,516
+Queens,29038,State Senate,14,Dem,Malcolm Smith,554
+Queens,29039,State Senate,14,Dem,Malcolm Smith,270
+Queens,29050,State Senate,14,Dem,Malcolm Smith,768
+Queens,29051,State Senate,14,Dem,Malcolm Smith,724
+Queens,29052,State Senate,14,Dem,Malcolm Smith,652
+Queens,29053,State Senate,14,Dem,Malcolm Smith,466
+Queens,29054,State Senate,14,Dem,Malcolm Smith,661
+Queens,29055,State Senate,14,Dem,Malcolm Smith,671
+Queens,29056,State Senate,14,Dem,Malcolm Smith,650
+Queens,29057,State Senate,14,Dem,Malcolm Smith,646
+Queens,29058,State Senate,14,Dem,Malcolm Smith,538
+Queens,29059,State Senate,14,Dem,Malcolm Smith,717
+Queens,29060,State Senate,14,Dem,Malcolm Smith,727
+Queens,29061,State Senate,14,Dem,Malcolm Smith,665
+Queens,29062,State Senate,14,Dem,Malcolm Smith,661
+Queens,29063,State Senate,14,Dem,Malcolm Smith,564
+Queens,29064,State Senate,14,Dem,Malcolm Smith,506
+Queens,29065,State Senate,14,Dem,Malcolm Smith,494
+Queens,29066,State Senate,14,Dem,Malcolm Smith,553
+Queens,29067,State Senate,14,Dem,Malcolm Smith,588
+Queens,29068,State Senate,14,Dem,Malcolm Smith,600
+Queens,32001,State Senate,14,Dem,Malcolm Smith,455
+Queens,32003,State Senate,14,Dem,Malcolm Smith,484
+Queens,32004,State Senate,14,Dem,Malcolm Smith,487
+Queens,32005,State Senate,14,Dem,Malcolm Smith,509
+Queens,32006,State Senate,14,Dem,Malcolm Smith,483
+Queens,32011,State Senate,14,Dem,Malcolm Smith,202
+Queens,32014,State Senate,14,Dem,Malcolm Smith,20
+Queens,32015,State Senate,14,Dem,Malcolm Smith,468
+Queens,32016,State Senate,14,Dem,Malcolm Smith,491
+Queens,32023,State Senate,14,Dem,Malcolm Smith,380
+Queens,32024,State Senate,14,Dem,Malcolm Smith,298
+Queens,32040,State Senate,14,Dem,Malcolm Smith,550
+Queens,32041,State Senate,14,Dem,Malcolm Smith,542
+Queens,32042,State Senate,14,Dem,Malcolm Smith,590
+Queens,32043,State Senate,14,Dem,Malcolm Smith,744
+Queens,32044,State Senate,14,Dem,Malcolm Smith,308
+Queens,32045,State Senate,14,Dem,Malcolm Smith,421
+Queens,33016,State Senate,14,Dem,Malcolm Smith,97
+Queens,33017,State Senate,14,Dem,Malcolm Smith,502
+Queens,33018,State Senate,14,Dem,Malcolm Smith,453
+Queens,33019,State Senate,14,Dem,Malcolm Smith,421
+Queens,33020,State Senate,14,Dem,Malcolm Smith,432
+Queens,33021,State Senate,14,Dem,Malcolm Smith,543
+Queens,33022,State Senate,14,Dem,Malcolm Smith,504
+Queens,33023,State Senate,14,Dem,Malcolm Smith,561
+Queens,33024,State Senate,14,Dem,Malcolm Smith,526
+Queens,33025,State Senate,14,Dem,Malcolm Smith,500
+Queens,33026,State Senate,14,Dem,Malcolm Smith,388
+Queens,33027,State Senate,14,Dem,Malcolm Smith,426
+Queens,33028,State Senate,14,Dem,Malcolm Smith,454
+Queens,33029,State Senate,14,Dem,Malcolm Smith,546
+Queens,33030,State Senate,14,Dem,Malcolm Smith,576
+Queens,33031,State Senate,14,Dem,Malcolm Smith,645
+Queens,33032,State Senate,14,Dem,Malcolm Smith,596
+Queens,33033,State Senate,14,Dem,Malcolm Smith,640
+Queens,33034,State Senate,14,Dem,Malcolm Smith,634
+Queens,33035,State Senate,14,Dem,Malcolm Smith,529
+Queens,33036,State Senate,14,Dem,Malcolm Smith,451
+Queens,33037,State Senate,14,Dem,Malcolm Smith,531
+Queens,33038,State Senate,14,Dem,Malcolm Smith,520
+Queens,33039,State Senate,14,Dem,Malcolm Smith,637
+Queens,33040,State Senate,14,Dem,Malcolm Smith,645
+Queens,33041,State Senate,14,Dem,Malcolm Smith,621
+Queens,33042,State Senate,14,Dem,Malcolm Smith,531
+Queens,33043,State Senate,14,Dem,Malcolm Smith,547
+Queens,33044,State Senate,14,Dem,Malcolm Smith,598
+Queens,33045,State Senate,14,Dem,Malcolm Smith,570
+Queens,33046,State Senate,14,Dem,Malcolm Smith,566
+Queens,33047,State Senate,14,Dem,Malcolm Smith,507
+Queens,33048,State Senate,14,Dem,Malcolm Smith,644
+Queens,33049,State Senate,14,Dem,Malcolm Smith,608
+Queens,33050,State Senate,14,Dem,Malcolm Smith,622
+Queens,33051,State Senate,14,Dem,Malcolm Smith,521
+Queens,33052,State Senate,14,Dem,Malcolm Smith,542
+Queens,33053,State Senate,14,Dem,Malcolm Smith,481
+Queens,33054,State Senate,14,Dem,Malcolm Smith,556
+Queens,33055,State Senate,14,Dem,Malcolm Smith,575
+Queens,33056,State Senate,14,Dem,Malcolm Smith,591
+Queens,33057,State Senate,14,Dem,Malcolm Smith,642
+Queens,33058,State Senate,14,Dem,Malcolm Smith,621
+Queens,33059,State Senate,14,Dem,Malcolm Smith,632
+Queens,33060,State Senate,14,Dem,Malcolm Smith,579
+Queens,33061,State Senate,14,Dem,Malcolm Smith,551
+Queens,33062,State Senate,14,Dem,Malcolm Smith,636
+Queens,33063,State Senate,14,Dem,Malcolm Smith,634
+Queens,33064,State Senate,14,Dem,Malcolm Smith,622
+Queens,33065,State Senate,14,Dem,Malcolm Smith,674
+Queens,33066,State Senate,14,Dem,Malcolm Smith,604
+Queens,33067,State Senate,14,Dem,Malcolm Smith,600
+Queens,33068,State Senate,14,Dem,Malcolm Smith,666
+Queens,33069,State Senate,14,Dem,Malcolm Smith,484
+Queens,33070,State Senate,14,Dem,Malcolm Smith,483
+Queens,33071,State Senate,14,Dem,Malcolm Smith,470
+Queens,24008,State Senate,14,WF,Malcolm Smith,8
+Queens,24009,State Senate,14,WF,Malcolm Smith,0
+Queens,24013,State Senate,14,WF,Malcolm Smith,14
+Queens,24014,State Senate,14,WF,Malcolm Smith,12
+Queens,24027,State Senate,14,WF,Malcolm Smith,10
+Queens,24029,State Senate,14,WF,Malcolm Smith,15
+Queens,24030,State Senate,14,WF,Malcolm Smith,9
+Queens,24031,State Senate,14,WF,Malcolm Smith,12
+Queens,24037,State Senate,14,WF,Malcolm Smith,28
+Queens,24039,State Senate,14,WF,Malcolm Smith,3
+Queens,24040,State Senate,14,WF,Malcolm Smith,20
+Queens,24041,State Senate,14,WF,Malcolm Smith,11
+Queens,24043,State Senate,14,WF,Malcolm Smith,13
+Queens,24044,State Senate,14,WF,Malcolm Smith,12
+Queens,24045,State Senate,14,WF,Malcolm Smith,15
+Queens,24046,State Senate,14,WF,Malcolm Smith,12
+Queens,24047,State Senate,14,WF,Malcolm Smith,23
+Queens,24048,State Senate,14,WF,Malcolm Smith,2
+Queens,24049,State Senate,14,WF,Malcolm Smith,39
+Queens,24056,State Senate,14,WF,Malcolm Smith,0
+Queens,24058,State Senate,14,WF,Malcolm Smith,0
+Queens,24059,State Senate,14,WF,Malcolm Smith,11
+Queens,24060,State Senate,14,WF,Malcolm Smith,1
+Queens,24065,State Senate,14,WF,Malcolm Smith,7
+Queens,24066,State Senate,14,WF,Malcolm Smith,15
+Queens,25002,State Senate,14,WF,Malcolm Smith,1
+Queens,25003,State Senate,14,WF,Malcolm Smith,27
+Queens,25004,State Senate,14,WF,Malcolm Smith,3
+Queens,25005,State Senate,14,WF,Malcolm Smith,3
+Queens,25006,State Senate,14,WF,Malcolm Smith,20
+Queens,25007,State Senate,14,WF,Malcolm Smith,27
+Queens,25008,State Senate,14,WF,Malcolm Smith,15
+Queens,25009,State Senate,14,WF,Malcolm Smith,2
+Queens,27002,State Senate,14,WF,Malcolm Smith,9
+Queens,27003,State Senate,14,WF,Malcolm Smith,24
+Queens,27004,State Senate,14,WF,Malcolm Smith,22
+Queens,27005,State Senate,14,WF,Malcolm Smith,41
+Queens,27006,State Senate,14,WF,Malcolm Smith,16
+Queens,27007,State Senate,14,WF,Malcolm Smith,46
+Queens,27008,State Senate,14,WF,Malcolm Smith,16
+Queens,27009,State Senate,14,WF,Malcolm Smith,24
+Queens,27011,State Senate,14,WF,Malcolm Smith,6
+Queens,27012,State Senate,14,WF,Malcolm Smith,30
+Queens,27013,State Senate,14,WF,Malcolm Smith,15
+Queens,27014,State Senate,14,WF,Malcolm Smith,39
+Queens,27015,State Senate,14,WF,Malcolm Smith,27
+Queens,27016,State Senate,14,WF,Malcolm Smith,8
+Queens,27017,State Senate,14,WF,Malcolm Smith,13
+Queens,27020,State Senate,14,WF,Malcolm Smith,26
+Queens,27021,State Senate,14,WF,Malcolm Smith,15
+Queens,27031,State Senate,14,WF,Malcolm Smith,1
+Queens,27032,State Senate,14,WF,Malcolm Smith,5
+Queens,28006,State Senate,14,WF,Malcolm Smith,6
+Queens,28007,State Senate,14,WF,Malcolm Smith,5
+Queens,28011,State Senate,14,WF,Malcolm Smith,25
+Queens,28025,State Senate,14,WF,Malcolm Smith,33
+Queens,28026,State Senate,14,WF,Malcolm Smith,11
+Queens,29001,State Senate,14,WF,Malcolm Smith,9
+Queens,29002,State Senate,14,WF,Malcolm Smith,3
+Queens,29003,State Senate,14,WF,Malcolm Smith,3
+Queens,29006,State Senate,14,WF,Malcolm Smith,9
+Queens,29008,State Senate,14,WF,Malcolm Smith,8
+Queens,29012,State Senate,14,WF,Malcolm Smith,6
+Queens,29013,State Senate,14,WF,Malcolm Smith,14
+Queens,29014,State Senate,14,WF,Malcolm Smith,5
+Queens,29015,State Senate,14,WF,Malcolm Smith,11
+Queens,29016,State Senate,14,WF,Malcolm Smith,6
+Queens,29017,State Senate,14,WF,Malcolm Smith,3
+Queens,29018,State Senate,14,WF,Malcolm Smith,9
+Queens,29019,State Senate,14,WF,Malcolm Smith,9
+Queens,29020,State Senate,14,WF,Malcolm Smith,6
+Queens,29021,State Senate,14,WF,Malcolm Smith,12
+Queens,29022,State Senate,14,WF,Malcolm Smith,10
+Queens,29023,State Senate,14,WF,Malcolm Smith,16
+Queens,29024,State Senate,14,WF,Malcolm Smith,8
+Queens,29025,State Senate,14,WF,Malcolm Smith,8
+Queens,29026,State Senate,14,WF,Malcolm Smith,8
+Queens,29027,State Senate,14,WF,Malcolm Smith,8
+Queens,29028,State Senate,14,WF,Malcolm Smith,6
+Queens,29029,State Senate,14,WF,Malcolm Smith,5
+Queens,29030,State Senate,14,WF,Malcolm Smith,2
+Queens,29031,State Senate,14,WF,Malcolm Smith,9
+Queens,29032,State Senate,14,WF,Malcolm Smith,17
+Queens,29033,State Senate,14,WF,Malcolm Smith,9
+Queens,29034,State Senate,14,WF,Malcolm Smith,12
+Queens,29036,State Senate,14,WF,Malcolm Smith,13
+Queens,29037,State Senate,14,WF,Malcolm Smith,12
+Queens,29038,State Senate,14,WF,Malcolm Smith,7
+Queens,29039,State Senate,14,WF,Malcolm Smith,4
+Queens,29050,State Senate,14,WF,Malcolm Smith,5
+Queens,29051,State Senate,14,WF,Malcolm Smith,2
+Queens,29052,State Senate,14,WF,Malcolm Smith,10
+Queens,29053,State Senate,14,WF,Malcolm Smith,5
+Queens,29054,State Senate,14,WF,Malcolm Smith,12
+Queens,29055,State Senate,14,WF,Malcolm Smith,5
+Queens,29056,State Senate,14,WF,Malcolm Smith,10
+Queens,29057,State Senate,14,WF,Malcolm Smith,4
+Queens,29058,State Senate,14,WF,Malcolm Smith,6
+Queens,29059,State Senate,14,WF,Malcolm Smith,10
+Queens,29060,State Senate,14,WF,Malcolm Smith,13
+Queens,29061,State Senate,14,WF,Malcolm Smith,10
+Queens,29062,State Senate,14,WF,Malcolm Smith,7
+Queens,29063,State Senate,14,WF,Malcolm Smith,6
+Queens,29064,State Senate,14,WF,Malcolm Smith,8
+Queens,29065,State Senate,14,WF,Malcolm Smith,3
+Queens,29066,State Senate,14,WF,Malcolm Smith,3
+Queens,29067,State Senate,14,WF,Malcolm Smith,4
+Queens,29068,State Senate,14,WF,Malcolm Smith,7
+Queens,32001,State Senate,14,WF,Malcolm Smith,4
+Queens,32003,State Senate,14,WF,Malcolm Smith,6
+Queens,32004,State Senate,14,WF,Malcolm Smith,13
+Queens,32005,State Senate,14,WF,Malcolm Smith,7
+Queens,32006,State Senate,14,WF,Malcolm Smith,9
+Queens,32011,State Senate,14,WF,Malcolm Smith,6
+Queens,32014,State Senate,14,WF,Malcolm Smith,0
+Queens,32015,State Senate,14,WF,Malcolm Smith,7
+Queens,32016,State Senate,14,WF,Malcolm Smith,7
+Queens,32023,State Senate,14,WF,Malcolm Smith,2
+Queens,32024,State Senate,14,WF,Malcolm Smith,5
+Queens,32040,State Senate,14,WF,Malcolm Smith,4
+Queens,32041,State Senate,14,WF,Malcolm Smith,5
+Queens,32042,State Senate,14,WF,Malcolm Smith,1
+Queens,32043,State Senate,14,WF,Malcolm Smith,4
+Queens,32044,State Senate,14,WF,Malcolm Smith,1
+Queens,32045,State Senate,14,WF,Malcolm Smith,6
+Queens,33016,State Senate,14,WF,Malcolm Smith,1
+Queens,33017,State Senate,14,WF,Malcolm Smith,19
+Queens,33018,State Senate,14,WF,Malcolm Smith,24
+Queens,33019,State Senate,14,WF,Malcolm Smith,24
+Queens,33020,State Senate,14,WF,Malcolm Smith,22
+Queens,33021,State Senate,14,WF,Malcolm Smith,12
+Queens,33022,State Senate,14,WF,Malcolm Smith,12
+Queens,33023,State Senate,14,WF,Malcolm Smith,12
+Queens,33024,State Senate,14,WF,Malcolm Smith,5
+Queens,33025,State Senate,14,WF,Malcolm Smith,17
+Queens,33026,State Senate,14,WF,Malcolm Smith,9
+Queens,33027,State Senate,14,WF,Malcolm Smith,8
+Queens,33028,State Senate,14,WF,Malcolm Smith,7
+Queens,33029,State Senate,14,WF,Malcolm Smith,8
+Queens,33030,State Senate,14,WF,Malcolm Smith,6
+Queens,33031,State Senate,14,WF,Malcolm Smith,10
+Queens,33032,State Senate,14,WF,Malcolm Smith,9
+Queens,33033,State Senate,14,WF,Malcolm Smith,7
+Queens,33034,State Senate,14,WF,Malcolm Smith,7
+Queens,33035,State Senate,14,WF,Malcolm Smith,5
+Queens,33036,State Senate,14,WF,Malcolm Smith,6
+Queens,33037,State Senate,14,WF,Malcolm Smith,7
+Queens,33038,State Senate,14,WF,Malcolm Smith,9
+Queens,33039,State Senate,14,WF,Malcolm Smith,8
+Queens,33040,State Senate,14,WF,Malcolm Smith,6
+Queens,33041,State Senate,14,WF,Malcolm Smith,11
+Queens,33042,State Senate,14,WF,Malcolm Smith,7
+Queens,33043,State Senate,14,WF,Malcolm Smith,20
+Queens,33044,State Senate,14,WF,Malcolm Smith,10
+Queens,33045,State Senate,14,WF,Malcolm Smith,7
+Queens,33046,State Senate,14,WF,Malcolm Smith,6
+Queens,33047,State Senate,14,WF,Malcolm Smith,8
+Queens,33048,State Senate,14,WF,Malcolm Smith,10
+Queens,33049,State Senate,14,WF,Malcolm Smith,3
+Queens,33050,State Senate,14,WF,Malcolm Smith,8
+Queens,33051,State Senate,14,WF,Malcolm Smith,14
+Queens,33052,State Senate,14,WF,Malcolm Smith,12
+Queens,33053,State Senate,14,WF,Malcolm Smith,10
+Queens,33054,State Senate,14,WF,Malcolm Smith,7
+Queens,33055,State Senate,14,WF,Malcolm Smith,16
+Queens,33056,State Senate,14,WF,Malcolm Smith,10
+Queens,33057,State Senate,14,WF,Malcolm Smith,12
+Queens,33058,State Senate,14,WF,Malcolm Smith,17
+Queens,33059,State Senate,14,WF,Malcolm Smith,9
+Queens,33060,State Senate,14,WF,Malcolm Smith,6
+Queens,33061,State Senate,14,WF,Malcolm Smith,6
+Queens,33062,State Senate,14,WF,Malcolm Smith,16
+Queens,33063,State Senate,14,WF,Malcolm Smith,9
+Queens,33064,State Senate,14,WF,Malcolm Smith,11
+Queens,33065,State Senate,14,WF,Malcolm Smith,10
+Queens,33066,State Senate,14,WF,Malcolm Smith,8
+Queens,33067,State Senate,14,WF,Malcolm Smith,4
+Queens,33068,State Senate,14,WF,Malcolm Smith,6
+Queens,33069,State Senate,14,WF,Malcolm Smith,9
+Queens,33070,State Senate,14,WF,Malcolm Smith,6
+Queens,33071,State Senate,14,WF,Malcolm Smith,13
+Queens,24008,State Senate,14,Ind,writein,0
+Queens,24009,State Senate,14,Ind,writein,0
+Queens,24013,State Senate,14,Ind,writein,2
+Queens,24014,State Senate,14,Ind,writein,0
+Queens,24027,State Senate,14,Ind,writein,1
+Queens,24029,State Senate,14,Ind,writein,1
+Queens,24030,State Senate,14,Ind,writein,0
+Queens,24031,State Senate,14,Ind,writein,0
+Queens,24037,State Senate,14,Ind,writein,1
+Queens,24039,State Senate,14,Ind,writein,0
+Queens,24040,State Senate,14,Ind,writein,1
+Queens,24041,State Senate,14,Ind,writein,0
+Queens,24043,State Senate,14,Ind,writein,0
+Queens,24044,State Senate,14,Ind,writein,0
+Queens,24045,State Senate,14,Ind,writein,2
+Queens,24046,State Senate,14,Ind,writein,1
+Queens,24047,State Senate,14,Ind,writein,0
+Queens,24048,State Senate,14,Ind,writein,0
+Queens,24049,State Senate,14,Ind,writein,5
+Queens,24056,State Senate,14,Ind,writein,0
+Queens,24058,State Senate,14,Ind,writein,0
+Queens,24059,State Senate,14,Ind,writein,0
+Queens,24060,State Senate,14,Ind,writein,0
+Queens,24065,State Senate,14,Ind,writein,0
+Queens,24066,State Senate,14,Ind,writein,1
+Queens,25002,State Senate,14,Ind,writein,0
+Queens,25003,State Senate,14,Ind,writein,1
+Queens,25004,State Senate,14,Ind,writein,0
+Queens,25005,State Senate,14,Ind,writein,0
+Queens,25006,State Senate,14,Ind,writein,3
+Queens,25007,State Senate,14,Ind,writein,3
+Queens,25008,State Senate,14,Ind,writein,1
+Queens,25009,State Senate,14,Ind,writein,0
+Queens,27002,State Senate,14,Ind,writein,1
+Queens,27003,State Senate,14,Ind,writein,1
+Queens,27004,State Senate,14,Ind,writein,1
+Queens,27005,State Senate,14,Ind,writein,5
+Queens,27006,State Senate,14,Ind,writein,1
+Queens,27007,State Senate,14,Ind,writein,0
+Queens,27008,State Senate,14,Ind,writein,3
+Queens,27009,State Senate,14,Ind,writein,0
+Queens,27011,State Senate,14,Ind,writein,2
+Queens,27012,State Senate,14,Ind,writein,1
+Queens,27013,State Senate,14,Ind,writein,1
+Queens,27014,State Senate,14,Ind,writein,1
+Queens,27015,State Senate,14,Ind,writein,2
+Queens,27016,State Senate,14,Ind,writein,0
+Queens,27017,State Senate,14,Ind,writein,5
+Queens,27020,State Senate,14,Ind,writein,3
+Queens,27021,State Senate,14,Ind,writein,2
+Queens,27031,State Senate,14,Ind,writein,0
+Queens,27032,State Senate,14,Ind,writein,0
+Queens,28006,State Senate,14,Ind,writein,1
+Queens,28007,State Senate,14,Ind,writein,1
+Queens,28011,State Senate,14,Ind,writein,5
+Queens,28025,State Senate,14,Ind,writein,0
+Queens,28026,State Senate,14,Ind,writein,0
+Queens,29001,State Senate,14,Ind,writein,0
+Queens,29002,State Senate,14,Ind,writein,0
+Queens,29003,State Senate,14,Ind,writein,0
+Queens,29006,State Senate,14,Ind,writein,1
+Queens,29008,State Senate,14,Ind,writein,0
+Queens,29012,State Senate,14,Ind,writein,0
+Queens,29013,State Senate,14,Ind,writein,0
+Queens,29014,State Senate,14,Ind,writein,0
+Queens,29015,State Senate,14,Ind,writein,0
+Queens,29016,State Senate,14,Ind,writein,0
+Queens,29017,State Senate,14,Ind,writein,0
+Queens,29018,State Senate,14,Ind,writein,0
+Queens,29019,State Senate,14,Ind,writein,0
+Queens,29020,State Senate,14,Ind,writein,1
+Queens,29021,State Senate,14,Ind,writein,0
+Queens,29022,State Senate,14,Ind,writein,1
+Queens,29023,State Senate,14,Ind,writein,0
+Queens,29024,State Senate,14,Ind,writein,0
+Queens,29025,State Senate,14,Ind,writein,0
+Queens,29026,State Senate,14,Ind,writein,0
+Queens,29027,State Senate,14,Ind,writein,0
+Queens,29028,State Senate,14,Ind,writein,1
+Queens,29029,State Senate,14,Ind,writein,0
+Queens,29030,State Senate,14,Ind,writein,0
+Queens,29031,State Senate,14,Ind,writein,0
+Queens,29032,State Senate,14,Ind,writein,0
+Queens,29033,State Senate,14,Ind,writein,0
+Queens,29034,State Senate,14,Ind,writein,0
+Queens,29036,State Senate,14,Ind,writein,0
+Queens,29037,State Senate,14,Ind,writein,0
+Queens,29038,State Senate,14,Ind,writein,0
+Queens,29039,State Senate,14,Ind,writein,0
+Queens,29050,State Senate,14,Ind,writein,0
+Queens,29051,State Senate,14,Ind,writein,0
+Queens,29052,State Senate,14,Ind,writein,0
+Queens,29053,State Senate,14,Ind,writein,0
+Queens,29054,State Senate,14,Ind,writein,0
+Queens,29055,State Senate,14,Ind,writein,0
+Queens,29056,State Senate,14,Ind,writein,0
+Queens,29057,State Senate,14,Ind,writein,0
+Queens,29058,State Senate,14,Ind,writein,0
+Queens,29059,State Senate,14,Ind,writein,1
+Queens,29060,State Senate,14,Ind,writein,1
+Queens,29061,State Senate,14,Ind,writein,1
+Queens,29062,State Senate,14,Ind,writein,0
+Queens,29063,State Senate,14,Ind,writein,0
+Queens,29064,State Senate,14,Ind,writein,0
+Queens,29065,State Senate,14,Ind,writein,0
+Queens,29066,State Senate,14,Ind,writein,0
+Queens,29067,State Senate,14,Ind,writein,0
+Queens,29068,State Senate,14,Ind,writein,2
+Queens,32001,State Senate,14,Ind,writein,1
+Queens,32003,State Senate,14,Ind,writein,1
+Queens,32004,State Senate,14,Ind,writein,1
+Queens,32005,State Senate,14,Ind,writein,0
+Queens,32006,State Senate,14,Ind,writein,1
+Queens,32011,State Senate,14,Ind,writein,0
+Queens,32014,State Senate,14,Ind,writein,0
+Queens,32015,State Senate,14,Ind,writein,0
+Queens,32016,State Senate,14,Ind,writein,0
+Queens,32023,State Senate,14,Ind,writein,0
+Queens,32024,State Senate,14,Ind,writein,0
+Queens,32040,State Senate,14,Ind,writein,0
+Queens,32041,State Senate,14,Ind,writein,1
+Queens,32042,State Senate,14,Ind,writein,0
+Queens,32043,State Senate,14,Ind,writein,0
+Queens,32044,State Senate,14,Ind,writein,1
+Queens,32045,State Senate,14,Ind,writein,0
+Queens,33016,State Senate,14,Ind,writein,0
+Queens,33017,State Senate,14,Ind,writein,3
+Queens,33018,State Senate,14,Ind,writein,1
+Queens,33019,State Senate,14,Ind,writein,1
+Queens,33020,State Senate,14,Ind,writein,2
+Queens,33021,State Senate,14,Ind,writein,3
+Queens,33022,State Senate,14,Ind,writein,0
+Queens,33023,State Senate,14,Ind,writein,0
+Queens,33024,State Senate,14,Ind,writein,1
+Queens,33025,State Senate,14,Ind,writein,2
+Queens,33026,State Senate,14,Ind,writein,0
+Queens,33027,State Senate,14,Ind,writein,0
+Queens,33028,State Senate,14,Ind,writein,1
+Queens,33029,State Senate,14,Ind,writein,0
+Queens,33030,State Senate,14,Ind,writein,0
+Queens,33031,State Senate,14,Ind,writein,0
+Queens,33032,State Senate,14,Ind,writein,0
+Queens,33033,State Senate,14,Ind,writein,0
+Queens,33034,State Senate,14,Ind,writein,0
+Queens,33035,State Senate,14,Ind,writein,1
+Queens,33036,State Senate,14,Ind,writein,0
+Queens,33037,State Senate,14,Ind,writein,1
+Queens,33038,State Senate,14,Ind,writein,0
+Queens,33039,State Senate,14,Ind,writein,0
+Queens,33040,State Senate,14,Ind,writein,0
+Queens,33041,State Senate,14,Ind,writein,0
+Queens,33042,State Senate,14,Ind,writein,0
+Queens,33043,State Senate,14,Ind,writein,0
+Queens,33044,State Senate,14,Ind,writein,0
+Queens,33045,State Senate,14,Ind,writein,0
+Queens,33046,State Senate,14,Ind,writein,0
+Queens,33047,State Senate,14,Ind,writein,0
+Queens,33048,State Senate,14,Ind,writein,0
+Queens,33049,State Senate,14,Ind,writein,1
+Queens,33050,State Senate,14,Ind,writein,0
+Queens,33051,State Senate,14,Ind,writein,2
+Queens,33052,State Senate,14,Ind,writein,1
+Queens,33053,State Senate,14,Ind,writein,1
+Queens,33054,State Senate,14,Ind,writein,0
+Queens,33055,State Senate,14,Ind,writein,0
+Queens,33056,State Senate,14,Ind,writein,0
+Queens,33057,State Senate,14,Ind,writein,0
+Queens,33058,State Senate,14,Ind,writein,0
+Queens,33059,State Senate,14,Ind,writein,1
+Queens,33060,State Senate,14,Ind,writein,0
+Queens,33061,State Senate,14,Ind,writein,0
+Queens,33062,State Senate,14,Ind,writein,0
+Queens,33063,State Senate,14,Ind,writein,0
+Queens,33064,State Senate,14,Ind,writein,0
+Queens,33065,State Senate,14,Ind,writein,1
+Queens,33066,State Senate,14,Ind,writein,2
+Queens,33067,State Senate,14,Ind,writein,2
+Queens,33068,State Senate,14,Ind,writein,0
+Queens,33069,State Senate,14,Ind,writein,0
+Queens,33070,State Senate,14,Ind,writein,0
+Queens,33071,State Senate,14,Ind,writein,1
+Queens,23001,State Senate,15,Rep,Eric Ulrich,293
+Queens,23002,State Senate,15,Rep,Eric Ulrich,316
+Queens,23003,State Senate,15,Rep,Eric Ulrich,244
+Queens,23004,State Senate,15,Rep,Eric Ulrich,60
+Queens,23005,State Senate,15,Rep,Eric Ulrich,163
+Queens,23006,State Senate,15,Rep,Eric Ulrich,166
+Queens,23007,State Senate,15,Rep,Eric Ulrich,178
+Queens,23008,State Senate,15,Rep,Eric Ulrich,155
+Queens,23009,State Senate,15,Rep,Eric Ulrich,144
+Queens,23010,State Senate,15,Rep,Eric Ulrich,137
+Queens,23011,State Senate,15,Rep,Eric Ulrich,126
+Queens,23012,State Senate,15,Rep,Eric Ulrich,60
+Queens,23013,State Senate,15,Rep,Eric Ulrich,81
+Queens,23014,State Senate,15,Rep,Eric Ulrich,114
+Queens,23015,State Senate,15,Rep,Eric Ulrich,53
+Queens,23016,State Senate,15,Rep,Eric Ulrich,55
+Queens,23017,State Senate,15,Rep,Eric Ulrich,14
+Queens,23021,State Senate,15,Rep,Eric Ulrich,12
+Queens,23023,State Senate,15,Rep,Eric Ulrich,53
+Queens,23024,State Senate,15,Rep,Eric Ulrich,50
+Queens,23025,State Senate,15,Rep,Eric Ulrich,134
+Queens,23026,State Senate,15,Rep,Eric Ulrich,106
+Queens,23027,State Senate,15,Rep,Eric Ulrich,242
+Queens,23028,State Senate,15,Rep,Eric Ulrich,254
+Queens,23040,State Senate,15,Rep,Eric Ulrich,234
+Queens,23041,State Senate,15,Rep,Eric Ulrich,170
+Queens,23042,State Senate,15,Rep,Eric Ulrich,9
+Queens,23044,State Senate,15,Rep,Eric Ulrich,229
+Queens,23045,State Senate,15,Rep,Eric Ulrich,179
+Queens,23046,State Senate,15,Rep,Eric Ulrich,262
+Queens,23047,State Senate,15,Rep,Eric Ulrich,109
+Queens,23048,State Senate,15,Rep,Eric Ulrich,109
+Queens,23049,State Senate,15,Rep,Eric Ulrich,175
+Queens,23050,State Senate,15,Rep,Eric Ulrich,126
+Queens,23051,State Senate,15,Rep,Eric Ulrich,167
+Queens,23052,State Senate,15,Rep,Eric Ulrich,107
+Queens,23053,State Senate,15,Rep,Eric Ulrich,192
+Queens,23054,State Senate,15,Rep,Eric Ulrich,225
+Queens,23055,State Senate,15,Rep,Eric Ulrich,55
+Queens,23056,State Senate,15,Rep,Eric Ulrich,172
+Queens,23057,State Senate,15,Rep,Eric Ulrich,211
+Queens,23058,State Senate,15,Rep,Eric Ulrich,155
+Queens,23059,State Senate,15,Rep,Eric Ulrich,103
+Queens,23060,State Senate,15,Rep,Eric Ulrich,116
+Queens,23061,State Senate,15,Rep,Eric Ulrich,168
+Queens,23062,State Senate,15,Rep,Eric Ulrich,281
+Queens,23063,State Senate,15,Rep,Eric Ulrich,212
+Queens,23064,State Senate,15,Rep,Eric Ulrich,275
+Queens,23065,State Senate,15,Rep,Eric Ulrich,131
+Queens,23068,State Senate,15,Rep,Eric Ulrich,96
+Queens,23069,State Senate,15,Rep,Eric Ulrich,92
+Queens,23072,State Senate,15,Rep,Eric Ulrich,102
+Queens,25001,State Senate,15,Rep,Eric Ulrich,204
+Queens,27019,State Senate,15,Rep,Eric Ulrich,112
+Queens,27024,State Senate,15,Rep,Eric Ulrich,409
+Queens,27025,State Senate,15,Rep,Eric Ulrich,451
+Queens,27026,State Senate,15,Rep,Eric Ulrich,380
+Queens,27027,State Senate,15,Rep,Eric Ulrich,377
+Queens,27028,State Senate,15,Rep,Eric Ulrich,212
+Queens,27029,State Senate,15,Rep,Eric Ulrich,230
+Queens,27030,State Senate,15,Rep,Eric Ulrich,251
+Queens,27046,State Senate,15,Rep,Eric Ulrich,94
+Queens,27076,State Senate,15,Rep,Eric Ulrich,185
+Queens,27077,State Senate,15,Rep,Eric Ulrich,27
+Queens,28003,State Senate,15,Rep,Eric Ulrich,130
+Queens,28009,State Senate,15,Rep,Eric Ulrich,89
+Queens,28010,State Senate,15,Rep,Eric Ulrich,152
+Queens,28012,State Senate,15,Rep,Eric Ulrich,86
+Queens,28014,State Senate,15,Rep,Eric Ulrich,29
+Queens,28015,State Senate,15,Rep,Eric Ulrich,243
+Queens,28016,State Senate,15,Rep,Eric Ulrich,253
+Queens,28017,State Senate,15,Rep,Eric Ulrich,205
+Queens,28018,State Senate,15,Rep,Eric Ulrich,216
+Queens,28019,State Senate,15,Rep,Eric Ulrich,211
+Queens,28020,State Senate,15,Rep,Eric Ulrich,170
+Queens,28021,State Senate,15,Rep,Eric Ulrich,255
+Queens,28022,State Senate,15,Rep,Eric Ulrich,188
+Queens,28023,State Senate,15,Rep,Eric Ulrich,137
+Queens,28024,State Senate,15,Rep,Eric Ulrich,75
+Queens,28032,State Senate,15,Rep,Eric Ulrich,108
+Queens,28033,State Senate,15,Rep,Eric Ulrich,5
+Queens,28047,State Senate,15,Rep,Eric Ulrich,183
+Queens,28048,State Senate,15,Rep,Eric Ulrich,142
+Queens,28049,State Senate,15,Rep,Eric Ulrich,138
+Queens,28060,State Senate,15,Rep,Eric Ulrich,146
+Queens,28061,State Senate,15,Rep,Eric Ulrich,159
+Queens,28062,State Senate,15,Rep,Eric Ulrich,191
+Queens,28063,State Senate,15,Rep,Eric Ulrich,219
+Queens,28064,State Senate,15,Rep,Eric Ulrich,209
+Queens,28065,State Senate,15,Rep,Eric Ulrich,188
+Queens,28066,State Senate,15,Rep,Eric Ulrich,237
+Queens,28067,State Senate,15,Rep,Eric Ulrich,202
+Queens,28068,State Senate,15,Rep,Eric Ulrich,150
+Queens,28069,State Senate,15,Rep,Eric Ulrich,128
+Queens,28070,State Senate,15,Rep,Eric Ulrich,249
+Queens,28071,State Senate,15,Rep,Eric Ulrich,314
+Queens,28072,State Senate,15,Rep,Eric Ulrich,169
+Queens,28073,State Senate,15,Rep,Eric Ulrich,197
+Queens,28074,State Senate,15,Rep,Eric Ulrich,255
+Queens,28075,State Senate,15,Rep,Eric Ulrich,281
+Queens,28076,State Senate,15,Rep,Eric Ulrich,315
+Queens,28077,State Senate,15,Rep,Eric Ulrich,269
+Queens,28078,State Senate,15,Rep,Eric Ulrich,103
+Queens,28079,State Senate,15,Rep,Eric Ulrich,87
+Queens,28080,State Senate,15,Rep,Eric Ulrich,112
+Queens,30003,State Senate,15,Rep,Eric Ulrich,5
+Queens,30004,State Senate,15,Rep,Eric Ulrich,239
+Queens,30005,State Senate,15,Rep,Eric Ulrich,293
+Queens,30006,State Senate,15,Rep,Eric Ulrich,274
+Queens,30007,State Senate,15,Rep,Eric Ulrich,261
+Queens,30008,State Senate,15,Rep,Eric Ulrich,328
+Queens,30009,State Senate,15,Rep,Eric Ulrich,274
+Queens,30010,State Senate,15,Rep,Eric Ulrich,222
+Queens,30011,State Senate,15,Rep,Eric Ulrich,264
+Queens,30012,State Senate,15,Rep,Eric Ulrich,329
+Queens,30013,State Senate,15,Rep,Eric Ulrich,186
+Queens,30014,State Senate,15,Rep,Eric Ulrich,274
+Queens,30015,State Senate,15,Rep,Eric Ulrich,182
+Queens,30016,State Senate,15,Rep,Eric Ulrich,168
+Queens,30017,State Senate,15,Rep,Eric Ulrich,187
+Queens,30018,State Senate,15,Rep,Eric Ulrich,193
+Queens,30019,State Senate,15,Rep,Eric Ulrich,5
+Queens,30020,State Senate,15,Rep,Eric Ulrich,108
+Queens,30021,State Senate,15,Rep,Eric Ulrich,235
+Queens,30022,State Senate,15,Rep,Eric Ulrich,219
+Queens,30023,State Senate,15,Rep,Eric Ulrich,180
+Queens,30024,State Senate,15,Rep,Eric Ulrich,83
+Queens,30025,State Senate,15,Rep,Eric Ulrich,204
+Queens,30026,State Senate,15,Rep,Eric Ulrich,123
+Queens,30027,State Senate,15,Rep,Eric Ulrich,147
+Queens,30028,State Senate,15,Rep,Eric Ulrich,2
+Queens,30029,State Senate,15,Rep,Eric Ulrich,8
+Queens,30033,State Senate,15,Rep,Eric Ulrich,24
+Queens,30036,State Senate,15,Rep,Eric Ulrich,163
+Queens,30037,State Senate,15,Rep,Eric Ulrich,117
+Queens,31006,State Senate,15,Rep,Eric Ulrich,3
+Queens,31021,State Senate,15,Rep,Eric Ulrich,7
+Queens,31027,State Senate,15,Rep,Eric Ulrich,100
+Queens,31028,State Senate,15,Rep,Eric Ulrich,65
+Queens,34054,State Senate,15,Rep,Eric Ulrich,1
+Queens,34056,State Senate,15,Rep,Eric Ulrich,12
+Queens,34062,State Senate,15,Rep,Eric Ulrich,12
+Queens,34063,State Senate,15,Rep,Eric Ulrich,23
+Queens,37042,State Senate,15,Rep,Eric Ulrich,27
+Queens,37043,State Senate,15,Rep,Eric Ulrich,167
+Queens,37044,State Senate,15,Rep,Eric Ulrich,173
+Queens,37045,State Senate,15,Rep,Eric Ulrich,158
+Queens,37046,State Senate,15,Rep,Eric Ulrich,162
+Queens,37047,State Senate,15,Rep,Eric Ulrich,87
+Queens,37048,State Senate,15,Rep,Eric Ulrich,116
+Queens,37049,State Senate,15,Rep,Eric Ulrich,75
+Queens,37050,State Senate,15,Rep,Eric Ulrich,85
+Queens,37052,State Senate,15,Rep,Eric Ulrich,42
+Queens,37053,State Senate,15,Rep,Eric Ulrich,28
+Queens,37054,State Senate,15,Rep,Eric Ulrich,16
+Queens,37060,State Senate,15,Rep,Eric Ulrich,4
+Queens,37061,State Senate,15,Rep,Eric Ulrich,74
+Queens,37062,State Senate,15,Rep,Eric Ulrich,134
+Queens,37066,State Senate,15,Rep,Eric Ulrich,2
+Queens,37069,State Senate,15,Rep,Eric Ulrich,6
+Queens,38014,State Senate,15,Rep,Eric Ulrich,153
+Queens,38015,State Senate,15,Rep,Eric Ulrich,53
+Queens,38016,State Senate,15,Rep,Eric Ulrich,180
+Queens,38017,State Senate,15,Rep,Eric Ulrich,198
+Queens,38018,State Senate,15,Rep,Eric Ulrich,171
+Queens,38019,State Senate,15,Rep,Eric Ulrich,153
+Queens,38028,State Senate,15,Rep,Eric Ulrich,169
+Queens,38030,State Senate,15,Rep,Eric Ulrich,91
+Queens,38031,State Senate,15,Rep,Eric Ulrich,77
+Queens,38032,State Senate,15,Rep,Eric Ulrich,103
+Queens,38033,State Senate,15,Rep,Eric Ulrich,42
+Queens,38035,State Senate,15,Rep,Eric Ulrich,3
+Queens,38037,State Senate,15,Rep,Eric Ulrich,49
+Queens,38050,State Senate,15,Rep,Eric Ulrich,135
+Queens,38051,State Senate,15,Rep,Eric Ulrich,83
+Queens,38052,State Senate,15,Rep,Eric Ulrich,145
+Queens,38054,State Senate,15,Rep,Eric Ulrich,88
+Queens,38055,State Senate,15,Rep,Eric Ulrich,63
+Queens,38056,State Senate,15,Rep,Eric Ulrich,103
+Queens,38057,State Senate,15,Rep,Eric Ulrich,100
+Queens,38058,State Senate,15,Rep,Eric Ulrich,100
+Queens,39036,State Senate,15,Rep,Eric Ulrich,20
+Queens,23001,State Senate,15,Con,Eric Ulrich,62
+Queens,23002,State Senate,15,Con,Eric Ulrich,45
+Queens,23003,State Senate,15,Con,Eric Ulrich,38
+Queens,23004,State Senate,15,Con,Eric Ulrich,3
+Queens,23005,State Senate,15,Con,Eric Ulrich,16
+Queens,23006,State Senate,15,Con,Eric Ulrich,17
+Queens,23007,State Senate,15,Con,Eric Ulrich,9
+Queens,23008,State Senate,15,Con,Eric Ulrich,23
+Queens,23009,State Senate,15,Con,Eric Ulrich,15
+Queens,23010,State Senate,15,Con,Eric Ulrich,18
+Queens,23011,State Senate,15,Con,Eric Ulrich,11
+Queens,23012,State Senate,15,Con,Eric Ulrich,9
+Queens,23013,State Senate,15,Con,Eric Ulrich,14
+Queens,23014,State Senate,15,Con,Eric Ulrich,18
+Queens,23015,State Senate,15,Con,Eric Ulrich,8
+Queens,23016,State Senate,15,Con,Eric Ulrich,6
+Queens,23017,State Senate,15,Con,Eric Ulrich,1
+Queens,23021,State Senate,15,Con,Eric Ulrich,0
+Queens,23023,State Senate,15,Con,Eric Ulrich,2
+Queens,23024,State Senate,15,Con,Eric Ulrich,57
+Queens,23025,State Senate,15,Con,Eric Ulrich,32
+Queens,23026,State Senate,15,Con,Eric Ulrich,22
+Queens,23027,State Senate,15,Con,Eric Ulrich,53
+Queens,23028,State Senate,15,Con,Eric Ulrich,86
+Queens,23040,State Senate,15,Con,Eric Ulrich,17
+Queens,23041,State Senate,15,Con,Eric Ulrich,19
+Queens,23042,State Senate,15,Con,Eric Ulrich,2
+Queens,23044,State Senate,15,Con,Eric Ulrich,24
+Queens,23045,State Senate,15,Con,Eric Ulrich,16
+Queens,23046,State Senate,15,Con,Eric Ulrich,21
+Queens,23047,State Senate,15,Con,Eric Ulrich,9
+Queens,23048,State Senate,15,Con,Eric Ulrich,11
+Queens,23049,State Senate,15,Con,Eric Ulrich,18
+Queens,23050,State Senate,15,Con,Eric Ulrich,12
+Queens,23051,State Senate,15,Con,Eric Ulrich,28
+Queens,23052,State Senate,15,Con,Eric Ulrich,15
+Queens,23053,State Senate,15,Con,Eric Ulrich,13
+Queens,23054,State Senate,15,Con,Eric Ulrich,15
+Queens,23055,State Senate,15,Con,Eric Ulrich,3
+Queens,23056,State Senate,15,Con,Eric Ulrich,13
+Queens,23057,State Senate,15,Con,Eric Ulrich,20
+Queens,23058,State Senate,15,Con,Eric Ulrich,18
+Queens,23059,State Senate,15,Con,Eric Ulrich,8
+Queens,23060,State Senate,15,Con,Eric Ulrich,10
+Queens,23061,State Senate,15,Con,Eric Ulrich,16
+Queens,23062,State Senate,15,Con,Eric Ulrich,27
+Queens,23063,State Senate,15,Con,Eric Ulrich,28
+Queens,23064,State Senate,15,Con,Eric Ulrich,33
+Queens,23065,State Senate,15,Con,Eric Ulrich,14
+Queens,23068,State Senate,15,Con,Eric Ulrich,8
+Queens,23069,State Senate,15,Con,Eric Ulrich,13
+Queens,23072,State Senate,15,Con,Eric Ulrich,5
+Queens,25001,State Senate,15,Con,Eric Ulrich,13
+Queens,27019,State Senate,15,Con,Eric Ulrich,5
+Queens,27024,State Senate,15,Con,Eric Ulrich,24
+Queens,27025,State Senate,15,Con,Eric Ulrich,25
+Queens,27026,State Senate,15,Con,Eric Ulrich,33
+Queens,27027,State Senate,15,Con,Eric Ulrich,26
+Queens,27028,State Senate,15,Con,Eric Ulrich,10
+Queens,27029,State Senate,15,Con,Eric Ulrich,19
+Queens,27030,State Senate,15,Con,Eric Ulrich,43
+Queens,27046,State Senate,15,Con,Eric Ulrich,1
+Queens,27076,State Senate,15,Con,Eric Ulrich,10
+Queens,27077,State Senate,15,Con,Eric Ulrich,0
+Queens,28003,State Senate,15,Con,Eric Ulrich,22
+Queens,28009,State Senate,15,Con,Eric Ulrich,9
+Queens,28010,State Senate,15,Con,Eric Ulrich,9
+Queens,28012,State Senate,15,Con,Eric Ulrich,9
+Queens,28014,State Senate,15,Con,Eric Ulrich,8
+Queens,28015,State Senate,15,Con,Eric Ulrich,31
+Queens,28016,State Senate,15,Con,Eric Ulrich,30
+Queens,28017,State Senate,15,Con,Eric Ulrich,26
+Queens,28018,State Senate,15,Con,Eric Ulrich,17
+Queens,28019,State Senate,15,Con,Eric Ulrich,17
+Queens,28020,State Senate,15,Con,Eric Ulrich,11
+Queens,28021,State Senate,15,Con,Eric Ulrich,10
+Queens,28022,State Senate,15,Con,Eric Ulrich,9
+Queens,28023,State Senate,15,Con,Eric Ulrich,6
+Queens,28024,State Senate,15,Con,Eric Ulrich,6
+Queens,28032,State Senate,15,Con,Eric Ulrich,10
+Queens,28033,State Senate,15,Con,Eric Ulrich,0
+Queens,28047,State Senate,15,Con,Eric Ulrich,13
+Queens,28048,State Senate,15,Con,Eric Ulrich,6
+Queens,28049,State Senate,15,Con,Eric Ulrich,7
+Queens,28060,State Senate,15,Con,Eric Ulrich,12
+Queens,28061,State Senate,15,Con,Eric Ulrich,8
+Queens,28062,State Senate,15,Con,Eric Ulrich,11
+Queens,28063,State Senate,15,Con,Eric Ulrich,16
+Queens,28064,State Senate,15,Con,Eric Ulrich,25
+Queens,28065,State Senate,15,Con,Eric Ulrich,21
+Queens,28066,State Senate,15,Con,Eric Ulrich,17
+Queens,28067,State Senate,15,Con,Eric Ulrich,9
+Queens,28068,State Senate,15,Con,Eric Ulrich,17
+Queens,28069,State Senate,15,Con,Eric Ulrich,9
+Queens,28070,State Senate,15,Con,Eric Ulrich,31
+Queens,28071,State Senate,15,Con,Eric Ulrich,39
+Queens,28072,State Senate,15,Con,Eric Ulrich,19
+Queens,28073,State Senate,15,Con,Eric Ulrich,15
+Queens,28074,State Senate,15,Con,Eric Ulrich,26
+Queens,28075,State Senate,15,Con,Eric Ulrich,34
+Queens,28076,State Senate,15,Con,Eric Ulrich,29
+Queens,28077,State Senate,15,Con,Eric Ulrich,28
+Queens,28078,State Senate,15,Con,Eric Ulrich,11
+Queens,28079,State Senate,15,Con,Eric Ulrich,14
+Queens,28080,State Senate,15,Con,Eric Ulrich,16
+Queens,30003,State Senate,15,Con,Eric Ulrich,1
+Queens,30004,State Senate,15,Con,Eric Ulrich,25
+Queens,30005,State Senate,15,Con,Eric Ulrich,28
+Queens,30006,State Senate,15,Con,Eric Ulrich,25
+Queens,30007,State Senate,15,Con,Eric Ulrich,29
+Queens,30008,State Senate,15,Con,Eric Ulrich,21
+Queens,30009,State Senate,15,Con,Eric Ulrich,21
+Queens,30010,State Senate,15,Con,Eric Ulrich,22
+Queens,30011,State Senate,15,Con,Eric Ulrich,31
+Queens,30012,State Senate,15,Con,Eric Ulrich,46
+Queens,30013,State Senate,15,Con,Eric Ulrich,18
+Queens,30014,State Senate,15,Con,Eric Ulrich,27
+Queens,30015,State Senate,15,Con,Eric Ulrich,18
+Queens,30016,State Senate,15,Con,Eric Ulrich,23
+Queens,30017,State Senate,15,Con,Eric Ulrich,25
+Queens,30018,State Senate,15,Con,Eric Ulrich,16
+Queens,30019,State Senate,15,Con,Eric Ulrich,0
+Queens,30020,State Senate,15,Con,Eric Ulrich,17
+Queens,30021,State Senate,15,Con,Eric Ulrich,28
+Queens,30022,State Senate,15,Con,Eric Ulrich,21
+Queens,30023,State Senate,15,Con,Eric Ulrich,19
+Queens,30024,State Senate,15,Con,Eric Ulrich,8
+Queens,30025,State Senate,15,Con,Eric Ulrich,30
+Queens,30026,State Senate,15,Con,Eric Ulrich,10
+Queens,30027,State Senate,15,Con,Eric Ulrich,10
+Queens,30028,State Senate,15,Con,Eric Ulrich,0
+Queens,30029,State Senate,15,Con,Eric Ulrich,0
+Queens,30033,State Senate,15,Con,Eric Ulrich,0
+Queens,30036,State Senate,15,Con,Eric Ulrich,18
+Queens,30037,State Senate,15,Con,Eric Ulrich,14
+Queens,31006,State Senate,15,Con,Eric Ulrich,0
+Queens,31021,State Senate,15,Con,Eric Ulrich,0
+Queens,31027,State Senate,15,Con,Eric Ulrich,14
+Queens,31028,State Senate,15,Con,Eric Ulrich,4
+Queens,34054,State Senate,15,Con,Eric Ulrich,1
+Queens,34056,State Senate,15,Con,Eric Ulrich,2
+Queens,34062,State Senate,15,Con,Eric Ulrich,1
+Queens,34063,State Senate,15,Con,Eric Ulrich,1
+Queens,37042,State Senate,15,Con,Eric Ulrich,4
+Queens,37043,State Senate,15,Con,Eric Ulrich,23
+Queens,37044,State Senate,15,Con,Eric Ulrich,10
+Queens,37045,State Senate,15,Con,Eric Ulrich,14
+Queens,37046,State Senate,15,Con,Eric Ulrich,26
+Queens,37047,State Senate,15,Con,Eric Ulrich,13
+Queens,37048,State Senate,15,Con,Eric Ulrich,9
+Queens,37049,State Senate,15,Con,Eric Ulrich,4
+Queens,37050,State Senate,15,Con,Eric Ulrich,12
+Queens,37052,State Senate,15,Con,Eric Ulrich,3
+Queens,37053,State Senate,15,Con,Eric Ulrich,2
+Queens,37054,State Senate,15,Con,Eric Ulrich,2
+Queens,37060,State Senate,15,Con,Eric Ulrich,0
+Queens,37061,State Senate,15,Con,Eric Ulrich,8
+Queens,37062,State Senate,15,Con,Eric Ulrich,23
+Queens,37066,State Senate,15,Con,Eric Ulrich,1
+Queens,37069,State Senate,15,Con,Eric Ulrich,1
+Queens,38014,State Senate,15,Con,Eric Ulrich,18
+Queens,38015,State Senate,15,Con,Eric Ulrich,3
+Queens,38016,State Senate,15,Con,Eric Ulrich,27
+Queens,38017,State Senate,15,Con,Eric Ulrich,25
+Queens,38018,State Senate,15,Con,Eric Ulrich,32
+Queens,38019,State Senate,15,Con,Eric Ulrich,22
+Queens,38028,State Senate,15,Con,Eric Ulrich,15
+Queens,38030,State Senate,15,Con,Eric Ulrich,7
+Queens,38031,State Senate,15,Con,Eric Ulrich,17
+Queens,38032,State Senate,15,Con,Eric Ulrich,9
+Queens,38033,State Senate,15,Con,Eric Ulrich,12
+Queens,38035,State Senate,15,Con,Eric Ulrich,0
+Queens,38037,State Senate,15,Con,Eric Ulrich,5
+Queens,38050,State Senate,15,Con,Eric Ulrich,14
+Queens,38051,State Senate,15,Con,Eric Ulrich,16
+Queens,38052,State Senate,15,Con,Eric Ulrich,21
+Queens,38054,State Senate,15,Con,Eric Ulrich,10
+Queens,38055,State Senate,15,Con,Eric Ulrich,12
+Queens,38056,State Senate,15,Con,Eric Ulrich,22
+Queens,38057,State Senate,15,Con,Eric Ulrich,12
+Queens,38058,State Senate,15,Con,Eric Ulrich,15
+Queens,39036,State Senate,15,Con,Eric Ulrich,1
+Queens,23001,State Senate,15,Ind,Eric Ulrich,13
+Queens,23002,State Senate,15,Ind,Eric Ulrich,9
+Queens,23003,State Senate,15,Ind,Eric Ulrich,12
+Queens,23004,State Senate,15,Ind,Eric Ulrich,2
+Queens,23005,State Senate,15,Ind,Eric Ulrich,3
+Queens,23006,State Senate,15,Ind,Eric Ulrich,1
+Queens,23007,State Senate,15,Ind,Eric Ulrich,4
+Queens,23008,State Senate,15,Ind,Eric Ulrich,11
+Queens,23009,State Senate,15,Ind,Eric Ulrich,5
+Queens,23010,State Senate,15,Ind,Eric Ulrich,7
+Queens,23011,State Senate,15,Ind,Eric Ulrich,9
+Queens,23012,State Senate,15,Ind,Eric Ulrich,6
+Queens,23013,State Senate,15,Ind,Eric Ulrich,11
+Queens,23014,State Senate,15,Ind,Eric Ulrich,11
+Queens,23015,State Senate,15,Ind,Eric Ulrich,4
+Queens,23016,State Senate,15,Ind,Eric Ulrich,4
+Queens,23017,State Senate,15,Ind,Eric Ulrich,2
+Queens,23021,State Senate,15,Ind,Eric Ulrich,2
+Queens,23023,State Senate,15,Ind,Eric Ulrich,0
+Queens,23024,State Senate,15,Ind,Eric Ulrich,0
+Queens,23025,State Senate,15,Ind,Eric Ulrich,5
+Queens,23026,State Senate,15,Ind,Eric Ulrich,1
+Queens,23027,State Senate,15,Ind,Eric Ulrich,2
+Queens,23028,State Senate,15,Ind,Eric Ulrich,13
+Queens,23040,State Senate,15,Ind,Eric Ulrich,12
+Queens,23041,State Senate,15,Ind,Eric Ulrich,13
+Queens,23042,State Senate,15,Ind,Eric Ulrich,0
+Queens,23044,State Senate,15,Ind,Eric Ulrich,12
+Queens,23045,State Senate,15,Ind,Eric Ulrich,3
+Queens,23046,State Senate,15,Ind,Eric Ulrich,4
+Queens,23047,State Senate,15,Ind,Eric Ulrich,5
+Queens,23048,State Senate,15,Ind,Eric Ulrich,5
+Queens,23049,State Senate,15,Ind,Eric Ulrich,3
+Queens,23050,State Senate,15,Ind,Eric Ulrich,7
+Queens,23051,State Senate,15,Ind,Eric Ulrich,4
+Queens,23052,State Senate,15,Ind,Eric Ulrich,4
+Queens,23053,State Senate,15,Ind,Eric Ulrich,17
+Queens,23054,State Senate,15,Ind,Eric Ulrich,17
+Queens,23055,State Senate,15,Ind,Eric Ulrich,4
+Queens,23056,State Senate,15,Ind,Eric Ulrich,11
+Queens,23057,State Senate,15,Ind,Eric Ulrich,19
+Queens,23058,State Senate,15,Ind,Eric Ulrich,10
+Queens,23059,State Senate,15,Ind,Eric Ulrich,8
+Queens,23060,State Senate,15,Ind,Eric Ulrich,9
+Queens,23061,State Senate,15,Ind,Eric Ulrich,7
+Queens,23062,State Senate,15,Ind,Eric Ulrich,13
+Queens,23063,State Senate,15,Ind,Eric Ulrich,8
+Queens,23064,State Senate,15,Ind,Eric Ulrich,15
+Queens,23065,State Senate,15,Ind,Eric Ulrich,7
+Queens,23068,State Senate,15,Ind,Eric Ulrich,7
+Queens,23069,State Senate,15,Ind,Eric Ulrich,5
+Queens,23072,State Senate,15,Ind,Eric Ulrich,2
+Queens,25001,State Senate,15,Ind,Eric Ulrich,7
+Queens,27019,State Senate,15,Ind,Eric Ulrich,6
+Queens,27024,State Senate,15,Ind,Eric Ulrich,4
+Queens,27025,State Senate,15,Ind,Eric Ulrich,5
+Queens,27026,State Senate,15,Ind,Eric Ulrich,5
+Queens,27027,State Senate,15,Ind,Eric Ulrich,8
+Queens,27028,State Senate,15,Ind,Eric Ulrich,1
+Queens,27029,State Senate,15,Ind,Eric Ulrich,4
+Queens,27030,State Senate,15,Ind,Eric Ulrich,6
+Queens,27046,State Senate,15,Ind,Eric Ulrich,5
+Queens,27076,State Senate,15,Ind,Eric Ulrich,7
+Queens,27077,State Senate,15,Ind,Eric Ulrich,0
+Queens,28003,State Senate,15,Ind,Eric Ulrich,7
+Queens,28009,State Senate,15,Ind,Eric Ulrich,6
+Queens,28010,State Senate,15,Ind,Eric Ulrich,8
+Queens,28012,State Senate,15,Ind,Eric Ulrich,3
+Queens,28014,State Senate,15,Ind,Eric Ulrich,3
+Queens,28015,State Senate,15,Ind,Eric Ulrich,7
+Queens,28016,State Senate,15,Ind,Eric Ulrich,7
+Queens,28017,State Senate,15,Ind,Eric Ulrich,9
+Queens,28018,State Senate,15,Ind,Eric Ulrich,11
+Queens,28019,State Senate,15,Ind,Eric Ulrich,12
+Queens,28020,State Senate,15,Ind,Eric Ulrich,10
+Queens,28021,State Senate,15,Ind,Eric Ulrich,7
+Queens,28022,State Senate,15,Ind,Eric Ulrich,7
+Queens,28023,State Senate,15,Ind,Eric Ulrich,4
+Queens,28024,State Senate,15,Ind,Eric Ulrich,5
+Queens,28032,State Senate,15,Ind,Eric Ulrich,3
+Queens,28033,State Senate,15,Ind,Eric Ulrich,0
+Queens,28047,State Senate,15,Ind,Eric Ulrich,6
+Queens,28048,State Senate,15,Ind,Eric Ulrich,9
+Queens,28049,State Senate,15,Ind,Eric Ulrich,0
+Queens,28060,State Senate,15,Ind,Eric Ulrich,8
+Queens,28061,State Senate,15,Ind,Eric Ulrich,9
+Queens,28062,State Senate,15,Ind,Eric Ulrich,9
+Queens,28063,State Senate,15,Ind,Eric Ulrich,3
+Queens,28064,State Senate,15,Ind,Eric Ulrich,11
+Queens,28065,State Senate,15,Ind,Eric Ulrich,12
+Queens,28066,State Senate,15,Ind,Eric Ulrich,16
+Queens,28067,State Senate,15,Ind,Eric Ulrich,9
+Queens,28068,State Senate,15,Ind,Eric Ulrich,9
+Queens,28069,State Senate,15,Ind,Eric Ulrich,4
+Queens,28070,State Senate,15,Ind,Eric Ulrich,5
+Queens,28071,State Senate,15,Ind,Eric Ulrich,13
+Queens,28072,State Senate,15,Ind,Eric Ulrich,10
+Queens,28073,State Senate,15,Ind,Eric Ulrich,4
+Queens,28074,State Senate,15,Ind,Eric Ulrich,10
+Queens,28075,State Senate,15,Ind,Eric Ulrich,10
+Queens,28076,State Senate,15,Ind,Eric Ulrich,14
+Queens,28077,State Senate,15,Ind,Eric Ulrich,6
+Queens,28078,State Senate,15,Ind,Eric Ulrich,7
+Queens,28079,State Senate,15,Ind,Eric Ulrich,2
+Queens,28080,State Senate,15,Ind,Eric Ulrich,9
+Queens,30003,State Senate,15,Ind,Eric Ulrich,0
+Queens,30004,State Senate,15,Ind,Eric Ulrich,8
+Queens,30005,State Senate,15,Ind,Eric Ulrich,10
+Queens,30006,State Senate,15,Ind,Eric Ulrich,6
+Queens,30007,State Senate,15,Ind,Eric Ulrich,11
+Queens,30008,State Senate,15,Ind,Eric Ulrich,8
+Queens,30009,State Senate,15,Ind,Eric Ulrich,7
+Queens,30010,State Senate,15,Ind,Eric Ulrich,12
+Queens,30011,State Senate,15,Ind,Eric Ulrich,9
+Queens,30012,State Senate,15,Ind,Eric Ulrich,7
+Queens,30013,State Senate,15,Ind,Eric Ulrich,12
+Queens,30014,State Senate,15,Ind,Eric Ulrich,15
+Queens,30015,State Senate,15,Ind,Eric Ulrich,6
+Queens,30016,State Senate,15,Ind,Eric Ulrich,13
+Queens,30017,State Senate,15,Ind,Eric Ulrich,14
+Queens,30018,State Senate,15,Ind,Eric Ulrich,12
+Queens,30019,State Senate,15,Ind,Eric Ulrich,0
+Queens,30020,State Senate,15,Ind,Eric Ulrich,5
+Queens,30021,State Senate,15,Ind,Eric Ulrich,15
+Queens,30022,State Senate,15,Ind,Eric Ulrich,15
+Queens,30023,State Senate,15,Ind,Eric Ulrich,4
+Queens,30024,State Senate,15,Ind,Eric Ulrich,4
+Queens,30025,State Senate,15,Ind,Eric Ulrich,9
+Queens,30026,State Senate,15,Ind,Eric Ulrich,7
+Queens,30027,State Senate,15,Ind,Eric Ulrich,6
+Queens,30028,State Senate,15,Ind,Eric Ulrich,0
+Queens,30029,State Senate,15,Ind,Eric Ulrich,0
+Queens,30033,State Senate,15,Ind,Eric Ulrich,3
+Queens,30036,State Senate,15,Ind,Eric Ulrich,5
+Queens,30037,State Senate,15,Ind,Eric Ulrich,7
+Queens,31006,State Senate,15,Ind,Eric Ulrich,0
+Queens,31021,State Senate,15,Ind,Eric Ulrich,0
+Queens,31027,State Senate,15,Ind,Eric Ulrich,5
+Queens,31028,State Senate,15,Ind,Eric Ulrich,2
+Queens,34054,State Senate,15,Ind,Eric Ulrich,0
+Queens,34056,State Senate,15,Ind,Eric Ulrich,0
+Queens,34062,State Senate,15,Ind,Eric Ulrich,0
+Queens,34063,State Senate,15,Ind,Eric Ulrich,0
+Queens,37042,State Senate,15,Ind,Eric Ulrich,2
+Queens,37043,State Senate,15,Ind,Eric Ulrich,11
+Queens,37044,State Senate,15,Ind,Eric Ulrich,5
+Queens,37045,State Senate,15,Ind,Eric Ulrich,5
+Queens,37046,State Senate,15,Ind,Eric Ulrich,5
+Queens,37047,State Senate,15,Ind,Eric Ulrich,7
+Queens,37048,State Senate,15,Ind,Eric Ulrich,7
+Queens,37049,State Senate,15,Ind,Eric Ulrich,1
+Queens,37050,State Senate,15,Ind,Eric Ulrich,5
+Queens,37052,State Senate,15,Ind,Eric Ulrich,0
+Queens,37053,State Senate,15,Ind,Eric Ulrich,0
+Queens,37054,State Senate,15,Ind,Eric Ulrich,4
+Queens,37060,State Senate,15,Ind,Eric Ulrich,0
+Queens,37061,State Senate,15,Ind,Eric Ulrich,8
+Queens,37062,State Senate,15,Ind,Eric Ulrich,6
+Queens,37066,State Senate,15,Ind,Eric Ulrich,1
+Queens,37069,State Senate,15,Ind,Eric Ulrich,1
+Queens,38014,State Senate,15,Ind,Eric Ulrich,6
+Queens,38015,State Senate,15,Ind,Eric Ulrich,4
+Queens,38016,State Senate,15,Ind,Eric Ulrich,8
+Queens,38017,State Senate,15,Ind,Eric Ulrich,11
+Queens,38018,State Senate,15,Ind,Eric Ulrich,11
+Queens,38019,State Senate,15,Ind,Eric Ulrich,5
+Queens,38028,State Senate,15,Ind,Eric Ulrich,9
+Queens,38030,State Senate,15,Ind,Eric Ulrich,8
+Queens,38031,State Senate,15,Ind,Eric Ulrich,4
+Queens,38032,State Senate,15,Ind,Eric Ulrich,9
+Queens,38033,State Senate,15,Ind,Eric Ulrich,3
+Queens,38035,State Senate,15,Ind,Eric Ulrich,1
+Queens,38037,State Senate,15,Ind,Eric Ulrich,2
+Queens,38050,State Senate,15,Ind,Eric Ulrich,7
+Queens,38051,State Senate,15,Ind,Eric Ulrich,5
+Queens,38052,State Senate,15,Ind,Eric Ulrich,11
+Queens,38054,State Senate,15,Ind,Eric Ulrich,2
+Queens,38055,State Senate,15,Ind,Eric Ulrich,8
+Queens,38056,State Senate,15,Ind,Eric Ulrich,4
+Queens,38057,State Senate,15,Ind,Eric Ulrich,5
+Queens,38058,State Senate,15,Ind,Eric Ulrich,6
+Queens,39036,State Senate,15,Ind,Eric Ulrich,1
+Queens,23001,State Senate,15,Dem,Joseph Addabbo,46
+Queens,23002,State Senate,15,Dem,Joseph Addabbo,53
+Queens,23003,State Senate,15,Dem,Joseph Addabbo,55
+Queens,23004,State Senate,15,Dem,Joseph Addabbo,21
+Queens,23005,State Senate,15,Dem,Joseph Addabbo,78
+Queens,23006,State Senate,15,Dem,Joseph Addabbo,70
+Queens,23007,State Senate,15,Dem,Joseph Addabbo,57
+Queens,23008,State Senate,15,Dem,Joseph Addabbo,85
+Queens,23009,State Senate,15,Dem,Joseph Addabbo,81
+Queens,23010,State Senate,15,Dem,Joseph Addabbo,81
+Queens,23011,State Senate,15,Dem,Joseph Addabbo,102
+Queens,23012,State Senate,15,Dem,Joseph Addabbo,101
+Queens,23013,State Senate,15,Dem,Joseph Addabbo,93
+Queens,23014,State Senate,15,Dem,Joseph Addabbo,129
+Queens,23015,State Senate,15,Dem,Joseph Addabbo,160
+Queens,23016,State Senate,15,Dem,Joseph Addabbo,163
+Queens,23017,State Senate,15,Dem,Joseph Addabbo,98
+Queens,23021,State Senate,15,Dem,Joseph Addabbo,62
+Queens,23023,State Senate,15,Dem,Joseph Addabbo,48
+Queens,23024,State Senate,15,Dem,Joseph Addabbo,228
+Queens,23025,State Senate,15,Dem,Joseph Addabbo,201
+Queens,23026,State Senate,15,Dem,Joseph Addabbo,108
+Queens,23027,State Senate,15,Dem,Joseph Addabbo,102
+Queens,23028,State Senate,15,Dem,Joseph Addabbo,103
+Queens,23040,State Senate,15,Dem,Joseph Addabbo,61
+Queens,23041,State Senate,15,Dem,Joseph Addabbo,43
+Queens,23042,State Senate,15,Dem,Joseph Addabbo,7
+Queens,23044,State Senate,15,Dem,Joseph Addabbo,148
+Queens,23045,State Senate,15,Dem,Joseph Addabbo,142
+Queens,23046,State Senate,15,Dem,Joseph Addabbo,159
+Queens,23047,State Senate,15,Dem,Joseph Addabbo,96
+Queens,23048,State Senate,15,Dem,Joseph Addabbo,92
+Queens,23049,State Senate,15,Dem,Joseph Addabbo,141
+Queens,23050,State Senate,15,Dem,Joseph Addabbo,224
+Queens,23051,State Senate,15,Dem,Joseph Addabbo,168
+Queens,23052,State Senate,15,Dem,Joseph Addabbo,133
+Queens,23053,State Senate,15,Dem,Joseph Addabbo,296
+Queens,23054,State Senate,15,Dem,Joseph Addabbo,296
+Queens,23055,State Senate,15,Dem,Joseph Addabbo,171
+Queens,23056,State Senate,15,Dem,Joseph Addabbo,404
+Queens,23057,State Senate,15,Dem,Joseph Addabbo,365
+Queens,23058,State Senate,15,Dem,Joseph Addabbo,377
+Queens,23059,State Senate,15,Dem,Joseph Addabbo,339
+Queens,23060,State Senate,15,Dem,Joseph Addabbo,356
+Queens,23061,State Senate,15,Dem,Joseph Addabbo,309
+Queens,23062,State Senate,15,Dem,Joseph Addabbo,343
+Queens,23063,State Senate,15,Dem,Joseph Addabbo,419
+Queens,23064,State Senate,15,Dem,Joseph Addabbo,367
+Queens,23065,State Senate,15,Dem,Joseph Addabbo,314
+Queens,23068,State Senate,15,Dem,Joseph Addabbo,439
+Queens,23069,State Senate,15,Dem,Joseph Addabbo,247
+Queens,23072,State Senate,15,Dem,Joseph Addabbo,347
+Queens,25001,State Senate,15,Dem,Joseph Addabbo,271
+Queens,27019,State Senate,15,Dem,Joseph Addabbo,300
+Queens,27024,State Senate,15,Dem,Joseph Addabbo,219
+Queens,27025,State Senate,15,Dem,Joseph Addabbo,83
+Queens,27026,State Senate,15,Dem,Joseph Addabbo,137
+Queens,27027,State Senate,15,Dem,Joseph Addabbo,134
+Queens,27028,State Senate,15,Dem,Joseph Addabbo,364
+Queens,27029,State Senate,15,Dem,Joseph Addabbo,256
+Queens,27030,State Senate,15,Dem,Joseph Addabbo,128
+Queens,27046,State Senate,15,Dem,Joseph Addabbo,76
+Queens,27076,State Senate,15,Dem,Joseph Addabbo,207
+Queens,27077,State Senate,15,Dem,Joseph Addabbo,31
+Queens,28003,State Senate,15,Dem,Joseph Addabbo,308
+Queens,28009,State Senate,15,Dem,Joseph Addabbo,185
+Queens,28010,State Senate,15,Dem,Joseph Addabbo,239
+Queens,28012,State Senate,15,Dem,Joseph Addabbo,239
+Queens,28014,State Senate,15,Dem,Joseph Addabbo,44
+Queens,28015,State Senate,15,Dem,Joseph Addabbo,303
+Queens,28016,State Senate,15,Dem,Joseph Addabbo,214
+Queens,28017,State Senate,15,Dem,Joseph Addabbo,260
+Queens,28018,State Senate,15,Dem,Joseph Addabbo,345
+Queens,28019,State Senate,15,Dem,Joseph Addabbo,400
+Queens,28020,State Senate,15,Dem,Joseph Addabbo,419
+Queens,28021,State Senate,15,Dem,Joseph Addabbo,324
+Queens,28022,State Senate,15,Dem,Joseph Addabbo,401
+Queens,28023,State Senate,15,Dem,Joseph Addabbo,453
+Queens,28024,State Senate,15,Dem,Joseph Addabbo,261
+Queens,28032,State Senate,15,Dem,Joseph Addabbo,206
+Queens,28033,State Senate,15,Dem,Joseph Addabbo,6
+Queens,28047,State Senate,15,Dem,Joseph Addabbo,468
+Queens,28048,State Senate,15,Dem,Joseph Addabbo,391
+Queens,28049,State Senate,15,Dem,Joseph Addabbo,222
+Queens,28060,State Senate,15,Dem,Joseph Addabbo,346
+Queens,28061,State Senate,15,Dem,Joseph Addabbo,281
+Queens,28062,State Senate,15,Dem,Joseph Addabbo,285
+Queens,28063,State Senate,15,Dem,Joseph Addabbo,307
+Queens,28064,State Senate,15,Dem,Joseph Addabbo,289
+Queens,28065,State Senate,15,Dem,Joseph Addabbo,336
+Queens,28066,State Senate,15,Dem,Joseph Addabbo,326
+Queens,28067,State Senate,15,Dem,Joseph Addabbo,319
+Queens,28068,State Senate,15,Dem,Joseph Addabbo,321
+Queens,28069,State Senate,15,Dem,Joseph Addabbo,190
+Queens,28070,State Senate,15,Dem,Joseph Addabbo,328
+Queens,28071,State Senate,15,Dem,Joseph Addabbo,280
+Queens,28072,State Senate,15,Dem,Joseph Addabbo,238
+Queens,28073,State Senate,15,Dem,Joseph Addabbo,325
+Queens,28074,State Senate,15,Dem,Joseph Addabbo,305
+Queens,28075,State Senate,15,Dem,Joseph Addabbo,295
+Queens,28076,State Senate,15,Dem,Joseph Addabbo,233
+Queens,28077,State Senate,15,Dem,Joseph Addabbo,251
+Queens,28078,State Senate,15,Dem,Joseph Addabbo,242
+Queens,28079,State Senate,15,Dem,Joseph Addabbo,241
+Queens,28080,State Senate,15,Dem,Joseph Addabbo,190
+Queens,30003,State Senate,15,Dem,Joseph Addabbo,5
+Queens,30004,State Senate,15,Dem,Joseph Addabbo,273
+Queens,30005,State Senate,15,Dem,Joseph Addabbo,238
+Queens,30006,State Senate,15,Dem,Joseph Addabbo,228
+Queens,30007,State Senate,15,Dem,Joseph Addabbo,233
+Queens,30008,State Senate,15,Dem,Joseph Addabbo,255
+Queens,30009,State Senate,15,Dem,Joseph Addabbo,258
+Queens,30010,State Senate,15,Dem,Joseph Addabbo,296
+Queens,30011,State Senate,15,Dem,Joseph Addabbo,242
+Queens,30012,State Senate,15,Dem,Joseph Addabbo,230
+Queens,30013,State Senate,15,Dem,Joseph Addabbo,288
+Queens,30014,State Senate,15,Dem,Joseph Addabbo,237
+Queens,30015,State Senate,15,Dem,Joseph Addabbo,143
+Queens,30016,State Senate,15,Dem,Joseph Addabbo,277
+Queens,30017,State Senate,15,Dem,Joseph Addabbo,309
+Queens,30018,State Senate,15,Dem,Joseph Addabbo,327
+Queens,30019,State Senate,15,Dem,Joseph Addabbo,10
+Queens,30020,State Senate,15,Dem,Joseph Addabbo,169
+Queens,30021,State Senate,15,Dem,Joseph Addabbo,297
+Queens,30022,State Senate,15,Dem,Joseph Addabbo,339
+Queens,30023,State Senate,15,Dem,Joseph Addabbo,253
+Queens,30024,State Senate,15,Dem,Joseph Addabbo,154
+Queens,30025,State Senate,15,Dem,Joseph Addabbo,345
+Queens,30026,State Senate,15,Dem,Joseph Addabbo,240
+Queens,30027,State Senate,15,Dem,Joseph Addabbo,279
+Queens,30028,State Senate,15,Dem,Joseph Addabbo,0
+Queens,30029,State Senate,15,Dem,Joseph Addabbo,24
+Queens,30033,State Senate,15,Dem,Joseph Addabbo,67
+Queens,30036,State Senate,15,Dem,Joseph Addabbo,306
+Queens,30037,State Senate,15,Dem,Joseph Addabbo,317
+Queens,31006,State Senate,15,Dem,Joseph Addabbo,16
+Queens,31021,State Senate,15,Dem,Joseph Addabbo,20
+Queens,31027,State Senate,15,Dem,Joseph Addabbo,254
+Queens,31028,State Senate,15,Dem,Joseph Addabbo,216
+Queens,34054,State Senate,15,Dem,Joseph Addabbo,5
+Queens,34056,State Senate,15,Dem,Joseph Addabbo,46
+Queens,34062,State Senate,15,Dem,Joseph Addabbo,15
+Queens,34063,State Senate,15,Dem,Joseph Addabbo,45
+Queens,37042,State Senate,15,Dem,Joseph Addabbo,112
+Queens,37043,State Senate,15,Dem,Joseph Addabbo,319
+Queens,37044,State Senate,15,Dem,Joseph Addabbo,270
+Queens,37045,State Senate,15,Dem,Joseph Addabbo,277
+Queens,37046,State Senate,15,Dem,Joseph Addabbo,271
+Queens,37047,State Senate,15,Dem,Joseph Addabbo,344
+Queens,37048,State Senate,15,Dem,Joseph Addabbo,337
+Queens,37049,State Senate,15,Dem,Joseph Addabbo,288
+Queens,37050,State Senate,15,Dem,Joseph Addabbo,287
+Queens,37052,State Senate,15,Dem,Joseph Addabbo,88
+Queens,37053,State Senate,15,Dem,Joseph Addabbo,52
+Queens,37054,State Senate,15,Dem,Joseph Addabbo,114
+Queens,37060,State Senate,15,Dem,Joseph Addabbo,54
+Queens,37061,State Senate,15,Dem,Joseph Addabbo,210
+Queens,37062,State Senate,15,Dem,Joseph Addabbo,308
+Queens,37066,State Senate,15,Dem,Joseph Addabbo,12
+Queens,37069,State Senate,15,Dem,Joseph Addabbo,29
+Queens,38014,State Senate,15,Dem,Joseph Addabbo,344
+Queens,38015,State Senate,15,Dem,Joseph Addabbo,92
+Queens,38016,State Senate,15,Dem,Joseph Addabbo,331
+Queens,38017,State Senate,15,Dem,Joseph Addabbo,323
+Queens,38018,State Senate,15,Dem,Joseph Addabbo,306
+Queens,38019,State Senate,15,Dem,Joseph Addabbo,213
+Queens,38028,State Senate,15,Dem,Joseph Addabbo,277
+Queens,38030,State Senate,15,Dem,Joseph Addabbo,448
+Queens,38031,State Senate,15,Dem,Joseph Addabbo,281
+Queens,38032,State Senate,15,Dem,Joseph Addabbo,348
+Queens,38033,State Senate,15,Dem,Joseph Addabbo,179
+Queens,38035,State Senate,15,Dem,Joseph Addabbo,70
+Queens,38037,State Senate,15,Dem,Joseph Addabbo,215
+Queens,38050,State Senate,15,Dem,Joseph Addabbo,529
+Queens,38051,State Senate,15,Dem,Joseph Addabbo,442
+Queens,38052,State Senate,15,Dem,Joseph Addabbo,387
+Queens,38054,State Senate,15,Dem,Joseph Addabbo,415
+Queens,38055,State Senate,15,Dem,Joseph Addabbo,374
+Queens,38056,State Senate,15,Dem,Joseph Addabbo,401
+Queens,38057,State Senate,15,Dem,Joseph Addabbo,423
+Queens,38058,State Senate,15,Dem,Joseph Addabbo,458
+Queens,39036,State Senate,15,Dem,Joseph Addabbo,22
+Queens,23001,State Senate,15,WF,Joseph Addabbo,1
+Queens,23002,State Senate,15,WF,Joseph Addabbo,3
+Queens,23003,State Senate,15,WF,Joseph Addabbo,2
+Queens,23004,State Senate,15,WF,Joseph Addabbo,2
+Queens,23005,State Senate,15,WF,Joseph Addabbo,2
+Queens,23006,State Senate,15,WF,Joseph Addabbo,3
+Queens,23007,State Senate,15,WF,Joseph Addabbo,1
+Queens,23008,State Senate,15,WF,Joseph Addabbo,4
+Queens,23009,State Senate,15,WF,Joseph Addabbo,2
+Queens,23010,State Senate,15,WF,Joseph Addabbo,10
+Queens,23011,State Senate,15,WF,Joseph Addabbo,1
+Queens,23012,State Senate,15,WF,Joseph Addabbo,3
+Queens,23013,State Senate,15,WF,Joseph Addabbo,6
+Queens,23014,State Senate,15,WF,Joseph Addabbo,4
+Queens,23015,State Senate,15,WF,Joseph Addabbo,5
+Queens,23016,State Senate,15,WF,Joseph Addabbo,5
+Queens,23017,State Senate,15,WF,Joseph Addabbo,1
+Queens,23021,State Senate,15,WF,Joseph Addabbo,3
+Queens,23023,State Senate,15,WF,Joseph Addabbo,0
+Queens,23024,State Senate,15,WF,Joseph Addabbo,2
+Queens,23025,State Senate,15,WF,Joseph Addabbo,4
+Queens,23026,State Senate,15,WF,Joseph Addabbo,4
+Queens,23027,State Senate,15,WF,Joseph Addabbo,2
+Queens,23028,State Senate,15,WF,Joseph Addabbo,0
+Queens,23040,State Senate,15,WF,Joseph Addabbo,3
+Queens,23041,State Senate,15,WF,Joseph Addabbo,7
+Queens,23042,State Senate,15,WF,Joseph Addabbo,0
+Queens,23044,State Senate,15,WF,Joseph Addabbo,10
+Queens,23045,State Senate,15,WF,Joseph Addabbo,2
+Queens,23046,State Senate,15,WF,Joseph Addabbo,10
+Queens,23047,State Senate,15,WF,Joseph Addabbo,4
+Queens,23048,State Senate,15,WF,Joseph Addabbo,4
+Queens,23049,State Senate,15,WF,Joseph Addabbo,9
+Queens,23050,State Senate,15,WF,Joseph Addabbo,13
+Queens,23051,State Senate,15,WF,Joseph Addabbo,6
+Queens,23052,State Senate,15,WF,Joseph Addabbo,11
+Queens,23053,State Senate,15,WF,Joseph Addabbo,15
+Queens,23054,State Senate,15,WF,Joseph Addabbo,12
+Queens,23055,State Senate,15,WF,Joseph Addabbo,6
+Queens,23056,State Senate,15,WF,Joseph Addabbo,9
+Queens,23057,State Senate,15,WF,Joseph Addabbo,13
+Queens,23058,State Senate,15,WF,Joseph Addabbo,17
+Queens,23059,State Senate,15,WF,Joseph Addabbo,11
+Queens,23060,State Senate,15,WF,Joseph Addabbo,13
+Queens,23061,State Senate,15,WF,Joseph Addabbo,16
+Queens,23062,State Senate,15,WF,Joseph Addabbo,22
+Queens,23063,State Senate,15,WF,Joseph Addabbo,9
+Queens,23064,State Senate,15,WF,Joseph Addabbo,23
+Queens,23065,State Senate,15,WF,Joseph Addabbo,12
+Queens,23068,State Senate,15,WF,Joseph Addabbo,7
+Queens,23069,State Senate,15,WF,Joseph Addabbo,5
+Queens,23072,State Senate,15,WF,Joseph Addabbo,14
+Queens,25001,State Senate,15,WF,Joseph Addabbo,10
+Queens,27019,State Senate,15,WF,Joseph Addabbo,13
+Queens,27024,State Senate,15,WF,Joseph Addabbo,4
+Queens,27025,State Senate,15,WF,Joseph Addabbo,5
+Queens,27026,State Senate,15,WF,Joseph Addabbo,4
+Queens,27027,State Senate,15,WF,Joseph Addabbo,11
+Queens,27028,State Senate,15,WF,Joseph Addabbo,8
+Queens,27029,State Senate,15,WF,Joseph Addabbo,5
+Queens,27030,State Senate,15,WF,Joseph Addabbo,2
+Queens,27046,State Senate,15,WF,Joseph Addabbo,3
+Queens,27076,State Senate,15,WF,Joseph Addabbo,15
+Queens,27077,State Senate,15,WF,Joseph Addabbo,0
+Queens,28003,State Senate,15,WF,Joseph Addabbo,9
+Queens,28009,State Senate,15,WF,Joseph Addabbo,12
+Queens,28010,State Senate,15,WF,Joseph Addabbo,15
+Queens,28012,State Senate,15,WF,Joseph Addabbo,11
+Queens,28014,State Senate,15,WF,Joseph Addabbo,2
+Queens,28015,State Senate,15,WF,Joseph Addabbo,12
+Queens,28016,State Senate,15,WF,Joseph Addabbo,14
+Queens,28017,State Senate,15,WF,Joseph Addabbo,29
+Queens,28018,State Senate,15,WF,Joseph Addabbo,18
+Queens,28019,State Senate,15,WF,Joseph Addabbo,27
+Queens,28020,State Senate,15,WF,Joseph Addabbo,22
+Queens,28021,State Senate,15,WF,Joseph Addabbo,8
+Queens,28022,State Senate,15,WF,Joseph Addabbo,19
+Queens,28023,State Senate,15,WF,Joseph Addabbo,25
+Queens,28024,State Senate,15,WF,Joseph Addabbo,3
+Queens,28032,State Senate,15,WF,Joseph Addabbo,10
+Queens,28033,State Senate,15,WF,Joseph Addabbo,0
+Queens,28047,State Senate,15,WF,Joseph Addabbo,11
+Queens,28048,State Senate,15,WF,Joseph Addabbo,19
+Queens,28049,State Senate,15,WF,Joseph Addabbo,8
+Queens,28060,State Senate,15,WF,Joseph Addabbo,9
+Queens,28061,State Senate,15,WF,Joseph Addabbo,16
+Queens,28062,State Senate,15,WF,Joseph Addabbo,15
+Queens,28063,State Senate,15,WF,Joseph Addabbo,19
+Queens,28064,State Senate,15,WF,Joseph Addabbo,20
+Queens,28065,State Senate,15,WF,Joseph Addabbo,20
+Queens,28066,State Senate,15,WF,Joseph Addabbo,14
+Queens,28067,State Senate,15,WF,Joseph Addabbo,6
+Queens,28068,State Senate,15,WF,Joseph Addabbo,14
+Queens,28069,State Senate,15,WF,Joseph Addabbo,12
+Queens,28070,State Senate,15,WF,Joseph Addabbo,26
+Queens,28071,State Senate,15,WF,Joseph Addabbo,17
+Queens,28072,State Senate,15,WF,Joseph Addabbo,16
+Queens,28073,State Senate,15,WF,Joseph Addabbo,14
+Queens,28074,State Senate,15,WF,Joseph Addabbo,16
+Queens,28075,State Senate,15,WF,Joseph Addabbo,14
+Queens,28076,State Senate,15,WF,Joseph Addabbo,11
+Queens,28077,State Senate,15,WF,Joseph Addabbo,17
+Queens,28078,State Senate,15,WF,Joseph Addabbo,12
+Queens,28079,State Senate,15,WF,Joseph Addabbo,10
+Queens,28080,State Senate,15,WF,Joseph Addabbo,7
+Queens,30003,State Senate,15,WF,Joseph Addabbo,0
+Queens,30004,State Senate,15,WF,Joseph Addabbo,12
+Queens,30005,State Senate,15,WF,Joseph Addabbo,8
+Queens,30006,State Senate,15,WF,Joseph Addabbo,22
+Queens,30007,State Senate,15,WF,Joseph Addabbo,8
+Queens,30008,State Senate,15,WF,Joseph Addabbo,12
+Queens,30009,State Senate,15,WF,Joseph Addabbo,12
+Queens,30010,State Senate,15,WF,Joseph Addabbo,11
+Queens,30011,State Senate,15,WF,Joseph Addabbo,5
+Queens,30012,State Senate,15,WF,Joseph Addabbo,11
+Queens,30013,State Senate,15,WF,Joseph Addabbo,14
+Queens,30014,State Senate,15,WF,Joseph Addabbo,11
+Queens,30015,State Senate,15,WF,Joseph Addabbo,10
+Queens,30016,State Senate,15,WF,Joseph Addabbo,10
+Queens,30017,State Senate,15,WF,Joseph Addabbo,12
+Queens,30018,State Senate,15,WF,Joseph Addabbo,14
+Queens,30019,State Senate,15,WF,Joseph Addabbo,0
+Queens,30020,State Senate,15,WF,Joseph Addabbo,8
+Queens,30021,State Senate,15,WF,Joseph Addabbo,14
+Queens,30022,State Senate,15,WF,Joseph Addabbo,11
+Queens,30023,State Senate,15,WF,Joseph Addabbo,10
+Queens,30024,State Senate,15,WF,Joseph Addabbo,8
+Queens,30025,State Senate,15,WF,Joseph Addabbo,11
+Queens,30026,State Senate,15,WF,Joseph Addabbo,8
+Queens,30027,State Senate,15,WF,Joseph Addabbo,10
+Queens,30028,State Senate,15,WF,Joseph Addabbo,0
+Queens,30029,State Senate,15,WF,Joseph Addabbo,0
+Queens,30033,State Senate,15,WF,Joseph Addabbo,1
+Queens,30036,State Senate,15,WF,Joseph Addabbo,3
+Queens,30037,State Senate,15,WF,Joseph Addabbo,7
+Queens,31006,State Senate,15,WF,Joseph Addabbo,1
+Queens,31021,State Senate,15,WF,Joseph Addabbo,0
+Queens,31027,State Senate,15,WF,Joseph Addabbo,3
+Queens,31028,State Senate,15,WF,Joseph Addabbo,3
+Queens,34054,State Senate,15,WF,Joseph Addabbo,0
+Queens,34056,State Senate,15,WF,Joseph Addabbo,4
+Queens,34062,State Senate,15,WF,Joseph Addabbo,0
+Queens,34063,State Senate,15,WF,Joseph Addabbo,1
+Queens,37042,State Senate,15,WF,Joseph Addabbo,9
+Queens,37043,State Senate,15,WF,Joseph Addabbo,16
+Queens,37044,State Senate,15,WF,Joseph Addabbo,16
+Queens,37045,State Senate,15,WF,Joseph Addabbo,12
+Queens,37046,State Senate,15,WF,Joseph Addabbo,21
+Queens,37047,State Senate,15,WF,Joseph Addabbo,27
+Queens,37048,State Senate,15,WF,Joseph Addabbo,13
+Queens,37049,State Senate,15,WF,Joseph Addabbo,9
+Queens,37050,State Senate,15,WF,Joseph Addabbo,8
+Queens,37052,State Senate,15,WF,Joseph Addabbo,4
+Queens,37053,State Senate,15,WF,Joseph Addabbo,5
+Queens,37054,State Senate,15,WF,Joseph Addabbo,2
+Queens,37060,State Senate,15,WF,Joseph Addabbo,4
+Queens,37061,State Senate,15,WF,Joseph Addabbo,16
+Queens,37062,State Senate,15,WF,Joseph Addabbo,16
+Queens,37066,State Senate,15,WF,Joseph Addabbo,0
+Queens,37069,State Senate,15,WF,Joseph Addabbo,1
+Queens,38014,State Senate,15,WF,Joseph Addabbo,12
+Queens,38015,State Senate,15,WF,Joseph Addabbo,5
+Queens,38016,State Senate,15,WF,Joseph Addabbo,21
+Queens,38017,State Senate,15,WF,Joseph Addabbo,15
+Queens,38018,State Senate,15,WF,Joseph Addabbo,15
+Queens,38019,State Senate,15,WF,Joseph Addabbo,16
+Queens,38028,State Senate,15,WF,Joseph Addabbo,16
+Queens,38030,State Senate,15,WF,Joseph Addabbo,14
+Queens,38031,State Senate,15,WF,Joseph Addabbo,6
+Queens,38032,State Senate,15,WF,Joseph Addabbo,10
+Queens,38033,State Senate,15,WF,Joseph Addabbo,4
+Queens,38035,State Senate,15,WF,Joseph Addabbo,3
+Queens,38037,State Senate,15,WF,Joseph Addabbo,5
+Queens,38050,State Senate,15,WF,Joseph Addabbo,14
+Queens,38051,State Senate,15,WF,Joseph Addabbo,21
+Queens,38052,State Senate,15,WF,Joseph Addabbo,9
+Queens,38054,State Senate,15,WF,Joseph Addabbo,21
+Queens,38055,State Senate,15,WF,Joseph Addabbo,12
+Queens,38056,State Senate,15,WF,Joseph Addabbo,15
+Queens,38057,State Senate,15,WF,Joseph Addabbo,19
+Queens,38058,State Senate,15,WF,Joseph Addabbo,15
+Queens,39036,State Senate,15,WF,Joseph Addabbo,0
+Queens,23001,State Senate,15,Ind,writein,1
+Queens,23002,State Senate,15,Ind,writein,0
+Queens,23003,State Senate,15,Ind,writein,0
+Queens,23004,State Senate,15,Ind,writein,0
+Queens,23005,State Senate,15,Ind,writein,0
+Queens,23006,State Senate,15,Ind,writein,0
+Queens,23007,State Senate,15,Ind,writein,0
+Queens,23008,State Senate,15,Ind,writein,0
+Queens,23009,State Senate,15,Ind,writein,0
+Queens,23010,State Senate,15,Ind,writein,0
+Queens,23011,State Senate,15,Ind,writein,1
+Queens,23012,State Senate,15,Ind,writein,0
+Queens,23013,State Senate,15,Ind,writein,0
+Queens,23014,State Senate,15,Ind,writein,1
+Queens,23015,State Senate,15,Ind,writein,2
+Queens,23016,State Senate,15,Ind,writein,0
+Queens,23017,State Senate,15,Ind,writein,0
+Queens,23021,State Senate,15,Ind,writein,0
+Queens,23023,State Senate,15,Ind,writein,0
+Queens,23024,State Senate,15,Ind,writein,0
+Queens,23025,State Senate,15,Ind,writein,0
+Queens,23026,State Senate,15,Ind,writein,1
+Queens,23027,State Senate,15,Ind,writein,0
+Queens,23028,State Senate,15,Ind,writein,0
+Queens,23040,State Senate,15,Ind,writein,0
+Queens,23041,State Senate,15,Ind,writein,0
+Queens,23042,State Senate,15,Ind,writein,0
+Queens,23044,State Senate,15,Ind,writein,1
+Queens,23045,State Senate,15,Ind,writein,0
+Queens,23046,State Senate,15,Ind,writein,0
+Queens,23047,State Senate,15,Ind,writein,1
+Queens,23048,State Senate,15,Ind,writein,0
+Queens,23049,State Senate,15,Ind,writein,0
+Queens,23050,State Senate,15,Ind,writein,0
+Queens,23051,State Senate,15,Ind,writein,0
+Queens,23052,State Senate,15,Ind,writein,0
+Queens,23053,State Senate,15,Ind,writein,0
+Queens,23054,State Senate,15,Ind,writein,0
+Queens,23055,State Senate,15,Ind,writein,0
+Queens,23056,State Senate,15,Ind,writein,0
+Queens,23057,State Senate,15,Ind,writein,0
+Queens,23058,State Senate,15,Ind,writein,0
+Queens,23059,State Senate,15,Ind,writein,1
+Queens,23060,State Senate,15,Ind,writein,0
+Queens,23061,State Senate,15,Ind,writein,0
+Queens,23062,State Senate,15,Ind,writein,0
+Queens,23063,State Senate,15,Ind,writein,0
+Queens,23064,State Senate,15,Ind,writein,0
+Queens,23065,State Senate,15,Ind,writein,1
+Queens,23068,State Senate,15,Ind,writein,0
+Queens,23069,State Senate,15,Ind,writein,0
+Queens,23072,State Senate,15,Ind,writein,1
+Queens,25001,State Senate,15,Ind,writein,0
+Queens,27019,State Senate,15,Ind,writein,1
+Queens,27024,State Senate,15,Ind,writein,0
+Queens,27025,State Senate,15,Ind,writein,0
+Queens,27026,State Senate,15,Ind,writein,1
+Queens,27027,State Senate,15,Ind,writein,0
+Queens,27028,State Senate,15,Ind,writein,0
+Queens,27029,State Senate,15,Ind,writein,1
+Queens,27030,State Senate,15,Ind,writein,0
+Queens,27046,State Senate,15,Ind,writein,0
+Queens,27076,State Senate,15,Ind,writein,0
+Queens,27077,State Senate,15,Ind,writein,0
+Queens,28003,State Senate,15,Ind,writein,1
+Queens,28009,State Senate,15,Ind,writein,0
+Queens,28010,State Senate,15,Ind,writein,1
+Queens,28012,State Senate,15,Ind,writein,2
+Queens,28014,State Senate,15,Ind,writein,0
+Queens,28015,State Senate,15,Ind,writein,1
+Queens,28016,State Senate,15,Ind,writein,0
+Queens,28017,State Senate,15,Ind,writein,0
+Queens,28018,State Senate,15,Ind,writein,0
+Queens,28019,State Senate,15,Ind,writein,0
+Queens,28020,State Senate,15,Ind,writein,2
+Queens,28021,State Senate,15,Ind,writein,0
+Queens,28022,State Senate,15,Ind,writein,1
+Queens,28023,State Senate,15,Ind,writein,0
+Queens,28024,State Senate,15,Ind,writein,0
+Queens,28032,State Senate,15,Ind,writein,0
+Queens,28033,State Senate,15,Ind,writein,0
+Queens,28047,State Senate,15,Ind,writein,0
+Queens,28048,State Senate,15,Ind,writein,0
+Queens,28049,State Senate,15,Ind,writein,1
+Queens,28060,State Senate,15,Ind,writein,0
+Queens,28061,State Senate,15,Ind,writein,0
+Queens,28062,State Senate,15,Ind,writein,2
+Queens,28063,State Senate,15,Ind,writein,1
+Queens,28064,State Senate,15,Ind,writein,0
+Queens,28065,State Senate,15,Ind,writein,1
+Queens,28066,State Senate,15,Ind,writein,1
+Queens,28067,State Senate,15,Ind,writein,1
+Queens,28068,State Senate,15,Ind,writein,2
+Queens,28069,State Senate,15,Ind,writein,0
+Queens,28070,State Senate,15,Ind,writein,1
+Queens,28071,State Senate,15,Ind,writein,0
+Queens,28072,State Senate,15,Ind,writein,1
+Queens,28073,State Senate,15,Ind,writein,1
+Queens,28074,State Senate,15,Ind,writein,0
+Queens,28075,State Senate,15,Ind,writein,1
+Queens,28076,State Senate,15,Ind,writein,1
+Queens,28077,State Senate,15,Ind,writein,0
+Queens,28078,State Senate,15,Ind,writein,0
+Queens,28079,State Senate,15,Ind,writein,1
+Queens,28080,State Senate,15,Ind,writein,1
+Queens,30003,State Senate,15,Ind,writein,0
+Queens,30004,State Senate,15,Ind,writein,0
+Queens,30005,State Senate,15,Ind,writein,0
+Queens,30006,State Senate,15,Ind,writein,0
+Queens,30007,State Senate,15,Ind,writein,0
+Queens,30008,State Senate,15,Ind,writein,0
+Queens,30009,State Senate,15,Ind,writein,0
+Queens,30010,State Senate,15,Ind,writein,0
+Queens,30011,State Senate,15,Ind,writein,0
+Queens,30012,State Senate,15,Ind,writein,0
+Queens,30013,State Senate,15,Ind,writein,1
+Queens,30014,State Senate,15,Ind,writein,0
+Queens,30015,State Senate,15,Ind,writein,0
+Queens,30016,State Senate,15,Ind,writein,0
+Queens,30017,State Senate,15,Ind,writein,0
+Queens,30018,State Senate,15,Ind,writein,1
+Queens,30019,State Senate,15,Ind,writein,0
+Queens,30020,State Senate,15,Ind,writein,0
+Queens,30021,State Senate,15,Ind,writein,0
+Queens,30022,State Senate,15,Ind,writein,0
+Queens,30023,State Senate,15,Ind,writein,1
+Queens,30024,State Senate,15,Ind,writein,0
+Queens,30025,State Senate,15,Ind,writein,0
+Queens,30026,State Senate,15,Ind,writein,0
+Queens,30027,State Senate,15,Ind,writein,0
+Queens,30028,State Senate,15,Ind,writein,0
+Queens,30029,State Senate,15,Ind,writein,0
+Queens,30033,State Senate,15,Ind,writein,0
+Queens,30036,State Senate,15,Ind,writein,0
+Queens,30037,State Senate,15,Ind,writein,0
+Queens,31006,State Senate,15,Ind,writein,0
+Queens,31021,State Senate,15,Ind,writein,0
+Queens,31027,State Senate,15,Ind,writein,0
+Queens,31028,State Senate,15,Ind,writein,0
+Queens,34054,State Senate,15,Ind,writein,0
+Queens,34056,State Senate,15,Ind,writein,0
+Queens,34062,State Senate,15,Ind,writein,0
+Queens,34063,State Senate,15,Ind,writein,0
+Queens,37042,State Senate,15,Ind,writein,0
+Queens,37043,State Senate,15,Ind,writein,1
+Queens,37044,State Senate,15,Ind,writein,0
+Queens,37045,State Senate,15,Ind,writein,0
+Queens,37046,State Senate,15,Ind,writein,0
+Queens,37047,State Senate,15,Ind,writein,0
+Queens,37048,State Senate,15,Ind,writein,1
+Queens,37049,State Senate,15,Ind,writein,0
+Queens,37050,State Senate,15,Ind,writein,1
+Queens,37052,State Senate,15,Ind,writein,0
+Queens,37053,State Senate,15,Ind,writein,0
+Queens,37054,State Senate,15,Ind,writein,1
+Queens,37060,State Senate,15,Ind,writein,0
+Queens,37061,State Senate,15,Ind,writein,0
+Queens,37062,State Senate,15,Ind,writein,0
+Queens,37066,State Senate,15,Ind,writein,0
+Queens,37069,State Senate,15,Ind,writein,0
+Queens,38014,State Senate,15,Ind,writein,0
+Queens,38015,State Senate,15,Ind,writein,0
+Queens,38016,State Senate,15,Ind,writein,0
+Queens,38017,State Senate,15,Ind,writein,0
+Queens,38018,State Senate,15,Ind,writein,1
+Queens,38019,State Senate,15,Ind,writein,1
+Queens,38028,State Senate,15,Ind,writein,0
+Queens,38030,State Senate,15,Ind,writein,1
+Queens,38031,State Senate,15,Ind,writein,0
+Queens,38032,State Senate,15,Ind,writein,0
+Queens,38033,State Senate,15,Ind,writein,0
+Queens,38035,State Senate,15,Ind,writein,0
+Queens,38037,State Senate,15,Ind,writein,0
+Queens,38050,State Senate,15,Ind,writein,0
+Queens,38051,State Senate,15,Ind,writein,0
+Queens,38052,State Senate,15,Ind,writein,1
+Queens,38054,State Senate,15,Ind,writein,0
+Queens,38055,State Senate,15,Ind,writein,2
+Queens,38056,State Senate,15,Ind,writein,1
+Queens,38057,State Senate,15,Ind,writein,0
+Queens,38058,State Senate,15,Ind,writein,0
+Queens,39036,State Senate,15,Ind,writein,0
+Queens,24016,State Senate,16,Rep,J D Kim,66
+Queens,24023,State Senate,16,Rep,J D Kim,15
+Queens,25020,State Senate,16,Rep,J D Kim,77
+Queens,25021,State Senate,16,Rep,J D Kim,155
+Queens,25022,State Senate,16,Rep,J D Kim,110
+Queens,25023,State Senate,16,Rep,J D Kim,71
+Queens,25024,State Senate,16,Rep,J D Kim,165
+Queens,25034,State Senate,16,Rep,J D Kim,16
+Queens,25042,State Senate,16,Rep,J D Kim,149
+Queens,25043,State Senate,16,Rep,J D Kim,153
+Queens,25044,State Senate,16,Rep,J D Kim,107
+Queens,25045,State Senate,16,Rep,J D Kim,83
+Queens,25046,State Senate,16,Rep,J D Kim,68
+Queens,25047,State Senate,16,Rep,J D Kim,91
+Queens,25048,State Senate,16,Rep,J D Kim,89
+Queens,25049,State Senate,16,Rep,J D Kim,106
+Queens,25050,State Senate,16,Rep,J D Kim,61
+Queens,25051,State Senate,16,Rep,J D Kim,68
+Queens,25052,State Senate,16,Rep,J D Kim,78
+Queens,25053,State Senate,16,Rep,J D Kim,86
+Queens,25054,State Senate,16,Rep,J D Kim,52
+Queens,25055,State Senate,16,Rep,J D Kim,110
+Queens,25056,State Senate,16,Rep,J D Kim,105
+Queens,25057,State Senate,16,Rep,J D Kim,54
+Queens,25058,State Senate,16,Rep,J D Kim,15
+Queens,25059,State Senate,16,Rep,J D Kim,117
+Queens,25060,State Senate,16,Rep,J D Kim,73
+Queens,25061,State Senate,16,Rep,J D Kim,100
+Queens,25062,State Senate,16,Rep,J D Kim,68
+Queens,25063,State Senate,16,Rep,J D Kim,104
+Queens,25064,State Senate,16,Rep,J D Kim,24
+Queens,26039,State Senate,16,Rep,J D Kim,97
+Queens,26040,State Senate,16,Rep,J D Kim,27
+Queens,26041,State Senate,16,Rep,J D Kim,15
+Queens,26044,State Senate,16,Rep,J D Kim,193
+Queens,27034,State Senate,16,Rep,J D Kim,101
+Queens,27035,State Senate,16,Rep,J D Kim,72
+Queens,27036,State Senate,16,Rep,J D Kim,123
+Queens,27037,State Senate,16,Rep,J D Kim,47
+Queens,27038,State Senate,16,Rep,J D Kim,65
+Queens,27039,State Senate,16,Rep,J D Kim,26
+Queens,27040,State Senate,16,Rep,J D Kim,39
+Queens,27041,State Senate,16,Rep,J D Kim,23
+Queens,27042,State Senate,16,Rep,J D Kim,61
+Queens,27043,State Senate,16,Rep,J D Kim,71
+Queens,27044,State Senate,16,Rep,J D Kim,64
+Queens,27045,State Senate,16,Rep,J D Kim,57
+Queens,27047,State Senate,16,Rep,J D Kim,87
+Queens,27048,State Senate,16,Rep,J D Kim,131
+Queens,27049,State Senate,16,Rep,J D Kim,157
+Queens,27050,State Senate,16,Rep,J D Kim,100
+Queens,27052,State Senate,16,Rep,J D Kim,87
+Queens,27053,State Senate,16,Rep,J D Kim,95
+Queens,27054,State Senate,16,Rep,J D Kim,82
+Queens,27055,State Senate,16,Rep,J D Kim,63
+Queens,27056,State Senate,16,Rep,J D Kim,51
+Queens,28027,State Senate,16,Rep,J D Kim,52
+Queens,28028,State Senate,16,Rep,J D Kim,122
+Queens,28029,State Senate,16,Rep,J D Kim,95
+Queens,28030,State Senate,16,Rep,J D Kim,74
+Queens,28031,State Senate,16,Rep,J D Kim,108
+Queens,28034,State Senate,16,Rep,J D Kim,13
+Queens,28035,State Senate,16,Rep,J D Kim,126
+Queens,28036,State Senate,16,Rep,J D Kim,70
+Queens,28037,State Senate,16,Rep,J D Kim,101
+Queens,28038,State Senate,16,Rep,J D Kim,86
+Queens,28039,State Senate,16,Rep,J D Kim,117
+Queens,28040,State Senate,16,Rep,J D Kim,100
+Queens,28041,State Senate,16,Rep,J D Kim,145
+Queens,28042,State Senate,16,Rep,J D Kim,124
+Queens,28043,State Senate,16,Rep,J D Kim,114
+Queens,28044,State Senate,16,Rep,J D Kim,107
+Queens,28045,State Senate,16,Rep,J D Kim,133
+Queens,28046,State Senate,16,Rep,J D Kim,109
+Queens,28050,State Senate,16,Rep,J D Kim,100
+Queens,28051,State Senate,16,Rep,J D Kim,141
+Queens,28052,State Senate,16,Rep,J D Kim,72
+Queens,28053,State Senate,16,Rep,J D Kim,124
+Queens,28054,State Senate,16,Rep,J D Kim,33
+Queens,28055,State Senate,16,Rep,J D Kim,19
+Queens,28056,State Senate,16,Rep,J D Kim,78
+Queens,28057,State Senate,16,Rep,J D Kim,56
+Queens,28058,State Senate,16,Rep,J D Kim,66
+Queens,28059,State Senate,16,Rep,J D Kim,12
+Queens,30001,State Senate,16,Rep,J D Kim,38
+Queens,30002,State Senate,16,Rep,J D Kim,100
+Queens,30030,State Senate,16,Rep,J D Kim,81
+Queens,30031,State Senate,16,Rep,J D Kim,56
+Queens,30032,State Senate,16,Rep,J D Kim,11
+Queens,30034,State Senate,16,Rep,J D Kim,2
+Queens,30054,State Senate,16,Rep,J D Kim,4
+Queens,34031,State Senate,16,Rep,J D Kim,18
+Queens,34032,State Senate,16,Rep,J D Kim,12
+Queens,34033,State Senate,16,Rep,J D Kim,7
+Queens,34045,State Senate,16,Rep,J D Kim,92
+Queens,34046,State Senate,16,Rep,J D Kim,27
+Queens,34057,State Senate,16,Rep,J D Kim,13
+Queens,34058,State Senate,16,Rep,J D Kim,0
+Queens,34061,State Senate,16,Rep,J D Kim,5
+Queens,35001,State Senate,16,Rep,J D Kim,12
+Queens,35002,State Senate,16,Rep,J D Kim,105
+Queens,35003,State Senate,16,Rep,J D Kim,80
+Queens,35004,State Senate,16,Rep,J D Kim,51
+Queens,35005,State Senate,16,Rep,J D Kim,106
+Queens,35006,State Senate,16,Rep,J D Kim,83
+Queens,35007,State Senate,16,Rep,J D Kim,81
+Queens,35008,State Senate,16,Rep,J D Kim,93
+Queens,35009,State Senate,16,Rep,J D Kim,89
+Queens,35010,State Senate,16,Rep,J D Kim,81
+Queens,35023,State Senate,16,Rep,J D Kim,113
+Queens,35024,State Senate,16,Rep,J D Kim,63
+Queens,35026,State Senate,16,Rep,J D Kim,97
+Queens,35027,State Senate,16,Rep,J D Kim,128
+Queens,35028,State Senate,16,Rep,J D Kim,2
+Queens,35029,State Senate,16,Rep,J D Kim,0
+Queens,35030,State Senate,16,Rep,J D Kim,37
+Queens,35031,State Senate,16,Rep,J D Kim,0
+Queens,35034,State Senate,16,Rep,J D Kim,7
+Queens,39023,State Senate,16,Rep,J D Kim,67
+Queens,39024,State Senate,16,Rep,J D Kim,24
+Queens,39027,State Senate,16,Rep,J D Kim,7
+Queens,39029,State Senate,16,Rep,J D Kim,58
+Queens,39030,State Senate,16,Rep,J D Kim,96
+Queens,39031,State Senate,16,Rep,J D Kim,63
+Queens,39034,State Senate,16,Rep,J D Kim,93
+Queens,39035,State Senate,16,Rep,J D Kim,34
+Queens,39037,State Senate,16,Rep,J D Kim,50
+Queens,39038,State Senate,16,Rep,J D Kim,38
+Queens,39040,State Senate,16,Rep,J D Kim,22
+Queens,39042,State Senate,16,Rep,J D Kim,9
+Queens,39048,State Senate,16,Rep,J D Kim,30
+Queens,39049,State Senate,16,Rep,J D Kim,49
+Queens,39052,State Senate,16,Rep,J D Kim,2
+Queens,39053,State Senate,16,Rep,J D Kim,13
+Queens,40011,State Senate,16,Rep,J D Kim,20
+Queens,40012,State Senate,16,Rep,J D Kim,26
+Queens,40016,State Senate,16,Rep,J D Kim,86
+Queens,40017,State Senate,16,Rep,J D Kim,136
+Queens,40018,State Senate,16,Rep,J D Kim,106
+Queens,40019,State Senate,16,Rep,J D Kim,127
+Queens,40020,State Senate,16,Rep,J D Kim,153
+Queens,40021,State Senate,16,Rep,J D Kim,110
+Queens,40022,State Senate,16,Rep,J D Kim,134
+Queens,40023,State Senate,16,Rep,J D Kim,114
+Queens,40024,State Senate,16,Rep,J D Kim,101
+Queens,40025,State Senate,16,Rep,J D Kim,111
+Queens,40026,State Senate,16,Rep,J D Kim,128
+Queens,40027,State Senate,16,Rep,J D Kim,141
+Queens,40029,State Senate,16,Rep,J D Kim,98
+Queens,40030,State Senate,16,Rep,J D Kim,170
+Queens,40031,State Senate,16,Rep,J D Kim,111
+Queens,40032,State Senate,16,Rep,J D Kim,68
+Queens,40033,State Senate,16,Rep,J D Kim,82
+Queens,40034,State Senate,16,Rep,J D Kim,48
+Queens,40035,State Senate,16,Rep,J D Kim,77
+Queens,40036,State Senate,16,Rep,J D Kim,116
+Queens,40037,State Senate,16,Rep,J D Kim,82
+Queens,40038,State Senate,16,Rep,J D Kim,83
+Queens,40039,State Senate,16,Rep,J D Kim,120
+Queens,40040,State Senate,16,Rep,J D Kim,77
+Queens,40041,State Senate,16,Rep,J D Kim,94
+Queens,40042,State Senate,16,Rep,J D Kim,81
+Queens,40043,State Senate,16,Rep,J D Kim,91
+Queens,40044,State Senate,16,Rep,J D Kim,57
+Queens,40045,State Senate,16,Rep,J D Kim,38
+Queens,40046,State Senate,16,Rep,J D Kim,22
+Queens,24016,State Senate,16,Con,J D Kim,6
+Queens,24023,State Senate,16,Con,J D Kim,3
+Queens,25020,State Senate,16,Con,J D Kim,12
+Queens,25021,State Senate,16,Con,J D Kim,22
+Queens,25022,State Senate,16,Con,J D Kim,10
+Queens,25023,State Senate,16,Con,J D Kim,5
+Queens,25024,State Senate,16,Con,J D Kim,10
+Queens,25034,State Senate,16,Con,J D Kim,3
+Queens,25042,State Senate,16,Con,J D Kim,18
+Queens,25043,State Senate,16,Con,J D Kim,13
+Queens,25044,State Senate,16,Con,J D Kim,11
+Queens,25045,State Senate,16,Con,J D Kim,8
+Queens,25046,State Senate,16,Con,J D Kim,9
+Queens,25047,State Senate,16,Con,J D Kim,9
+Queens,25048,State Senate,16,Con,J D Kim,15
+Queens,25049,State Senate,16,Con,J D Kim,12
+Queens,25050,State Senate,16,Con,J D Kim,2
+Queens,25051,State Senate,16,Con,J D Kim,5
+Queens,25052,State Senate,16,Con,J D Kim,6
+Queens,25053,State Senate,16,Con,J D Kim,8
+Queens,25054,State Senate,16,Con,J D Kim,8
+Queens,25055,State Senate,16,Con,J D Kim,12
+Queens,25056,State Senate,16,Con,J D Kim,11
+Queens,25057,State Senate,16,Con,J D Kim,6
+Queens,25058,State Senate,16,Con,J D Kim,1
+Queens,25059,State Senate,16,Con,J D Kim,10
+Queens,25060,State Senate,16,Con,J D Kim,14
+Queens,25061,State Senate,16,Con,J D Kim,7
+Queens,25062,State Senate,16,Con,J D Kim,10
+Queens,25063,State Senate,16,Con,J D Kim,18
+Queens,25064,State Senate,16,Con,J D Kim,4
+Queens,26039,State Senate,16,Con,J D Kim,9
+Queens,26040,State Senate,16,Con,J D Kim,0
+Queens,26041,State Senate,16,Con,J D Kim,2
+Queens,26044,State Senate,16,Con,J D Kim,12
+Queens,27034,State Senate,16,Con,J D Kim,4
+Queens,27035,State Senate,16,Con,J D Kim,6
+Queens,27036,State Senate,16,Con,J D Kim,9
+Queens,27037,State Senate,16,Con,J D Kim,6
+Queens,27038,State Senate,16,Con,J D Kim,5
+Queens,27039,State Senate,16,Con,J D Kim,11
+Queens,27040,State Senate,16,Con,J D Kim,8
+Queens,27041,State Senate,16,Con,J D Kim,1
+Queens,27042,State Senate,16,Con,J D Kim,4
+Queens,27043,State Senate,16,Con,J D Kim,10
+Queens,27044,State Senate,16,Con,J D Kim,5
+Queens,27045,State Senate,16,Con,J D Kim,5
+Queens,27047,State Senate,16,Con,J D Kim,10
+Queens,27048,State Senate,16,Con,J D Kim,6
+Queens,27049,State Senate,16,Con,J D Kim,13
+Queens,27050,State Senate,16,Con,J D Kim,8
+Queens,27052,State Senate,16,Con,J D Kim,19
+Queens,27053,State Senate,16,Con,J D Kim,7
+Queens,27054,State Senate,16,Con,J D Kim,5
+Queens,27055,State Senate,16,Con,J D Kim,4
+Queens,27056,State Senate,16,Con,J D Kim,3
+Queens,28027,State Senate,16,Con,J D Kim,7
+Queens,28028,State Senate,16,Con,J D Kim,7
+Queens,28029,State Senate,16,Con,J D Kim,4
+Queens,28030,State Senate,16,Con,J D Kim,8
+Queens,28031,State Senate,16,Con,J D Kim,10
+Queens,28034,State Senate,16,Con,J D Kim,1
+Queens,28035,State Senate,16,Con,J D Kim,13
+Queens,28036,State Senate,16,Con,J D Kim,4
+Queens,28037,State Senate,16,Con,J D Kim,10
+Queens,28038,State Senate,16,Con,J D Kim,9
+Queens,28039,State Senate,16,Con,J D Kim,6
+Queens,28040,State Senate,16,Con,J D Kim,8
+Queens,28041,State Senate,16,Con,J D Kim,12
+Queens,28042,State Senate,16,Con,J D Kim,6
+Queens,28043,State Senate,16,Con,J D Kim,4
+Queens,28044,State Senate,16,Con,J D Kim,18
+Queens,28045,State Senate,16,Con,J D Kim,4
+Queens,28046,State Senate,16,Con,J D Kim,13
+Queens,28050,State Senate,16,Con,J D Kim,6
+Queens,28051,State Senate,16,Con,J D Kim,4
+Queens,28052,State Senate,16,Con,J D Kim,1
+Queens,28053,State Senate,16,Con,J D Kim,8
+Queens,28054,State Senate,16,Con,J D Kim,1
+Queens,28055,State Senate,16,Con,J D Kim,1
+Queens,28056,State Senate,16,Con,J D Kim,5
+Queens,28057,State Senate,16,Con,J D Kim,2
+Queens,28058,State Senate,16,Con,J D Kim,4
+Queens,28059,State Senate,16,Con,J D Kim,2
+Queens,30001,State Senate,16,Con,J D Kim,7
+Queens,30002,State Senate,16,Con,J D Kim,10
+Queens,30030,State Senate,16,Con,J D Kim,19
+Queens,30031,State Senate,16,Con,J D Kim,2
+Queens,30032,State Senate,16,Con,J D Kim,0
+Queens,30034,State Senate,16,Con,J D Kim,0
+Queens,30054,State Senate,16,Con,J D Kim,0
+Queens,34031,State Senate,16,Con,J D Kim,3
+Queens,34032,State Senate,16,Con,J D Kim,2
+Queens,34033,State Senate,16,Con,J D Kim,0
+Queens,34045,State Senate,16,Con,J D Kim,13
+Queens,34046,State Senate,16,Con,J D Kim,1
+Queens,34057,State Senate,16,Con,J D Kim,0
+Queens,34058,State Senate,16,Con,J D Kim,0
+Queens,34061,State Senate,16,Con,J D Kim,0
+Queens,35001,State Senate,16,Con,J D Kim,0
+Queens,35002,State Senate,16,Con,J D Kim,6
+Queens,35003,State Senate,16,Con,J D Kim,11
+Queens,35004,State Senate,16,Con,J D Kim,7
+Queens,35005,State Senate,16,Con,J D Kim,7
+Queens,35006,State Senate,16,Con,J D Kim,7
+Queens,35007,State Senate,16,Con,J D Kim,5
+Queens,35008,State Senate,16,Con,J D Kim,10
+Queens,35009,State Senate,16,Con,J D Kim,8
+Queens,35010,State Senate,16,Con,J D Kim,3
+Queens,35023,State Senate,16,Con,J D Kim,8
+Queens,35024,State Senate,16,Con,J D Kim,6
+Queens,35026,State Senate,16,Con,J D Kim,2
+Queens,35027,State Senate,16,Con,J D Kim,12
+Queens,35028,State Senate,16,Con,J D Kim,0
+Queens,35029,State Senate,16,Con,J D Kim,0
+Queens,35030,State Senate,16,Con,J D Kim,2
+Queens,35031,State Senate,16,Con,J D Kim,0
+Queens,35034,State Senate,16,Con,J D Kim,0
+Queens,39023,State Senate,16,Con,J D Kim,1
+Queens,39024,State Senate,16,Con,J D Kim,2
+Queens,39027,State Senate,16,Con,J D Kim,0
+Queens,39029,State Senate,16,Con,J D Kim,7
+Queens,39030,State Senate,16,Con,J D Kim,4
+Queens,39031,State Senate,16,Con,J D Kim,2
+Queens,39034,State Senate,16,Con,J D Kim,7
+Queens,39035,State Senate,16,Con,J D Kim,9
+Queens,39037,State Senate,16,Con,J D Kim,3
+Queens,39038,State Senate,16,Con,J D Kim,2
+Queens,39040,State Senate,16,Con,J D Kim,1
+Queens,39042,State Senate,16,Con,J D Kim,0
+Queens,39048,State Senate,16,Con,J D Kim,6
+Queens,39049,State Senate,16,Con,J D Kim,6
+Queens,39052,State Senate,16,Con,J D Kim,0
+Queens,39053,State Senate,16,Con,J D Kim,0
+Queens,40011,State Senate,16,Con,J D Kim,3
+Queens,40012,State Senate,16,Con,J D Kim,1
+Queens,40016,State Senate,16,Con,J D Kim,6
+Queens,40017,State Senate,16,Con,J D Kim,18
+Queens,40018,State Senate,16,Con,J D Kim,7
+Queens,40019,State Senate,16,Con,J D Kim,9
+Queens,40020,State Senate,16,Con,J D Kim,18
+Queens,40021,State Senate,16,Con,J D Kim,8
+Queens,40022,State Senate,16,Con,J D Kim,5
+Queens,40023,State Senate,16,Con,J D Kim,6
+Queens,40024,State Senate,16,Con,J D Kim,5
+Queens,40025,State Senate,16,Con,J D Kim,7
+Queens,40026,State Senate,16,Con,J D Kim,12
+Queens,40027,State Senate,16,Con,J D Kim,8
+Queens,40029,State Senate,16,Con,J D Kim,8
+Queens,40030,State Senate,16,Con,J D Kim,24
+Queens,40031,State Senate,16,Con,J D Kim,12
+Queens,40032,State Senate,16,Con,J D Kim,9
+Queens,40033,State Senate,16,Con,J D Kim,2
+Queens,40034,State Senate,16,Con,J D Kim,0
+Queens,40035,State Senate,16,Con,J D Kim,3
+Queens,40036,State Senate,16,Con,J D Kim,9
+Queens,40037,State Senate,16,Con,J D Kim,7
+Queens,40038,State Senate,16,Con,J D Kim,9
+Queens,40039,State Senate,16,Con,J D Kim,8
+Queens,40040,State Senate,16,Con,J D Kim,5
+Queens,40041,State Senate,16,Con,J D Kim,11
+Queens,40042,State Senate,16,Con,J D Kim,6
+Queens,40043,State Senate,16,Con,J D Kim,6
+Queens,40044,State Senate,16,Con,J D Kim,3
+Queens,40045,State Senate,16,Con,J D Kim,9
+Queens,40046,State Senate,16,Con,J D Kim,0
+Queens,24016,State Senate,16,Dem,Toby Ann Stavisky,157
+Queens,24023,State Senate,16,Dem,Toby Ann Stavisky,44
+Queens,25020,State Senate,16,Dem,Toby Ann Stavisky,379
+Queens,25021,State Senate,16,Dem,Toby Ann Stavisky,342
+Queens,25022,State Senate,16,Dem,Toby Ann Stavisky,344
+Queens,25023,State Senate,16,Dem,Toby Ann Stavisky,147
+Queens,25024,State Senate,16,Dem,Toby Ann Stavisky,320
+Queens,25034,State Senate,16,Dem,Toby Ann Stavisky,26
+Queens,25042,State Senate,16,Dem,Toby Ann Stavisky,259
+Queens,25043,State Senate,16,Dem,Toby Ann Stavisky,295
+Queens,25044,State Senate,16,Dem,Toby Ann Stavisky,343
+Queens,25045,State Senate,16,Dem,Toby Ann Stavisky,257
+Queens,25046,State Senate,16,Dem,Toby Ann Stavisky,239
+Queens,25047,State Senate,16,Dem,Toby Ann Stavisky,234
+Queens,25048,State Senate,16,Dem,Toby Ann Stavisky,297
+Queens,25049,State Senate,16,Dem,Toby Ann Stavisky,291
+Queens,25050,State Senate,16,Dem,Toby Ann Stavisky,272
+Queens,25051,State Senate,16,Dem,Toby Ann Stavisky,237
+Queens,25052,State Senate,16,Dem,Toby Ann Stavisky,212
+Queens,25053,State Senate,16,Dem,Toby Ann Stavisky,293
+Queens,25054,State Senate,16,Dem,Toby Ann Stavisky,432
+Queens,25055,State Senate,16,Dem,Toby Ann Stavisky,276
+Queens,25056,State Senate,16,Dem,Toby Ann Stavisky,254
+Queens,25057,State Senate,16,Dem,Toby Ann Stavisky,113
+Queens,25058,State Senate,16,Dem,Toby Ann Stavisky,8
+Queens,25059,State Senate,16,Dem,Toby Ann Stavisky,345
+Queens,25060,State Senate,16,Dem,Toby Ann Stavisky,158
+Queens,25061,State Senate,16,Dem,Toby Ann Stavisky,205
+Queens,25062,State Senate,16,Dem,Toby Ann Stavisky,271
+Queens,25063,State Senate,16,Dem,Toby Ann Stavisky,294
+Queens,25064,State Senate,16,Dem,Toby Ann Stavisky,87
+Queens,26039,State Senate,16,Dem,Toby Ann Stavisky,191
+Queens,26040,State Senate,16,Dem,Toby Ann Stavisky,46
+Queens,26041,State Senate,16,Dem,Toby Ann Stavisky,31
+Queens,26044,State Senate,16,Dem,Toby Ann Stavisky,244
+Queens,27034,State Senate,16,Dem,Toby Ann Stavisky,342
+Queens,27035,State Senate,16,Dem,Toby Ann Stavisky,502
+Queens,27036,State Senate,16,Dem,Toby Ann Stavisky,378
+Queens,27037,State Senate,16,Dem,Toby Ann Stavisky,510
+Queens,27038,State Senate,16,Dem,Toby Ann Stavisky,549
+Queens,27039,State Senate,16,Dem,Toby Ann Stavisky,486
+Queens,27040,State Senate,16,Dem,Toby Ann Stavisky,429
+Queens,27041,State Senate,16,Dem,Toby Ann Stavisky,487
+Queens,27042,State Senate,16,Dem,Toby Ann Stavisky,497
+Queens,27043,State Senate,16,Dem,Toby Ann Stavisky,207
+Queens,27044,State Senate,16,Dem,Toby Ann Stavisky,284
+Queens,27045,State Senate,16,Dem,Toby Ann Stavisky,452
+Queens,27047,State Senate,16,Dem,Toby Ann Stavisky,334
+Queens,27048,State Senate,16,Dem,Toby Ann Stavisky,284
+Queens,27049,State Senate,16,Dem,Toby Ann Stavisky,324
+Queens,27050,State Senate,16,Dem,Toby Ann Stavisky,216
+Queens,27052,State Senate,16,Dem,Toby Ann Stavisky,300
+Queens,27053,State Senate,16,Dem,Toby Ann Stavisky,230
+Queens,27054,State Senate,16,Dem,Toby Ann Stavisky,278
+Queens,27055,State Senate,16,Dem,Toby Ann Stavisky,244
+Queens,27056,State Senate,16,Dem,Toby Ann Stavisky,276
+Queens,28027,State Senate,16,Dem,Toby Ann Stavisky,199
+Queens,28028,State Senate,16,Dem,Toby Ann Stavisky,424
+Queens,28029,State Senate,16,Dem,Toby Ann Stavisky,334
+Queens,28030,State Senate,16,Dem,Toby Ann Stavisky,302
+Queens,28031,State Senate,16,Dem,Toby Ann Stavisky,467
+Queens,28034,State Senate,16,Dem,Toby Ann Stavisky,32
+Queens,28035,State Senate,16,Dem,Toby Ann Stavisky,440
+Queens,28036,State Senate,16,Dem,Toby Ann Stavisky,278
+Queens,28037,State Senate,16,Dem,Toby Ann Stavisky,451
+Queens,28038,State Senate,16,Dem,Toby Ann Stavisky,458
+Queens,28039,State Senate,16,Dem,Toby Ann Stavisky,448
+Queens,28040,State Senate,16,Dem,Toby Ann Stavisky,418
+Queens,28041,State Senate,16,Dem,Toby Ann Stavisky,385
+Queens,28042,State Senate,16,Dem,Toby Ann Stavisky,512
+Queens,28043,State Senate,16,Dem,Toby Ann Stavisky,326
+Queens,28044,State Senate,16,Dem,Toby Ann Stavisky,463
+Queens,28045,State Senate,16,Dem,Toby Ann Stavisky,347
+Queens,28046,State Senate,16,Dem,Toby Ann Stavisky,358
+Queens,28050,State Senate,16,Dem,Toby Ann Stavisky,333
+Queens,28051,State Senate,16,Dem,Toby Ann Stavisky,348
+Queens,28052,State Senate,16,Dem,Toby Ann Stavisky,148
+Queens,28053,State Senate,16,Dem,Toby Ann Stavisky,244
+Queens,28054,State Senate,16,Dem,Toby Ann Stavisky,116
+Queens,28055,State Senate,16,Dem,Toby Ann Stavisky,106
+Queens,28056,State Senate,16,Dem,Toby Ann Stavisky,265
+Queens,28057,State Senate,16,Dem,Toby Ann Stavisky,214
+Queens,28058,State Senate,16,Dem,Toby Ann Stavisky,237
+Queens,28059,State Senate,16,Dem,Toby Ann Stavisky,40
+Queens,30001,State Senate,16,Dem,Toby Ann Stavisky,109
+Queens,30002,State Senate,16,Dem,Toby Ann Stavisky,280
+Queens,30030,State Senate,16,Dem,Toby Ann Stavisky,219
+Queens,30031,State Senate,16,Dem,Toby Ann Stavisky,166
+Queens,30032,State Senate,16,Dem,Toby Ann Stavisky,62
+Queens,30034,State Senate,16,Dem,Toby Ann Stavisky,1
+Queens,30054,State Senate,16,Dem,Toby Ann Stavisky,32
+Queens,34031,State Senate,16,Dem,Toby Ann Stavisky,92
+Queens,34032,State Senate,16,Dem,Toby Ann Stavisky,36
+Queens,34033,State Senate,16,Dem,Toby Ann Stavisky,46
+Queens,34045,State Senate,16,Dem,Toby Ann Stavisky,425
+Queens,34046,State Senate,16,Dem,Toby Ann Stavisky,148
+Queens,34057,State Senate,16,Dem,Toby Ann Stavisky,64
+Queens,34058,State Senate,16,Dem,Toby Ann Stavisky,6
+Queens,34061,State Senate,16,Dem,Toby Ann Stavisky,24
+Queens,35001,State Senate,16,Dem,Toby Ann Stavisky,57
+Queens,35002,State Senate,16,Dem,Toby Ann Stavisky,292
+Queens,35003,State Senate,16,Dem,Toby Ann Stavisky,241
+Queens,35004,State Senate,16,Dem,Toby Ann Stavisky,172
+Queens,35005,State Senate,16,Dem,Toby Ann Stavisky,296
+Queens,35006,State Senate,16,Dem,Toby Ann Stavisky,402
+Queens,35007,State Senate,16,Dem,Toby Ann Stavisky,398
+Queens,35008,State Senate,16,Dem,Toby Ann Stavisky,344
+Queens,35009,State Senate,16,Dem,Toby Ann Stavisky,349
+Queens,35010,State Senate,16,Dem,Toby Ann Stavisky,426
+Queens,35023,State Senate,16,Dem,Toby Ann Stavisky,374
+Queens,35024,State Senate,16,Dem,Toby Ann Stavisky,330
+Queens,35026,State Senate,16,Dem,Toby Ann Stavisky,248
+Queens,35027,State Senate,16,Dem,Toby Ann Stavisky,294
+Queens,35028,State Senate,16,Dem,Toby Ann Stavisky,11
+Queens,35029,State Senate,16,Dem,Toby Ann Stavisky,2
+Queens,35030,State Senate,16,Dem,Toby Ann Stavisky,85
+Queens,35031,State Senate,16,Dem,Toby Ann Stavisky,2
+Queens,35034,State Senate,16,Dem,Toby Ann Stavisky,37
+Queens,39023,State Senate,16,Dem,Toby Ann Stavisky,263
+Queens,39024,State Senate,16,Dem,Toby Ann Stavisky,108
+Queens,39027,State Senate,16,Dem,Toby Ann Stavisky,67
+Queens,39029,State Senate,16,Dem,Toby Ann Stavisky,325
+Queens,39030,State Senate,16,Dem,Toby Ann Stavisky,421
+Queens,39031,State Senate,16,Dem,Toby Ann Stavisky,189
+Queens,39034,State Senate,16,Dem,Toby Ann Stavisky,334
+Queens,39035,State Senate,16,Dem,Toby Ann Stavisky,135
+Queens,39037,State Senate,16,Dem,Toby Ann Stavisky,267
+Queens,39038,State Senate,16,Dem,Toby Ann Stavisky,188
+Queens,39040,State Senate,16,Dem,Toby Ann Stavisky,60
+Queens,39042,State Senate,16,Dem,Toby Ann Stavisky,47
+Queens,39048,State Senate,16,Dem,Toby Ann Stavisky,206
+Queens,39049,State Senate,16,Dem,Toby Ann Stavisky,422
+Queens,39052,State Senate,16,Dem,Toby Ann Stavisky,6
+Queens,39053,State Senate,16,Dem,Toby Ann Stavisky,64
+Queens,40011,State Senate,16,Dem,Toby Ann Stavisky,43
+Queens,40012,State Senate,16,Dem,Toby Ann Stavisky,25
+Queens,40016,State Senate,16,Dem,Toby Ann Stavisky,261
+Queens,40017,State Senate,16,Dem,Toby Ann Stavisky,275
+Queens,40018,State Senate,16,Dem,Toby Ann Stavisky,313
+Queens,40019,State Senate,16,Dem,Toby Ann Stavisky,332
+Queens,40020,State Senate,16,Dem,Toby Ann Stavisky,286
+Queens,40021,State Senate,16,Dem,Toby Ann Stavisky,245
+Queens,40022,State Senate,16,Dem,Toby Ann Stavisky,254
+Queens,40023,State Senate,16,Dem,Toby Ann Stavisky,282
+Queens,40024,State Senate,16,Dem,Toby Ann Stavisky,296
+Queens,40025,State Senate,16,Dem,Toby Ann Stavisky,248
+Queens,40026,State Senate,16,Dem,Toby Ann Stavisky,272
+Queens,40027,State Senate,16,Dem,Toby Ann Stavisky,300
+Queens,40029,State Senate,16,Dem,Toby Ann Stavisky,293
+Queens,40030,State Senate,16,Dem,Toby Ann Stavisky,273
+Queens,40031,State Senate,16,Dem,Toby Ann Stavisky,248
+Queens,40032,State Senate,16,Dem,Toby Ann Stavisky,263
+Queens,40033,State Senate,16,Dem,Toby Ann Stavisky,310
+Queens,40034,State Senate,16,Dem,Toby Ann Stavisky,408
+Queens,40035,State Senate,16,Dem,Toby Ann Stavisky,380
+Queens,40036,State Senate,16,Dem,Toby Ann Stavisky,242
+Queens,40037,State Senate,16,Dem,Toby Ann Stavisky,353
+Queens,40038,State Senate,16,Dem,Toby Ann Stavisky,235
+Queens,40039,State Senate,16,Dem,Toby Ann Stavisky,357
+Queens,40040,State Senate,16,Dem,Toby Ann Stavisky,306
+Queens,40041,State Senate,16,Dem,Toby Ann Stavisky,257
+Queens,40042,State Senate,16,Dem,Toby Ann Stavisky,255
+Queens,40043,State Senate,16,Dem,Toby Ann Stavisky,219
+Queens,40044,State Senate,16,Dem,Toby Ann Stavisky,282
+Queens,40045,State Senate,16,Dem,Toby Ann Stavisky,201
+Queens,40046,State Senate,16,Dem,Toby Ann Stavisky,189
+Queens,24016,State Senate,16,WF,Toby Ann Stavisky,5
+Queens,24023,State Senate,16,WF,Toby Ann Stavisky,2
+Queens,25020,State Senate,16,WF,Toby Ann Stavisky,9
+Queens,25021,State Senate,16,WF,Toby Ann Stavisky,12
+Queens,25022,State Senate,16,WF,Toby Ann Stavisky,4
+Queens,25023,State Senate,16,WF,Toby Ann Stavisky,2
+Queens,25024,State Senate,16,WF,Toby Ann Stavisky,9
+Queens,25034,State Senate,16,WF,Toby Ann Stavisky,0
+Queens,25042,State Senate,16,WF,Toby Ann Stavisky,13
+Queens,25043,State Senate,16,WF,Toby Ann Stavisky,10
+Queens,25044,State Senate,16,WF,Toby Ann Stavisky,9
+Queens,25045,State Senate,16,WF,Toby Ann Stavisky,12
+Queens,25046,State Senate,16,WF,Toby Ann Stavisky,10
+Queens,25047,State Senate,16,WF,Toby Ann Stavisky,15
+Queens,25048,State Senate,16,WF,Toby Ann Stavisky,9
+Queens,25049,State Senate,16,WF,Toby Ann Stavisky,7
+Queens,25050,State Senate,16,WF,Toby Ann Stavisky,9
+Queens,25051,State Senate,16,WF,Toby Ann Stavisky,4
+Queens,25052,State Senate,16,WF,Toby Ann Stavisky,4
+Queens,25053,State Senate,16,WF,Toby Ann Stavisky,4
+Queens,25054,State Senate,16,WF,Toby Ann Stavisky,9
+Queens,25055,State Senate,16,WF,Toby Ann Stavisky,11
+Queens,25056,State Senate,16,WF,Toby Ann Stavisky,13
+Queens,25057,State Senate,16,WF,Toby Ann Stavisky,5
+Queens,25058,State Senate,16,WF,Toby Ann Stavisky,4
+Queens,25059,State Senate,16,WF,Toby Ann Stavisky,12
+Queens,25060,State Senate,16,WF,Toby Ann Stavisky,16
+Queens,25061,State Senate,16,WF,Toby Ann Stavisky,5
+Queens,25062,State Senate,16,WF,Toby Ann Stavisky,7
+Queens,25063,State Senate,16,WF,Toby Ann Stavisky,15
+Queens,25064,State Senate,16,WF,Toby Ann Stavisky,4
+Queens,26039,State Senate,16,WF,Toby Ann Stavisky,9
+Queens,26040,State Senate,16,WF,Toby Ann Stavisky,2
+Queens,26041,State Senate,16,WF,Toby Ann Stavisky,0
+Queens,26044,State Senate,16,WF,Toby Ann Stavisky,3
+Queens,27034,State Senate,16,WF,Toby Ann Stavisky,8
+Queens,27035,State Senate,16,WF,Toby Ann Stavisky,11
+Queens,27036,State Senate,16,WF,Toby Ann Stavisky,14
+Queens,27037,State Senate,16,WF,Toby Ann Stavisky,11
+Queens,27038,State Senate,16,WF,Toby Ann Stavisky,18
+Queens,27039,State Senate,16,WF,Toby Ann Stavisky,15
+Queens,27040,State Senate,16,WF,Toby Ann Stavisky,17
+Queens,27041,State Senate,16,WF,Toby Ann Stavisky,8
+Queens,27042,State Senate,16,WF,Toby Ann Stavisky,13
+Queens,27043,State Senate,16,WF,Toby Ann Stavisky,5
+Queens,27044,State Senate,16,WF,Toby Ann Stavisky,7
+Queens,27045,State Senate,16,WF,Toby Ann Stavisky,8
+Queens,27047,State Senate,16,WF,Toby Ann Stavisky,11
+Queens,27048,State Senate,16,WF,Toby Ann Stavisky,15
+Queens,27049,State Senate,16,WF,Toby Ann Stavisky,10
+Queens,27050,State Senate,16,WF,Toby Ann Stavisky,11
+Queens,27052,State Senate,16,WF,Toby Ann Stavisky,13
+Queens,27053,State Senate,16,WF,Toby Ann Stavisky,7
+Queens,27054,State Senate,16,WF,Toby Ann Stavisky,6
+Queens,27055,State Senate,16,WF,Toby Ann Stavisky,10
+Queens,27056,State Senate,16,WF,Toby Ann Stavisky,3
+Queens,28027,State Senate,16,WF,Toby Ann Stavisky,10
+Queens,28028,State Senate,16,WF,Toby Ann Stavisky,21
+Queens,28029,State Senate,16,WF,Toby Ann Stavisky,11
+Queens,28030,State Senate,16,WF,Toby Ann Stavisky,8
+Queens,28031,State Senate,16,WF,Toby Ann Stavisky,18
+Queens,28034,State Senate,16,WF,Toby Ann Stavisky,1
+Queens,28035,State Senate,16,WF,Toby Ann Stavisky,10
+Queens,28036,State Senate,16,WF,Toby Ann Stavisky,18
+Queens,28037,State Senate,16,WF,Toby Ann Stavisky,24
+Queens,28038,State Senate,16,WF,Toby Ann Stavisky,14
+Queens,28039,State Senate,16,WF,Toby Ann Stavisky,22
+Queens,28040,State Senate,16,WF,Toby Ann Stavisky,21
+Queens,28041,State Senate,16,WF,Toby Ann Stavisky,17
+Queens,28042,State Senate,16,WF,Toby Ann Stavisky,21
+Queens,28043,State Senate,16,WF,Toby Ann Stavisky,14
+Queens,28044,State Senate,16,WF,Toby Ann Stavisky,15
+Queens,28045,State Senate,16,WF,Toby Ann Stavisky,16
+Queens,28046,State Senate,16,WF,Toby Ann Stavisky,14
+Queens,28050,State Senate,16,WF,Toby Ann Stavisky,10
+Queens,28051,State Senate,16,WF,Toby Ann Stavisky,20
+Queens,28052,State Senate,16,WF,Toby Ann Stavisky,9
+Queens,28053,State Senate,16,WF,Toby Ann Stavisky,4
+Queens,28054,State Senate,16,WF,Toby Ann Stavisky,2
+Queens,28055,State Senate,16,WF,Toby Ann Stavisky,1
+Queens,28056,State Senate,16,WF,Toby Ann Stavisky,12
+Queens,28057,State Senate,16,WF,Toby Ann Stavisky,13
+Queens,28058,State Senate,16,WF,Toby Ann Stavisky,11
+Queens,28059,State Senate,16,WF,Toby Ann Stavisky,0
+Queens,30001,State Senate,16,WF,Toby Ann Stavisky,6
+Queens,30002,State Senate,16,WF,Toby Ann Stavisky,6
+Queens,30030,State Senate,16,WF,Toby Ann Stavisky,7
+Queens,30031,State Senate,16,WF,Toby Ann Stavisky,5
+Queens,30032,State Senate,16,WF,Toby Ann Stavisky,1
+Queens,30034,State Senate,16,WF,Toby Ann Stavisky,0
+Queens,30054,State Senate,16,WF,Toby Ann Stavisky,1
+Queens,34031,State Senate,16,WF,Toby Ann Stavisky,3
+Queens,34032,State Senate,16,WF,Toby Ann Stavisky,7
+Queens,34033,State Senate,16,WF,Toby Ann Stavisky,1
+Queens,34045,State Senate,16,WF,Toby Ann Stavisky,18
+Queens,34046,State Senate,16,WF,Toby Ann Stavisky,4
+Queens,34057,State Senate,16,WF,Toby Ann Stavisky,1
+Queens,34058,State Senate,16,WF,Toby Ann Stavisky,0
+Queens,34061,State Senate,16,WF,Toby Ann Stavisky,1
+Queens,35001,State Senate,16,WF,Toby Ann Stavisky,3
+Queens,35002,State Senate,16,WF,Toby Ann Stavisky,7
+Queens,35003,State Senate,16,WF,Toby Ann Stavisky,10
+Queens,35004,State Senate,16,WF,Toby Ann Stavisky,3
+Queens,35005,State Senate,16,WF,Toby Ann Stavisky,8
+Queens,35006,State Senate,16,WF,Toby Ann Stavisky,9
+Queens,35007,State Senate,16,WF,Toby Ann Stavisky,17
+Queens,35008,State Senate,16,WF,Toby Ann Stavisky,7
+Queens,35009,State Senate,16,WF,Toby Ann Stavisky,9
+Queens,35010,State Senate,16,WF,Toby Ann Stavisky,9
+Queens,35023,State Senate,16,WF,Toby Ann Stavisky,9
+Queens,35024,State Senate,16,WF,Toby Ann Stavisky,8
+Queens,35026,State Senate,16,WF,Toby Ann Stavisky,12
+Queens,35027,State Senate,16,WF,Toby Ann Stavisky,16
+Queens,35028,State Senate,16,WF,Toby Ann Stavisky,0
+Queens,35029,State Senate,16,WF,Toby Ann Stavisky,1
+Queens,35030,State Senate,16,WF,Toby Ann Stavisky,7
+Queens,35031,State Senate,16,WF,Toby Ann Stavisky,0
+Queens,35034,State Senate,16,WF,Toby Ann Stavisky,0
+Queens,39023,State Senate,16,WF,Toby Ann Stavisky,2
+Queens,39024,State Senate,16,WF,Toby Ann Stavisky,2
+Queens,39027,State Senate,16,WF,Toby Ann Stavisky,0
+Queens,39029,State Senate,16,WF,Toby Ann Stavisky,3
+Queens,39030,State Senate,16,WF,Toby Ann Stavisky,17
+Queens,39031,State Senate,16,WF,Toby Ann Stavisky,6
+Queens,39034,State Senate,16,WF,Toby Ann Stavisky,6
+Queens,39035,State Senate,16,WF,Toby Ann Stavisky,8
+Queens,39037,State Senate,16,WF,Toby Ann Stavisky,12
+Queens,39038,State Senate,16,WF,Toby Ann Stavisky,6
+Queens,39040,State Senate,16,WF,Toby Ann Stavisky,0
+Queens,39042,State Senate,16,WF,Toby Ann Stavisky,2
+Queens,39048,State Senate,16,WF,Toby Ann Stavisky,8
+Queens,39049,State Senate,16,WF,Toby Ann Stavisky,6
+Queens,39052,State Senate,16,WF,Toby Ann Stavisky,0
+Queens,39053,State Senate,16,WF,Toby Ann Stavisky,0
+Queens,40011,State Senate,16,WF,Toby Ann Stavisky,2
+Queens,40012,State Senate,16,WF,Toby Ann Stavisky,0
+Queens,40016,State Senate,16,WF,Toby Ann Stavisky,11
+Queens,40017,State Senate,16,WF,Toby Ann Stavisky,13
+Queens,40018,State Senate,16,WF,Toby Ann Stavisky,14
+Queens,40019,State Senate,16,WF,Toby Ann Stavisky,3
+Queens,40020,State Senate,16,WF,Toby Ann Stavisky,9
+Queens,40021,State Senate,16,WF,Toby Ann Stavisky,4
+Queens,40022,State Senate,16,WF,Toby Ann Stavisky,9
+Queens,40023,State Senate,16,WF,Toby Ann Stavisky,9
+Queens,40024,State Senate,16,WF,Toby Ann Stavisky,6
+Queens,40025,State Senate,16,WF,Toby Ann Stavisky,9
+Queens,40026,State Senate,16,WF,Toby Ann Stavisky,6
+Queens,40027,State Senate,16,WF,Toby Ann Stavisky,6
+Queens,40029,State Senate,16,WF,Toby Ann Stavisky,11
+Queens,40030,State Senate,16,WF,Toby Ann Stavisky,8
+Queens,40031,State Senate,16,WF,Toby Ann Stavisky,10
+Queens,40032,State Senate,16,WF,Toby Ann Stavisky,8
+Queens,40033,State Senate,16,WF,Toby Ann Stavisky,7
+Queens,40034,State Senate,16,WF,Toby Ann Stavisky,8
+Queens,40035,State Senate,16,WF,Toby Ann Stavisky,5
+Queens,40036,State Senate,16,WF,Toby Ann Stavisky,3
+Queens,40037,State Senate,16,WF,Toby Ann Stavisky,7
+Queens,40038,State Senate,16,WF,Toby Ann Stavisky,6
+Queens,40039,State Senate,16,WF,Toby Ann Stavisky,7
+Queens,40040,State Senate,16,WF,Toby Ann Stavisky,9
+Queens,40041,State Senate,16,WF,Toby Ann Stavisky,5
+Queens,40042,State Senate,16,WF,Toby Ann Stavisky,8
+Queens,40043,State Senate,16,WF,Toby Ann Stavisky,5
+Queens,40044,State Senate,16,WF,Toby Ann Stavisky,5
+Queens,40045,State Senate,16,WF,Toby Ann Stavisky,5
+Queens,40046,State Senate,16,WF,Toby Ann Stavisky,4
+Queens,24016,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,24023,State Senate,16,Ind,Toby Ann Stavisky,1
+Queens,25020,State Senate,16,Ind,Toby Ann Stavisky,5
+Queens,25021,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,25022,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,25023,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,25024,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,25034,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,25042,State Senate,16,Ind,Toby Ann Stavisky,5
+Queens,25043,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,25044,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,25045,State Senate,16,Ind,Toby Ann Stavisky,7
+Queens,25046,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,25047,State Senate,16,Ind,Toby Ann Stavisky,8
+Queens,25048,State Senate,16,Ind,Toby Ann Stavisky,10
+Queens,25049,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,25050,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,25051,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,25052,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,25053,State Senate,16,Ind,Toby Ann Stavisky,1
+Queens,25054,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,25055,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,25056,State Senate,16,Ind,Toby Ann Stavisky,7
+Queens,25057,State Senate,16,Ind,Toby Ann Stavisky,5
+Queens,25058,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,25059,State Senate,16,Ind,Toby Ann Stavisky,12
+Queens,25060,State Senate,16,Ind,Toby Ann Stavisky,24
+Queens,25061,State Senate,16,Ind,Toby Ann Stavisky,5
+Queens,25062,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,25063,State Senate,16,Ind,Toby Ann Stavisky,9
+Queens,25064,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,26039,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,26040,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,26041,State Senate,16,Ind,Toby Ann Stavisky,1
+Queens,26044,State Senate,16,Ind,Toby Ann Stavisky,10
+Queens,27034,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,27035,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,27036,State Senate,16,Ind,Toby Ann Stavisky,12
+Queens,27037,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,27038,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,27039,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,27040,State Senate,16,Ind,Toby Ann Stavisky,5
+Queens,27041,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,27042,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,27043,State Senate,16,Ind,Toby Ann Stavisky,5
+Queens,27044,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,27045,State Senate,16,Ind,Toby Ann Stavisky,10
+Queens,27047,State Senate,16,Ind,Toby Ann Stavisky,7
+Queens,27048,State Senate,16,Ind,Toby Ann Stavisky,5
+Queens,27049,State Senate,16,Ind,Toby Ann Stavisky,8
+Queens,27050,State Senate,16,Ind,Toby Ann Stavisky,5
+Queens,27052,State Senate,16,Ind,Toby Ann Stavisky,5
+Queens,27053,State Senate,16,Ind,Toby Ann Stavisky,1
+Queens,27054,State Senate,16,Ind,Toby Ann Stavisky,9
+Queens,27055,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,27056,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,28027,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,28028,State Senate,16,Ind,Toby Ann Stavisky,15
+Queens,28029,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,28030,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,28031,State Senate,16,Ind,Toby Ann Stavisky,8
+Queens,28034,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,28035,State Senate,16,Ind,Toby Ann Stavisky,10
+Queens,28036,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,28037,State Senate,16,Ind,Toby Ann Stavisky,13
+Queens,28038,State Senate,16,Ind,Toby Ann Stavisky,8
+Queens,28039,State Senate,16,Ind,Toby Ann Stavisky,15
+Queens,28040,State Senate,16,Ind,Toby Ann Stavisky,7
+Queens,28041,State Senate,16,Ind,Toby Ann Stavisky,9
+Queens,28042,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,28043,State Senate,16,Ind,Toby Ann Stavisky,12
+Queens,28044,State Senate,16,Ind,Toby Ann Stavisky,5
+Queens,28045,State Senate,16,Ind,Toby Ann Stavisky,9
+Queens,28046,State Senate,16,Ind,Toby Ann Stavisky,8
+Queens,28050,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,28051,State Senate,16,Ind,Toby Ann Stavisky,7
+Queens,28052,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,28053,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,28054,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,28055,State Senate,16,Ind,Toby Ann Stavisky,1
+Queens,28056,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,28057,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,28058,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,28059,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,30001,State Senate,16,Ind,Toby Ann Stavisky,1
+Queens,30002,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,30030,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,30031,State Senate,16,Ind,Toby Ann Stavisky,1
+Queens,30032,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,30034,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,30054,State Senate,16,Ind,Toby Ann Stavisky,1
+Queens,34031,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,34032,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,34033,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,34045,State Senate,16,Ind,Toby Ann Stavisky,7
+Queens,34046,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,34057,State Senate,16,Ind,Toby Ann Stavisky,1
+Queens,34058,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,34061,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,35001,State Senate,16,Ind,Toby Ann Stavisky,1
+Queens,35002,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,35003,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,35004,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,35005,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,35006,State Senate,16,Ind,Toby Ann Stavisky,7
+Queens,35007,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,35008,State Senate,16,Ind,Toby Ann Stavisky,12
+Queens,35009,State Senate,16,Ind,Toby Ann Stavisky,5
+Queens,35010,State Senate,16,Ind,Toby Ann Stavisky,7
+Queens,35023,State Senate,16,Ind,Toby Ann Stavisky,8
+Queens,35024,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,35026,State Senate,16,Ind,Toby Ann Stavisky,5
+Queens,35027,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,35028,State Senate,16,Ind,Toby Ann Stavisky,1
+Queens,35029,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,35030,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,35031,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,35034,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,39023,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,39024,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,39027,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,39029,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,39030,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,39031,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,39034,State Senate,16,Ind,Toby Ann Stavisky,5
+Queens,39035,State Senate,16,Ind,Toby Ann Stavisky,1
+Queens,39037,State Senate,16,Ind,Toby Ann Stavisky,11
+Queens,39038,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,39040,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,39042,State Senate,16,Ind,Toby Ann Stavisky,1
+Queens,39048,State Senate,16,Ind,Toby Ann Stavisky,5
+Queens,39049,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,39052,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,39053,State Senate,16,Ind,Toby Ann Stavisky,1
+Queens,40011,State Senate,16,Ind,Toby Ann Stavisky,1
+Queens,40012,State Senate,16,Ind,Toby Ann Stavisky,0
+Queens,40016,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,40017,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,40018,State Senate,16,Ind,Toby Ann Stavisky,7
+Queens,40019,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,40020,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,40021,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,40022,State Senate,16,Ind,Toby Ann Stavisky,5
+Queens,40023,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,40024,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,40025,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,40026,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,40027,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,40029,State Senate,16,Ind,Toby Ann Stavisky,9
+Queens,40030,State Senate,16,Ind,Toby Ann Stavisky,8
+Queens,40031,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,40032,State Senate,16,Ind,Toby Ann Stavisky,7
+Queens,40033,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,40034,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,40035,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,40036,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,40037,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,40038,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,40039,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,40040,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,40041,State Senate,16,Ind,Toby Ann Stavisky,6
+Queens,40042,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,40043,State Senate,16,Ind,Toby Ann Stavisky,3
+Queens,40044,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,40045,State Senate,16,Ind,Toby Ann Stavisky,2
+Queens,40046,State Senate,16,Ind,Toby Ann Stavisky,4
+Queens,24016,State Senate,16,Ind,writein,0
+Queens,24023,State Senate,16,Ind,writein,0
+Queens,25020,State Senate,16,Ind,writein,0
+Queens,25021,State Senate,16,Ind,writein,1
+Queens,25022,State Senate,16,Ind,writein,2
+Queens,25023,State Senate,16,Ind,writein,0
+Queens,25024,State Senate,16,Ind,writein,0
+Queens,25034,State Senate,16,Ind,writein,0
+Queens,25042,State Senate,16,Ind,writein,0
+Queens,25043,State Senate,16,Ind,writein,1
+Queens,25044,State Senate,16,Ind,writein,1
+Queens,25045,State Senate,16,Ind,writein,0
+Queens,25046,State Senate,16,Ind,writein,0
+Queens,25047,State Senate,16,Ind,writein,0
+Queens,25048,State Senate,16,Ind,writein,0
+Queens,25049,State Senate,16,Ind,writein,1
+Queens,25050,State Senate,16,Ind,writein,0
+Queens,25051,State Senate,16,Ind,writein,1
+Queens,25052,State Senate,16,Ind,writein,0
+Queens,25053,State Senate,16,Ind,writein,2
+Queens,25054,State Senate,16,Ind,writein,0
+Queens,25055,State Senate,16,Ind,writein,0
+Queens,25056,State Senate,16,Ind,writein,0
+Queens,25057,State Senate,16,Ind,writein,0
+Queens,25058,State Senate,16,Ind,writein,0
+Queens,25059,State Senate,16,Ind,writein,1
+Queens,25060,State Senate,16,Ind,writein,2
+Queens,25061,State Senate,16,Ind,writein,0
+Queens,25062,State Senate,16,Ind,writein,0
+Queens,25063,State Senate,16,Ind,writein,0
+Queens,25064,State Senate,16,Ind,writein,0
+Queens,26039,State Senate,16,Ind,writein,0
+Queens,26040,State Senate,16,Ind,writein,0
+Queens,26041,State Senate,16,Ind,writein,0
+Queens,26044,State Senate,16,Ind,writein,0
+Queens,27034,State Senate,16,Ind,writein,1
+Queens,27035,State Senate,16,Ind,writein,0
+Queens,27036,State Senate,16,Ind,writein,0
+Queens,27037,State Senate,16,Ind,writein,0
+Queens,27038,State Senate,16,Ind,writein,2
+Queens,27039,State Senate,16,Ind,writein,1
+Queens,27040,State Senate,16,Ind,writein,0
+Queens,27041,State Senate,16,Ind,writein,0
+Queens,27042,State Senate,16,Ind,writein,0
+Queens,27043,State Senate,16,Ind,writein,0
+Queens,27044,State Senate,16,Ind,writein,0
+Queens,27045,State Senate,16,Ind,writein,0
+Queens,27047,State Senate,16,Ind,writein,0
+Queens,27048,State Senate,16,Ind,writein,0
+Queens,27049,State Senate,16,Ind,writein,0
+Queens,27050,State Senate,16,Ind,writein,0
+Queens,27052,State Senate,16,Ind,writein,1
+Queens,27053,State Senate,16,Ind,writein,1
+Queens,27054,State Senate,16,Ind,writein,1
+Queens,27055,State Senate,16,Ind,writein,0
+Queens,27056,State Senate,16,Ind,writein,0
+Queens,28027,State Senate,16,Ind,writein,0
+Queens,28028,State Senate,16,Ind,writein,0
+Queens,28029,State Senate,16,Ind,writein,0
+Queens,28030,State Senate,16,Ind,writein,1
+Queens,28031,State Senate,16,Ind,writein,1
+Queens,28034,State Senate,16,Ind,writein,0
+Queens,28035,State Senate,16,Ind,writein,1
+Queens,28036,State Senate,16,Ind,writein,0
+Queens,28037,State Senate,16,Ind,writein,0
+Queens,28038,State Senate,16,Ind,writein,0
+Queens,28039,State Senate,16,Ind,writein,0
+Queens,28040,State Senate,16,Ind,writein,0
+Queens,28041,State Senate,16,Ind,writein,0
+Queens,28042,State Senate,16,Ind,writein,0
+Queens,28043,State Senate,16,Ind,writein,0
+Queens,28044,State Senate,16,Ind,writein,0
+Queens,28045,State Senate,16,Ind,writein,0
+Queens,28046,State Senate,16,Ind,writein,0
+Queens,28050,State Senate,16,Ind,writein,0
+Queens,28051,State Senate,16,Ind,writein,0
+Queens,28052,State Senate,16,Ind,writein,0
+Queens,28053,State Senate,16,Ind,writein,0
+Queens,28054,State Senate,16,Ind,writein,0
+Queens,28055,State Senate,16,Ind,writein,0
+Queens,28056,State Senate,16,Ind,writein,1
+Queens,28057,State Senate,16,Ind,writein,2
+Queens,28058,State Senate,16,Ind,writein,0
+Queens,28059,State Senate,16,Ind,writein,0
+Queens,30001,State Senate,16,Ind,writein,0
+Queens,30002,State Senate,16,Ind,writein,0
+Queens,30030,State Senate,16,Ind,writein,0
+Queens,30031,State Senate,16,Ind,writein,0
+Queens,30032,State Senate,16,Ind,writein,0
+Queens,30034,State Senate,16,Ind,writein,0
+Queens,30054,State Senate,16,Ind,writein,0
+Queens,34031,State Senate,16,Ind,writein,1
+Queens,34032,State Senate,16,Ind,writein,0
+Queens,34033,State Senate,16,Ind,writein,0
+Queens,34045,State Senate,16,Ind,writein,2
+Queens,34046,State Senate,16,Ind,writein,1
+Queens,34057,State Senate,16,Ind,writein,0
+Queens,34058,State Senate,16,Ind,writein,0
+Queens,34061,State Senate,16,Ind,writein,0
+Queens,35001,State Senate,16,Ind,writein,0
+Queens,35002,State Senate,16,Ind,writein,1
+Queens,35003,State Senate,16,Ind,writein,2
+Queens,35004,State Senate,16,Ind,writein,0
+Queens,35005,State Senate,16,Ind,writein,1
+Queens,35006,State Senate,16,Ind,writein,1
+Queens,35007,State Senate,16,Ind,writein,0
+Queens,35008,State Senate,16,Ind,writein,1
+Queens,35009,State Senate,16,Ind,writein,0
+Queens,35010,State Senate,16,Ind,writein,0
+Queens,35023,State Senate,16,Ind,writein,1
+Queens,35024,State Senate,16,Ind,writein,1
+Queens,35026,State Senate,16,Ind,writein,0
+Queens,35027,State Senate,16,Ind,writein,0
+Queens,35028,State Senate,16,Ind,writein,0
+Queens,35029,State Senate,16,Ind,writein,0
+Queens,35030,State Senate,16,Ind,writein,0
+Queens,35031,State Senate,16,Ind,writein,0
+Queens,35034,State Senate,16,Ind,writein,0
+Queens,39023,State Senate,16,Ind,writein,0
+Queens,39024,State Senate,16,Ind,writein,0
+Queens,39027,State Senate,16,Ind,writein,0
+Queens,39029,State Senate,16,Ind,writein,0
+Queens,39030,State Senate,16,Ind,writein,0
+Queens,39031,State Senate,16,Ind,writein,0
+Queens,39034,State Senate,16,Ind,writein,0
+Queens,39035,State Senate,16,Ind,writein,0
+Queens,39037,State Senate,16,Ind,writein,0
+Queens,39038,State Senate,16,Ind,writein,0
+Queens,39040,State Senate,16,Ind,writein,0
+Queens,39042,State Senate,16,Ind,writein,0
+Queens,39048,State Senate,16,Ind,writein,0
+Queens,39049,State Senate,16,Ind,writein,0
+Queens,39052,State Senate,16,Ind,writein,0
+Queens,39053,State Senate,16,Ind,writein,0
+Queens,40011,State Senate,16,Ind,writein,0
+Queens,40012,State Senate,16,Ind,writein,0
+Queens,40016,State Senate,16,Ind,writein,0
+Queens,40017,State Senate,16,Ind,writein,0
+Queens,40018,State Senate,16,Ind,writein,2
+Queens,40019,State Senate,16,Ind,writein,0
+Queens,40020,State Senate,16,Ind,writein,2
+Queens,40021,State Senate,16,Ind,writein,1
+Queens,40022,State Senate,16,Ind,writein,0
+Queens,40023,State Senate,16,Ind,writein,0
+Queens,40024,State Senate,16,Ind,writein,0
+Queens,40025,State Senate,16,Ind,writein,2
+Queens,40026,State Senate,16,Ind,writein,0
+Queens,40027,State Senate,16,Ind,writein,0
+Queens,40029,State Senate,16,Ind,writein,0
+Queens,40030,State Senate,16,Ind,writein,0
+Queens,40031,State Senate,16,Ind,writein,0
+Queens,40032,State Senate,16,Ind,writein,0
+Queens,40033,State Senate,16,Ind,writein,0
+Queens,40034,State Senate,16,Ind,writein,1
+Queens,40035,State Senate,16,Ind,writein,1
+Queens,40036,State Senate,16,Ind,writein,0
+Queens,40037,State Senate,16,Ind,writein,0
+Queens,40038,State Senate,16,Ind,writein,1
+Queens,40039,State Senate,16,Ind,writein,0
+Queens,40040,State Senate,16,Ind,writein,0
+Queens,40041,State Senate,16,Ind,writein,0
+Queens,40042,State Senate,16,Ind,writein,0
+Queens,40043,State Senate,16,Ind,writein,0
+Queens,40044,State Senate,16,Ind,writein,0
+Queens,40045,State Senate,16,Ind,writein,1
+Queens,40046,State Senate,16,Ind,writein,0
 Queens,24001,U.S. House,03,Dem,Steve Israel,460
 Queens,24002,U.S. House,03,Dem,Steve Israel,461
 Queens,24003,U.S. House,03,Dem,Steve Israel,366

--- a/2012/counties/20121106__ny__general__richmond__precinct.csv
+++ b/2012/counties/20121106__ny__general__richmond__precinct.csv
@@ -3678,1560 +3678,1560 @@ Richmond,64050,President,,,writeins,0
 Richmond,64051,President,,,writeins,1
 Richmond,64052,President,,,writeins,1
 Richmond,64053,President,,,writeins,0
-Richmond,61001,State Senate,SD23,Dem,Diane Savino,557
-Richmond,61002,State Senate,SD23,Dem,Diane Savino,455
-Richmond,61003,State Senate,SD23,Dem,Diane Savino,578
-Richmond,61004,State Senate,SD23,Dem,Diane Savino,463
-Richmond,61005,State Senate,SD23,Dem,Diane Savino,364
-Richmond,61006,State Senate,SD23,Dem,Diane Savino,381
-Richmond,61007,State Senate,SD23,Dem,Diane Savino,566
-Richmond,61008,State Senate,SD23,Dem,Diane Savino,584
-Richmond,61009,State Senate,SD23,Dem,Diane Savino,547
-Richmond,61010,State Senate,SD23,Dem,Diane Savino,460
-Richmond,61011,State Senate,SD23,Dem,Diane Savino,275
-Richmond,61012,State Senate,SD23,Dem,Diane Savino,508
-Richmond,61013,State Senate,SD23,Dem,Diane Savino,584
-Richmond,61014,State Senate,SD23,Dem,Diane Savino,450
-Richmond,61015,State Senate,SD23,Dem,Diane Savino,488
-Richmond,61016,State Senate,SD23,Dem,Diane Savino,551
-Richmond,61017,State Senate,SD23,Dem,Diane Savino,519
-Richmond,61018,State Senate,SD23,Dem,Diane Savino,506
-Richmond,61019,State Senate,SD23,Dem,Diane Savino,432
-Richmond,61020,State Senate,SD23,Dem,Diane Savino,410
-Richmond,61021,State Senate,SD23,Dem,Diane Savino,508
-Richmond,61022,State Senate,SD23,Dem,Diane Savino,460
-Richmond,61023,State Senate,SD23,Dem,Diane Savino,452
-Richmond,61024,State Senate,SD23,Dem,Diane Savino,373
-Richmond,61025,State Senate,SD23,Dem,Diane Savino,484
-Richmond,61026,State Senate,SD23,Dem,Diane Savino,496
-Richmond,61027,State Senate,SD23,Dem,Diane Savino,449
-Richmond,61028,State Senate,SD23,Dem,Diane Savino,416
-Richmond,61029,State Senate,SD23,Dem,Diane Savino,413
-Richmond,61030,State Senate,SD23,Dem,Diane Savino,478
-Richmond,61031,State Senate,SD23,Dem,Diane Savino,407
-Richmond,61032,State Senate,SD23,Dem,Diane Savino,333
-Richmond,61033,State Senate,SD23,Dem,Diane Savino,279
-Richmond,61049,State Senate,SD23,Dem,Diane Savino,545
-Richmond,61050,State Senate,SD23,Dem,Diane Savino,534
-Richmond,61051,State Senate,SD23,Dem,Diane Savino,463
-Richmond,61052,State Senate,SD23,Dem,Diane Savino,492
-Richmond,61053,State Senate,SD23,Dem,Diane Savino,694
-Richmond,61054,State Senate,SD23,Dem,Diane Savino,374
-Richmond,61055,State Senate,SD23,Dem,Diane Savino,554
-Richmond,61056,State Senate,SD23,Dem,Diane Savino,585
-Richmond,61057,State Senate,SD23,Dem,Diane Savino,475
-Richmond,61058,State Senate,SD23,Dem,Diane Savino,645
-Richmond,61059,State Senate,SD23,Dem,Diane Savino,641
-Richmond,61060,State Senate,SD23,Dem,Diane Savino,399
-Richmond,61061,State Senate,SD23,Dem,Diane Savino,607
-Richmond,63010,State Senate,SD23,Dem,Diane Savino,184
-Richmond,63017,State Senate,SD23,Dem,Diane Savino,121
-Richmond,63037,State Senate,SD23,Dem,Diane Savino,472
-Richmond,63038,State Senate,SD23,Dem,Diane Savino,454
-Richmond,63039,State Senate,SD23,Dem,Diane Savino,494
-Richmond,63040,State Senate,SD23,Dem,Diane Savino,345
-Richmond,63041,State Senate,SD23,Dem,Diane Savino,334
-Richmond,63042,State Senate,SD23,Dem,Diane Savino,546
-Richmond,63043,State Senate,SD23,Dem,Diane Savino,574
-Richmond,63044,State Senate,SD23,Dem,Diane Savino,334
-Richmond,63045,State Senate,SD23,Dem,Diane Savino,454
-Richmond,64039,State Senate,SD23,Dem,Diane Savino,263
-Richmond,64040,State Senate,SD23,Dem,Diane Savino,400
-Richmond,64041,State Senate,SD23,Dem,Diane Savino,251
-Richmond,64042,State Senate,SD23,Dem,Diane Savino,265
-Richmond,64043,State Senate,SD23,Dem,Diane Savino,210
-Richmond,64044,State Senate,SD23,Dem,Diane Savino,304
-Richmond,64045,State Senate,SD23,Dem,Diane Savino,198
-Richmond,64046,State Senate,SD23,Dem,Diane Savino,195
-Richmond,64047,State Senate,SD23,Dem,Diane Savino,235
-Richmond,64048,State Senate,SD23,Dem,Diane Savino,0
-Richmond,64049,State Senate,SD23,Dem,Diane Savino,410
-Richmond,64050,State Senate,SD23,Dem,Diane Savino,386
-Richmond,64051,State Senate,SD23,Dem,Diane Savino,408
-Richmond,64052,State Senate,SD23,Dem,Diane Savino,305
-Richmond,64053,State Senate,SD23,Dem,Diane Savino,282
-Richmond,61001,State Senate,SD23,WF,Diane Savino,43
-Richmond,61002,State Senate,SD23,WF,Diane Savino,14
-Richmond,61003,State Senate,SD23,WF,Diane Savino,26
-Richmond,61004,State Senate,SD23,WF,Diane Savino,35
-Richmond,61005,State Senate,SD23,WF,Diane Savino,34
-Richmond,61006,State Senate,SD23,WF,Diane Savino,19
-Richmond,61007,State Senate,SD23,WF,Diane Savino,16
-Richmond,61008,State Senate,SD23,WF,Diane Savino,33
-Richmond,61009,State Senate,SD23,WF,Diane Savino,32
-Richmond,61010,State Senate,SD23,WF,Diane Savino,17
-Richmond,61011,State Senate,SD23,WF,Diane Savino,14
-Richmond,61012,State Senate,SD23,WF,Diane Savino,29
-Richmond,61013,State Senate,SD23,WF,Diane Savino,27
-Richmond,61014,State Senate,SD23,WF,Diane Savino,27
-Richmond,61015,State Senate,SD23,WF,Diane Savino,24
-Richmond,61016,State Senate,SD23,WF,Diane Savino,23
-Richmond,61017,State Senate,SD23,WF,Diane Savino,27
-Richmond,61018,State Senate,SD23,WF,Diane Savino,26
-Richmond,61019,State Senate,SD23,WF,Diane Savino,28
-Richmond,61020,State Senate,SD23,WF,Diane Savino,27
-Richmond,61021,State Senate,SD23,WF,Diane Savino,16
-Richmond,61022,State Senate,SD23,WF,Diane Savino,16
-Richmond,61023,State Senate,SD23,WF,Diane Savino,26
-Richmond,61024,State Senate,SD23,WF,Diane Savino,21
-Richmond,61025,State Senate,SD23,WF,Diane Savino,19
-Richmond,61026,State Senate,SD23,WF,Diane Savino,22
-Richmond,61027,State Senate,SD23,WF,Diane Savino,22
-Richmond,61028,State Senate,SD23,WF,Diane Savino,28
-Richmond,61029,State Senate,SD23,WF,Diane Savino,21
-Richmond,61030,State Senate,SD23,WF,Diane Savino,20
-Richmond,61031,State Senate,SD23,WF,Diane Savino,17
-Richmond,61032,State Senate,SD23,WF,Diane Savino,13
-Richmond,61033,State Senate,SD23,WF,Diane Savino,8
-Richmond,61049,State Senate,SD23,WF,Diane Savino,30
-Richmond,61050,State Senate,SD23,WF,Diane Savino,17
-Richmond,61051,State Senate,SD23,WF,Diane Savino,23
-Richmond,61052,State Senate,SD23,WF,Diane Savino,21
-Richmond,61053,State Senate,SD23,WF,Diane Savino,10
-Richmond,61054,State Senate,SD23,WF,Diane Savino,18
-Richmond,61055,State Senate,SD23,WF,Diane Savino,19
-Richmond,61056,State Senate,SD23,WF,Diane Savino,26
-Richmond,61057,State Senate,SD23,WF,Diane Savino,21
-Richmond,61058,State Senate,SD23,WF,Diane Savino,6
-Richmond,61059,State Senate,SD23,WF,Diane Savino,17
-Richmond,61060,State Senate,SD23,WF,Diane Savino,18
-Richmond,61061,State Senate,SD23,WF,Diane Savino,5
-Richmond,63010,State Senate,SD23,WF,Diane Savino,7
-Richmond,63017,State Senate,SD23,WF,Diane Savino,4
-Richmond,63037,State Senate,SD23,WF,Diane Savino,21
-Richmond,63038,State Senate,SD23,WF,Diane Savino,18
-Richmond,63039,State Senate,SD23,WF,Diane Savino,20
-Richmond,63040,State Senate,SD23,WF,Diane Savino,18
-Richmond,63041,State Senate,SD23,WF,Diane Savino,14
-Richmond,63042,State Senate,SD23,WF,Diane Savino,11
-Richmond,63043,State Senate,SD23,WF,Diane Savino,14
-Richmond,63044,State Senate,SD23,WF,Diane Savino,11
-Richmond,63045,State Senate,SD23,WF,Diane Savino,9
-Richmond,64039,State Senate,SD23,WF,Diane Savino,18
-Richmond,64040,State Senate,SD23,WF,Diane Savino,12
-Richmond,64041,State Senate,SD23,WF,Diane Savino,21
-Richmond,64042,State Senate,SD23,WF,Diane Savino,12
-Richmond,64043,State Senate,SD23,WF,Diane Savino,11
-Richmond,64044,State Senate,SD23,WF,Diane Savino,26
-Richmond,64045,State Senate,SD23,WF,Diane Savino,3
-Richmond,64046,State Senate,SD23,WF,Diane Savino,16
-Richmond,64047,State Senate,SD23,WF,Diane Savino,21
-Richmond,64048,State Senate,SD23,WF,Diane Savino,0
-Richmond,64049,State Senate,SD23,WF,Diane Savino,19
-Richmond,64050,State Senate,SD23,WF,Diane Savino,32
-Richmond,64051,State Senate,SD23,WF,Diane Savino,22
-Richmond,64052,State Senate,SD23,WF,Diane Savino,21
-Richmond,64053,State Senate,SD23,WF,Diane Savino,10
-Richmond,61001,State Senate,SD23,Ind,Diane Savino,13
-Richmond,61002,State Senate,SD23,Ind,Diane Savino,2
-Richmond,61003,State Senate,SD23,Ind,Diane Savino,14
-Richmond,61004,State Senate,SD23,Ind,Diane Savino,12
-Richmond,61005,State Senate,SD23,Ind,Diane Savino,9
-Richmond,61006,State Senate,SD23,Ind,Diane Savino,6
-Richmond,61007,State Senate,SD23,Ind,Diane Savino,3
-Richmond,61008,State Senate,SD23,Ind,Diane Savino,6
-Richmond,61009,State Senate,SD23,Ind,Diane Savino,11
-Richmond,61010,State Senate,SD23,Ind,Diane Savino,17
-Richmond,61011,State Senate,SD23,Ind,Diane Savino,10
-Richmond,61012,State Senate,SD23,Ind,Diane Savino,18
-Richmond,61013,State Senate,SD23,Ind,Diane Savino,11
-Richmond,61014,State Senate,SD23,Ind,Diane Savino,10
-Richmond,61015,State Senate,SD23,Ind,Diane Savino,5
-Richmond,61016,State Senate,SD23,Ind,Diane Savino,3
-Richmond,61017,State Senate,SD23,Ind,Diane Savino,5
-Richmond,61018,State Senate,SD23,Ind,Diane Savino,14
-Richmond,61019,State Senate,SD23,Ind,Diane Savino,10
-Richmond,61020,State Senate,SD23,Ind,Diane Savino,9
-Richmond,61021,State Senate,SD23,Ind,Diane Savino,5
-Richmond,61022,State Senate,SD23,Ind,Diane Savino,6
-Richmond,61023,State Senate,SD23,Ind,Diane Savino,6
-Richmond,61024,State Senate,SD23,Ind,Diane Savino,16
-Richmond,61025,State Senate,SD23,Ind,Diane Savino,10
-Richmond,61026,State Senate,SD23,Ind,Diane Savino,14
-Richmond,61027,State Senate,SD23,Ind,Diane Savino,5
-Richmond,61028,State Senate,SD23,Ind,Diane Savino,9
-Richmond,61029,State Senate,SD23,Ind,Diane Savino,13
-Richmond,61030,State Senate,SD23,Ind,Diane Savino,12
-Richmond,61031,State Senate,SD23,Ind,Diane Savino,7
-Richmond,61032,State Senate,SD23,Ind,Diane Savino,2
-Richmond,61033,State Senate,SD23,Ind,Diane Savino,4
-Richmond,61049,State Senate,SD23,Ind,Diane Savino,15
-Richmond,61050,State Senate,SD23,Ind,Diane Savino,8
-Richmond,61051,State Senate,SD23,Ind,Diane Savino,11
-Richmond,61052,State Senate,SD23,Ind,Diane Savino,9
-Richmond,61053,State Senate,SD23,Ind,Diane Savino,6
-Richmond,61054,State Senate,SD23,Ind,Diane Savino,10
-Richmond,61055,State Senate,SD23,Ind,Diane Savino,10
-Richmond,61056,State Senate,SD23,Ind,Diane Savino,9
-Richmond,61057,State Senate,SD23,Ind,Diane Savino,8
-Richmond,61058,State Senate,SD23,Ind,Diane Savino,3
-Richmond,61059,State Senate,SD23,Ind,Diane Savino,4
-Richmond,61060,State Senate,SD23,Ind,Diane Savino,5
-Richmond,61061,State Senate,SD23,Ind,Diane Savino,1
-Richmond,63010,State Senate,SD23,Ind,Diane Savino,8
-Richmond,63017,State Senate,SD23,Ind,Diane Savino,4
-Richmond,63037,State Senate,SD23,Ind,Diane Savino,8
-Richmond,63038,State Senate,SD23,Ind,Diane Savino,11
-Richmond,63039,State Senate,SD23,Ind,Diane Savino,5
-Richmond,63040,State Senate,SD23,Ind,Diane Savino,4
-Richmond,63041,State Senate,SD23,Ind,Diane Savino,4
-Richmond,63042,State Senate,SD23,Ind,Diane Savino,3
-Richmond,63043,State Senate,SD23,Ind,Diane Savino,4
-Richmond,63044,State Senate,SD23,Ind,Diane Savino,4
-Richmond,63045,State Senate,SD23,Ind,Diane Savino,6
-Richmond,64039,State Senate,SD23,Ind,Diane Savino,9
-Richmond,64040,State Senate,SD23,Ind,Diane Savino,8
-Richmond,64041,State Senate,SD23,Ind,Diane Savino,9
-Richmond,64042,State Senate,SD23,Ind,Diane Savino,12
-Richmond,64043,State Senate,SD23,Ind,Diane Savino,13
-Richmond,64044,State Senate,SD23,Ind,Diane Savino,12
-Richmond,64045,State Senate,SD23,Ind,Diane Savino,4
-Richmond,64046,State Senate,SD23,Ind,Diane Savino,9
-Richmond,64047,State Senate,SD23,Ind,Diane Savino,11
-Richmond,64048,State Senate,SD23,Ind,Diane Savino,0
-Richmond,64049,State Senate,SD23,Ind,Diane Savino,10
-Richmond,64050,State Senate,SD23,Ind,Diane Savino,9
-Richmond,64051,State Senate,SD23,Ind,Diane Savino,11
-Richmond,64052,State Senate,SD23,Ind,Diane Savino,9
-Richmond,64053,State Senate,SD23,Ind,Diane Savino,13
-Richmond,61001,State Senate,SD23,Rep,Lisa Grey,51
-Richmond,61002,State Senate,SD23,Rep,Lisa Grey,12
-Richmond,61003,State Senate,SD23,Rep,Lisa Grey,74
-Richmond,61004,State Senate,SD23,Rep,Lisa Grey,81
-Richmond,61005,State Senate,SD23,Rep,Lisa Grey,25
-Richmond,61006,State Senate,SD23,Rep,Lisa Grey,90
-Richmond,61007,State Senate,SD23,Rep,Lisa Grey,18
-Richmond,61008,State Senate,SD23,Rep,Lisa Grey,31
-Richmond,61009,State Senate,SD23,Rep,Lisa Grey,83
-Richmond,61010,State Senate,SD23,Rep,Lisa Grey,62
-Richmond,61011,State Senate,SD23,Rep,Lisa Grey,56
-Richmond,61012,State Senate,SD23,Rep,Lisa Grey,181
-Richmond,61013,State Senate,SD23,Rep,Lisa Grey,59
-Richmond,61014,State Senate,SD23,Rep,Lisa Grey,155
-Richmond,61015,State Senate,SD23,Rep,Lisa Grey,126
-Richmond,61016,State Senate,SD23,Rep,Lisa Grey,12
-Richmond,61017,State Senate,SD23,Rep,Lisa Grey,34
-Richmond,61018,State Senate,SD23,Rep,Lisa Grey,101
-Richmond,61019,State Senate,SD23,Rep,Lisa Grey,79
-Richmond,61020,State Senate,SD23,Rep,Lisa Grey,119
-Richmond,61021,State Senate,SD23,Rep,Lisa Grey,42
-Richmond,61022,State Senate,SD23,Rep,Lisa Grey,56
-Richmond,61023,State Senate,SD23,Rep,Lisa Grey,100
-Richmond,61024,State Senate,SD23,Rep,Lisa Grey,185
-Richmond,61025,State Senate,SD23,Rep,Lisa Grey,103
-Richmond,61026,State Senate,SD23,Rep,Lisa Grey,45
-Richmond,61027,State Senate,SD23,Rep,Lisa Grey,60
-Richmond,61028,State Senate,SD23,Rep,Lisa Grey,84
-Richmond,61029,State Senate,SD23,Rep,Lisa Grey,156
-Richmond,61030,State Senate,SD23,Rep,Lisa Grey,111
-Richmond,61031,State Senate,SD23,Rep,Lisa Grey,57
-Richmond,61032,State Senate,SD23,Rep,Lisa Grey,42
-Richmond,61033,State Senate,SD23,Rep,Lisa Grey,33
-Richmond,61049,State Senate,SD23,Rep,Lisa Grey,88
-Richmond,61050,State Senate,SD23,Rep,Lisa Grey,69
-Richmond,61051,State Senate,SD23,Rep,Lisa Grey,99
-Richmond,61052,State Senate,SD23,Rep,Lisa Grey,126
-Richmond,61053,State Senate,SD23,Rep,Lisa Grey,16
-Richmond,61054,State Senate,SD23,Rep,Lisa Grey,79
-Richmond,61055,State Senate,SD23,Rep,Lisa Grey,43
-Richmond,61056,State Senate,SD23,Rep,Lisa Grey,54
-Richmond,61057,State Senate,SD23,Rep,Lisa Grey,108
-Richmond,61058,State Senate,SD23,Rep,Lisa Grey,18
-Richmond,61059,State Senate,SD23,Rep,Lisa Grey,16
-Richmond,61060,State Senate,SD23,Rep,Lisa Grey,65
-Richmond,61061,State Senate,SD23,Rep,Lisa Grey,10
-Richmond,63010,State Senate,SD23,Rep,Lisa Grey,58
-Richmond,63017,State Senate,SD23,Rep,Lisa Grey,70
-Richmond,63037,State Senate,SD23,Rep,Lisa Grey,114
-Richmond,63038,State Senate,SD23,Rep,Lisa Grey,85
-Richmond,63039,State Senate,SD23,Rep,Lisa Grey,68
-Richmond,63040,State Senate,SD23,Rep,Lisa Grey,42
-Richmond,63041,State Senate,SD23,Rep,Lisa Grey,10
-Richmond,63042,State Senate,SD23,Rep,Lisa Grey,11
-Richmond,63043,State Senate,SD23,Rep,Lisa Grey,31
-Richmond,63044,State Senate,SD23,Rep,Lisa Grey,18
-Richmond,63045,State Senate,SD23,Rep,Lisa Grey,20
-Richmond,64039,State Senate,SD23,Rep,Lisa Grey,195
-Richmond,64040,State Senate,SD23,Rep,Lisa Grey,103
-Richmond,64041,State Senate,SD23,Rep,Lisa Grey,180
-Richmond,64042,State Senate,SD23,Rep,Lisa Grey,129
-Richmond,64043,State Senate,SD23,Rep,Lisa Grey,125
-Richmond,64044,State Senate,SD23,Rep,Lisa Grey,192
-Richmond,64045,State Senate,SD23,Rep,Lisa Grey,107
-Richmond,64046,State Senate,SD23,Rep,Lisa Grey,95
-Richmond,64047,State Senate,SD23,Rep,Lisa Grey,111
-Richmond,64048,State Senate,SD23,Rep,Lisa Grey,2
-Richmond,64049,State Senate,SD23,Rep,Lisa Grey,155
-Richmond,64050,State Senate,SD23,Rep,Lisa Grey,150
-Richmond,64051,State Senate,SD23,Rep,Lisa Grey,131
-Richmond,64052,State Senate,SD23,Rep,Lisa Grey,186
-Richmond,64053,State Senate,SD23,Rep,Lisa Grey,141
-Richmond,61001,State Senate,SD23,Con,Lisa Grey,15
-Richmond,61002,State Senate,SD23,Con,Lisa Grey,2
-Richmond,61003,State Senate,SD23,Con,Lisa Grey,7
-Richmond,61004,State Senate,SD23,Con,Lisa Grey,10
-Richmond,61005,State Senate,SD23,Con,Lisa Grey,2
-Richmond,61006,State Senate,SD23,Con,Lisa Grey,6
-Richmond,61007,State Senate,SD23,Con,Lisa Grey,1
-Richmond,61008,State Senate,SD23,Con,Lisa Grey,8
-Richmond,61009,State Senate,SD23,Con,Lisa Grey,13
-Richmond,61010,State Senate,SD23,Con,Lisa Grey,10
-Richmond,61011,State Senate,SD23,Con,Lisa Grey,14
-Richmond,61012,State Senate,SD23,Con,Lisa Grey,34
-Richmond,61013,State Senate,SD23,Con,Lisa Grey,17
-Richmond,61014,State Senate,SD23,Con,Lisa Grey,22
-Richmond,61015,State Senate,SD23,Con,Lisa Grey,20
-Richmond,61016,State Senate,SD23,Con,Lisa Grey,0
-Richmond,61017,State Senate,SD23,Con,Lisa Grey,8
-Richmond,61018,State Senate,SD23,Con,Lisa Grey,21
-Richmond,61019,State Senate,SD23,Con,Lisa Grey,26
-Richmond,61020,State Senate,SD23,Con,Lisa Grey,29
-Richmond,61021,State Senate,SD23,Con,Lisa Grey,7
-Richmond,61022,State Senate,SD23,Con,Lisa Grey,12
-Richmond,61023,State Senate,SD23,Con,Lisa Grey,17
-Richmond,61024,State Senate,SD23,Con,Lisa Grey,33
-Richmond,61025,State Senate,SD23,Con,Lisa Grey,13
-Richmond,61026,State Senate,SD23,Con,Lisa Grey,9
-Richmond,61027,State Senate,SD23,Con,Lisa Grey,12
-Richmond,61028,State Senate,SD23,Con,Lisa Grey,19
-Richmond,61029,State Senate,SD23,Con,Lisa Grey,25
-Richmond,61030,State Senate,SD23,Con,Lisa Grey,10
-Richmond,61031,State Senate,SD23,Con,Lisa Grey,12
-Richmond,61032,State Senate,SD23,Con,Lisa Grey,11
-Richmond,61033,State Senate,SD23,Con,Lisa Grey,1
-Richmond,61049,State Senate,SD23,Con,Lisa Grey,15
-Richmond,61050,State Senate,SD23,Con,Lisa Grey,21
-Richmond,61051,State Senate,SD23,Con,Lisa Grey,13
-Richmond,61052,State Senate,SD23,Con,Lisa Grey,12
-Richmond,61053,State Senate,SD23,Con,Lisa Grey,3
-Richmond,61054,State Senate,SD23,Con,Lisa Grey,12
-Richmond,61055,State Senate,SD23,Con,Lisa Grey,6
-Richmond,61056,State Senate,SD23,Con,Lisa Grey,3
-Richmond,61057,State Senate,SD23,Con,Lisa Grey,17
-Richmond,61058,State Senate,SD23,Con,Lisa Grey,5
-Richmond,61059,State Senate,SD23,Con,Lisa Grey,2
-Richmond,61060,State Senate,SD23,Con,Lisa Grey,9
-Richmond,61061,State Senate,SD23,Con,Lisa Grey,0
-Richmond,63010,State Senate,SD23,Con,Lisa Grey,8
-Richmond,63017,State Senate,SD23,Con,Lisa Grey,5
-Richmond,63037,State Senate,SD23,Con,Lisa Grey,20
-Richmond,63038,State Senate,SD23,Con,Lisa Grey,14
-Richmond,63039,State Senate,SD23,Con,Lisa Grey,3
-Richmond,63040,State Senate,SD23,Con,Lisa Grey,4
-Richmond,63041,State Senate,SD23,Con,Lisa Grey,1
-Richmond,63042,State Senate,SD23,Con,Lisa Grey,5
-Richmond,63043,State Senate,SD23,Con,Lisa Grey,5
-Richmond,63044,State Senate,SD23,Con,Lisa Grey,4
-Richmond,63045,State Senate,SD23,Con,Lisa Grey,2
-Richmond,64039,State Senate,SD23,Con,Lisa Grey,19
-Richmond,64040,State Senate,SD23,Con,Lisa Grey,8
-Richmond,64041,State Senate,SD23,Con,Lisa Grey,23
-Richmond,64042,State Senate,SD23,Con,Lisa Grey,15
-Richmond,64043,State Senate,SD23,Con,Lisa Grey,7
-Richmond,64044,State Senate,SD23,Con,Lisa Grey,19
-Richmond,64045,State Senate,SD23,Con,Lisa Grey,10
-Richmond,64046,State Senate,SD23,Con,Lisa Grey,27
-Richmond,64047,State Senate,SD23,Con,Lisa Grey,28
-Richmond,64048,State Senate,SD23,Con,Lisa Grey,0
-Richmond,64049,State Senate,SD23,Con,Lisa Grey,10
-Richmond,64050,State Senate,SD23,Con,Lisa Grey,45
-Richmond,64051,State Senate,SD23,Con,Lisa Grey,21
-Richmond,64052,State Senate,SD23,Con,Lisa Grey,24
-Richmond,64053,State Senate,SD23,Con,Lisa Grey,29
-Richmond,61001,State Senate,SD23,Ind,writein,2
-Richmond,61002,State Senate,SD23,Ind,writein,0
-Richmond,61003,State Senate,SD23,Ind,writein,0
-Richmond,61004,State Senate,SD23,Ind,writein,1
-Richmond,61005,State Senate,SD23,Ind,writein,0
-Richmond,61006,State Senate,SD23,Ind,writein,5
-Richmond,61007,State Senate,SD23,Ind,writein,0
-Richmond,61008,State Senate,SD23,Ind,writein,0
-Richmond,61009,State Senate,SD23,Ind,writein,0
-Richmond,61010,State Senate,SD23,Ind,writein,0
-Richmond,61011,State Senate,SD23,Ind,writein,1
-Richmond,61012,State Senate,SD23,Ind,writein,0
-Richmond,61013,State Senate,SD23,Ind,writein,0
-Richmond,61014,State Senate,SD23,Ind,writein,0
-Richmond,61015,State Senate,SD23,Ind,writein,0
-Richmond,61016,State Senate,SD23,Ind,writein,0
-Richmond,61017,State Senate,SD23,Ind,writein,1
-Richmond,61018,State Senate,SD23,Ind,writein,0
-Richmond,61019,State Senate,SD23,Ind,writein,0
-Richmond,61020,State Senate,SD23,Ind,writein,0
-Richmond,61021,State Senate,SD23,Ind,writein,0
-Richmond,61022,State Senate,SD23,Ind,writein,0
-Richmond,61023,State Senate,SD23,Ind,writein,2
-Richmond,61024,State Senate,SD23,Ind,writein,0
-Richmond,61025,State Senate,SD23,Ind,writein,0
-Richmond,61026,State Senate,SD23,Ind,writein,0
-Richmond,61027,State Senate,SD23,Ind,writein,1
-Richmond,61028,State Senate,SD23,Ind,writein,0
-Richmond,61029,State Senate,SD23,Ind,writein,1
-Richmond,61030,State Senate,SD23,Ind,writein,1
-Richmond,61031,State Senate,SD23,Ind,writein,1
-Richmond,61032,State Senate,SD23,Ind,writein,1
-Richmond,61033,State Senate,SD23,Ind,writein,0
-Richmond,61049,State Senate,SD23,Ind,writein,0
-Richmond,61050,State Senate,SD23,Ind,writein,1
-Richmond,61051,State Senate,SD23,Ind,writein,0
-Richmond,61052,State Senate,SD23,Ind,writein,0
-Richmond,61053,State Senate,SD23,Ind,writein,0
-Richmond,61054,State Senate,SD23,Ind,writein,0
-Richmond,61055,State Senate,SD23,Ind,writein,1
-Richmond,61056,State Senate,SD23,Ind,writein,0
-Richmond,61057,State Senate,SD23,Ind,writein,0
-Richmond,61058,State Senate,SD23,Ind,writein,0
-Richmond,61059,State Senate,SD23,Ind,writein,1
-Richmond,61060,State Senate,SD23,Ind,writein,0
-Richmond,61061,State Senate,SD23,Ind,writein,0
-Richmond,63010,State Senate,SD23,Ind,writein,0
-Richmond,63017,State Senate,SD23,Ind,writein,0
-Richmond,63037,State Senate,SD23,Ind,writein,0
-Richmond,63038,State Senate,SD23,Ind,writein,0
-Richmond,63039,State Senate,SD23,Ind,writein,0
-Richmond,63040,State Senate,SD23,Ind,writein,0
-Richmond,63041,State Senate,SD23,Ind,writein,0
-Richmond,63042,State Senate,SD23,Ind,writein,0
-Richmond,63043,State Senate,SD23,Ind,writein,0
-Richmond,63044,State Senate,SD23,Ind,writein,0
-Richmond,63045,State Senate,SD23,Ind,writein,0
-Richmond,64039,State Senate,SD23,Ind,writein,0
-Richmond,64040,State Senate,SD23,Ind,writein,0
-Richmond,64041,State Senate,SD23,Ind,writein,0
-Richmond,64042,State Senate,SD23,Ind,writein,2
-Richmond,64043,State Senate,SD23,Ind,writein,0
-Richmond,64044,State Senate,SD23,Ind,writein,0
-Richmond,64045,State Senate,SD23,Ind,writein,0
-Richmond,64046,State Senate,SD23,Ind,writein,0
-Richmond,64047,State Senate,SD23,Ind,writein,0
-Richmond,64048,State Senate,SD23,Ind,writein,0
-Richmond,64049,State Senate,SD23,Ind,writein,2
-Richmond,64050,State Senate,SD23,Ind,writein,0
-Richmond,64051,State Senate,SD23,Ind,writein,1
-Richmond,64052,State Senate,SD23,Ind,writein,0
-Richmond,64053,State Senate,SD23,Ind,writein,0
-Richmond,61034,State Senate,SD24,Rep,Andew Lanza,389
-Richmond,61035,State Senate,SD24,Rep,Andew Lanza,288
-Richmond,61036,State Senate,SD24,Rep,Andew Lanza,205
-Richmond,61037,State Senate,SD24,Rep,Andew Lanza,227
-Richmond,61038,State Senate,SD24,Rep,Andew Lanza,332
-Richmond,61039,State Senate,SD24,Rep,Andew Lanza,353
-Richmond,61040,State Senate,SD24,Rep,Andew Lanza,415
-Richmond,61041,State Senate,SD24,Rep,Andew Lanza,410
-Richmond,61042,State Senate,SD24,Rep,Andew Lanza,445
-Richmond,61043,State Senate,SD24,Rep,Andew Lanza,379
-Richmond,61044,State Senate,SD24,Rep,Andew Lanza,376
-Richmond,61045,State Senate,SD24,Rep,Andew Lanza,338
-Richmond,61046,State Senate,SD24,Rep,Andew Lanza,401
-Richmond,61047,State Senate,SD24,Rep,Andew Lanza,287
-Richmond,61048,State Senate,SD24,Rep,Andew Lanza,291
-Richmond,62001,State Senate,SD24,Rep,Andew Lanza,472
-Richmond,62002,State Senate,SD24,Rep,Andew Lanza,506
-Richmond,62003,State Senate,SD24,Rep,Andew Lanza,461
-Richmond,62004,State Senate,SD24,Rep,Andew Lanza,345
-Richmond,62005,State Senate,SD24,Rep,Andew Lanza,527
-Richmond,62006,State Senate,SD24,Rep,Andew Lanza,448
-Richmond,62007,State Senate,SD24,Rep,Andew Lanza,451
-Richmond,62008,State Senate,SD24,Rep,Andew Lanza,477
-Richmond,62009,State Senate,SD24,Rep,Andew Lanza,211
-Richmond,62010,State Senate,SD24,Rep,Andew Lanza,254
-Richmond,62011,State Senate,SD24,Rep,Andew Lanza,464
-Richmond,62012,State Senate,SD24,Rep,Andew Lanza,432
-Richmond,62013,State Senate,SD24,Rep,Andew Lanza,425
-Richmond,62014,State Senate,SD24,Rep,Andew Lanza,383
-Richmond,62015,State Senate,SD24,Rep,Andew Lanza,406
-Richmond,62016,State Senate,SD24,Rep,Andew Lanza,366
-Richmond,62017,State Senate,SD24,Rep,Andew Lanza,439
-Richmond,62018,State Senate,SD24,Rep,Andew Lanza,432
-Richmond,62019,State Senate,SD24,Rep,Andew Lanza,497
-Richmond,62020,State Senate,SD24,Rep,Andew Lanza,463
-Richmond,62021,State Senate,SD24,Rep,Andew Lanza,424
-Richmond,62022,State Senate,SD24,Rep,Andew Lanza,465
-Richmond,62023,State Senate,SD24,Rep,Andew Lanza,458
-Richmond,62024,State Senate,SD24,Rep,Andew Lanza,377
-Richmond,62025,State Senate,SD24,Rep,Andew Lanza,462
-Richmond,62026,State Senate,SD24,Rep,Andew Lanza,369
-Richmond,62027,State Senate,SD24,Rep,Andew Lanza,446
-Richmond,62028,State Senate,SD24,Rep,Andew Lanza,413
-Richmond,62029,State Senate,SD24,Rep,Andew Lanza,375
-Richmond,62030,State Senate,SD24,Rep,Andew Lanza,508
-Richmond,62031,State Senate,SD24,Rep,Andew Lanza,423
-Richmond,62032,State Senate,SD24,Rep,Andew Lanza,475
-Richmond,62033,State Senate,SD24,Rep,Andew Lanza,489
-Richmond,62034,State Senate,SD24,Rep,Andew Lanza,494
-Richmond,62035,State Senate,SD24,Rep,Andew Lanza,505
-Richmond,62036,State Senate,SD24,Rep,Andew Lanza,488
-Richmond,62037,State Senate,SD24,Rep,Andew Lanza,493
-Richmond,62038,State Senate,SD24,Rep,Andew Lanza,416
-Richmond,62039,State Senate,SD24,Rep,Andew Lanza,486
-Richmond,62040,State Senate,SD24,Rep,Andew Lanza,438
-Richmond,62041,State Senate,SD24,Rep,Andew Lanza,422
-Richmond,62042,State Senate,SD24,Rep,Andew Lanza,475
-Richmond,62043,State Senate,SD24,Rep,Andew Lanza,454
-Richmond,62044,State Senate,SD24,Rep,Andew Lanza,434
-Richmond,62045,State Senate,SD24,Rep,Andew Lanza,401
-Richmond,62046,State Senate,SD24,Rep,Andew Lanza,464
-Richmond,62047,State Senate,SD24,Rep,Andew Lanza,465
-Richmond,62048,State Senate,SD24,Rep,Andew Lanza,412
-Richmond,62049,State Senate,SD24,Rep,Andew Lanza,434
-Richmond,62050,State Senate,SD24,Rep,Andew Lanza,441
-Richmond,62051,State Senate,SD24,Rep,Andew Lanza,375
-Richmond,62052,State Senate,SD24,Rep,Andew Lanza,424
-Richmond,62053,State Senate,SD24,Rep,Andew Lanza,457
-Richmond,62054,State Senate,SD24,Rep,Andew Lanza,403
-Richmond,62055,State Senate,SD24,Rep,Andew Lanza,417
-Richmond,62056,State Senate,SD24,Rep,Andew Lanza,392
-Richmond,62057,State Senate,SD24,Rep,Andew Lanza,427
-Richmond,62058,State Senate,SD24,Rep,Andew Lanza,481
-Richmond,62059,State Senate,SD24,Rep,Andew Lanza,329
-Richmond,62060,State Senate,SD24,Rep,Andew Lanza,250
-Richmond,62061,State Senate,SD24,Rep,Andew Lanza,281
-Richmond,62062,State Senate,SD24,Rep,Andew Lanza,298
-Richmond,62063,State Senate,SD24,Rep,Andew Lanza,181
-Richmond,62064,State Senate,SD24,Rep,Andew Lanza,235
-Richmond,62065,State Senate,SD24,Rep,Andew Lanza,572
-Richmond,62066,State Senate,SD24,Rep,Andew Lanza,510
-Richmond,62067,State Senate,SD24,Rep,Andew Lanza,454
-Richmond,62068,State Senate,SD24,Rep,Andew Lanza,417
-Richmond,62069,State Senate,SD24,Rep,Andew Lanza,442
-Richmond,62070,State Senate,SD24,Rep,Andew Lanza,375
-Richmond,62071,State Senate,SD24,Rep,Andew Lanza,479
-Richmond,62072,State Senate,SD24,Rep,Andew Lanza,316
-Richmond,63001,State Senate,SD24,Rep,Andew Lanza,380
-Richmond,63002,State Senate,SD24,Rep,Andew Lanza,228
-Richmond,63003,State Senate,SD24,Rep,Andew Lanza,204
-Richmond,63004,State Senate,SD24,Rep,Andew Lanza,384
-Richmond,63005,State Senate,SD24,Rep,Andew Lanza,401
-Richmond,63006,State Senate,SD24,Rep,Andew Lanza,338
-Richmond,63007,State Senate,SD24,Rep,Andew Lanza,249
-Richmond,63008,State Senate,SD24,Rep,Andew Lanza,233
-Richmond,63009,State Senate,SD24,Rep,Andew Lanza,34
-Richmond,63011,State Senate,SD24,Rep,Andew Lanza,327
-Richmond,63012,State Senate,SD24,Rep,Andew Lanza,323
-Richmond,63013,State Senate,SD24,Rep,Andew Lanza,240
-Richmond,63014,State Senate,SD24,Rep,Andew Lanza,297
-Richmond,63015,State Senate,SD24,Rep,Andew Lanza,301
-Richmond,63016,State Senate,SD24,Rep,Andew Lanza,346
-Richmond,63018,State Senate,SD24,Rep,Andew Lanza,349
-Richmond,63019,State Senate,SD24,Rep,Andew Lanza,146
-Richmond,63020,State Senate,SD24,Rep,Andew Lanza,274
-Richmond,63021,State Senate,SD24,Rep,Andew Lanza,404
-Richmond,63022,State Senate,SD24,Rep,Andew Lanza,344
-Richmond,63023,State Senate,SD24,Rep,Andew Lanza,426
-Richmond,63024,State Senate,SD24,Rep,Andew Lanza,340
-Richmond,63025,State Senate,SD24,Rep,Andew Lanza,409
-Richmond,63026,State Senate,SD24,Rep,Andew Lanza,331
-Richmond,63027,State Senate,SD24,Rep,Andew Lanza,309
-Richmond,63028,State Senate,SD24,Rep,Andew Lanza,386
-Richmond,63029,State Senate,SD24,Rep,Andew Lanza,402
-Richmond,63030,State Senate,SD24,Rep,Andew Lanza,299
-Richmond,63031,State Senate,SD24,Rep,Andew Lanza,291
-Richmond,63032,State Senate,SD24,Rep,Andew Lanza,379
-Richmond,63033,State Senate,SD24,Rep,Andew Lanza,353
-Richmond,63034,State Senate,SD24,Rep,Andew Lanza,215
-Richmond,63035,State Senate,SD24,Rep,Andew Lanza,290
-Richmond,63036,State Senate,SD24,Rep,Andew Lanza,349
-Richmond,63046,State Senate,SD24,Rep,Andew Lanza,247
-Richmond,63047,State Senate,SD24,Rep,Andew Lanza,410
-Richmond,63048,State Senate,SD24,Rep,Andew Lanza,433
-Richmond,63049,State Senate,SD24,Rep,Andew Lanza,406
-Richmond,63050,State Senate,SD24,Rep,Andew Lanza,348
-Richmond,63051,State Senate,SD24,Rep,Andew Lanza,346
-Richmond,63052,State Senate,SD24,Rep,Andew Lanza,261
-Richmond,63053,State Senate,SD24,Rep,Andew Lanza,214
-Richmond,63054,State Senate,SD24,Rep,Andew Lanza,302
-Richmond,63055,State Senate,SD24,Rep,Andew Lanza,254
-Richmond,63056,State Senate,SD24,Rep,Andew Lanza,301
-Richmond,63057,State Senate,SD24,Rep,Andew Lanza,408
-Richmond,63058,State Senate,SD24,Rep,Andew Lanza,383
-Richmond,63059,State Senate,SD24,Rep,Andew Lanza,408
-Richmond,63060,State Senate,SD24,Rep,Andew Lanza,333
-Richmond,63061,State Senate,SD24,Rep,Andew Lanza,265
-Richmond,63062,State Senate,SD24,Rep,Andew Lanza,405
-Richmond,63063,State Senate,SD24,Rep,Andew Lanza,386
-Richmond,63064,State Senate,SD24,Rep,Andew Lanza,486
-Richmond,63065,State Senate,SD24,Rep,Andew Lanza,321
-Richmond,63066,State Senate,SD24,Rep,Andew Lanza,360
-Richmond,63067,State Senate,SD24,Rep,Andew Lanza,284
-Richmond,63068,State Senate,SD24,Rep,Andew Lanza,208
-Richmond,63069,State Senate,SD24,Rep,Andew Lanza,185
-Richmond,63070,State Senate,SD24,Rep,Andew Lanza,192
-Richmond,63071,State Senate,SD24,Rep,Andew Lanza,60
-Richmond,63072,State Senate,SD24,Rep,Andew Lanza,307
-Richmond,63073,State Senate,SD24,Rep,Andew Lanza,263
-Richmond,64001,State Senate,SD24,Rep,Andew Lanza,332
-Richmond,64002,State Senate,SD24,Rep,Andew Lanza,453
-Richmond,64003,State Senate,SD24,Rep,Andew Lanza,494
-Richmond,64004,State Senate,SD24,Rep,Andew Lanza,374
-Richmond,64005,State Senate,SD24,Rep,Andew Lanza,445
-Richmond,64006,State Senate,SD24,Rep,Andew Lanza,407
-Richmond,64007,State Senate,SD24,Rep,Andew Lanza,459
-Richmond,64008,State Senate,SD24,Rep,Andew Lanza,443
-Richmond,64009,State Senate,SD24,Rep,Andew Lanza,428
-Richmond,64010,State Senate,SD24,Rep,Andew Lanza,446
-Richmond,64011,State Senate,SD24,Rep,Andew Lanza,418
-Richmond,64012,State Senate,SD24,Rep,Andew Lanza,226
-Richmond,64013,State Senate,SD24,Rep,Andew Lanza,171
-Richmond,64014,State Senate,SD24,Rep,Andew Lanza,352
-Richmond,64015,State Senate,SD24,Rep,Andew Lanza,449
-Richmond,64016,State Senate,SD24,Rep,Andew Lanza,467
-Richmond,64017,State Senate,SD24,Rep,Andew Lanza,409
-Richmond,64018,State Senate,SD24,Rep,Andew Lanza,285
-Richmond,64019,State Senate,SD24,Rep,Andew Lanza,227
-Richmond,64020,State Senate,SD24,Rep,Andew Lanza,289
-Richmond,64021,State Senate,SD24,Rep,Andew Lanza,232
-Richmond,64022,State Senate,SD24,Rep,Andew Lanza,376
-Richmond,64023,State Senate,SD24,Rep,Andew Lanza,363
-Richmond,64024,State Senate,SD24,Rep,Andew Lanza,287
-Richmond,64025,State Senate,SD24,Rep,Andew Lanza,219
-Richmond,64026,State Senate,SD24,Rep,Andew Lanza,387
-Richmond,64027,State Senate,SD24,Rep,Andew Lanza,212
-Richmond,64028,State Senate,SD24,Rep,Andew Lanza,188
-Richmond,64029,State Senate,SD24,Rep,Andew Lanza,302
-Richmond,64030,State Senate,SD24,Rep,Andew Lanza,242
-Richmond,64031,State Senate,SD24,Rep,Andew Lanza,302
-Richmond,64032,State Senate,SD24,Rep,Andew Lanza,291
-Richmond,64033,State Senate,SD24,Rep,Andew Lanza,347
-Richmond,64034,State Senate,SD24,Rep,Andew Lanza,298
-Richmond,64035,State Senate,SD24,Rep,Andew Lanza,432
-Richmond,64036,State Senate,SD24,Rep,Andew Lanza,335
-Richmond,64037,State Senate,SD24,Rep,Andew Lanza,280
-Richmond,64038,State Senate,SD24,Rep,Andew Lanza,191
-Richmond,61034,State Senate,SD24,Con,Andew Lanza,50
-Richmond,61035,State Senate,SD24,Con,Andew Lanza,49
-Richmond,61036,State Senate,SD24,Con,Andew Lanza,23
-Richmond,61037,State Senate,SD24,Con,Andew Lanza,35
-Richmond,61038,State Senate,SD24,Con,Andew Lanza,44
-Richmond,61039,State Senate,SD24,Con,Andew Lanza,55
-Richmond,61040,State Senate,SD24,Con,Andew Lanza,70
-Richmond,61041,State Senate,SD24,Con,Andew Lanza,55
-Richmond,61042,State Senate,SD24,Con,Andew Lanza,55
-Richmond,61043,State Senate,SD24,Con,Andew Lanza,65
-Richmond,61044,State Senate,SD24,Con,Andew Lanza,51
-Richmond,61045,State Senate,SD24,Con,Andew Lanza,54
-Richmond,61046,State Senate,SD24,Con,Andew Lanza,56
-Richmond,61047,State Senate,SD24,Con,Andew Lanza,35
-Richmond,61048,State Senate,SD24,Con,Andew Lanza,48
-Richmond,62001,State Senate,SD24,Con,Andew Lanza,39
-Richmond,62002,State Senate,SD24,Con,Andew Lanza,57
-Richmond,62003,State Senate,SD24,Con,Andew Lanza,39
-Richmond,62004,State Senate,SD24,Con,Andew Lanza,31
-Richmond,62005,State Senate,SD24,Con,Andew Lanza,53
-Richmond,62006,State Senate,SD24,Con,Andew Lanza,64
-Richmond,62007,State Senate,SD24,Con,Andew Lanza,68
-Richmond,62008,State Senate,SD24,Con,Andew Lanza,66
-Richmond,62009,State Senate,SD24,Con,Andew Lanza,21
-Richmond,62010,State Senate,SD24,Con,Andew Lanza,31
-Richmond,62011,State Senate,SD24,Con,Andew Lanza,70
-Richmond,62012,State Senate,SD24,Con,Andew Lanza,39
-Richmond,62013,State Senate,SD24,Con,Andew Lanza,34
-Richmond,62014,State Senate,SD24,Con,Andew Lanza,32
-Richmond,62015,State Senate,SD24,Con,Andew Lanza,46
-Richmond,62016,State Senate,SD24,Con,Andew Lanza,35
-Richmond,62017,State Senate,SD24,Con,Andew Lanza,34
-Richmond,62018,State Senate,SD24,Con,Andew Lanza,38
-Richmond,62019,State Senate,SD24,Con,Andew Lanza,60
-Richmond,62020,State Senate,SD24,Con,Andew Lanza,43
-Richmond,62021,State Senate,SD24,Con,Andew Lanza,53
-Richmond,62022,State Senate,SD24,Con,Andew Lanza,45
-Richmond,62023,State Senate,SD24,Con,Andew Lanza,67
-Richmond,62024,State Senate,SD24,Con,Andew Lanza,31
-Richmond,62025,State Senate,SD24,Con,Andew Lanza,37
-Richmond,62026,State Senate,SD24,Con,Andew Lanza,37
-Richmond,62027,State Senate,SD24,Con,Andew Lanza,41
-Richmond,62028,State Senate,SD24,Con,Andew Lanza,43
-Richmond,62029,State Senate,SD24,Con,Andew Lanza,39
-Richmond,62030,State Senate,SD24,Con,Andew Lanza,47
-Richmond,62031,State Senate,SD24,Con,Andew Lanza,54
-Richmond,62032,State Senate,SD24,Con,Andew Lanza,44
-Richmond,62033,State Senate,SD24,Con,Andew Lanza,48
-Richmond,62034,State Senate,SD24,Con,Andew Lanza,68
-Richmond,62035,State Senate,SD24,Con,Andew Lanza,65
-Richmond,62036,State Senate,SD24,Con,Andew Lanza,54
-Richmond,62037,State Senate,SD24,Con,Andew Lanza,53
-Richmond,62038,State Senate,SD24,Con,Andew Lanza,54
-Richmond,62039,State Senate,SD24,Con,Andew Lanza,69
-Richmond,62040,State Senate,SD24,Con,Andew Lanza,52
-Richmond,62041,State Senate,SD24,Con,Andew Lanza,51
-Richmond,62042,State Senate,SD24,Con,Andew Lanza,60
-Richmond,62043,State Senate,SD24,Con,Andew Lanza,40
-Richmond,62044,State Senate,SD24,Con,Andew Lanza,56
-Richmond,62045,State Senate,SD24,Con,Andew Lanza,46
-Richmond,62046,State Senate,SD24,Con,Andew Lanza,45
-Richmond,62047,State Senate,SD24,Con,Andew Lanza,36
-Richmond,62048,State Senate,SD24,Con,Andew Lanza,39
-Richmond,62049,State Senate,SD24,Con,Andew Lanza,48
-Richmond,62050,State Senate,SD24,Con,Andew Lanza,57
-Richmond,62051,State Senate,SD24,Con,Andew Lanza,45
-Richmond,62052,State Senate,SD24,Con,Andew Lanza,55
-Richmond,62053,State Senate,SD24,Con,Andew Lanza,48
-Richmond,62054,State Senate,SD24,Con,Andew Lanza,40
-Richmond,62055,State Senate,SD24,Con,Andew Lanza,65
-Richmond,62056,State Senate,SD24,Con,Andew Lanza,34
-Richmond,62057,State Senate,SD24,Con,Andew Lanza,40
-Richmond,62058,State Senate,SD24,Con,Andew Lanza,59
-Richmond,62059,State Senate,SD24,Con,Andew Lanza,40
-Richmond,62060,State Senate,SD24,Con,Andew Lanza,19
-Richmond,62061,State Senate,SD24,Con,Andew Lanza,26
-Richmond,62062,State Senate,SD24,Con,Andew Lanza,25
-Richmond,62063,State Senate,SD24,Con,Andew Lanza,14
-Richmond,62064,State Senate,SD24,Con,Andew Lanza,20
-Richmond,62065,State Senate,SD24,Con,Andew Lanza,42
-Richmond,62066,State Senate,SD24,Con,Andew Lanza,50
-Richmond,62067,State Senate,SD24,Con,Andew Lanza,45
-Richmond,62068,State Senate,SD24,Con,Andew Lanza,53
-Richmond,62069,State Senate,SD24,Con,Andew Lanza,47
-Richmond,62070,State Senate,SD24,Con,Andew Lanza,53
-Richmond,62071,State Senate,SD24,Con,Andew Lanza,42
-Richmond,62072,State Senate,SD24,Con,Andew Lanza,37
-Richmond,63001,State Senate,SD24,Con,Andew Lanza,44
-Richmond,63002,State Senate,SD24,Con,Andew Lanza,27
-Richmond,63003,State Senate,SD24,Con,Andew Lanza,18
-Richmond,63004,State Senate,SD24,Con,Andew Lanza,27
-Richmond,63005,State Senate,SD24,Con,Andew Lanza,43
-Richmond,63006,State Senate,SD24,Con,Andew Lanza,33
-Richmond,63007,State Senate,SD24,Con,Andew Lanza,24
-Richmond,63008,State Senate,SD24,Con,Andew Lanza,24
-Richmond,63009,State Senate,SD24,Con,Andew Lanza,0
-Richmond,63011,State Senate,SD24,Con,Andew Lanza,43
-Richmond,63012,State Senate,SD24,Con,Andew Lanza,34
-Richmond,63013,State Senate,SD24,Con,Andew Lanza,35
-Richmond,63014,State Senate,SD24,Con,Andew Lanza,23
-Richmond,63015,State Senate,SD24,Con,Andew Lanza,36
-Richmond,63016,State Senate,SD24,Con,Andew Lanza,36
-Richmond,63018,State Senate,SD24,Con,Andew Lanza,29
-Richmond,63019,State Senate,SD24,Con,Andew Lanza,19
-Richmond,63020,State Senate,SD24,Con,Andew Lanza,39
-Richmond,63021,State Senate,SD24,Con,Andew Lanza,34
-Richmond,63022,State Senate,SD24,Con,Andew Lanza,30
-Richmond,63023,State Senate,SD24,Con,Andew Lanza,31
-Richmond,63024,State Senate,SD24,Con,Andew Lanza,29
-Richmond,63025,State Senate,SD24,Con,Andew Lanza,38
-Richmond,63026,State Senate,SD24,Con,Andew Lanza,28
-Richmond,63027,State Senate,SD24,Con,Andew Lanza,35
-Richmond,63028,State Senate,SD24,Con,Andew Lanza,45
-Richmond,63029,State Senate,SD24,Con,Andew Lanza,29
-Richmond,63030,State Senate,SD24,Con,Andew Lanza,56
-Richmond,63031,State Senate,SD24,Con,Andew Lanza,27
-Richmond,63032,State Senate,SD24,Con,Andew Lanza,40
-Richmond,63033,State Senate,SD24,Con,Andew Lanza,35
-Richmond,63034,State Senate,SD24,Con,Andew Lanza,23
-Richmond,63035,State Senate,SD24,Con,Andew Lanza,45
-Richmond,63036,State Senate,SD24,Con,Andew Lanza,45
-Richmond,63046,State Senate,SD24,Con,Andew Lanza,22
-Richmond,63047,State Senate,SD24,Con,Andew Lanza,50
-Richmond,63048,State Senate,SD24,Con,Andew Lanza,36
-Richmond,63049,State Senate,SD24,Con,Andew Lanza,51
-Richmond,63050,State Senate,SD24,Con,Andew Lanza,33
-Richmond,63051,State Senate,SD24,Con,Andew Lanza,33
-Richmond,63052,State Senate,SD24,Con,Andew Lanza,24
-Richmond,63053,State Senate,SD24,Con,Andew Lanza,21
-Richmond,63054,State Senate,SD24,Con,Andew Lanza,33
-Richmond,63055,State Senate,SD24,Con,Andew Lanza,26
-Richmond,63056,State Senate,SD24,Con,Andew Lanza,28
-Richmond,63057,State Senate,SD24,Con,Andew Lanza,22
-Richmond,63058,State Senate,SD24,Con,Andew Lanza,39
-Richmond,63059,State Senate,SD24,Con,Andew Lanza,41
-Richmond,63060,State Senate,SD24,Con,Andew Lanza,50
-Richmond,63061,State Senate,SD24,Con,Andew Lanza,27
-Richmond,63062,State Senate,SD24,Con,Andew Lanza,39
-Richmond,63063,State Senate,SD24,Con,Andew Lanza,54
-Richmond,63064,State Senate,SD24,Con,Andew Lanza,67
-Richmond,63065,State Senate,SD24,Con,Andew Lanza,39
-Richmond,63066,State Senate,SD24,Con,Andew Lanza,65
-Richmond,63067,State Senate,SD24,Con,Andew Lanza,41
-Richmond,63068,State Senate,SD24,Con,Andew Lanza,24
-Richmond,63069,State Senate,SD24,Con,Andew Lanza,23
-Richmond,63070,State Senate,SD24,Con,Andew Lanza,17
-Richmond,63071,State Senate,SD24,Con,Andew Lanza,8
-Richmond,63072,State Senate,SD24,Con,Andew Lanza,25
-Richmond,63073,State Senate,SD24,Con,Andew Lanza,38
-Richmond,64001,State Senate,SD24,Con,Andew Lanza,42
-Richmond,64002,State Senate,SD24,Con,Andew Lanza,62
-Richmond,64003,State Senate,SD24,Con,Andew Lanza,65
-Richmond,64004,State Senate,SD24,Con,Andew Lanza,51
-Richmond,64005,State Senate,SD24,Con,Andew Lanza,51
-Richmond,64006,State Senate,SD24,Con,Andew Lanza,57
-Richmond,64007,State Senate,SD24,Con,Andew Lanza,61
-Richmond,64008,State Senate,SD24,Con,Andew Lanza,51
-Richmond,64009,State Senate,SD24,Con,Andew Lanza,57
-Richmond,64010,State Senate,SD24,Con,Andew Lanza,56
-Richmond,64011,State Senate,SD24,Con,Andew Lanza,69
-Richmond,64012,State Senate,SD24,Con,Andew Lanza,30
-Richmond,64013,State Senate,SD24,Con,Andew Lanza,17
-Richmond,64014,State Senate,SD24,Con,Andew Lanza,38
-Richmond,64015,State Senate,SD24,Con,Andew Lanza,41
-Richmond,64016,State Senate,SD24,Con,Andew Lanza,72
-Richmond,64017,State Senate,SD24,Con,Andew Lanza,64
-Richmond,64018,State Senate,SD24,Con,Andew Lanza,39
-Richmond,64019,State Senate,SD24,Con,Andew Lanza,28
-Richmond,64020,State Senate,SD24,Con,Andew Lanza,29
-Richmond,64021,State Senate,SD24,Con,Andew Lanza,27
-Richmond,64022,State Senate,SD24,Con,Andew Lanza,55
-Richmond,64023,State Senate,SD24,Con,Andew Lanza,40
-Richmond,64024,State Senate,SD24,Con,Andew Lanza,43
-Richmond,64025,State Senate,SD24,Con,Andew Lanza,25
-Richmond,64026,State Senate,SD24,Con,Andew Lanza,42
-Richmond,64027,State Senate,SD24,Con,Andew Lanza,26
-Richmond,64028,State Senate,SD24,Con,Andew Lanza,15
-Richmond,64029,State Senate,SD24,Con,Andew Lanza,32
-Richmond,64030,State Senate,SD24,Con,Andew Lanza,25
-Richmond,64031,State Senate,SD24,Con,Andew Lanza,27
-Richmond,64032,State Senate,SD24,Con,Andew Lanza,55
-Richmond,64033,State Senate,SD24,Con,Andew Lanza,27
-Richmond,64034,State Senate,SD24,Con,Andew Lanza,35
-Richmond,64035,State Senate,SD24,Con,Andew Lanza,36
-Richmond,64036,State Senate,SD24,Con,Andew Lanza,40
-Richmond,64037,State Senate,SD24,Con,Andew Lanza,31
-Richmond,64038,State Senate,SD24,Con,Andew Lanza,33
-Richmond,61034,State Senate,SD24,Ind,Andrew Lanza,24
-Richmond,61035,State Senate,SD24,Ind,Andrew Lanza,15
-Richmond,61036,State Senate,SD24,Ind,Andrew Lanza,11
-Richmond,61037,State Senate,SD24,Ind,Andrew Lanza,20
-Richmond,61038,State Senate,SD24,Ind,Andrew Lanza,30
-Richmond,61039,State Senate,SD24,Ind,Andrew Lanza,30
-Richmond,61040,State Senate,SD24,Ind,Andrew Lanza,27
-Richmond,61041,State Senate,SD24,Ind,Andrew Lanza,26
-Richmond,61042,State Senate,SD24,Ind,Andrew Lanza,27
-Richmond,61043,State Senate,SD24,Ind,Andrew Lanza,34
-Richmond,61044,State Senate,SD24,Ind,Andrew Lanza,19
-Richmond,61045,State Senate,SD24,Ind,Andrew Lanza,13
-Richmond,61046,State Senate,SD24,Ind,Andrew Lanza,21
-Richmond,61047,State Senate,SD24,Ind,Andrew Lanza,18
-Richmond,61048,State Senate,SD24,Ind,Andrew Lanza,11
-Richmond,62001,State Senate,SD24,Ind,Andrew Lanza,18
-Richmond,62002,State Senate,SD24,Ind,Andrew Lanza,19
-Richmond,62003,State Senate,SD24,Ind,Andrew Lanza,19
-Richmond,62004,State Senate,SD24,Ind,Andrew Lanza,21
-Richmond,62005,State Senate,SD24,Ind,Andrew Lanza,13
-Richmond,62006,State Senate,SD24,Ind,Andrew Lanza,18
-Richmond,62007,State Senate,SD24,Ind,Andrew Lanza,23
-Richmond,62008,State Senate,SD24,Ind,Andrew Lanza,20
-Richmond,62009,State Senate,SD24,Ind,Andrew Lanza,13
-Richmond,62010,State Senate,SD24,Ind,Andrew Lanza,6
-Richmond,62011,State Senate,SD24,Ind,Andrew Lanza,26
-Richmond,62012,State Senate,SD24,Ind,Andrew Lanza,14
-Richmond,62013,State Senate,SD24,Ind,Andrew Lanza,16
-Richmond,62014,State Senate,SD24,Ind,Andrew Lanza,8
-Richmond,62015,State Senate,SD24,Ind,Andrew Lanza,20
-Richmond,62016,State Senate,SD24,Ind,Andrew Lanza,27
-Richmond,62017,State Senate,SD24,Ind,Andrew Lanza,11
-Richmond,62018,State Senate,SD24,Ind,Andrew Lanza,18
-Richmond,62019,State Senate,SD24,Ind,Andrew Lanza,21
-Richmond,62020,State Senate,SD24,Ind,Andrew Lanza,10
-Richmond,62021,State Senate,SD24,Ind,Andrew Lanza,12
-Richmond,62022,State Senate,SD24,Ind,Andrew Lanza,11
-Richmond,62023,State Senate,SD24,Ind,Andrew Lanza,19
-Richmond,62024,State Senate,SD24,Ind,Andrew Lanza,22
-Richmond,62025,State Senate,SD24,Ind,Andrew Lanza,15
-Richmond,62026,State Senate,SD24,Ind,Andrew Lanza,21
-Richmond,62027,State Senate,SD24,Ind,Andrew Lanza,21
-Richmond,62028,State Senate,SD24,Ind,Andrew Lanza,21
-Richmond,62029,State Senate,SD24,Ind,Andrew Lanza,12
-Richmond,62030,State Senate,SD24,Ind,Andrew Lanza,13
-Richmond,62031,State Senate,SD24,Ind,Andrew Lanza,19
-Richmond,62032,State Senate,SD24,Ind,Andrew Lanza,10
-Richmond,62033,State Senate,SD24,Ind,Andrew Lanza,9
-Richmond,62034,State Senate,SD24,Ind,Andrew Lanza,17
-Richmond,62035,State Senate,SD24,Ind,Andrew Lanza,11
-Richmond,62036,State Senate,SD24,Ind,Andrew Lanza,10
-Richmond,62037,State Senate,SD24,Ind,Andrew Lanza,9
-Richmond,62038,State Senate,SD24,Ind,Andrew Lanza,17
-Richmond,62039,State Senate,SD24,Ind,Andrew Lanza,17
-Richmond,62040,State Senate,SD24,Ind,Andrew Lanza,15
-Richmond,62041,State Senate,SD24,Ind,Andrew Lanza,12
-Richmond,62042,State Senate,SD24,Ind,Andrew Lanza,17
-Richmond,62043,State Senate,SD24,Ind,Andrew Lanza,21
-Richmond,62044,State Senate,SD24,Ind,Andrew Lanza,12
-Richmond,62045,State Senate,SD24,Ind,Andrew Lanza,15
-Richmond,62046,State Senate,SD24,Ind,Andrew Lanza,12
-Richmond,62047,State Senate,SD24,Ind,Andrew Lanza,12
-Richmond,62048,State Senate,SD24,Ind,Andrew Lanza,14
-Richmond,62049,State Senate,SD24,Ind,Andrew Lanza,18
-Richmond,62050,State Senate,SD24,Ind,Andrew Lanza,14
-Richmond,62051,State Senate,SD24,Ind,Andrew Lanza,15
-Richmond,62052,State Senate,SD24,Ind,Andrew Lanza,13
-Richmond,62053,State Senate,SD24,Ind,Andrew Lanza,23
-Richmond,62054,State Senate,SD24,Ind,Andrew Lanza,26
-Richmond,62055,State Senate,SD24,Ind,Andrew Lanza,22
-Richmond,62056,State Senate,SD24,Ind,Andrew Lanza,22
-Richmond,62057,State Senate,SD24,Ind,Andrew Lanza,16
-Richmond,62058,State Senate,SD24,Ind,Andrew Lanza,14
-Richmond,62059,State Senate,SD24,Ind,Andrew Lanza,17
-Richmond,62060,State Senate,SD24,Ind,Andrew Lanza,10
-Richmond,62061,State Senate,SD24,Ind,Andrew Lanza,12
-Richmond,62062,State Senate,SD24,Ind,Andrew Lanza,9
-Richmond,62063,State Senate,SD24,Ind,Andrew Lanza,12
-Richmond,62064,State Senate,SD24,Ind,Andrew Lanza,11
-Richmond,62065,State Senate,SD24,Ind,Andrew Lanza,22
-Richmond,62066,State Senate,SD24,Ind,Andrew Lanza,20
-Richmond,62067,State Senate,SD24,Ind,Andrew Lanza,13
-Richmond,62068,State Senate,SD24,Ind,Andrew Lanza,14
-Richmond,62069,State Senate,SD24,Ind,Andrew Lanza,18
-Richmond,62070,State Senate,SD24,Ind,Andrew Lanza,21
-Richmond,62071,State Senate,SD24,Ind,Andrew Lanza,14
-Richmond,62072,State Senate,SD24,Ind,Andrew Lanza,12
-Richmond,63001,State Senate,SD24,Ind,Andrew Lanza,11
-Richmond,63002,State Senate,SD24,Ind,Andrew Lanza,12
-Richmond,63003,State Senate,SD24,Ind,Andrew Lanza,12
-Richmond,63004,State Senate,SD24,Ind,Andrew Lanza,9
-Richmond,63005,State Senate,SD24,Ind,Andrew Lanza,18
-Richmond,63006,State Senate,SD24,Ind,Andrew Lanza,17
-Richmond,63007,State Senate,SD24,Ind,Andrew Lanza,18
-Richmond,63008,State Senate,SD24,Ind,Andrew Lanza,6
-Richmond,63009,State Senate,SD24,Ind,Andrew Lanza,0
-Richmond,63011,State Senate,SD24,Ind,Andrew Lanza,18
-Richmond,63012,State Senate,SD24,Ind,Andrew Lanza,20
-Richmond,63013,State Senate,SD24,Ind,Andrew Lanza,16
-Richmond,63014,State Senate,SD24,Ind,Andrew Lanza,18
-Richmond,63015,State Senate,SD24,Ind,Andrew Lanza,18
-Richmond,63016,State Senate,SD24,Ind,Andrew Lanza,11
-Richmond,63018,State Senate,SD24,Ind,Andrew Lanza,12
-Richmond,63019,State Senate,SD24,Ind,Andrew Lanza,9
-Richmond,63020,State Senate,SD24,Ind,Andrew Lanza,19
-Richmond,63021,State Senate,SD24,Ind,Andrew Lanza,14
-Richmond,63022,State Senate,SD24,Ind,Andrew Lanza,17
-Richmond,63023,State Senate,SD24,Ind,Andrew Lanza,12
-Richmond,63024,State Senate,SD24,Ind,Andrew Lanza,13
-Richmond,63025,State Senate,SD24,Ind,Andrew Lanza,14
-Richmond,63026,State Senate,SD24,Ind,Andrew Lanza,12
-Richmond,63027,State Senate,SD24,Ind,Andrew Lanza,17
-Richmond,63028,State Senate,SD24,Ind,Andrew Lanza,10
-Richmond,63029,State Senate,SD24,Ind,Andrew Lanza,14
-Richmond,63030,State Senate,SD24,Ind,Andrew Lanza,12
-Richmond,63031,State Senate,SD24,Ind,Andrew Lanza,14
-Richmond,63032,State Senate,SD24,Ind,Andrew Lanza,31
-Richmond,63033,State Senate,SD24,Ind,Andrew Lanza,19
-Richmond,63034,State Senate,SD24,Ind,Andrew Lanza,7
-Richmond,63035,State Senate,SD24,Ind,Andrew Lanza,15
-Richmond,63036,State Senate,SD24,Ind,Andrew Lanza,22
-Richmond,63046,State Senate,SD24,Ind,Andrew Lanza,15
-Richmond,63047,State Senate,SD24,Ind,Andrew Lanza,18
-Richmond,63048,State Senate,SD24,Ind,Andrew Lanza,14
-Richmond,63049,State Senate,SD24,Ind,Andrew Lanza,9
-Richmond,63050,State Senate,SD24,Ind,Andrew Lanza,17
-Richmond,63051,State Senate,SD24,Ind,Andrew Lanza,9
-Richmond,63052,State Senate,SD24,Ind,Andrew Lanza,6
-Richmond,63053,State Senate,SD24,Ind,Andrew Lanza,14
-Richmond,63054,State Senate,SD24,Ind,Andrew Lanza,14
-Richmond,63055,State Senate,SD24,Ind,Andrew Lanza,10
-Richmond,63056,State Senate,SD24,Ind,Andrew Lanza,24
-Richmond,63057,State Senate,SD24,Ind,Andrew Lanza,23
-Richmond,63058,State Senate,SD24,Ind,Andrew Lanza,11
-Richmond,63059,State Senate,SD24,Ind,Andrew Lanza,20
-Richmond,63060,State Senate,SD24,Ind,Andrew Lanza,16
-Richmond,63061,State Senate,SD24,Ind,Andrew Lanza,16
-Richmond,63062,State Senate,SD24,Ind,Andrew Lanza,22
-Richmond,63063,State Senate,SD24,Ind,Andrew Lanza,7
-Richmond,63064,State Senate,SD24,Ind,Andrew Lanza,26
-Richmond,63065,State Senate,SD24,Ind,Andrew Lanza,19
-Richmond,63066,State Senate,SD24,Ind,Andrew Lanza,26
-Richmond,63067,State Senate,SD24,Ind,Andrew Lanza,16
-Richmond,63068,State Senate,SD24,Ind,Andrew Lanza,13
-Richmond,63069,State Senate,SD24,Ind,Andrew Lanza,7
-Richmond,63070,State Senate,SD24,Ind,Andrew Lanza,4
-Richmond,63071,State Senate,SD24,Ind,Andrew Lanza,6
-Richmond,63072,State Senate,SD24,Ind,Andrew Lanza,15
-Richmond,63073,State Senate,SD24,Ind,Andrew Lanza,15
-Richmond,64001,State Senate,SD24,Ind,Andrew Lanza,18
-Richmond,64002,State Senate,SD24,Ind,Andrew Lanza,20
-Richmond,64003,State Senate,SD24,Ind,Andrew Lanza,20
-Richmond,64004,State Senate,SD24,Ind,Andrew Lanza,18
-Richmond,64005,State Senate,SD24,Ind,Andrew Lanza,20
-Richmond,64006,State Senate,SD24,Ind,Andrew Lanza,24
-Richmond,64007,State Senate,SD24,Ind,Andrew Lanza,27
-Richmond,64008,State Senate,SD24,Ind,Andrew Lanza,25
-Richmond,64009,State Senate,SD24,Ind,Andrew Lanza,20
-Richmond,64010,State Senate,SD24,Ind,Andrew Lanza,19
-Richmond,64011,State Senate,SD24,Ind,Andrew Lanza,8
-Richmond,64012,State Senate,SD24,Ind,Andrew Lanza,13
-Richmond,64013,State Senate,SD24,Ind,Andrew Lanza,11
-Richmond,64014,State Senate,SD24,Ind,Andrew Lanza,22
-Richmond,64015,State Senate,SD24,Ind,Andrew Lanza,23
-Richmond,64016,State Senate,SD24,Ind,Andrew Lanza,24
-Richmond,64017,State Senate,SD24,Ind,Andrew Lanza,23
-Richmond,64018,State Senate,SD24,Ind,Andrew Lanza,12
-Richmond,64019,State Senate,SD24,Ind,Andrew Lanza,5
-Richmond,64020,State Senate,SD24,Ind,Andrew Lanza,17
-Richmond,64021,State Senate,SD24,Ind,Andrew Lanza,13
-Richmond,64022,State Senate,SD24,Ind,Andrew Lanza,25
-Richmond,64023,State Senate,SD24,Ind,Andrew Lanza,28
-Richmond,64024,State Senate,SD24,Ind,Andrew Lanza,11
-Richmond,64025,State Senate,SD24,Ind,Andrew Lanza,6
-Richmond,64026,State Senate,SD24,Ind,Andrew Lanza,12
-Richmond,64027,State Senate,SD24,Ind,Andrew Lanza,14
-Richmond,64028,State Senate,SD24,Ind,Andrew Lanza,6
-Richmond,64029,State Senate,SD24,Ind,Andrew Lanza,11
-Richmond,64030,State Senate,SD24,Ind,Andrew Lanza,8
-Richmond,64031,State Senate,SD24,Ind,Andrew Lanza,20
-Richmond,64032,State Senate,SD24,Ind,Andrew Lanza,13
-Richmond,64033,State Senate,SD24,Ind,Andrew Lanza,13
-Richmond,64034,State Senate,SD24,Ind,Andrew Lanza,20
-Richmond,64035,State Senate,SD24,Ind,Andrew Lanza,13
-Richmond,64036,State Senate,SD24,Ind,Andrew Lanza,15
-Richmond,64037,State Senate,SD24,Ind,Andrew Lanza,16
-Richmond,64038,State Senate,SD24,Ind,Andrew Lanza,7
-Richmond,61034,State Senate,SD24,Dem,Gary Carsel,148
-Richmond,61035,State Senate,SD24,Dem,Gary Carsel,101
-Richmond,61036,State Senate,SD24,Dem,Gary Carsel,91
-Richmond,61037,State Senate,SD24,Dem,Gary Carsel,290
-Richmond,61038,State Senate,SD24,Dem,Gary Carsel,237
-Richmond,61039,State Senate,SD24,Dem,Gary Carsel,232
-Richmond,61040,State Senate,SD24,Dem,Gary Carsel,199
-Richmond,61041,State Senate,SD24,Dem,Gary Carsel,169
-Richmond,61042,State Senate,SD24,Dem,Gary Carsel,217
-Richmond,61043,State Senate,SD24,Dem,Gary Carsel,181
-Richmond,61044,State Senate,SD24,Dem,Gary Carsel,209
-Richmond,61045,State Senate,SD24,Dem,Gary Carsel,192
-Richmond,61046,State Senate,SD24,Dem,Gary Carsel,158
-Richmond,61047,State Senate,SD24,Dem,Gary Carsel,100
-Richmond,61048,State Senate,SD24,Dem,Gary Carsel,88
-Richmond,62001,State Senate,SD24,Dem,Gary Carsel,113
-Richmond,62002,State Senate,SD24,Dem,Gary Carsel,82
-Richmond,62003,State Senate,SD24,Dem,Gary Carsel,97
-Richmond,62004,State Senate,SD24,Dem,Gary Carsel,96
-Richmond,62005,State Senate,SD24,Dem,Gary Carsel,100
-Richmond,62006,State Senate,SD24,Dem,Gary Carsel,123
-Richmond,62007,State Senate,SD24,Dem,Gary Carsel,129
-Richmond,62008,State Senate,SD24,Dem,Gary Carsel,102
-Richmond,62009,State Senate,SD24,Dem,Gary Carsel,53
-Richmond,62010,State Senate,SD24,Dem,Gary Carsel,55
-Richmond,62011,State Senate,SD24,Dem,Gary Carsel,94
-Richmond,62012,State Senate,SD24,Dem,Gary Carsel,119
-Richmond,62013,State Senate,SD24,Dem,Gary Carsel,137
-Richmond,62014,State Senate,SD24,Dem,Gary Carsel,132
-Richmond,62015,State Senate,SD24,Dem,Gary Carsel,137
-Richmond,62016,State Senate,SD24,Dem,Gary Carsel,158
-Richmond,62017,State Senate,SD24,Dem,Gary Carsel,123
-Richmond,62018,State Senate,SD24,Dem,Gary Carsel,137
-Richmond,62019,State Senate,SD24,Dem,Gary Carsel,93
-Richmond,62020,State Senate,SD24,Dem,Gary Carsel,101
-Richmond,62021,State Senate,SD24,Dem,Gary Carsel,77
-Richmond,62022,State Senate,SD24,Dem,Gary Carsel,105
-Richmond,62023,State Senate,SD24,Dem,Gary Carsel,77
-Richmond,62024,State Senate,SD24,Dem,Gary Carsel,140
-Richmond,62025,State Senate,SD24,Dem,Gary Carsel,116
-Richmond,62026,State Senate,SD24,Dem,Gary Carsel,197
-Richmond,62027,State Senate,SD24,Dem,Gary Carsel,117
-Richmond,62028,State Senate,SD24,Dem,Gary Carsel,104
-Richmond,62029,State Senate,SD24,Dem,Gary Carsel,82
-Richmond,62030,State Senate,SD24,Dem,Gary Carsel,87
-Richmond,62031,State Senate,SD24,Dem,Gary Carsel,131
-Richmond,62032,State Senate,SD24,Dem,Gary Carsel,101
-Richmond,62033,State Senate,SD24,Dem,Gary Carsel,85
-Richmond,62034,State Senate,SD24,Dem,Gary Carsel,93
-Richmond,62035,State Senate,SD24,Dem,Gary Carsel,71
-Richmond,62036,State Senate,SD24,Dem,Gary Carsel,94
-Richmond,62037,State Senate,SD24,Dem,Gary Carsel,117
-Richmond,62038,State Senate,SD24,Dem,Gary Carsel,119
-Richmond,62039,State Senate,SD24,Dem,Gary Carsel,84
-Richmond,62040,State Senate,SD24,Dem,Gary Carsel,92
-Richmond,62041,State Senate,SD24,Dem,Gary Carsel,89
-Richmond,62042,State Senate,SD24,Dem,Gary Carsel,116
-Richmond,62043,State Senate,SD24,Dem,Gary Carsel,122
-Richmond,62044,State Senate,SD24,Dem,Gary Carsel,125
-Richmond,62045,State Senate,SD24,Dem,Gary Carsel,112
-Richmond,62046,State Senate,SD24,Dem,Gary Carsel,103
-Richmond,62047,State Senate,SD24,Dem,Gary Carsel,112
-Richmond,62048,State Senate,SD24,Dem,Gary Carsel,120
-Richmond,62049,State Senate,SD24,Dem,Gary Carsel,128
-Richmond,62050,State Senate,SD24,Dem,Gary Carsel,93
-Richmond,62051,State Senate,SD24,Dem,Gary Carsel,150
-Richmond,62052,State Senate,SD24,Dem,Gary Carsel,112
-Richmond,62053,State Senate,SD24,Dem,Gary Carsel,110
-Richmond,62054,State Senate,SD24,Dem,Gary Carsel,165
-Richmond,62055,State Senate,SD24,Dem,Gary Carsel,107
-Richmond,62056,State Senate,SD24,Dem,Gary Carsel,109
-Richmond,62057,State Senate,SD24,Dem,Gary Carsel,74
-Richmond,62058,State Senate,SD24,Dem,Gary Carsel,76
-Richmond,62059,State Senate,SD24,Dem,Gary Carsel,108
-Richmond,62060,State Senate,SD24,Dem,Gary Carsel,60
-Richmond,62061,State Senate,SD24,Dem,Gary Carsel,112
-Richmond,62062,State Senate,SD24,Dem,Gary Carsel,84
-Richmond,62063,State Senate,SD24,Dem,Gary Carsel,102
-Richmond,62064,State Senate,SD24,Dem,Gary Carsel,67
-Richmond,62065,State Senate,SD24,Dem,Gary Carsel,97
-Richmond,62066,State Senate,SD24,Dem,Gary Carsel,114
-Richmond,62067,State Senate,SD24,Dem,Gary Carsel,134
-Richmond,62068,State Senate,SD24,Dem,Gary Carsel,141
-Richmond,62069,State Senate,SD24,Dem,Gary Carsel,133
-Richmond,62070,State Senate,SD24,Dem,Gary Carsel,87
-Richmond,62071,State Senate,SD24,Dem,Gary Carsel,132
-Richmond,62072,State Senate,SD24,Dem,Gary Carsel,72
-Richmond,63001,State Senate,SD24,Dem,Gary Carsel,179
-Richmond,63002,State Senate,SD24,Dem,Gary Carsel,206
-Richmond,63003,State Senate,SD24,Dem,Gary Carsel,178
-Richmond,63004,State Senate,SD24,Dem,Gary Carsel,126
-Richmond,63005,State Senate,SD24,Dem,Gary Carsel,137
-Richmond,63006,State Senate,SD24,Dem,Gary Carsel,140
-Richmond,63007,State Senate,SD24,Dem,Gary Carsel,251
-Richmond,63008,State Senate,SD24,Dem,Gary Carsel,130
-Richmond,63009,State Senate,SD24,Dem,Gary Carsel,5
-Richmond,63011,State Senate,SD24,Dem,Gary Carsel,256
-Richmond,63012,State Senate,SD24,Dem,Gary Carsel,245
-Richmond,63013,State Senate,SD24,Dem,Gary Carsel,258
-Richmond,63014,State Senate,SD24,Dem,Gary Carsel,206
-Richmond,63015,State Senate,SD24,Dem,Gary Carsel,217
-Richmond,63016,State Senate,SD24,Dem,Gary Carsel,182
-Richmond,63018,State Senate,SD24,Dem,Gary Carsel,128
-Richmond,63019,State Senate,SD24,Dem,Gary Carsel,119
-Richmond,63020,State Senate,SD24,Dem,Gary Carsel,119
-Richmond,63021,State Senate,SD24,Dem,Gary Carsel,146
-Richmond,63022,State Senate,SD24,Dem,Gary Carsel,211
-Richmond,63023,State Senate,SD24,Dem,Gary Carsel,181
-Richmond,63024,State Senate,SD24,Dem,Gary Carsel,205
-Richmond,63025,State Senate,SD24,Dem,Gary Carsel,162
-Richmond,63026,State Senate,SD24,Dem,Gary Carsel,82
-Richmond,63027,State Senate,SD24,Dem,Gary Carsel,155
-Richmond,63028,State Senate,SD24,Dem,Gary Carsel,146
-Richmond,63029,State Senate,SD24,Dem,Gary Carsel,195
-Richmond,63030,State Senate,SD24,Dem,Gary Carsel,222
-Richmond,63031,State Senate,SD24,Dem,Gary Carsel,206
-Richmond,63032,State Senate,SD24,Dem,Gary Carsel,222
-Richmond,63033,State Senate,SD24,Dem,Gary Carsel,132
-Richmond,63034,State Senate,SD24,Dem,Gary Carsel,85
-Richmond,63035,State Senate,SD24,Dem,Gary Carsel,95
-Richmond,63036,State Senate,SD24,Dem,Gary Carsel,208
-Richmond,63046,State Senate,SD24,Dem,Gary Carsel,320
-Richmond,63047,State Senate,SD24,Dem,Gary Carsel,150
-Richmond,63048,State Senate,SD24,Dem,Gary Carsel,95
-Richmond,63049,State Senate,SD24,Dem,Gary Carsel,125
-Richmond,63050,State Senate,SD24,Dem,Gary Carsel,212
-Richmond,63051,State Senate,SD24,Dem,Gary Carsel,120
-Richmond,63052,State Senate,SD24,Dem,Gary Carsel,102
-Richmond,63053,State Senate,SD24,Dem,Gary Carsel,132
-Richmond,63054,State Senate,SD24,Dem,Gary Carsel,245
-Richmond,63055,State Senate,SD24,Dem,Gary Carsel,174
-Richmond,63056,State Senate,SD24,Dem,Gary Carsel,287
-Richmond,63057,State Senate,SD24,Dem,Gary Carsel,168
-Richmond,63058,State Senate,SD24,Dem,Gary Carsel,150
-Richmond,63059,State Senate,SD24,Dem,Gary Carsel,182
-Richmond,63060,State Senate,SD24,Dem,Gary Carsel,209
-Richmond,63061,State Senate,SD24,Dem,Gary Carsel,199
-Richmond,63062,State Senate,SD24,Dem,Gary Carsel,180
-Richmond,63063,State Senate,SD24,Dem,Gary Carsel,144
-Richmond,63064,State Senate,SD24,Dem,Gary Carsel,172
-Richmond,63065,State Senate,SD24,Dem,Gary Carsel,176
-Richmond,63066,State Senate,SD24,Dem,Gary Carsel,140
-Richmond,63067,State Senate,SD24,Dem,Gary Carsel,110
-Richmond,63068,State Senate,SD24,Dem,Gary Carsel,349
-Richmond,63069,State Senate,SD24,Dem,Gary Carsel,143
-Richmond,63070,State Senate,SD24,Dem,Gary Carsel,102
-Richmond,63071,State Senate,SD24,Dem,Gary Carsel,295
-Richmond,63072,State Senate,SD24,Dem,Gary Carsel,160
-Richmond,63073,State Senate,SD24,Dem,Gary Carsel,157
-Richmond,64001,State Senate,SD24,Dem,Gary Carsel,93
-Richmond,64002,State Senate,SD24,Dem,Gary Carsel,79
-Richmond,64003,State Senate,SD24,Dem,Gary Carsel,92
-Richmond,64004,State Senate,SD24,Dem,Gary Carsel,109
-Richmond,64005,State Senate,SD24,Dem,Gary Carsel,131
-Richmond,64006,State Senate,SD24,Dem,Gary Carsel,101
-Richmond,64007,State Senate,SD24,Dem,Gary Carsel,72
-Richmond,64008,State Senate,SD24,Dem,Gary Carsel,110
-Richmond,64009,State Senate,SD24,Dem,Gary Carsel,125
-Richmond,64010,State Senate,SD24,Dem,Gary Carsel,120
-Richmond,64011,State Senate,SD24,Dem,Gary Carsel,81
-Richmond,64012,State Senate,SD24,Dem,Gary Carsel,53
-Richmond,64013,State Senate,SD24,Dem,Gary Carsel,69
-Richmond,64014,State Senate,SD24,Dem,Gary Carsel,116
-Richmond,64015,State Senate,SD24,Dem,Gary Carsel,106
-Richmond,64016,State Senate,SD24,Dem,Gary Carsel,117
-Richmond,64017,State Senate,SD24,Dem,Gary Carsel,142
-Richmond,64018,State Senate,SD24,Dem,Gary Carsel,149
-Richmond,64019,State Senate,SD24,Dem,Gary Carsel,242
-Richmond,64020,State Senate,SD24,Dem,Gary Carsel,140
-Richmond,64021,State Senate,SD24,Dem,Gary Carsel,96
-Richmond,64022,State Senate,SD24,Dem,Gary Carsel,120
-Richmond,64023,State Senate,SD24,Dem,Gary Carsel,153
-Richmond,64024,State Senate,SD24,Dem,Gary Carsel,108
-Richmond,64025,State Senate,SD24,Dem,Gary Carsel,103
-Richmond,64026,State Senate,SD24,Dem,Gary Carsel,128
-Richmond,64027,State Senate,SD24,Dem,Gary Carsel,89
-Richmond,64028,State Senate,SD24,Dem,Gary Carsel,88
-Richmond,64029,State Senate,SD24,Dem,Gary Carsel,124
-Richmond,64030,State Senate,SD24,Dem,Gary Carsel,100
-Richmond,64031,State Senate,SD24,Dem,Gary Carsel,121
-Richmond,64032,State Senate,SD24,Dem,Gary Carsel,173
-Richmond,64033,State Senate,SD24,Dem,Gary Carsel,110
-Richmond,64034,State Senate,SD24,Dem,Gary Carsel,163
-Richmond,64035,State Senate,SD24,Dem,Gary Carsel,146
-Richmond,64036,State Senate,SD24,Dem,Gary Carsel,192
-Richmond,64037,State Senate,SD24,Dem,Gary Carsel,97
-Richmond,64038,State Senate,SD24,Dem,Gary Carsel,122
-Richmond,61034,State Senate,SD24,WF,Gary Carsel,11
-Richmond,61035,State Senate,SD24,WF,Gary Carsel,4
-Richmond,61036,State Senate,SD24,WF,Gary Carsel,4
-Richmond,61037,State Senate,SD24,WF,Gary Carsel,25
-Richmond,61038,State Senate,SD24,WF,Gary Carsel,11
-Richmond,61039,State Senate,SD24,WF,Gary Carsel,17
-Richmond,61040,State Senate,SD24,WF,Gary Carsel,13
-Richmond,61041,State Senate,SD24,WF,Gary Carsel,7
-Richmond,61042,State Senate,SD24,WF,Gary Carsel,19
-Richmond,61043,State Senate,SD24,WF,Gary Carsel,8
-Richmond,61044,State Senate,SD24,WF,Gary Carsel,16
-Richmond,61045,State Senate,SD24,WF,Gary Carsel,6
-Richmond,61046,State Senate,SD24,WF,Gary Carsel,11
-Richmond,61047,State Senate,SD24,WF,Gary Carsel,10
-Richmond,61048,State Senate,SD24,WF,Gary Carsel,4
-Richmond,62001,State Senate,SD24,WF,Gary Carsel,7
-Richmond,62002,State Senate,SD24,WF,Gary Carsel,8
-Richmond,62003,State Senate,SD24,WF,Gary Carsel,9
-Richmond,62004,State Senate,SD24,WF,Gary Carsel,11
-Richmond,62005,State Senate,SD24,WF,Gary Carsel,5
-Richmond,62006,State Senate,SD24,WF,Gary Carsel,16
-Richmond,62007,State Senate,SD24,WF,Gary Carsel,11
-Richmond,62008,State Senate,SD24,WF,Gary Carsel,10
-Richmond,62009,State Senate,SD24,WF,Gary Carsel,1
-Richmond,62010,State Senate,SD24,WF,Gary Carsel,3
-Richmond,62011,State Senate,SD24,WF,Gary Carsel,7
-Richmond,62012,State Senate,SD24,WF,Gary Carsel,3
-Richmond,62013,State Senate,SD24,WF,Gary Carsel,7
-Richmond,62014,State Senate,SD24,WF,Gary Carsel,4
-Richmond,62015,State Senate,SD24,WF,Gary Carsel,9
-Richmond,62016,State Senate,SD24,WF,Gary Carsel,5
-Richmond,62017,State Senate,SD24,WF,Gary Carsel,5
-Richmond,62018,State Senate,SD24,WF,Gary Carsel,9
-Richmond,62019,State Senate,SD24,WF,Gary Carsel,4
-Richmond,62020,State Senate,SD24,WF,Gary Carsel,4
-Richmond,62021,State Senate,SD24,WF,Gary Carsel,7
-Richmond,62022,State Senate,SD24,WF,Gary Carsel,5
-Richmond,62023,State Senate,SD24,WF,Gary Carsel,7
-Richmond,62024,State Senate,SD24,WF,Gary Carsel,6
-Richmond,62025,State Senate,SD24,WF,Gary Carsel,4
-Richmond,62026,State Senate,SD24,WF,Gary Carsel,7
-Richmond,62027,State Senate,SD24,WF,Gary Carsel,3
-Richmond,62028,State Senate,SD24,WF,Gary Carsel,2
-Richmond,62029,State Senate,SD24,WF,Gary Carsel,2
-Richmond,62030,State Senate,SD24,WF,Gary Carsel,5
-Richmond,62031,State Senate,SD24,WF,Gary Carsel,6
-Richmond,62032,State Senate,SD24,WF,Gary Carsel,6
-Richmond,62033,State Senate,SD24,WF,Gary Carsel,6
-Richmond,62034,State Senate,SD24,WF,Gary Carsel,3
-Richmond,62035,State Senate,SD24,WF,Gary Carsel,5
-Richmond,62036,State Senate,SD24,WF,Gary Carsel,8
-Richmond,62037,State Senate,SD24,WF,Gary Carsel,2
-Richmond,62038,State Senate,SD24,WF,Gary Carsel,2
-Richmond,62039,State Senate,SD24,WF,Gary Carsel,3
-Richmond,62040,State Senate,SD24,WF,Gary Carsel,4
-Richmond,62041,State Senate,SD24,WF,Gary Carsel,4
-Richmond,62042,State Senate,SD24,WF,Gary Carsel,8
-Richmond,62043,State Senate,SD24,WF,Gary Carsel,5
-Richmond,62044,State Senate,SD24,WF,Gary Carsel,8
-Richmond,62045,State Senate,SD24,WF,Gary Carsel,5
-Richmond,62046,State Senate,SD24,WF,Gary Carsel,4
-Richmond,62047,State Senate,SD24,WF,Gary Carsel,5
-Richmond,62048,State Senate,SD24,WF,Gary Carsel,7
-Richmond,62049,State Senate,SD24,WF,Gary Carsel,1
-Richmond,62050,State Senate,SD24,WF,Gary Carsel,4
-Richmond,62051,State Senate,SD24,WF,Gary Carsel,1
-Richmond,62052,State Senate,SD24,WF,Gary Carsel,5
-Richmond,62053,State Senate,SD24,WF,Gary Carsel,7
-Richmond,62054,State Senate,SD24,WF,Gary Carsel,5
-Richmond,62055,State Senate,SD24,WF,Gary Carsel,8
-Richmond,62056,State Senate,SD24,WF,Gary Carsel,4
-Richmond,62057,State Senate,SD24,WF,Gary Carsel,7
-Richmond,62058,State Senate,SD24,WF,Gary Carsel,7
-Richmond,62059,State Senate,SD24,WF,Gary Carsel,5
-Richmond,62060,State Senate,SD24,WF,Gary Carsel,1
-Richmond,62061,State Senate,SD24,WF,Gary Carsel,3
-Richmond,62062,State Senate,SD24,WF,Gary Carsel,9
-Richmond,62063,State Senate,SD24,WF,Gary Carsel,6
-Richmond,62064,State Senate,SD24,WF,Gary Carsel,1
-Richmond,62065,State Senate,SD24,WF,Gary Carsel,8
-Richmond,62066,State Senate,SD24,WF,Gary Carsel,7
-Richmond,62067,State Senate,SD24,WF,Gary Carsel,12
-Richmond,62068,State Senate,SD24,WF,Gary Carsel,7
-Richmond,62069,State Senate,SD24,WF,Gary Carsel,8
-Richmond,62070,State Senate,SD24,WF,Gary Carsel,12
-Richmond,62071,State Senate,SD24,WF,Gary Carsel,4
-Richmond,62072,State Senate,SD24,WF,Gary Carsel,1
-Richmond,63001,State Senate,SD24,WF,Gary Carsel,5
-Richmond,63002,State Senate,SD24,WF,Gary Carsel,5
-Richmond,63003,State Senate,SD24,WF,Gary Carsel,9
-Richmond,63004,State Senate,SD24,WF,Gary Carsel,2
-Richmond,63005,State Senate,SD24,WF,Gary Carsel,8
-Richmond,63006,State Senate,SD24,WF,Gary Carsel,5
-Richmond,63007,State Senate,SD24,WF,Gary Carsel,10
-Richmond,63008,State Senate,SD24,WF,Gary Carsel,3
-Richmond,63009,State Senate,SD24,WF,Gary Carsel,1
-Richmond,63011,State Senate,SD24,WF,Gary Carsel,7
-Richmond,63012,State Senate,SD24,WF,Gary Carsel,3
-Richmond,63013,State Senate,SD24,WF,Gary Carsel,15
-Richmond,63014,State Senate,SD24,WF,Gary Carsel,4
-Richmond,63015,State Senate,SD24,WF,Gary Carsel,7
-Richmond,63016,State Senate,SD24,WF,Gary Carsel,11
-Richmond,63018,State Senate,SD24,WF,Gary Carsel,9
-Richmond,63019,State Senate,SD24,WF,Gary Carsel,3
-Richmond,63020,State Senate,SD24,WF,Gary Carsel,4
-Richmond,63021,State Senate,SD24,WF,Gary Carsel,11
-Richmond,63022,State Senate,SD24,WF,Gary Carsel,11
-Richmond,63023,State Senate,SD24,WF,Gary Carsel,12
-Richmond,63024,State Senate,SD24,WF,Gary Carsel,7
-Richmond,63025,State Senate,SD24,WF,Gary Carsel,8
-Richmond,63026,State Senate,SD24,WF,Gary Carsel,1
-Richmond,63027,State Senate,SD24,WF,Gary Carsel,6
-Richmond,63028,State Senate,SD24,WF,Gary Carsel,1
-Richmond,63029,State Senate,SD24,WF,Gary Carsel,8
-Richmond,63030,State Senate,SD24,WF,Gary Carsel,11
-Richmond,63031,State Senate,SD24,WF,Gary Carsel,5
-Richmond,63032,State Senate,SD24,WF,Gary Carsel,7
-Richmond,63033,State Senate,SD24,WF,Gary Carsel,6
-Richmond,63034,State Senate,SD24,WF,Gary Carsel,2
-Richmond,63035,State Senate,SD24,WF,Gary Carsel,6
-Richmond,63036,State Senate,SD24,WF,Gary Carsel,6
-Richmond,63046,State Senate,SD24,WF,Gary Carsel,13
-Richmond,63047,State Senate,SD24,WF,Gary Carsel,16
-Richmond,63048,State Senate,SD24,WF,Gary Carsel,2
-Richmond,63049,State Senate,SD24,WF,Gary Carsel,6
-Richmond,63050,State Senate,SD24,WF,Gary Carsel,9
-Richmond,63051,State Senate,SD24,WF,Gary Carsel,7
-Richmond,63052,State Senate,SD24,WF,Gary Carsel,2
-Richmond,63053,State Senate,SD24,WF,Gary Carsel,5
-Richmond,63054,State Senate,SD24,WF,Gary Carsel,2
-Richmond,63055,State Senate,SD24,WF,Gary Carsel,9
-Richmond,63056,State Senate,SD24,WF,Gary Carsel,10
-Richmond,63057,State Senate,SD24,WF,Gary Carsel,4
-Richmond,63058,State Senate,SD24,WF,Gary Carsel,7
-Richmond,63059,State Senate,SD24,WF,Gary Carsel,11
-Richmond,63060,State Senate,SD24,WF,Gary Carsel,15
-Richmond,63061,State Senate,SD24,WF,Gary Carsel,15
-Richmond,63062,State Senate,SD24,WF,Gary Carsel,11
-Richmond,63063,State Senate,SD24,WF,Gary Carsel,18
-Richmond,63064,State Senate,SD24,WF,Gary Carsel,4
-Richmond,63065,State Senate,SD24,WF,Gary Carsel,13
-Richmond,63066,State Senate,SD24,WF,Gary Carsel,8
-Richmond,63067,State Senate,SD24,WF,Gary Carsel,9
-Richmond,63068,State Senate,SD24,WF,Gary Carsel,8
-Richmond,63069,State Senate,SD24,WF,Gary Carsel,2
-Richmond,63070,State Senate,SD24,WF,Gary Carsel,4
-Richmond,63071,State Senate,SD24,WF,Gary Carsel,11
-Richmond,63072,State Senate,SD24,WF,Gary Carsel,12
-Richmond,63073,State Senate,SD24,WF,Gary Carsel,12
-Richmond,64001,State Senate,SD24,WF,Gary Carsel,5
-Richmond,64002,State Senate,SD24,WF,Gary Carsel,14
-Richmond,64003,State Senate,SD24,WF,Gary Carsel,4
-Richmond,64004,State Senate,SD24,WF,Gary Carsel,7
-Richmond,64005,State Senate,SD24,WF,Gary Carsel,5
-Richmond,64006,State Senate,SD24,WF,Gary Carsel,5
-Richmond,64007,State Senate,SD24,WF,Gary Carsel,9
-Richmond,64008,State Senate,SD24,WF,Gary Carsel,10
-Richmond,64009,State Senate,SD24,WF,Gary Carsel,5
-Richmond,64010,State Senate,SD24,WF,Gary Carsel,14
-Richmond,64011,State Senate,SD24,WF,Gary Carsel,12
-Richmond,64012,State Senate,SD24,WF,Gary Carsel,9
-Richmond,64013,State Senate,SD24,WF,Gary Carsel,3
-Richmond,64014,State Senate,SD24,WF,Gary Carsel,2
-Richmond,64015,State Senate,SD24,WF,Gary Carsel,1
-Richmond,64016,State Senate,SD24,WF,Gary Carsel,8
-Richmond,64017,State Senate,SD24,WF,Gary Carsel,12
-Richmond,64018,State Senate,SD24,WF,Gary Carsel,13
-Richmond,64019,State Senate,SD24,WF,Gary Carsel,17
-Richmond,64020,State Senate,SD24,WF,Gary Carsel,10
-Richmond,64021,State Senate,SD24,WF,Gary Carsel,3
-Richmond,64022,State Senate,SD24,WF,Gary Carsel,8
-Richmond,64023,State Senate,SD24,WF,Gary Carsel,9
-Richmond,64024,State Senate,SD24,WF,Gary Carsel,6
-Richmond,64025,State Senate,SD24,WF,Gary Carsel,4
-Richmond,64026,State Senate,SD24,WF,Gary Carsel,13
-Richmond,64027,State Senate,SD24,WF,Gary Carsel,7
-Richmond,64028,State Senate,SD24,WF,Gary Carsel,5
-Richmond,64029,State Senate,SD24,WF,Gary Carsel,3
-Richmond,64030,State Senate,SD24,WF,Gary Carsel,3
-Richmond,64031,State Senate,SD24,WF,Gary Carsel,9
-Richmond,64032,State Senate,SD24,WF,Gary Carsel,12
-Richmond,64033,State Senate,SD24,WF,Gary Carsel,5
-Richmond,64034,State Senate,SD24,WF,Gary Carsel,7
-Richmond,64035,State Senate,SD24,WF,Gary Carsel,7
-Richmond,64036,State Senate,SD24,WF,Gary Carsel,6
-Richmond,64037,State Senate,SD24,WF,Gary Carsel,6
-Richmond,64038,State Senate,SD24,WF,Gary Carsel,14
-Richmond,61034,State Senate,SD24,Ind,writein,0
-Richmond,61035,State Senate,SD24,Ind,writein,0
-Richmond,61036,State Senate,SD24,Ind,writein,0
-Richmond,61037,State Senate,SD24,Ind,writein,0
-Richmond,61038,State Senate,SD24,Ind,writein,1
-Richmond,61039,State Senate,SD24,Ind,writein,1
-Richmond,61040,State Senate,SD24,Ind,writein,0
-Richmond,61041,State Senate,SD24,Ind,writein,0
-Richmond,61042,State Senate,SD24,Ind,writein,2
-Richmond,61043,State Senate,SD24,Ind,writein,2
-Richmond,61044,State Senate,SD24,Ind,writein,0
-Richmond,61045,State Senate,SD24,Ind,writein,0
-Richmond,61046,State Senate,SD24,Ind,writein,1
-Richmond,61047,State Senate,SD24,Ind,writein,1
-Richmond,61048,State Senate,SD24,Ind,writein,0
-Richmond,62001,State Senate,SD24,Ind,writein,1
-Richmond,62002,State Senate,SD24,Ind,writein,1
-Richmond,62003,State Senate,SD24,Ind,writein,0
-Richmond,62004,State Senate,SD24,Ind,writein,1
-Richmond,62005,State Senate,SD24,Ind,writein,0
-Richmond,62006,State Senate,SD24,Ind,writein,1
-Richmond,62007,State Senate,SD24,Ind,writein,0
-Richmond,62008,State Senate,SD24,Ind,writein,1
-Richmond,62009,State Senate,SD24,Ind,writein,0
-Richmond,62010,State Senate,SD24,Ind,writein,0
-Richmond,62011,State Senate,SD24,Ind,writein,1
-Richmond,62012,State Senate,SD24,Ind,writein,0
-Richmond,62013,State Senate,SD24,Ind,writein,0
-Richmond,62014,State Senate,SD24,Ind,writein,1
-Richmond,62015,State Senate,SD24,Ind,writein,1
-Richmond,62016,State Senate,SD24,Ind,writein,1
-Richmond,62017,State Senate,SD24,Ind,writein,0
-Richmond,62018,State Senate,SD24,Ind,writein,1
-Richmond,62019,State Senate,SD24,Ind,writein,0
-Richmond,62020,State Senate,SD24,Ind,writein,0
-Richmond,62021,State Senate,SD24,Ind,writein,0
-Richmond,62022,State Senate,SD24,Ind,writein,0
-Richmond,62023,State Senate,SD24,Ind,writein,0
-Richmond,62024,State Senate,SD24,Ind,writein,0
-Richmond,62025,State Senate,SD24,Ind,writein,0
-Richmond,62026,State Senate,SD24,Ind,writein,2
-Richmond,62027,State Senate,SD24,Ind,writein,0
-Richmond,62028,State Senate,SD24,Ind,writein,0
-Richmond,62029,State Senate,SD24,Ind,writein,0
-Richmond,62030,State Senate,SD24,Ind,writein,0
-Richmond,62031,State Senate,SD24,Ind,writein,0
-Richmond,62032,State Senate,SD24,Ind,writein,0
-Richmond,62033,State Senate,SD24,Ind,writein,0
-Richmond,62034,State Senate,SD24,Ind,writein,1
-Richmond,62035,State Senate,SD24,Ind,writein,2
-Richmond,62036,State Senate,SD24,Ind,writein,0
-Richmond,62037,State Senate,SD24,Ind,writein,0
-Richmond,62038,State Senate,SD24,Ind,writein,0
-Richmond,62039,State Senate,SD24,Ind,writein,0
-Richmond,62040,State Senate,SD24,Ind,writein,0
-Richmond,62041,State Senate,SD24,Ind,writein,0
-Richmond,62042,State Senate,SD24,Ind,writein,0
-Richmond,62043,State Senate,SD24,Ind,writein,1
-Richmond,62044,State Senate,SD24,Ind,writein,0
-Richmond,62045,State Senate,SD24,Ind,writein,0
-Richmond,62046,State Senate,SD24,Ind,writein,1
-Richmond,62047,State Senate,SD24,Ind,writein,1
-Richmond,62048,State Senate,SD24,Ind,writein,0
-Richmond,62049,State Senate,SD24,Ind,writein,1
-Richmond,62050,State Senate,SD24,Ind,writein,1
-Richmond,62051,State Senate,SD24,Ind,writein,1
-Richmond,62052,State Senate,SD24,Ind,writein,0
-Richmond,62053,State Senate,SD24,Ind,writein,0
-Richmond,62054,State Senate,SD24,Ind,writein,0
-Richmond,62055,State Senate,SD24,Ind,writein,1
-Richmond,62056,State Senate,SD24,Ind,writein,0
-Richmond,62057,State Senate,SD24,Ind,writein,0
-Richmond,62058,State Senate,SD24,Ind,writein,0
-Richmond,62059,State Senate,SD24,Ind,writein,0
-Richmond,62060,State Senate,SD24,Ind,writein,0
-Richmond,62061,State Senate,SD24,Ind,writein,1
-Richmond,62062,State Senate,SD24,Ind,writein,0
-Richmond,62063,State Senate,SD24,Ind,writein,1
-Richmond,62064,State Senate,SD24,Ind,writein,0
-Richmond,62065,State Senate,SD24,Ind,writein,0
-Richmond,62066,State Senate,SD24,Ind,writein,0
-Richmond,62067,State Senate,SD24,Ind,writein,0
-Richmond,62068,State Senate,SD24,Ind,writein,0
-Richmond,62069,State Senate,SD24,Ind,writein,0
-Richmond,62070,State Senate,SD24,Ind,writein,0
-Richmond,62071,State Senate,SD24,Ind,writein,0
-Richmond,62072,State Senate,SD24,Ind,writein,0
-Richmond,63001,State Senate,SD24,Ind,writein,0
-Richmond,63002,State Senate,SD24,Ind,writein,0
-Richmond,63003,State Senate,SD24,Ind,writein,0
-Richmond,63004,State Senate,SD24,Ind,writein,0
-Richmond,63005,State Senate,SD24,Ind,writein,0
-Richmond,63006,State Senate,SD24,Ind,writein,0
-Richmond,63007,State Senate,SD24,Ind,writein,0
-Richmond,63008,State Senate,SD24,Ind,writein,0
-Richmond,63009,State Senate,SD24,Ind,writein,0
-Richmond,63011,State Senate,SD24,Ind,writein,1
-Richmond,63012,State Senate,SD24,Ind,writein,2
-Richmond,63013,State Senate,SD24,Ind,writein,0
-Richmond,63014,State Senate,SD24,Ind,writein,1
-Richmond,63015,State Senate,SD24,Ind,writein,1
-Richmond,63016,State Senate,SD24,Ind,writein,1
-Richmond,63018,State Senate,SD24,Ind,writein,0
-Richmond,63019,State Senate,SD24,Ind,writein,0
-Richmond,63020,State Senate,SD24,Ind,writein,1
-Richmond,63021,State Senate,SD24,Ind,writein,0
-Richmond,63022,State Senate,SD24,Ind,writein,2
-Richmond,63023,State Senate,SD24,Ind,writein,0
-Richmond,63024,State Senate,SD24,Ind,writein,2
-Richmond,63025,State Senate,SD24,Ind,writein,1
-Richmond,63026,State Senate,SD24,Ind,writein,1
-Richmond,63027,State Senate,SD24,Ind,writein,0
-Richmond,63028,State Senate,SD24,Ind,writein,1
-Richmond,63029,State Senate,SD24,Ind,writein,0
-Richmond,63030,State Senate,SD24,Ind,writein,0
-Richmond,63031,State Senate,SD24,Ind,writein,0
-Richmond,63032,State Senate,SD24,Ind,writein,0
-Richmond,63033,State Senate,SD24,Ind,writein,0
-Richmond,63034,State Senate,SD24,Ind,writein,0
-Richmond,63035,State Senate,SD24,Ind,writein,1
-Richmond,63036,State Senate,SD24,Ind,writein,0
-Richmond,63046,State Senate,SD24,Ind,writein,0
-Richmond,63047,State Senate,SD24,Ind,writein,0
-Richmond,63048,State Senate,SD24,Ind,writein,0
-Richmond,63049,State Senate,SD24,Ind,writein,0
-Richmond,63050,State Senate,SD24,Ind,writein,0
-Richmond,63051,State Senate,SD24,Ind,writein,1
-Richmond,63052,State Senate,SD24,Ind,writein,0
-Richmond,63053,State Senate,SD24,Ind,writein,0
-Richmond,63054,State Senate,SD24,Ind,writein,0
-Richmond,63055,State Senate,SD24,Ind,writein,0
-Richmond,63056,State Senate,SD24,Ind,writein,0
-Richmond,63057,State Senate,SD24,Ind,writein,2
-Richmond,63058,State Senate,SD24,Ind,writein,0
-Richmond,63059,State Senate,SD24,Ind,writein,1
-Richmond,63060,State Senate,SD24,Ind,writein,0
-Richmond,63061,State Senate,SD24,Ind,writein,3
-Richmond,63062,State Senate,SD24,Ind,writein,2
-Richmond,63063,State Senate,SD24,Ind,writein,1
-Richmond,63064,State Senate,SD24,Ind,writein,0
-Richmond,63065,State Senate,SD24,Ind,writein,1
-Richmond,63066,State Senate,SD24,Ind,writein,0
-Richmond,63067,State Senate,SD24,Ind,writein,1
-Richmond,63068,State Senate,SD24,Ind,writein,1
-Richmond,63069,State Senate,SD24,Ind,writein,0
-Richmond,63070,State Senate,SD24,Ind,writein,0
-Richmond,63071,State Senate,SD24,Ind,writein,0
-Richmond,63072,State Senate,SD24,Ind,writein,0
-Richmond,63073,State Senate,SD24,Ind,writein,0
-Richmond,64001,State Senate,SD24,Ind,writein,0
-Richmond,64002,State Senate,SD24,Ind,writein,1
-Richmond,64003,State Senate,SD24,Ind,writein,1
-Richmond,64004,State Senate,SD24,Ind,writein,1
-Richmond,64005,State Senate,SD24,Ind,writein,1
-Richmond,64006,State Senate,SD24,Ind,writein,0
-Richmond,64007,State Senate,SD24,Ind,writein,0
-Richmond,64008,State Senate,SD24,Ind,writein,0
-Richmond,64009,State Senate,SD24,Ind,writein,1
-Richmond,64010,State Senate,SD24,Ind,writein,1
-Richmond,64011,State Senate,SD24,Ind,writein,0
-Richmond,64012,State Senate,SD24,Ind,writein,0
-Richmond,64013,State Senate,SD24,Ind,writein,0
-Richmond,64014,State Senate,SD24,Ind,writein,0
-Richmond,64015,State Senate,SD24,Ind,writein,0
-Richmond,64016,State Senate,SD24,Ind,writein,1
-Richmond,64017,State Senate,SD24,Ind,writein,1
-Richmond,64018,State Senate,SD24,Ind,writein,0
-Richmond,64019,State Senate,SD24,Ind,writein,2
-Richmond,64020,State Senate,SD24,Ind,writein,0
-Richmond,64021,State Senate,SD24,Ind,writein,1
-Richmond,64022,State Senate,SD24,Ind,writein,0
-Richmond,64023,State Senate,SD24,Ind,writein,0
-Richmond,64024,State Senate,SD24,Ind,writein,0
-Richmond,64025,State Senate,SD24,Ind,writein,1
-Richmond,64026,State Senate,SD24,Ind,writein,0
-Richmond,64027,State Senate,SD24,Ind,writein,0
-Richmond,64028,State Senate,SD24,Ind,writein,0
-Richmond,64029,State Senate,SD24,Ind,writein,0
-Richmond,64030,State Senate,SD24,Ind,writein,0
-Richmond,64031,State Senate,SD24,Ind,writein,0
-Richmond,64032,State Senate,SD24,Ind,writein,0
-Richmond,64033,State Senate,SD24,Ind,writein,0
-Richmond,64034,State Senate,SD24,Ind,writein,0
-Richmond,64035,State Senate,SD24,Ind,writein,1
-Richmond,64036,State Senate,SD24,Ind,writein,1
-Richmond,64037,State Senate,SD24,Ind,writein,0
-Richmond,64038,State Senate,SD24,Ind,writein,1
+Richmond,61001,State Senate,23,Dem,Diane Savino,557
+Richmond,61002,State Senate,23,Dem,Diane Savino,455
+Richmond,61003,State Senate,23,Dem,Diane Savino,578
+Richmond,61004,State Senate,23,Dem,Diane Savino,463
+Richmond,61005,State Senate,23,Dem,Diane Savino,364
+Richmond,61006,State Senate,23,Dem,Diane Savino,381
+Richmond,61007,State Senate,23,Dem,Diane Savino,566
+Richmond,61008,State Senate,23,Dem,Diane Savino,584
+Richmond,61009,State Senate,23,Dem,Diane Savino,547
+Richmond,61010,State Senate,23,Dem,Diane Savino,460
+Richmond,61011,State Senate,23,Dem,Diane Savino,275
+Richmond,61012,State Senate,23,Dem,Diane Savino,508
+Richmond,61013,State Senate,23,Dem,Diane Savino,584
+Richmond,61014,State Senate,23,Dem,Diane Savino,450
+Richmond,61015,State Senate,23,Dem,Diane Savino,488
+Richmond,61016,State Senate,23,Dem,Diane Savino,551
+Richmond,61017,State Senate,23,Dem,Diane Savino,519
+Richmond,61018,State Senate,23,Dem,Diane Savino,506
+Richmond,61019,State Senate,23,Dem,Diane Savino,432
+Richmond,61020,State Senate,23,Dem,Diane Savino,410
+Richmond,61021,State Senate,23,Dem,Diane Savino,508
+Richmond,61022,State Senate,23,Dem,Diane Savino,460
+Richmond,61023,State Senate,23,Dem,Diane Savino,452
+Richmond,61024,State Senate,23,Dem,Diane Savino,373
+Richmond,61025,State Senate,23,Dem,Diane Savino,484
+Richmond,61026,State Senate,23,Dem,Diane Savino,496
+Richmond,61027,State Senate,23,Dem,Diane Savino,449
+Richmond,61028,State Senate,23,Dem,Diane Savino,416
+Richmond,61029,State Senate,23,Dem,Diane Savino,413
+Richmond,61030,State Senate,23,Dem,Diane Savino,478
+Richmond,61031,State Senate,23,Dem,Diane Savino,407
+Richmond,61032,State Senate,23,Dem,Diane Savino,333
+Richmond,61033,State Senate,23,Dem,Diane Savino,279
+Richmond,61049,State Senate,23,Dem,Diane Savino,545
+Richmond,61050,State Senate,23,Dem,Diane Savino,534
+Richmond,61051,State Senate,23,Dem,Diane Savino,463
+Richmond,61052,State Senate,23,Dem,Diane Savino,492
+Richmond,61053,State Senate,23,Dem,Diane Savino,694
+Richmond,61054,State Senate,23,Dem,Diane Savino,374
+Richmond,61055,State Senate,23,Dem,Diane Savino,554
+Richmond,61056,State Senate,23,Dem,Diane Savino,585
+Richmond,61057,State Senate,23,Dem,Diane Savino,475
+Richmond,61058,State Senate,23,Dem,Diane Savino,645
+Richmond,61059,State Senate,23,Dem,Diane Savino,641
+Richmond,61060,State Senate,23,Dem,Diane Savino,399
+Richmond,61061,State Senate,23,Dem,Diane Savino,607
+Richmond,63010,State Senate,23,Dem,Diane Savino,184
+Richmond,63017,State Senate,23,Dem,Diane Savino,121
+Richmond,63037,State Senate,23,Dem,Diane Savino,472
+Richmond,63038,State Senate,23,Dem,Diane Savino,454
+Richmond,63039,State Senate,23,Dem,Diane Savino,494
+Richmond,63040,State Senate,23,Dem,Diane Savino,345
+Richmond,63041,State Senate,23,Dem,Diane Savino,334
+Richmond,63042,State Senate,23,Dem,Diane Savino,546
+Richmond,63043,State Senate,23,Dem,Diane Savino,574
+Richmond,63044,State Senate,23,Dem,Diane Savino,334
+Richmond,63045,State Senate,23,Dem,Diane Savino,454
+Richmond,64039,State Senate,23,Dem,Diane Savino,263
+Richmond,64040,State Senate,23,Dem,Diane Savino,400
+Richmond,64041,State Senate,23,Dem,Diane Savino,251
+Richmond,64042,State Senate,23,Dem,Diane Savino,265
+Richmond,64043,State Senate,23,Dem,Diane Savino,210
+Richmond,64044,State Senate,23,Dem,Diane Savino,304
+Richmond,64045,State Senate,23,Dem,Diane Savino,198
+Richmond,64046,State Senate,23,Dem,Diane Savino,195
+Richmond,64047,State Senate,23,Dem,Diane Savino,235
+Richmond,64048,State Senate,23,Dem,Diane Savino,0
+Richmond,64049,State Senate,23,Dem,Diane Savino,410
+Richmond,64050,State Senate,23,Dem,Diane Savino,386
+Richmond,64051,State Senate,23,Dem,Diane Savino,408
+Richmond,64052,State Senate,23,Dem,Diane Savino,305
+Richmond,64053,State Senate,23,Dem,Diane Savino,282
+Richmond,61001,State Senate,23,WF,Diane Savino,43
+Richmond,61002,State Senate,23,WF,Diane Savino,14
+Richmond,61003,State Senate,23,WF,Diane Savino,26
+Richmond,61004,State Senate,23,WF,Diane Savino,35
+Richmond,61005,State Senate,23,WF,Diane Savino,34
+Richmond,61006,State Senate,23,WF,Diane Savino,19
+Richmond,61007,State Senate,23,WF,Diane Savino,16
+Richmond,61008,State Senate,23,WF,Diane Savino,33
+Richmond,61009,State Senate,23,WF,Diane Savino,32
+Richmond,61010,State Senate,23,WF,Diane Savino,17
+Richmond,61011,State Senate,23,WF,Diane Savino,14
+Richmond,61012,State Senate,23,WF,Diane Savino,29
+Richmond,61013,State Senate,23,WF,Diane Savino,27
+Richmond,61014,State Senate,23,WF,Diane Savino,27
+Richmond,61015,State Senate,23,WF,Diane Savino,24
+Richmond,61016,State Senate,23,WF,Diane Savino,23
+Richmond,61017,State Senate,23,WF,Diane Savino,27
+Richmond,61018,State Senate,23,WF,Diane Savino,26
+Richmond,61019,State Senate,23,WF,Diane Savino,28
+Richmond,61020,State Senate,23,WF,Diane Savino,27
+Richmond,61021,State Senate,23,WF,Diane Savino,16
+Richmond,61022,State Senate,23,WF,Diane Savino,16
+Richmond,61023,State Senate,23,WF,Diane Savino,26
+Richmond,61024,State Senate,23,WF,Diane Savino,21
+Richmond,61025,State Senate,23,WF,Diane Savino,19
+Richmond,61026,State Senate,23,WF,Diane Savino,22
+Richmond,61027,State Senate,23,WF,Diane Savino,22
+Richmond,61028,State Senate,23,WF,Diane Savino,28
+Richmond,61029,State Senate,23,WF,Diane Savino,21
+Richmond,61030,State Senate,23,WF,Diane Savino,20
+Richmond,61031,State Senate,23,WF,Diane Savino,17
+Richmond,61032,State Senate,23,WF,Diane Savino,13
+Richmond,61033,State Senate,23,WF,Diane Savino,8
+Richmond,61049,State Senate,23,WF,Diane Savino,30
+Richmond,61050,State Senate,23,WF,Diane Savino,17
+Richmond,61051,State Senate,23,WF,Diane Savino,23
+Richmond,61052,State Senate,23,WF,Diane Savino,21
+Richmond,61053,State Senate,23,WF,Diane Savino,10
+Richmond,61054,State Senate,23,WF,Diane Savino,18
+Richmond,61055,State Senate,23,WF,Diane Savino,19
+Richmond,61056,State Senate,23,WF,Diane Savino,26
+Richmond,61057,State Senate,23,WF,Diane Savino,21
+Richmond,61058,State Senate,23,WF,Diane Savino,6
+Richmond,61059,State Senate,23,WF,Diane Savino,17
+Richmond,61060,State Senate,23,WF,Diane Savino,18
+Richmond,61061,State Senate,23,WF,Diane Savino,5
+Richmond,63010,State Senate,23,WF,Diane Savino,7
+Richmond,63017,State Senate,23,WF,Diane Savino,4
+Richmond,63037,State Senate,23,WF,Diane Savino,21
+Richmond,63038,State Senate,23,WF,Diane Savino,18
+Richmond,63039,State Senate,23,WF,Diane Savino,20
+Richmond,63040,State Senate,23,WF,Diane Savino,18
+Richmond,63041,State Senate,23,WF,Diane Savino,14
+Richmond,63042,State Senate,23,WF,Diane Savino,11
+Richmond,63043,State Senate,23,WF,Diane Savino,14
+Richmond,63044,State Senate,23,WF,Diane Savino,11
+Richmond,63045,State Senate,23,WF,Diane Savino,9
+Richmond,64039,State Senate,23,WF,Diane Savino,18
+Richmond,64040,State Senate,23,WF,Diane Savino,12
+Richmond,64041,State Senate,23,WF,Diane Savino,21
+Richmond,64042,State Senate,23,WF,Diane Savino,12
+Richmond,64043,State Senate,23,WF,Diane Savino,11
+Richmond,64044,State Senate,23,WF,Diane Savino,26
+Richmond,64045,State Senate,23,WF,Diane Savino,3
+Richmond,64046,State Senate,23,WF,Diane Savino,16
+Richmond,64047,State Senate,23,WF,Diane Savino,21
+Richmond,64048,State Senate,23,WF,Diane Savino,0
+Richmond,64049,State Senate,23,WF,Diane Savino,19
+Richmond,64050,State Senate,23,WF,Diane Savino,32
+Richmond,64051,State Senate,23,WF,Diane Savino,22
+Richmond,64052,State Senate,23,WF,Diane Savino,21
+Richmond,64053,State Senate,23,WF,Diane Savino,10
+Richmond,61001,State Senate,23,Ind,Diane Savino,13
+Richmond,61002,State Senate,23,Ind,Diane Savino,2
+Richmond,61003,State Senate,23,Ind,Diane Savino,14
+Richmond,61004,State Senate,23,Ind,Diane Savino,12
+Richmond,61005,State Senate,23,Ind,Diane Savino,9
+Richmond,61006,State Senate,23,Ind,Diane Savino,6
+Richmond,61007,State Senate,23,Ind,Diane Savino,3
+Richmond,61008,State Senate,23,Ind,Diane Savino,6
+Richmond,61009,State Senate,23,Ind,Diane Savino,11
+Richmond,61010,State Senate,23,Ind,Diane Savino,17
+Richmond,61011,State Senate,23,Ind,Diane Savino,10
+Richmond,61012,State Senate,23,Ind,Diane Savino,18
+Richmond,61013,State Senate,23,Ind,Diane Savino,11
+Richmond,61014,State Senate,23,Ind,Diane Savino,10
+Richmond,61015,State Senate,23,Ind,Diane Savino,5
+Richmond,61016,State Senate,23,Ind,Diane Savino,3
+Richmond,61017,State Senate,23,Ind,Diane Savino,5
+Richmond,61018,State Senate,23,Ind,Diane Savino,14
+Richmond,61019,State Senate,23,Ind,Diane Savino,10
+Richmond,61020,State Senate,23,Ind,Diane Savino,9
+Richmond,61021,State Senate,23,Ind,Diane Savino,5
+Richmond,61022,State Senate,23,Ind,Diane Savino,6
+Richmond,61023,State Senate,23,Ind,Diane Savino,6
+Richmond,61024,State Senate,23,Ind,Diane Savino,16
+Richmond,61025,State Senate,23,Ind,Diane Savino,10
+Richmond,61026,State Senate,23,Ind,Diane Savino,14
+Richmond,61027,State Senate,23,Ind,Diane Savino,5
+Richmond,61028,State Senate,23,Ind,Diane Savino,9
+Richmond,61029,State Senate,23,Ind,Diane Savino,13
+Richmond,61030,State Senate,23,Ind,Diane Savino,12
+Richmond,61031,State Senate,23,Ind,Diane Savino,7
+Richmond,61032,State Senate,23,Ind,Diane Savino,2
+Richmond,61033,State Senate,23,Ind,Diane Savino,4
+Richmond,61049,State Senate,23,Ind,Diane Savino,15
+Richmond,61050,State Senate,23,Ind,Diane Savino,8
+Richmond,61051,State Senate,23,Ind,Diane Savino,11
+Richmond,61052,State Senate,23,Ind,Diane Savino,9
+Richmond,61053,State Senate,23,Ind,Diane Savino,6
+Richmond,61054,State Senate,23,Ind,Diane Savino,10
+Richmond,61055,State Senate,23,Ind,Diane Savino,10
+Richmond,61056,State Senate,23,Ind,Diane Savino,9
+Richmond,61057,State Senate,23,Ind,Diane Savino,8
+Richmond,61058,State Senate,23,Ind,Diane Savino,3
+Richmond,61059,State Senate,23,Ind,Diane Savino,4
+Richmond,61060,State Senate,23,Ind,Diane Savino,5
+Richmond,61061,State Senate,23,Ind,Diane Savino,1
+Richmond,63010,State Senate,23,Ind,Diane Savino,8
+Richmond,63017,State Senate,23,Ind,Diane Savino,4
+Richmond,63037,State Senate,23,Ind,Diane Savino,8
+Richmond,63038,State Senate,23,Ind,Diane Savino,11
+Richmond,63039,State Senate,23,Ind,Diane Savino,5
+Richmond,63040,State Senate,23,Ind,Diane Savino,4
+Richmond,63041,State Senate,23,Ind,Diane Savino,4
+Richmond,63042,State Senate,23,Ind,Diane Savino,3
+Richmond,63043,State Senate,23,Ind,Diane Savino,4
+Richmond,63044,State Senate,23,Ind,Diane Savino,4
+Richmond,63045,State Senate,23,Ind,Diane Savino,6
+Richmond,64039,State Senate,23,Ind,Diane Savino,9
+Richmond,64040,State Senate,23,Ind,Diane Savino,8
+Richmond,64041,State Senate,23,Ind,Diane Savino,9
+Richmond,64042,State Senate,23,Ind,Diane Savino,12
+Richmond,64043,State Senate,23,Ind,Diane Savino,13
+Richmond,64044,State Senate,23,Ind,Diane Savino,12
+Richmond,64045,State Senate,23,Ind,Diane Savino,4
+Richmond,64046,State Senate,23,Ind,Diane Savino,9
+Richmond,64047,State Senate,23,Ind,Diane Savino,11
+Richmond,64048,State Senate,23,Ind,Diane Savino,0
+Richmond,64049,State Senate,23,Ind,Diane Savino,10
+Richmond,64050,State Senate,23,Ind,Diane Savino,9
+Richmond,64051,State Senate,23,Ind,Diane Savino,11
+Richmond,64052,State Senate,23,Ind,Diane Savino,9
+Richmond,64053,State Senate,23,Ind,Diane Savino,13
+Richmond,61001,State Senate,23,Rep,Lisa Grey,51
+Richmond,61002,State Senate,23,Rep,Lisa Grey,12
+Richmond,61003,State Senate,23,Rep,Lisa Grey,74
+Richmond,61004,State Senate,23,Rep,Lisa Grey,81
+Richmond,61005,State Senate,23,Rep,Lisa Grey,25
+Richmond,61006,State Senate,23,Rep,Lisa Grey,90
+Richmond,61007,State Senate,23,Rep,Lisa Grey,18
+Richmond,61008,State Senate,23,Rep,Lisa Grey,31
+Richmond,61009,State Senate,23,Rep,Lisa Grey,83
+Richmond,61010,State Senate,23,Rep,Lisa Grey,62
+Richmond,61011,State Senate,23,Rep,Lisa Grey,56
+Richmond,61012,State Senate,23,Rep,Lisa Grey,181
+Richmond,61013,State Senate,23,Rep,Lisa Grey,59
+Richmond,61014,State Senate,23,Rep,Lisa Grey,155
+Richmond,61015,State Senate,23,Rep,Lisa Grey,126
+Richmond,61016,State Senate,23,Rep,Lisa Grey,12
+Richmond,61017,State Senate,23,Rep,Lisa Grey,34
+Richmond,61018,State Senate,23,Rep,Lisa Grey,101
+Richmond,61019,State Senate,23,Rep,Lisa Grey,79
+Richmond,61020,State Senate,23,Rep,Lisa Grey,119
+Richmond,61021,State Senate,23,Rep,Lisa Grey,42
+Richmond,61022,State Senate,23,Rep,Lisa Grey,56
+Richmond,61023,State Senate,23,Rep,Lisa Grey,100
+Richmond,61024,State Senate,23,Rep,Lisa Grey,185
+Richmond,61025,State Senate,23,Rep,Lisa Grey,103
+Richmond,61026,State Senate,23,Rep,Lisa Grey,45
+Richmond,61027,State Senate,23,Rep,Lisa Grey,60
+Richmond,61028,State Senate,23,Rep,Lisa Grey,84
+Richmond,61029,State Senate,23,Rep,Lisa Grey,156
+Richmond,61030,State Senate,23,Rep,Lisa Grey,111
+Richmond,61031,State Senate,23,Rep,Lisa Grey,57
+Richmond,61032,State Senate,23,Rep,Lisa Grey,42
+Richmond,61033,State Senate,23,Rep,Lisa Grey,33
+Richmond,61049,State Senate,23,Rep,Lisa Grey,88
+Richmond,61050,State Senate,23,Rep,Lisa Grey,69
+Richmond,61051,State Senate,23,Rep,Lisa Grey,99
+Richmond,61052,State Senate,23,Rep,Lisa Grey,126
+Richmond,61053,State Senate,23,Rep,Lisa Grey,16
+Richmond,61054,State Senate,23,Rep,Lisa Grey,79
+Richmond,61055,State Senate,23,Rep,Lisa Grey,43
+Richmond,61056,State Senate,23,Rep,Lisa Grey,54
+Richmond,61057,State Senate,23,Rep,Lisa Grey,108
+Richmond,61058,State Senate,23,Rep,Lisa Grey,18
+Richmond,61059,State Senate,23,Rep,Lisa Grey,16
+Richmond,61060,State Senate,23,Rep,Lisa Grey,65
+Richmond,61061,State Senate,23,Rep,Lisa Grey,10
+Richmond,63010,State Senate,23,Rep,Lisa Grey,58
+Richmond,63017,State Senate,23,Rep,Lisa Grey,70
+Richmond,63037,State Senate,23,Rep,Lisa Grey,114
+Richmond,63038,State Senate,23,Rep,Lisa Grey,85
+Richmond,63039,State Senate,23,Rep,Lisa Grey,68
+Richmond,63040,State Senate,23,Rep,Lisa Grey,42
+Richmond,63041,State Senate,23,Rep,Lisa Grey,10
+Richmond,63042,State Senate,23,Rep,Lisa Grey,11
+Richmond,63043,State Senate,23,Rep,Lisa Grey,31
+Richmond,63044,State Senate,23,Rep,Lisa Grey,18
+Richmond,63045,State Senate,23,Rep,Lisa Grey,20
+Richmond,64039,State Senate,23,Rep,Lisa Grey,195
+Richmond,64040,State Senate,23,Rep,Lisa Grey,103
+Richmond,64041,State Senate,23,Rep,Lisa Grey,180
+Richmond,64042,State Senate,23,Rep,Lisa Grey,129
+Richmond,64043,State Senate,23,Rep,Lisa Grey,125
+Richmond,64044,State Senate,23,Rep,Lisa Grey,192
+Richmond,64045,State Senate,23,Rep,Lisa Grey,107
+Richmond,64046,State Senate,23,Rep,Lisa Grey,95
+Richmond,64047,State Senate,23,Rep,Lisa Grey,111
+Richmond,64048,State Senate,23,Rep,Lisa Grey,2
+Richmond,64049,State Senate,23,Rep,Lisa Grey,155
+Richmond,64050,State Senate,23,Rep,Lisa Grey,150
+Richmond,64051,State Senate,23,Rep,Lisa Grey,131
+Richmond,64052,State Senate,23,Rep,Lisa Grey,186
+Richmond,64053,State Senate,23,Rep,Lisa Grey,141
+Richmond,61001,State Senate,23,Con,Lisa Grey,15
+Richmond,61002,State Senate,23,Con,Lisa Grey,2
+Richmond,61003,State Senate,23,Con,Lisa Grey,7
+Richmond,61004,State Senate,23,Con,Lisa Grey,10
+Richmond,61005,State Senate,23,Con,Lisa Grey,2
+Richmond,61006,State Senate,23,Con,Lisa Grey,6
+Richmond,61007,State Senate,23,Con,Lisa Grey,1
+Richmond,61008,State Senate,23,Con,Lisa Grey,8
+Richmond,61009,State Senate,23,Con,Lisa Grey,13
+Richmond,61010,State Senate,23,Con,Lisa Grey,10
+Richmond,61011,State Senate,23,Con,Lisa Grey,14
+Richmond,61012,State Senate,23,Con,Lisa Grey,34
+Richmond,61013,State Senate,23,Con,Lisa Grey,17
+Richmond,61014,State Senate,23,Con,Lisa Grey,22
+Richmond,61015,State Senate,23,Con,Lisa Grey,20
+Richmond,61016,State Senate,23,Con,Lisa Grey,0
+Richmond,61017,State Senate,23,Con,Lisa Grey,8
+Richmond,61018,State Senate,23,Con,Lisa Grey,21
+Richmond,61019,State Senate,23,Con,Lisa Grey,26
+Richmond,61020,State Senate,23,Con,Lisa Grey,29
+Richmond,61021,State Senate,23,Con,Lisa Grey,7
+Richmond,61022,State Senate,23,Con,Lisa Grey,12
+Richmond,61023,State Senate,23,Con,Lisa Grey,17
+Richmond,61024,State Senate,23,Con,Lisa Grey,33
+Richmond,61025,State Senate,23,Con,Lisa Grey,13
+Richmond,61026,State Senate,23,Con,Lisa Grey,9
+Richmond,61027,State Senate,23,Con,Lisa Grey,12
+Richmond,61028,State Senate,23,Con,Lisa Grey,19
+Richmond,61029,State Senate,23,Con,Lisa Grey,25
+Richmond,61030,State Senate,23,Con,Lisa Grey,10
+Richmond,61031,State Senate,23,Con,Lisa Grey,12
+Richmond,61032,State Senate,23,Con,Lisa Grey,11
+Richmond,61033,State Senate,23,Con,Lisa Grey,1
+Richmond,61049,State Senate,23,Con,Lisa Grey,15
+Richmond,61050,State Senate,23,Con,Lisa Grey,21
+Richmond,61051,State Senate,23,Con,Lisa Grey,13
+Richmond,61052,State Senate,23,Con,Lisa Grey,12
+Richmond,61053,State Senate,23,Con,Lisa Grey,3
+Richmond,61054,State Senate,23,Con,Lisa Grey,12
+Richmond,61055,State Senate,23,Con,Lisa Grey,6
+Richmond,61056,State Senate,23,Con,Lisa Grey,3
+Richmond,61057,State Senate,23,Con,Lisa Grey,17
+Richmond,61058,State Senate,23,Con,Lisa Grey,5
+Richmond,61059,State Senate,23,Con,Lisa Grey,2
+Richmond,61060,State Senate,23,Con,Lisa Grey,9
+Richmond,61061,State Senate,23,Con,Lisa Grey,0
+Richmond,63010,State Senate,23,Con,Lisa Grey,8
+Richmond,63017,State Senate,23,Con,Lisa Grey,5
+Richmond,63037,State Senate,23,Con,Lisa Grey,20
+Richmond,63038,State Senate,23,Con,Lisa Grey,14
+Richmond,63039,State Senate,23,Con,Lisa Grey,3
+Richmond,63040,State Senate,23,Con,Lisa Grey,4
+Richmond,63041,State Senate,23,Con,Lisa Grey,1
+Richmond,63042,State Senate,23,Con,Lisa Grey,5
+Richmond,63043,State Senate,23,Con,Lisa Grey,5
+Richmond,63044,State Senate,23,Con,Lisa Grey,4
+Richmond,63045,State Senate,23,Con,Lisa Grey,2
+Richmond,64039,State Senate,23,Con,Lisa Grey,19
+Richmond,64040,State Senate,23,Con,Lisa Grey,8
+Richmond,64041,State Senate,23,Con,Lisa Grey,23
+Richmond,64042,State Senate,23,Con,Lisa Grey,15
+Richmond,64043,State Senate,23,Con,Lisa Grey,7
+Richmond,64044,State Senate,23,Con,Lisa Grey,19
+Richmond,64045,State Senate,23,Con,Lisa Grey,10
+Richmond,64046,State Senate,23,Con,Lisa Grey,27
+Richmond,64047,State Senate,23,Con,Lisa Grey,28
+Richmond,64048,State Senate,23,Con,Lisa Grey,0
+Richmond,64049,State Senate,23,Con,Lisa Grey,10
+Richmond,64050,State Senate,23,Con,Lisa Grey,45
+Richmond,64051,State Senate,23,Con,Lisa Grey,21
+Richmond,64052,State Senate,23,Con,Lisa Grey,24
+Richmond,64053,State Senate,23,Con,Lisa Grey,29
+Richmond,61001,State Senate,23,Ind,writein,2
+Richmond,61002,State Senate,23,Ind,writein,0
+Richmond,61003,State Senate,23,Ind,writein,0
+Richmond,61004,State Senate,23,Ind,writein,1
+Richmond,61005,State Senate,23,Ind,writein,0
+Richmond,61006,State Senate,23,Ind,writein,5
+Richmond,61007,State Senate,23,Ind,writein,0
+Richmond,61008,State Senate,23,Ind,writein,0
+Richmond,61009,State Senate,23,Ind,writein,0
+Richmond,61010,State Senate,23,Ind,writein,0
+Richmond,61011,State Senate,23,Ind,writein,1
+Richmond,61012,State Senate,23,Ind,writein,0
+Richmond,61013,State Senate,23,Ind,writein,0
+Richmond,61014,State Senate,23,Ind,writein,0
+Richmond,61015,State Senate,23,Ind,writein,0
+Richmond,61016,State Senate,23,Ind,writein,0
+Richmond,61017,State Senate,23,Ind,writein,1
+Richmond,61018,State Senate,23,Ind,writein,0
+Richmond,61019,State Senate,23,Ind,writein,0
+Richmond,61020,State Senate,23,Ind,writein,0
+Richmond,61021,State Senate,23,Ind,writein,0
+Richmond,61022,State Senate,23,Ind,writein,0
+Richmond,61023,State Senate,23,Ind,writein,2
+Richmond,61024,State Senate,23,Ind,writein,0
+Richmond,61025,State Senate,23,Ind,writein,0
+Richmond,61026,State Senate,23,Ind,writein,0
+Richmond,61027,State Senate,23,Ind,writein,1
+Richmond,61028,State Senate,23,Ind,writein,0
+Richmond,61029,State Senate,23,Ind,writein,1
+Richmond,61030,State Senate,23,Ind,writein,1
+Richmond,61031,State Senate,23,Ind,writein,1
+Richmond,61032,State Senate,23,Ind,writein,1
+Richmond,61033,State Senate,23,Ind,writein,0
+Richmond,61049,State Senate,23,Ind,writein,0
+Richmond,61050,State Senate,23,Ind,writein,1
+Richmond,61051,State Senate,23,Ind,writein,0
+Richmond,61052,State Senate,23,Ind,writein,0
+Richmond,61053,State Senate,23,Ind,writein,0
+Richmond,61054,State Senate,23,Ind,writein,0
+Richmond,61055,State Senate,23,Ind,writein,1
+Richmond,61056,State Senate,23,Ind,writein,0
+Richmond,61057,State Senate,23,Ind,writein,0
+Richmond,61058,State Senate,23,Ind,writein,0
+Richmond,61059,State Senate,23,Ind,writein,1
+Richmond,61060,State Senate,23,Ind,writein,0
+Richmond,61061,State Senate,23,Ind,writein,0
+Richmond,63010,State Senate,23,Ind,writein,0
+Richmond,63017,State Senate,23,Ind,writein,0
+Richmond,63037,State Senate,23,Ind,writein,0
+Richmond,63038,State Senate,23,Ind,writein,0
+Richmond,63039,State Senate,23,Ind,writein,0
+Richmond,63040,State Senate,23,Ind,writein,0
+Richmond,63041,State Senate,23,Ind,writein,0
+Richmond,63042,State Senate,23,Ind,writein,0
+Richmond,63043,State Senate,23,Ind,writein,0
+Richmond,63044,State Senate,23,Ind,writein,0
+Richmond,63045,State Senate,23,Ind,writein,0
+Richmond,64039,State Senate,23,Ind,writein,0
+Richmond,64040,State Senate,23,Ind,writein,0
+Richmond,64041,State Senate,23,Ind,writein,0
+Richmond,64042,State Senate,23,Ind,writein,2
+Richmond,64043,State Senate,23,Ind,writein,0
+Richmond,64044,State Senate,23,Ind,writein,0
+Richmond,64045,State Senate,23,Ind,writein,0
+Richmond,64046,State Senate,23,Ind,writein,0
+Richmond,64047,State Senate,23,Ind,writein,0
+Richmond,64048,State Senate,23,Ind,writein,0
+Richmond,64049,State Senate,23,Ind,writein,2
+Richmond,64050,State Senate,23,Ind,writein,0
+Richmond,64051,State Senate,23,Ind,writein,1
+Richmond,64052,State Senate,23,Ind,writein,0
+Richmond,64053,State Senate,23,Ind,writein,0
+Richmond,61034,State Senate,24,Rep,Andew Lanza,389
+Richmond,61035,State Senate,24,Rep,Andew Lanza,288
+Richmond,61036,State Senate,24,Rep,Andew Lanza,205
+Richmond,61037,State Senate,24,Rep,Andew Lanza,227
+Richmond,61038,State Senate,24,Rep,Andew Lanza,332
+Richmond,61039,State Senate,24,Rep,Andew Lanza,353
+Richmond,61040,State Senate,24,Rep,Andew Lanza,415
+Richmond,61041,State Senate,24,Rep,Andew Lanza,410
+Richmond,61042,State Senate,24,Rep,Andew Lanza,445
+Richmond,61043,State Senate,24,Rep,Andew Lanza,379
+Richmond,61044,State Senate,24,Rep,Andew Lanza,376
+Richmond,61045,State Senate,24,Rep,Andew Lanza,338
+Richmond,61046,State Senate,24,Rep,Andew Lanza,401
+Richmond,61047,State Senate,24,Rep,Andew Lanza,287
+Richmond,61048,State Senate,24,Rep,Andew Lanza,291
+Richmond,62001,State Senate,24,Rep,Andew Lanza,472
+Richmond,62002,State Senate,24,Rep,Andew Lanza,506
+Richmond,62003,State Senate,24,Rep,Andew Lanza,461
+Richmond,62004,State Senate,24,Rep,Andew Lanza,345
+Richmond,62005,State Senate,24,Rep,Andew Lanza,527
+Richmond,62006,State Senate,24,Rep,Andew Lanza,448
+Richmond,62007,State Senate,24,Rep,Andew Lanza,451
+Richmond,62008,State Senate,24,Rep,Andew Lanza,477
+Richmond,62009,State Senate,24,Rep,Andew Lanza,211
+Richmond,62010,State Senate,24,Rep,Andew Lanza,254
+Richmond,62011,State Senate,24,Rep,Andew Lanza,464
+Richmond,62012,State Senate,24,Rep,Andew Lanza,432
+Richmond,62013,State Senate,24,Rep,Andew Lanza,425
+Richmond,62014,State Senate,24,Rep,Andew Lanza,383
+Richmond,62015,State Senate,24,Rep,Andew Lanza,406
+Richmond,62016,State Senate,24,Rep,Andew Lanza,366
+Richmond,62017,State Senate,24,Rep,Andew Lanza,439
+Richmond,62018,State Senate,24,Rep,Andew Lanza,432
+Richmond,62019,State Senate,24,Rep,Andew Lanza,497
+Richmond,62020,State Senate,24,Rep,Andew Lanza,463
+Richmond,62021,State Senate,24,Rep,Andew Lanza,424
+Richmond,62022,State Senate,24,Rep,Andew Lanza,465
+Richmond,62023,State Senate,24,Rep,Andew Lanza,458
+Richmond,62024,State Senate,24,Rep,Andew Lanza,377
+Richmond,62025,State Senate,24,Rep,Andew Lanza,462
+Richmond,62026,State Senate,24,Rep,Andew Lanza,369
+Richmond,62027,State Senate,24,Rep,Andew Lanza,446
+Richmond,62028,State Senate,24,Rep,Andew Lanza,413
+Richmond,62029,State Senate,24,Rep,Andew Lanza,375
+Richmond,62030,State Senate,24,Rep,Andew Lanza,508
+Richmond,62031,State Senate,24,Rep,Andew Lanza,423
+Richmond,62032,State Senate,24,Rep,Andew Lanza,475
+Richmond,62033,State Senate,24,Rep,Andew Lanza,489
+Richmond,62034,State Senate,24,Rep,Andew Lanza,494
+Richmond,62035,State Senate,24,Rep,Andew Lanza,505
+Richmond,62036,State Senate,24,Rep,Andew Lanza,488
+Richmond,62037,State Senate,24,Rep,Andew Lanza,493
+Richmond,62038,State Senate,24,Rep,Andew Lanza,416
+Richmond,62039,State Senate,24,Rep,Andew Lanza,486
+Richmond,62040,State Senate,24,Rep,Andew Lanza,438
+Richmond,62041,State Senate,24,Rep,Andew Lanza,422
+Richmond,62042,State Senate,24,Rep,Andew Lanza,475
+Richmond,62043,State Senate,24,Rep,Andew Lanza,454
+Richmond,62044,State Senate,24,Rep,Andew Lanza,434
+Richmond,62045,State Senate,24,Rep,Andew Lanza,401
+Richmond,62046,State Senate,24,Rep,Andew Lanza,464
+Richmond,62047,State Senate,24,Rep,Andew Lanza,465
+Richmond,62048,State Senate,24,Rep,Andew Lanza,412
+Richmond,62049,State Senate,24,Rep,Andew Lanza,434
+Richmond,62050,State Senate,24,Rep,Andew Lanza,441
+Richmond,62051,State Senate,24,Rep,Andew Lanza,375
+Richmond,62052,State Senate,24,Rep,Andew Lanza,424
+Richmond,62053,State Senate,24,Rep,Andew Lanza,457
+Richmond,62054,State Senate,24,Rep,Andew Lanza,403
+Richmond,62055,State Senate,24,Rep,Andew Lanza,417
+Richmond,62056,State Senate,24,Rep,Andew Lanza,392
+Richmond,62057,State Senate,24,Rep,Andew Lanza,427
+Richmond,62058,State Senate,24,Rep,Andew Lanza,481
+Richmond,62059,State Senate,24,Rep,Andew Lanza,329
+Richmond,62060,State Senate,24,Rep,Andew Lanza,250
+Richmond,62061,State Senate,24,Rep,Andew Lanza,281
+Richmond,62062,State Senate,24,Rep,Andew Lanza,298
+Richmond,62063,State Senate,24,Rep,Andew Lanza,181
+Richmond,62064,State Senate,24,Rep,Andew Lanza,235
+Richmond,62065,State Senate,24,Rep,Andew Lanza,572
+Richmond,62066,State Senate,24,Rep,Andew Lanza,510
+Richmond,62067,State Senate,24,Rep,Andew Lanza,454
+Richmond,62068,State Senate,24,Rep,Andew Lanza,417
+Richmond,62069,State Senate,24,Rep,Andew Lanza,442
+Richmond,62070,State Senate,24,Rep,Andew Lanza,375
+Richmond,62071,State Senate,24,Rep,Andew Lanza,479
+Richmond,62072,State Senate,24,Rep,Andew Lanza,316
+Richmond,63001,State Senate,24,Rep,Andew Lanza,380
+Richmond,63002,State Senate,24,Rep,Andew Lanza,228
+Richmond,63003,State Senate,24,Rep,Andew Lanza,204
+Richmond,63004,State Senate,24,Rep,Andew Lanza,384
+Richmond,63005,State Senate,24,Rep,Andew Lanza,401
+Richmond,63006,State Senate,24,Rep,Andew Lanza,338
+Richmond,63007,State Senate,24,Rep,Andew Lanza,249
+Richmond,63008,State Senate,24,Rep,Andew Lanza,233
+Richmond,63009,State Senate,24,Rep,Andew Lanza,34
+Richmond,63011,State Senate,24,Rep,Andew Lanza,327
+Richmond,63012,State Senate,24,Rep,Andew Lanza,323
+Richmond,63013,State Senate,24,Rep,Andew Lanza,240
+Richmond,63014,State Senate,24,Rep,Andew Lanza,297
+Richmond,63015,State Senate,24,Rep,Andew Lanza,301
+Richmond,63016,State Senate,24,Rep,Andew Lanza,346
+Richmond,63018,State Senate,24,Rep,Andew Lanza,349
+Richmond,63019,State Senate,24,Rep,Andew Lanza,146
+Richmond,63020,State Senate,24,Rep,Andew Lanza,274
+Richmond,63021,State Senate,24,Rep,Andew Lanza,404
+Richmond,63022,State Senate,24,Rep,Andew Lanza,344
+Richmond,63023,State Senate,24,Rep,Andew Lanza,426
+Richmond,63024,State Senate,24,Rep,Andew Lanza,340
+Richmond,63025,State Senate,24,Rep,Andew Lanza,409
+Richmond,63026,State Senate,24,Rep,Andew Lanza,331
+Richmond,63027,State Senate,24,Rep,Andew Lanza,309
+Richmond,63028,State Senate,24,Rep,Andew Lanza,386
+Richmond,63029,State Senate,24,Rep,Andew Lanza,402
+Richmond,63030,State Senate,24,Rep,Andew Lanza,299
+Richmond,63031,State Senate,24,Rep,Andew Lanza,291
+Richmond,63032,State Senate,24,Rep,Andew Lanza,379
+Richmond,63033,State Senate,24,Rep,Andew Lanza,353
+Richmond,63034,State Senate,24,Rep,Andew Lanza,215
+Richmond,63035,State Senate,24,Rep,Andew Lanza,290
+Richmond,63036,State Senate,24,Rep,Andew Lanza,349
+Richmond,63046,State Senate,24,Rep,Andew Lanza,247
+Richmond,63047,State Senate,24,Rep,Andew Lanza,410
+Richmond,63048,State Senate,24,Rep,Andew Lanza,433
+Richmond,63049,State Senate,24,Rep,Andew Lanza,406
+Richmond,63050,State Senate,24,Rep,Andew Lanza,348
+Richmond,63051,State Senate,24,Rep,Andew Lanza,346
+Richmond,63052,State Senate,24,Rep,Andew Lanza,261
+Richmond,63053,State Senate,24,Rep,Andew Lanza,214
+Richmond,63054,State Senate,24,Rep,Andew Lanza,302
+Richmond,63055,State Senate,24,Rep,Andew Lanza,254
+Richmond,63056,State Senate,24,Rep,Andew Lanza,301
+Richmond,63057,State Senate,24,Rep,Andew Lanza,408
+Richmond,63058,State Senate,24,Rep,Andew Lanza,383
+Richmond,63059,State Senate,24,Rep,Andew Lanza,408
+Richmond,63060,State Senate,24,Rep,Andew Lanza,333
+Richmond,63061,State Senate,24,Rep,Andew Lanza,265
+Richmond,63062,State Senate,24,Rep,Andew Lanza,405
+Richmond,63063,State Senate,24,Rep,Andew Lanza,386
+Richmond,63064,State Senate,24,Rep,Andew Lanza,486
+Richmond,63065,State Senate,24,Rep,Andew Lanza,321
+Richmond,63066,State Senate,24,Rep,Andew Lanza,360
+Richmond,63067,State Senate,24,Rep,Andew Lanza,284
+Richmond,63068,State Senate,24,Rep,Andew Lanza,208
+Richmond,63069,State Senate,24,Rep,Andew Lanza,185
+Richmond,63070,State Senate,24,Rep,Andew Lanza,192
+Richmond,63071,State Senate,24,Rep,Andew Lanza,60
+Richmond,63072,State Senate,24,Rep,Andew Lanza,307
+Richmond,63073,State Senate,24,Rep,Andew Lanza,263
+Richmond,64001,State Senate,24,Rep,Andew Lanza,332
+Richmond,64002,State Senate,24,Rep,Andew Lanza,453
+Richmond,64003,State Senate,24,Rep,Andew Lanza,494
+Richmond,64004,State Senate,24,Rep,Andew Lanza,374
+Richmond,64005,State Senate,24,Rep,Andew Lanza,445
+Richmond,64006,State Senate,24,Rep,Andew Lanza,407
+Richmond,64007,State Senate,24,Rep,Andew Lanza,459
+Richmond,64008,State Senate,24,Rep,Andew Lanza,443
+Richmond,64009,State Senate,24,Rep,Andew Lanza,428
+Richmond,64010,State Senate,24,Rep,Andew Lanza,446
+Richmond,64011,State Senate,24,Rep,Andew Lanza,418
+Richmond,64012,State Senate,24,Rep,Andew Lanza,226
+Richmond,64013,State Senate,24,Rep,Andew Lanza,171
+Richmond,64014,State Senate,24,Rep,Andew Lanza,352
+Richmond,64015,State Senate,24,Rep,Andew Lanza,449
+Richmond,64016,State Senate,24,Rep,Andew Lanza,467
+Richmond,64017,State Senate,24,Rep,Andew Lanza,409
+Richmond,64018,State Senate,24,Rep,Andew Lanza,285
+Richmond,64019,State Senate,24,Rep,Andew Lanza,227
+Richmond,64020,State Senate,24,Rep,Andew Lanza,289
+Richmond,64021,State Senate,24,Rep,Andew Lanza,232
+Richmond,64022,State Senate,24,Rep,Andew Lanza,376
+Richmond,64023,State Senate,24,Rep,Andew Lanza,363
+Richmond,64024,State Senate,24,Rep,Andew Lanza,287
+Richmond,64025,State Senate,24,Rep,Andew Lanza,219
+Richmond,64026,State Senate,24,Rep,Andew Lanza,387
+Richmond,64027,State Senate,24,Rep,Andew Lanza,212
+Richmond,64028,State Senate,24,Rep,Andew Lanza,188
+Richmond,64029,State Senate,24,Rep,Andew Lanza,302
+Richmond,64030,State Senate,24,Rep,Andew Lanza,242
+Richmond,64031,State Senate,24,Rep,Andew Lanza,302
+Richmond,64032,State Senate,24,Rep,Andew Lanza,291
+Richmond,64033,State Senate,24,Rep,Andew Lanza,347
+Richmond,64034,State Senate,24,Rep,Andew Lanza,298
+Richmond,64035,State Senate,24,Rep,Andew Lanza,432
+Richmond,64036,State Senate,24,Rep,Andew Lanza,335
+Richmond,64037,State Senate,24,Rep,Andew Lanza,280
+Richmond,64038,State Senate,24,Rep,Andew Lanza,191
+Richmond,61034,State Senate,24,Con,Andew Lanza,50
+Richmond,61035,State Senate,24,Con,Andew Lanza,49
+Richmond,61036,State Senate,24,Con,Andew Lanza,23
+Richmond,61037,State Senate,24,Con,Andew Lanza,35
+Richmond,61038,State Senate,24,Con,Andew Lanza,44
+Richmond,61039,State Senate,24,Con,Andew Lanza,55
+Richmond,61040,State Senate,24,Con,Andew Lanza,70
+Richmond,61041,State Senate,24,Con,Andew Lanza,55
+Richmond,61042,State Senate,24,Con,Andew Lanza,55
+Richmond,61043,State Senate,24,Con,Andew Lanza,65
+Richmond,61044,State Senate,24,Con,Andew Lanza,51
+Richmond,61045,State Senate,24,Con,Andew Lanza,54
+Richmond,61046,State Senate,24,Con,Andew Lanza,56
+Richmond,61047,State Senate,24,Con,Andew Lanza,35
+Richmond,61048,State Senate,24,Con,Andew Lanza,48
+Richmond,62001,State Senate,24,Con,Andew Lanza,39
+Richmond,62002,State Senate,24,Con,Andew Lanza,57
+Richmond,62003,State Senate,24,Con,Andew Lanza,39
+Richmond,62004,State Senate,24,Con,Andew Lanza,31
+Richmond,62005,State Senate,24,Con,Andew Lanza,53
+Richmond,62006,State Senate,24,Con,Andew Lanza,64
+Richmond,62007,State Senate,24,Con,Andew Lanza,68
+Richmond,62008,State Senate,24,Con,Andew Lanza,66
+Richmond,62009,State Senate,24,Con,Andew Lanza,21
+Richmond,62010,State Senate,24,Con,Andew Lanza,31
+Richmond,62011,State Senate,24,Con,Andew Lanza,70
+Richmond,62012,State Senate,24,Con,Andew Lanza,39
+Richmond,62013,State Senate,24,Con,Andew Lanza,34
+Richmond,62014,State Senate,24,Con,Andew Lanza,32
+Richmond,62015,State Senate,24,Con,Andew Lanza,46
+Richmond,62016,State Senate,24,Con,Andew Lanza,35
+Richmond,62017,State Senate,24,Con,Andew Lanza,34
+Richmond,62018,State Senate,24,Con,Andew Lanza,38
+Richmond,62019,State Senate,24,Con,Andew Lanza,60
+Richmond,62020,State Senate,24,Con,Andew Lanza,43
+Richmond,62021,State Senate,24,Con,Andew Lanza,53
+Richmond,62022,State Senate,24,Con,Andew Lanza,45
+Richmond,62023,State Senate,24,Con,Andew Lanza,67
+Richmond,62024,State Senate,24,Con,Andew Lanza,31
+Richmond,62025,State Senate,24,Con,Andew Lanza,37
+Richmond,62026,State Senate,24,Con,Andew Lanza,37
+Richmond,62027,State Senate,24,Con,Andew Lanza,41
+Richmond,62028,State Senate,24,Con,Andew Lanza,43
+Richmond,62029,State Senate,24,Con,Andew Lanza,39
+Richmond,62030,State Senate,24,Con,Andew Lanza,47
+Richmond,62031,State Senate,24,Con,Andew Lanza,54
+Richmond,62032,State Senate,24,Con,Andew Lanza,44
+Richmond,62033,State Senate,24,Con,Andew Lanza,48
+Richmond,62034,State Senate,24,Con,Andew Lanza,68
+Richmond,62035,State Senate,24,Con,Andew Lanza,65
+Richmond,62036,State Senate,24,Con,Andew Lanza,54
+Richmond,62037,State Senate,24,Con,Andew Lanza,53
+Richmond,62038,State Senate,24,Con,Andew Lanza,54
+Richmond,62039,State Senate,24,Con,Andew Lanza,69
+Richmond,62040,State Senate,24,Con,Andew Lanza,52
+Richmond,62041,State Senate,24,Con,Andew Lanza,51
+Richmond,62042,State Senate,24,Con,Andew Lanza,60
+Richmond,62043,State Senate,24,Con,Andew Lanza,40
+Richmond,62044,State Senate,24,Con,Andew Lanza,56
+Richmond,62045,State Senate,24,Con,Andew Lanza,46
+Richmond,62046,State Senate,24,Con,Andew Lanza,45
+Richmond,62047,State Senate,24,Con,Andew Lanza,36
+Richmond,62048,State Senate,24,Con,Andew Lanza,39
+Richmond,62049,State Senate,24,Con,Andew Lanza,48
+Richmond,62050,State Senate,24,Con,Andew Lanza,57
+Richmond,62051,State Senate,24,Con,Andew Lanza,45
+Richmond,62052,State Senate,24,Con,Andew Lanza,55
+Richmond,62053,State Senate,24,Con,Andew Lanza,48
+Richmond,62054,State Senate,24,Con,Andew Lanza,40
+Richmond,62055,State Senate,24,Con,Andew Lanza,65
+Richmond,62056,State Senate,24,Con,Andew Lanza,34
+Richmond,62057,State Senate,24,Con,Andew Lanza,40
+Richmond,62058,State Senate,24,Con,Andew Lanza,59
+Richmond,62059,State Senate,24,Con,Andew Lanza,40
+Richmond,62060,State Senate,24,Con,Andew Lanza,19
+Richmond,62061,State Senate,24,Con,Andew Lanza,26
+Richmond,62062,State Senate,24,Con,Andew Lanza,25
+Richmond,62063,State Senate,24,Con,Andew Lanza,14
+Richmond,62064,State Senate,24,Con,Andew Lanza,20
+Richmond,62065,State Senate,24,Con,Andew Lanza,42
+Richmond,62066,State Senate,24,Con,Andew Lanza,50
+Richmond,62067,State Senate,24,Con,Andew Lanza,45
+Richmond,62068,State Senate,24,Con,Andew Lanza,53
+Richmond,62069,State Senate,24,Con,Andew Lanza,47
+Richmond,62070,State Senate,24,Con,Andew Lanza,53
+Richmond,62071,State Senate,24,Con,Andew Lanza,42
+Richmond,62072,State Senate,24,Con,Andew Lanza,37
+Richmond,63001,State Senate,24,Con,Andew Lanza,44
+Richmond,63002,State Senate,24,Con,Andew Lanza,27
+Richmond,63003,State Senate,24,Con,Andew Lanza,18
+Richmond,63004,State Senate,24,Con,Andew Lanza,27
+Richmond,63005,State Senate,24,Con,Andew Lanza,43
+Richmond,63006,State Senate,24,Con,Andew Lanza,33
+Richmond,63007,State Senate,24,Con,Andew Lanza,24
+Richmond,63008,State Senate,24,Con,Andew Lanza,24
+Richmond,63009,State Senate,24,Con,Andew Lanza,0
+Richmond,63011,State Senate,24,Con,Andew Lanza,43
+Richmond,63012,State Senate,24,Con,Andew Lanza,34
+Richmond,63013,State Senate,24,Con,Andew Lanza,35
+Richmond,63014,State Senate,24,Con,Andew Lanza,23
+Richmond,63015,State Senate,24,Con,Andew Lanza,36
+Richmond,63016,State Senate,24,Con,Andew Lanza,36
+Richmond,63018,State Senate,24,Con,Andew Lanza,29
+Richmond,63019,State Senate,24,Con,Andew Lanza,19
+Richmond,63020,State Senate,24,Con,Andew Lanza,39
+Richmond,63021,State Senate,24,Con,Andew Lanza,34
+Richmond,63022,State Senate,24,Con,Andew Lanza,30
+Richmond,63023,State Senate,24,Con,Andew Lanza,31
+Richmond,63024,State Senate,24,Con,Andew Lanza,29
+Richmond,63025,State Senate,24,Con,Andew Lanza,38
+Richmond,63026,State Senate,24,Con,Andew Lanza,28
+Richmond,63027,State Senate,24,Con,Andew Lanza,35
+Richmond,63028,State Senate,24,Con,Andew Lanza,45
+Richmond,63029,State Senate,24,Con,Andew Lanza,29
+Richmond,63030,State Senate,24,Con,Andew Lanza,56
+Richmond,63031,State Senate,24,Con,Andew Lanza,27
+Richmond,63032,State Senate,24,Con,Andew Lanza,40
+Richmond,63033,State Senate,24,Con,Andew Lanza,35
+Richmond,63034,State Senate,24,Con,Andew Lanza,23
+Richmond,63035,State Senate,24,Con,Andew Lanza,45
+Richmond,63036,State Senate,24,Con,Andew Lanza,45
+Richmond,63046,State Senate,24,Con,Andew Lanza,22
+Richmond,63047,State Senate,24,Con,Andew Lanza,50
+Richmond,63048,State Senate,24,Con,Andew Lanza,36
+Richmond,63049,State Senate,24,Con,Andew Lanza,51
+Richmond,63050,State Senate,24,Con,Andew Lanza,33
+Richmond,63051,State Senate,24,Con,Andew Lanza,33
+Richmond,63052,State Senate,24,Con,Andew Lanza,24
+Richmond,63053,State Senate,24,Con,Andew Lanza,21
+Richmond,63054,State Senate,24,Con,Andew Lanza,33
+Richmond,63055,State Senate,24,Con,Andew Lanza,26
+Richmond,63056,State Senate,24,Con,Andew Lanza,28
+Richmond,63057,State Senate,24,Con,Andew Lanza,22
+Richmond,63058,State Senate,24,Con,Andew Lanza,39
+Richmond,63059,State Senate,24,Con,Andew Lanza,41
+Richmond,63060,State Senate,24,Con,Andew Lanza,50
+Richmond,63061,State Senate,24,Con,Andew Lanza,27
+Richmond,63062,State Senate,24,Con,Andew Lanza,39
+Richmond,63063,State Senate,24,Con,Andew Lanza,54
+Richmond,63064,State Senate,24,Con,Andew Lanza,67
+Richmond,63065,State Senate,24,Con,Andew Lanza,39
+Richmond,63066,State Senate,24,Con,Andew Lanza,65
+Richmond,63067,State Senate,24,Con,Andew Lanza,41
+Richmond,63068,State Senate,24,Con,Andew Lanza,24
+Richmond,63069,State Senate,24,Con,Andew Lanza,23
+Richmond,63070,State Senate,24,Con,Andew Lanza,17
+Richmond,63071,State Senate,24,Con,Andew Lanza,8
+Richmond,63072,State Senate,24,Con,Andew Lanza,25
+Richmond,63073,State Senate,24,Con,Andew Lanza,38
+Richmond,64001,State Senate,24,Con,Andew Lanza,42
+Richmond,64002,State Senate,24,Con,Andew Lanza,62
+Richmond,64003,State Senate,24,Con,Andew Lanza,65
+Richmond,64004,State Senate,24,Con,Andew Lanza,51
+Richmond,64005,State Senate,24,Con,Andew Lanza,51
+Richmond,64006,State Senate,24,Con,Andew Lanza,57
+Richmond,64007,State Senate,24,Con,Andew Lanza,61
+Richmond,64008,State Senate,24,Con,Andew Lanza,51
+Richmond,64009,State Senate,24,Con,Andew Lanza,57
+Richmond,64010,State Senate,24,Con,Andew Lanza,56
+Richmond,64011,State Senate,24,Con,Andew Lanza,69
+Richmond,64012,State Senate,24,Con,Andew Lanza,30
+Richmond,64013,State Senate,24,Con,Andew Lanza,17
+Richmond,64014,State Senate,24,Con,Andew Lanza,38
+Richmond,64015,State Senate,24,Con,Andew Lanza,41
+Richmond,64016,State Senate,24,Con,Andew Lanza,72
+Richmond,64017,State Senate,24,Con,Andew Lanza,64
+Richmond,64018,State Senate,24,Con,Andew Lanza,39
+Richmond,64019,State Senate,24,Con,Andew Lanza,28
+Richmond,64020,State Senate,24,Con,Andew Lanza,29
+Richmond,64021,State Senate,24,Con,Andew Lanza,27
+Richmond,64022,State Senate,24,Con,Andew Lanza,55
+Richmond,64023,State Senate,24,Con,Andew Lanza,40
+Richmond,64024,State Senate,24,Con,Andew Lanza,43
+Richmond,64025,State Senate,24,Con,Andew Lanza,25
+Richmond,64026,State Senate,24,Con,Andew Lanza,42
+Richmond,64027,State Senate,24,Con,Andew Lanza,26
+Richmond,64028,State Senate,24,Con,Andew Lanza,15
+Richmond,64029,State Senate,24,Con,Andew Lanza,32
+Richmond,64030,State Senate,24,Con,Andew Lanza,25
+Richmond,64031,State Senate,24,Con,Andew Lanza,27
+Richmond,64032,State Senate,24,Con,Andew Lanza,55
+Richmond,64033,State Senate,24,Con,Andew Lanza,27
+Richmond,64034,State Senate,24,Con,Andew Lanza,35
+Richmond,64035,State Senate,24,Con,Andew Lanza,36
+Richmond,64036,State Senate,24,Con,Andew Lanza,40
+Richmond,64037,State Senate,24,Con,Andew Lanza,31
+Richmond,64038,State Senate,24,Con,Andew Lanza,33
+Richmond,61034,State Senate,24,Ind,Andrew Lanza,24
+Richmond,61035,State Senate,24,Ind,Andrew Lanza,15
+Richmond,61036,State Senate,24,Ind,Andrew Lanza,11
+Richmond,61037,State Senate,24,Ind,Andrew Lanza,20
+Richmond,61038,State Senate,24,Ind,Andrew Lanza,30
+Richmond,61039,State Senate,24,Ind,Andrew Lanza,30
+Richmond,61040,State Senate,24,Ind,Andrew Lanza,27
+Richmond,61041,State Senate,24,Ind,Andrew Lanza,26
+Richmond,61042,State Senate,24,Ind,Andrew Lanza,27
+Richmond,61043,State Senate,24,Ind,Andrew Lanza,34
+Richmond,61044,State Senate,24,Ind,Andrew Lanza,19
+Richmond,61045,State Senate,24,Ind,Andrew Lanza,13
+Richmond,61046,State Senate,24,Ind,Andrew Lanza,21
+Richmond,61047,State Senate,24,Ind,Andrew Lanza,18
+Richmond,61048,State Senate,24,Ind,Andrew Lanza,11
+Richmond,62001,State Senate,24,Ind,Andrew Lanza,18
+Richmond,62002,State Senate,24,Ind,Andrew Lanza,19
+Richmond,62003,State Senate,24,Ind,Andrew Lanza,19
+Richmond,62004,State Senate,24,Ind,Andrew Lanza,21
+Richmond,62005,State Senate,24,Ind,Andrew Lanza,13
+Richmond,62006,State Senate,24,Ind,Andrew Lanza,18
+Richmond,62007,State Senate,24,Ind,Andrew Lanza,23
+Richmond,62008,State Senate,24,Ind,Andrew Lanza,20
+Richmond,62009,State Senate,24,Ind,Andrew Lanza,13
+Richmond,62010,State Senate,24,Ind,Andrew Lanza,6
+Richmond,62011,State Senate,24,Ind,Andrew Lanza,26
+Richmond,62012,State Senate,24,Ind,Andrew Lanza,14
+Richmond,62013,State Senate,24,Ind,Andrew Lanza,16
+Richmond,62014,State Senate,24,Ind,Andrew Lanza,8
+Richmond,62015,State Senate,24,Ind,Andrew Lanza,20
+Richmond,62016,State Senate,24,Ind,Andrew Lanza,27
+Richmond,62017,State Senate,24,Ind,Andrew Lanza,11
+Richmond,62018,State Senate,24,Ind,Andrew Lanza,18
+Richmond,62019,State Senate,24,Ind,Andrew Lanza,21
+Richmond,62020,State Senate,24,Ind,Andrew Lanza,10
+Richmond,62021,State Senate,24,Ind,Andrew Lanza,12
+Richmond,62022,State Senate,24,Ind,Andrew Lanza,11
+Richmond,62023,State Senate,24,Ind,Andrew Lanza,19
+Richmond,62024,State Senate,24,Ind,Andrew Lanza,22
+Richmond,62025,State Senate,24,Ind,Andrew Lanza,15
+Richmond,62026,State Senate,24,Ind,Andrew Lanza,21
+Richmond,62027,State Senate,24,Ind,Andrew Lanza,21
+Richmond,62028,State Senate,24,Ind,Andrew Lanza,21
+Richmond,62029,State Senate,24,Ind,Andrew Lanza,12
+Richmond,62030,State Senate,24,Ind,Andrew Lanza,13
+Richmond,62031,State Senate,24,Ind,Andrew Lanza,19
+Richmond,62032,State Senate,24,Ind,Andrew Lanza,10
+Richmond,62033,State Senate,24,Ind,Andrew Lanza,9
+Richmond,62034,State Senate,24,Ind,Andrew Lanza,17
+Richmond,62035,State Senate,24,Ind,Andrew Lanza,11
+Richmond,62036,State Senate,24,Ind,Andrew Lanza,10
+Richmond,62037,State Senate,24,Ind,Andrew Lanza,9
+Richmond,62038,State Senate,24,Ind,Andrew Lanza,17
+Richmond,62039,State Senate,24,Ind,Andrew Lanza,17
+Richmond,62040,State Senate,24,Ind,Andrew Lanza,15
+Richmond,62041,State Senate,24,Ind,Andrew Lanza,12
+Richmond,62042,State Senate,24,Ind,Andrew Lanza,17
+Richmond,62043,State Senate,24,Ind,Andrew Lanza,21
+Richmond,62044,State Senate,24,Ind,Andrew Lanza,12
+Richmond,62045,State Senate,24,Ind,Andrew Lanza,15
+Richmond,62046,State Senate,24,Ind,Andrew Lanza,12
+Richmond,62047,State Senate,24,Ind,Andrew Lanza,12
+Richmond,62048,State Senate,24,Ind,Andrew Lanza,14
+Richmond,62049,State Senate,24,Ind,Andrew Lanza,18
+Richmond,62050,State Senate,24,Ind,Andrew Lanza,14
+Richmond,62051,State Senate,24,Ind,Andrew Lanza,15
+Richmond,62052,State Senate,24,Ind,Andrew Lanza,13
+Richmond,62053,State Senate,24,Ind,Andrew Lanza,23
+Richmond,62054,State Senate,24,Ind,Andrew Lanza,26
+Richmond,62055,State Senate,24,Ind,Andrew Lanza,22
+Richmond,62056,State Senate,24,Ind,Andrew Lanza,22
+Richmond,62057,State Senate,24,Ind,Andrew Lanza,16
+Richmond,62058,State Senate,24,Ind,Andrew Lanza,14
+Richmond,62059,State Senate,24,Ind,Andrew Lanza,17
+Richmond,62060,State Senate,24,Ind,Andrew Lanza,10
+Richmond,62061,State Senate,24,Ind,Andrew Lanza,12
+Richmond,62062,State Senate,24,Ind,Andrew Lanza,9
+Richmond,62063,State Senate,24,Ind,Andrew Lanza,12
+Richmond,62064,State Senate,24,Ind,Andrew Lanza,11
+Richmond,62065,State Senate,24,Ind,Andrew Lanza,22
+Richmond,62066,State Senate,24,Ind,Andrew Lanza,20
+Richmond,62067,State Senate,24,Ind,Andrew Lanza,13
+Richmond,62068,State Senate,24,Ind,Andrew Lanza,14
+Richmond,62069,State Senate,24,Ind,Andrew Lanza,18
+Richmond,62070,State Senate,24,Ind,Andrew Lanza,21
+Richmond,62071,State Senate,24,Ind,Andrew Lanza,14
+Richmond,62072,State Senate,24,Ind,Andrew Lanza,12
+Richmond,63001,State Senate,24,Ind,Andrew Lanza,11
+Richmond,63002,State Senate,24,Ind,Andrew Lanza,12
+Richmond,63003,State Senate,24,Ind,Andrew Lanza,12
+Richmond,63004,State Senate,24,Ind,Andrew Lanza,9
+Richmond,63005,State Senate,24,Ind,Andrew Lanza,18
+Richmond,63006,State Senate,24,Ind,Andrew Lanza,17
+Richmond,63007,State Senate,24,Ind,Andrew Lanza,18
+Richmond,63008,State Senate,24,Ind,Andrew Lanza,6
+Richmond,63009,State Senate,24,Ind,Andrew Lanza,0
+Richmond,63011,State Senate,24,Ind,Andrew Lanza,18
+Richmond,63012,State Senate,24,Ind,Andrew Lanza,20
+Richmond,63013,State Senate,24,Ind,Andrew Lanza,16
+Richmond,63014,State Senate,24,Ind,Andrew Lanza,18
+Richmond,63015,State Senate,24,Ind,Andrew Lanza,18
+Richmond,63016,State Senate,24,Ind,Andrew Lanza,11
+Richmond,63018,State Senate,24,Ind,Andrew Lanza,12
+Richmond,63019,State Senate,24,Ind,Andrew Lanza,9
+Richmond,63020,State Senate,24,Ind,Andrew Lanza,19
+Richmond,63021,State Senate,24,Ind,Andrew Lanza,14
+Richmond,63022,State Senate,24,Ind,Andrew Lanza,17
+Richmond,63023,State Senate,24,Ind,Andrew Lanza,12
+Richmond,63024,State Senate,24,Ind,Andrew Lanza,13
+Richmond,63025,State Senate,24,Ind,Andrew Lanza,14
+Richmond,63026,State Senate,24,Ind,Andrew Lanza,12
+Richmond,63027,State Senate,24,Ind,Andrew Lanza,17
+Richmond,63028,State Senate,24,Ind,Andrew Lanza,10
+Richmond,63029,State Senate,24,Ind,Andrew Lanza,14
+Richmond,63030,State Senate,24,Ind,Andrew Lanza,12
+Richmond,63031,State Senate,24,Ind,Andrew Lanza,14
+Richmond,63032,State Senate,24,Ind,Andrew Lanza,31
+Richmond,63033,State Senate,24,Ind,Andrew Lanza,19
+Richmond,63034,State Senate,24,Ind,Andrew Lanza,7
+Richmond,63035,State Senate,24,Ind,Andrew Lanza,15
+Richmond,63036,State Senate,24,Ind,Andrew Lanza,22
+Richmond,63046,State Senate,24,Ind,Andrew Lanza,15
+Richmond,63047,State Senate,24,Ind,Andrew Lanza,18
+Richmond,63048,State Senate,24,Ind,Andrew Lanza,14
+Richmond,63049,State Senate,24,Ind,Andrew Lanza,9
+Richmond,63050,State Senate,24,Ind,Andrew Lanza,17
+Richmond,63051,State Senate,24,Ind,Andrew Lanza,9
+Richmond,63052,State Senate,24,Ind,Andrew Lanza,6
+Richmond,63053,State Senate,24,Ind,Andrew Lanza,14
+Richmond,63054,State Senate,24,Ind,Andrew Lanza,14
+Richmond,63055,State Senate,24,Ind,Andrew Lanza,10
+Richmond,63056,State Senate,24,Ind,Andrew Lanza,24
+Richmond,63057,State Senate,24,Ind,Andrew Lanza,23
+Richmond,63058,State Senate,24,Ind,Andrew Lanza,11
+Richmond,63059,State Senate,24,Ind,Andrew Lanza,20
+Richmond,63060,State Senate,24,Ind,Andrew Lanza,16
+Richmond,63061,State Senate,24,Ind,Andrew Lanza,16
+Richmond,63062,State Senate,24,Ind,Andrew Lanza,22
+Richmond,63063,State Senate,24,Ind,Andrew Lanza,7
+Richmond,63064,State Senate,24,Ind,Andrew Lanza,26
+Richmond,63065,State Senate,24,Ind,Andrew Lanza,19
+Richmond,63066,State Senate,24,Ind,Andrew Lanza,26
+Richmond,63067,State Senate,24,Ind,Andrew Lanza,16
+Richmond,63068,State Senate,24,Ind,Andrew Lanza,13
+Richmond,63069,State Senate,24,Ind,Andrew Lanza,7
+Richmond,63070,State Senate,24,Ind,Andrew Lanza,4
+Richmond,63071,State Senate,24,Ind,Andrew Lanza,6
+Richmond,63072,State Senate,24,Ind,Andrew Lanza,15
+Richmond,63073,State Senate,24,Ind,Andrew Lanza,15
+Richmond,64001,State Senate,24,Ind,Andrew Lanza,18
+Richmond,64002,State Senate,24,Ind,Andrew Lanza,20
+Richmond,64003,State Senate,24,Ind,Andrew Lanza,20
+Richmond,64004,State Senate,24,Ind,Andrew Lanza,18
+Richmond,64005,State Senate,24,Ind,Andrew Lanza,20
+Richmond,64006,State Senate,24,Ind,Andrew Lanza,24
+Richmond,64007,State Senate,24,Ind,Andrew Lanza,27
+Richmond,64008,State Senate,24,Ind,Andrew Lanza,25
+Richmond,64009,State Senate,24,Ind,Andrew Lanza,20
+Richmond,64010,State Senate,24,Ind,Andrew Lanza,19
+Richmond,64011,State Senate,24,Ind,Andrew Lanza,8
+Richmond,64012,State Senate,24,Ind,Andrew Lanza,13
+Richmond,64013,State Senate,24,Ind,Andrew Lanza,11
+Richmond,64014,State Senate,24,Ind,Andrew Lanza,22
+Richmond,64015,State Senate,24,Ind,Andrew Lanza,23
+Richmond,64016,State Senate,24,Ind,Andrew Lanza,24
+Richmond,64017,State Senate,24,Ind,Andrew Lanza,23
+Richmond,64018,State Senate,24,Ind,Andrew Lanza,12
+Richmond,64019,State Senate,24,Ind,Andrew Lanza,5
+Richmond,64020,State Senate,24,Ind,Andrew Lanza,17
+Richmond,64021,State Senate,24,Ind,Andrew Lanza,13
+Richmond,64022,State Senate,24,Ind,Andrew Lanza,25
+Richmond,64023,State Senate,24,Ind,Andrew Lanza,28
+Richmond,64024,State Senate,24,Ind,Andrew Lanza,11
+Richmond,64025,State Senate,24,Ind,Andrew Lanza,6
+Richmond,64026,State Senate,24,Ind,Andrew Lanza,12
+Richmond,64027,State Senate,24,Ind,Andrew Lanza,14
+Richmond,64028,State Senate,24,Ind,Andrew Lanza,6
+Richmond,64029,State Senate,24,Ind,Andrew Lanza,11
+Richmond,64030,State Senate,24,Ind,Andrew Lanza,8
+Richmond,64031,State Senate,24,Ind,Andrew Lanza,20
+Richmond,64032,State Senate,24,Ind,Andrew Lanza,13
+Richmond,64033,State Senate,24,Ind,Andrew Lanza,13
+Richmond,64034,State Senate,24,Ind,Andrew Lanza,20
+Richmond,64035,State Senate,24,Ind,Andrew Lanza,13
+Richmond,64036,State Senate,24,Ind,Andrew Lanza,15
+Richmond,64037,State Senate,24,Ind,Andrew Lanza,16
+Richmond,64038,State Senate,24,Ind,Andrew Lanza,7
+Richmond,61034,State Senate,24,Dem,Gary Carsel,148
+Richmond,61035,State Senate,24,Dem,Gary Carsel,101
+Richmond,61036,State Senate,24,Dem,Gary Carsel,91
+Richmond,61037,State Senate,24,Dem,Gary Carsel,290
+Richmond,61038,State Senate,24,Dem,Gary Carsel,237
+Richmond,61039,State Senate,24,Dem,Gary Carsel,232
+Richmond,61040,State Senate,24,Dem,Gary Carsel,199
+Richmond,61041,State Senate,24,Dem,Gary Carsel,169
+Richmond,61042,State Senate,24,Dem,Gary Carsel,217
+Richmond,61043,State Senate,24,Dem,Gary Carsel,181
+Richmond,61044,State Senate,24,Dem,Gary Carsel,209
+Richmond,61045,State Senate,24,Dem,Gary Carsel,192
+Richmond,61046,State Senate,24,Dem,Gary Carsel,158
+Richmond,61047,State Senate,24,Dem,Gary Carsel,100
+Richmond,61048,State Senate,24,Dem,Gary Carsel,88
+Richmond,62001,State Senate,24,Dem,Gary Carsel,113
+Richmond,62002,State Senate,24,Dem,Gary Carsel,82
+Richmond,62003,State Senate,24,Dem,Gary Carsel,97
+Richmond,62004,State Senate,24,Dem,Gary Carsel,96
+Richmond,62005,State Senate,24,Dem,Gary Carsel,100
+Richmond,62006,State Senate,24,Dem,Gary Carsel,123
+Richmond,62007,State Senate,24,Dem,Gary Carsel,129
+Richmond,62008,State Senate,24,Dem,Gary Carsel,102
+Richmond,62009,State Senate,24,Dem,Gary Carsel,53
+Richmond,62010,State Senate,24,Dem,Gary Carsel,55
+Richmond,62011,State Senate,24,Dem,Gary Carsel,94
+Richmond,62012,State Senate,24,Dem,Gary Carsel,119
+Richmond,62013,State Senate,24,Dem,Gary Carsel,137
+Richmond,62014,State Senate,24,Dem,Gary Carsel,132
+Richmond,62015,State Senate,24,Dem,Gary Carsel,137
+Richmond,62016,State Senate,24,Dem,Gary Carsel,158
+Richmond,62017,State Senate,24,Dem,Gary Carsel,123
+Richmond,62018,State Senate,24,Dem,Gary Carsel,137
+Richmond,62019,State Senate,24,Dem,Gary Carsel,93
+Richmond,62020,State Senate,24,Dem,Gary Carsel,101
+Richmond,62021,State Senate,24,Dem,Gary Carsel,77
+Richmond,62022,State Senate,24,Dem,Gary Carsel,105
+Richmond,62023,State Senate,24,Dem,Gary Carsel,77
+Richmond,62024,State Senate,24,Dem,Gary Carsel,140
+Richmond,62025,State Senate,24,Dem,Gary Carsel,116
+Richmond,62026,State Senate,24,Dem,Gary Carsel,197
+Richmond,62027,State Senate,24,Dem,Gary Carsel,117
+Richmond,62028,State Senate,24,Dem,Gary Carsel,104
+Richmond,62029,State Senate,24,Dem,Gary Carsel,82
+Richmond,62030,State Senate,24,Dem,Gary Carsel,87
+Richmond,62031,State Senate,24,Dem,Gary Carsel,131
+Richmond,62032,State Senate,24,Dem,Gary Carsel,101
+Richmond,62033,State Senate,24,Dem,Gary Carsel,85
+Richmond,62034,State Senate,24,Dem,Gary Carsel,93
+Richmond,62035,State Senate,24,Dem,Gary Carsel,71
+Richmond,62036,State Senate,24,Dem,Gary Carsel,94
+Richmond,62037,State Senate,24,Dem,Gary Carsel,117
+Richmond,62038,State Senate,24,Dem,Gary Carsel,119
+Richmond,62039,State Senate,24,Dem,Gary Carsel,84
+Richmond,62040,State Senate,24,Dem,Gary Carsel,92
+Richmond,62041,State Senate,24,Dem,Gary Carsel,89
+Richmond,62042,State Senate,24,Dem,Gary Carsel,116
+Richmond,62043,State Senate,24,Dem,Gary Carsel,122
+Richmond,62044,State Senate,24,Dem,Gary Carsel,125
+Richmond,62045,State Senate,24,Dem,Gary Carsel,112
+Richmond,62046,State Senate,24,Dem,Gary Carsel,103
+Richmond,62047,State Senate,24,Dem,Gary Carsel,112
+Richmond,62048,State Senate,24,Dem,Gary Carsel,120
+Richmond,62049,State Senate,24,Dem,Gary Carsel,128
+Richmond,62050,State Senate,24,Dem,Gary Carsel,93
+Richmond,62051,State Senate,24,Dem,Gary Carsel,150
+Richmond,62052,State Senate,24,Dem,Gary Carsel,112
+Richmond,62053,State Senate,24,Dem,Gary Carsel,110
+Richmond,62054,State Senate,24,Dem,Gary Carsel,165
+Richmond,62055,State Senate,24,Dem,Gary Carsel,107
+Richmond,62056,State Senate,24,Dem,Gary Carsel,109
+Richmond,62057,State Senate,24,Dem,Gary Carsel,74
+Richmond,62058,State Senate,24,Dem,Gary Carsel,76
+Richmond,62059,State Senate,24,Dem,Gary Carsel,108
+Richmond,62060,State Senate,24,Dem,Gary Carsel,60
+Richmond,62061,State Senate,24,Dem,Gary Carsel,112
+Richmond,62062,State Senate,24,Dem,Gary Carsel,84
+Richmond,62063,State Senate,24,Dem,Gary Carsel,102
+Richmond,62064,State Senate,24,Dem,Gary Carsel,67
+Richmond,62065,State Senate,24,Dem,Gary Carsel,97
+Richmond,62066,State Senate,24,Dem,Gary Carsel,114
+Richmond,62067,State Senate,24,Dem,Gary Carsel,134
+Richmond,62068,State Senate,24,Dem,Gary Carsel,141
+Richmond,62069,State Senate,24,Dem,Gary Carsel,133
+Richmond,62070,State Senate,24,Dem,Gary Carsel,87
+Richmond,62071,State Senate,24,Dem,Gary Carsel,132
+Richmond,62072,State Senate,24,Dem,Gary Carsel,72
+Richmond,63001,State Senate,24,Dem,Gary Carsel,179
+Richmond,63002,State Senate,24,Dem,Gary Carsel,206
+Richmond,63003,State Senate,24,Dem,Gary Carsel,178
+Richmond,63004,State Senate,24,Dem,Gary Carsel,126
+Richmond,63005,State Senate,24,Dem,Gary Carsel,137
+Richmond,63006,State Senate,24,Dem,Gary Carsel,140
+Richmond,63007,State Senate,24,Dem,Gary Carsel,251
+Richmond,63008,State Senate,24,Dem,Gary Carsel,130
+Richmond,63009,State Senate,24,Dem,Gary Carsel,5
+Richmond,63011,State Senate,24,Dem,Gary Carsel,256
+Richmond,63012,State Senate,24,Dem,Gary Carsel,245
+Richmond,63013,State Senate,24,Dem,Gary Carsel,258
+Richmond,63014,State Senate,24,Dem,Gary Carsel,206
+Richmond,63015,State Senate,24,Dem,Gary Carsel,217
+Richmond,63016,State Senate,24,Dem,Gary Carsel,182
+Richmond,63018,State Senate,24,Dem,Gary Carsel,128
+Richmond,63019,State Senate,24,Dem,Gary Carsel,119
+Richmond,63020,State Senate,24,Dem,Gary Carsel,119
+Richmond,63021,State Senate,24,Dem,Gary Carsel,146
+Richmond,63022,State Senate,24,Dem,Gary Carsel,211
+Richmond,63023,State Senate,24,Dem,Gary Carsel,181
+Richmond,63024,State Senate,24,Dem,Gary Carsel,205
+Richmond,63025,State Senate,24,Dem,Gary Carsel,162
+Richmond,63026,State Senate,24,Dem,Gary Carsel,82
+Richmond,63027,State Senate,24,Dem,Gary Carsel,155
+Richmond,63028,State Senate,24,Dem,Gary Carsel,146
+Richmond,63029,State Senate,24,Dem,Gary Carsel,195
+Richmond,63030,State Senate,24,Dem,Gary Carsel,222
+Richmond,63031,State Senate,24,Dem,Gary Carsel,206
+Richmond,63032,State Senate,24,Dem,Gary Carsel,222
+Richmond,63033,State Senate,24,Dem,Gary Carsel,132
+Richmond,63034,State Senate,24,Dem,Gary Carsel,85
+Richmond,63035,State Senate,24,Dem,Gary Carsel,95
+Richmond,63036,State Senate,24,Dem,Gary Carsel,208
+Richmond,63046,State Senate,24,Dem,Gary Carsel,320
+Richmond,63047,State Senate,24,Dem,Gary Carsel,150
+Richmond,63048,State Senate,24,Dem,Gary Carsel,95
+Richmond,63049,State Senate,24,Dem,Gary Carsel,125
+Richmond,63050,State Senate,24,Dem,Gary Carsel,212
+Richmond,63051,State Senate,24,Dem,Gary Carsel,120
+Richmond,63052,State Senate,24,Dem,Gary Carsel,102
+Richmond,63053,State Senate,24,Dem,Gary Carsel,132
+Richmond,63054,State Senate,24,Dem,Gary Carsel,245
+Richmond,63055,State Senate,24,Dem,Gary Carsel,174
+Richmond,63056,State Senate,24,Dem,Gary Carsel,287
+Richmond,63057,State Senate,24,Dem,Gary Carsel,168
+Richmond,63058,State Senate,24,Dem,Gary Carsel,150
+Richmond,63059,State Senate,24,Dem,Gary Carsel,182
+Richmond,63060,State Senate,24,Dem,Gary Carsel,209
+Richmond,63061,State Senate,24,Dem,Gary Carsel,199
+Richmond,63062,State Senate,24,Dem,Gary Carsel,180
+Richmond,63063,State Senate,24,Dem,Gary Carsel,144
+Richmond,63064,State Senate,24,Dem,Gary Carsel,172
+Richmond,63065,State Senate,24,Dem,Gary Carsel,176
+Richmond,63066,State Senate,24,Dem,Gary Carsel,140
+Richmond,63067,State Senate,24,Dem,Gary Carsel,110
+Richmond,63068,State Senate,24,Dem,Gary Carsel,349
+Richmond,63069,State Senate,24,Dem,Gary Carsel,143
+Richmond,63070,State Senate,24,Dem,Gary Carsel,102
+Richmond,63071,State Senate,24,Dem,Gary Carsel,295
+Richmond,63072,State Senate,24,Dem,Gary Carsel,160
+Richmond,63073,State Senate,24,Dem,Gary Carsel,157
+Richmond,64001,State Senate,24,Dem,Gary Carsel,93
+Richmond,64002,State Senate,24,Dem,Gary Carsel,79
+Richmond,64003,State Senate,24,Dem,Gary Carsel,92
+Richmond,64004,State Senate,24,Dem,Gary Carsel,109
+Richmond,64005,State Senate,24,Dem,Gary Carsel,131
+Richmond,64006,State Senate,24,Dem,Gary Carsel,101
+Richmond,64007,State Senate,24,Dem,Gary Carsel,72
+Richmond,64008,State Senate,24,Dem,Gary Carsel,110
+Richmond,64009,State Senate,24,Dem,Gary Carsel,125
+Richmond,64010,State Senate,24,Dem,Gary Carsel,120
+Richmond,64011,State Senate,24,Dem,Gary Carsel,81
+Richmond,64012,State Senate,24,Dem,Gary Carsel,53
+Richmond,64013,State Senate,24,Dem,Gary Carsel,69
+Richmond,64014,State Senate,24,Dem,Gary Carsel,116
+Richmond,64015,State Senate,24,Dem,Gary Carsel,106
+Richmond,64016,State Senate,24,Dem,Gary Carsel,117
+Richmond,64017,State Senate,24,Dem,Gary Carsel,142
+Richmond,64018,State Senate,24,Dem,Gary Carsel,149
+Richmond,64019,State Senate,24,Dem,Gary Carsel,242
+Richmond,64020,State Senate,24,Dem,Gary Carsel,140
+Richmond,64021,State Senate,24,Dem,Gary Carsel,96
+Richmond,64022,State Senate,24,Dem,Gary Carsel,120
+Richmond,64023,State Senate,24,Dem,Gary Carsel,153
+Richmond,64024,State Senate,24,Dem,Gary Carsel,108
+Richmond,64025,State Senate,24,Dem,Gary Carsel,103
+Richmond,64026,State Senate,24,Dem,Gary Carsel,128
+Richmond,64027,State Senate,24,Dem,Gary Carsel,89
+Richmond,64028,State Senate,24,Dem,Gary Carsel,88
+Richmond,64029,State Senate,24,Dem,Gary Carsel,124
+Richmond,64030,State Senate,24,Dem,Gary Carsel,100
+Richmond,64031,State Senate,24,Dem,Gary Carsel,121
+Richmond,64032,State Senate,24,Dem,Gary Carsel,173
+Richmond,64033,State Senate,24,Dem,Gary Carsel,110
+Richmond,64034,State Senate,24,Dem,Gary Carsel,163
+Richmond,64035,State Senate,24,Dem,Gary Carsel,146
+Richmond,64036,State Senate,24,Dem,Gary Carsel,192
+Richmond,64037,State Senate,24,Dem,Gary Carsel,97
+Richmond,64038,State Senate,24,Dem,Gary Carsel,122
+Richmond,61034,State Senate,24,WF,Gary Carsel,11
+Richmond,61035,State Senate,24,WF,Gary Carsel,4
+Richmond,61036,State Senate,24,WF,Gary Carsel,4
+Richmond,61037,State Senate,24,WF,Gary Carsel,25
+Richmond,61038,State Senate,24,WF,Gary Carsel,11
+Richmond,61039,State Senate,24,WF,Gary Carsel,17
+Richmond,61040,State Senate,24,WF,Gary Carsel,13
+Richmond,61041,State Senate,24,WF,Gary Carsel,7
+Richmond,61042,State Senate,24,WF,Gary Carsel,19
+Richmond,61043,State Senate,24,WF,Gary Carsel,8
+Richmond,61044,State Senate,24,WF,Gary Carsel,16
+Richmond,61045,State Senate,24,WF,Gary Carsel,6
+Richmond,61046,State Senate,24,WF,Gary Carsel,11
+Richmond,61047,State Senate,24,WF,Gary Carsel,10
+Richmond,61048,State Senate,24,WF,Gary Carsel,4
+Richmond,62001,State Senate,24,WF,Gary Carsel,7
+Richmond,62002,State Senate,24,WF,Gary Carsel,8
+Richmond,62003,State Senate,24,WF,Gary Carsel,9
+Richmond,62004,State Senate,24,WF,Gary Carsel,11
+Richmond,62005,State Senate,24,WF,Gary Carsel,5
+Richmond,62006,State Senate,24,WF,Gary Carsel,16
+Richmond,62007,State Senate,24,WF,Gary Carsel,11
+Richmond,62008,State Senate,24,WF,Gary Carsel,10
+Richmond,62009,State Senate,24,WF,Gary Carsel,1
+Richmond,62010,State Senate,24,WF,Gary Carsel,3
+Richmond,62011,State Senate,24,WF,Gary Carsel,7
+Richmond,62012,State Senate,24,WF,Gary Carsel,3
+Richmond,62013,State Senate,24,WF,Gary Carsel,7
+Richmond,62014,State Senate,24,WF,Gary Carsel,4
+Richmond,62015,State Senate,24,WF,Gary Carsel,9
+Richmond,62016,State Senate,24,WF,Gary Carsel,5
+Richmond,62017,State Senate,24,WF,Gary Carsel,5
+Richmond,62018,State Senate,24,WF,Gary Carsel,9
+Richmond,62019,State Senate,24,WF,Gary Carsel,4
+Richmond,62020,State Senate,24,WF,Gary Carsel,4
+Richmond,62021,State Senate,24,WF,Gary Carsel,7
+Richmond,62022,State Senate,24,WF,Gary Carsel,5
+Richmond,62023,State Senate,24,WF,Gary Carsel,7
+Richmond,62024,State Senate,24,WF,Gary Carsel,6
+Richmond,62025,State Senate,24,WF,Gary Carsel,4
+Richmond,62026,State Senate,24,WF,Gary Carsel,7
+Richmond,62027,State Senate,24,WF,Gary Carsel,3
+Richmond,62028,State Senate,24,WF,Gary Carsel,2
+Richmond,62029,State Senate,24,WF,Gary Carsel,2
+Richmond,62030,State Senate,24,WF,Gary Carsel,5
+Richmond,62031,State Senate,24,WF,Gary Carsel,6
+Richmond,62032,State Senate,24,WF,Gary Carsel,6
+Richmond,62033,State Senate,24,WF,Gary Carsel,6
+Richmond,62034,State Senate,24,WF,Gary Carsel,3
+Richmond,62035,State Senate,24,WF,Gary Carsel,5
+Richmond,62036,State Senate,24,WF,Gary Carsel,8
+Richmond,62037,State Senate,24,WF,Gary Carsel,2
+Richmond,62038,State Senate,24,WF,Gary Carsel,2
+Richmond,62039,State Senate,24,WF,Gary Carsel,3
+Richmond,62040,State Senate,24,WF,Gary Carsel,4
+Richmond,62041,State Senate,24,WF,Gary Carsel,4
+Richmond,62042,State Senate,24,WF,Gary Carsel,8
+Richmond,62043,State Senate,24,WF,Gary Carsel,5
+Richmond,62044,State Senate,24,WF,Gary Carsel,8
+Richmond,62045,State Senate,24,WF,Gary Carsel,5
+Richmond,62046,State Senate,24,WF,Gary Carsel,4
+Richmond,62047,State Senate,24,WF,Gary Carsel,5
+Richmond,62048,State Senate,24,WF,Gary Carsel,7
+Richmond,62049,State Senate,24,WF,Gary Carsel,1
+Richmond,62050,State Senate,24,WF,Gary Carsel,4
+Richmond,62051,State Senate,24,WF,Gary Carsel,1
+Richmond,62052,State Senate,24,WF,Gary Carsel,5
+Richmond,62053,State Senate,24,WF,Gary Carsel,7
+Richmond,62054,State Senate,24,WF,Gary Carsel,5
+Richmond,62055,State Senate,24,WF,Gary Carsel,8
+Richmond,62056,State Senate,24,WF,Gary Carsel,4
+Richmond,62057,State Senate,24,WF,Gary Carsel,7
+Richmond,62058,State Senate,24,WF,Gary Carsel,7
+Richmond,62059,State Senate,24,WF,Gary Carsel,5
+Richmond,62060,State Senate,24,WF,Gary Carsel,1
+Richmond,62061,State Senate,24,WF,Gary Carsel,3
+Richmond,62062,State Senate,24,WF,Gary Carsel,9
+Richmond,62063,State Senate,24,WF,Gary Carsel,6
+Richmond,62064,State Senate,24,WF,Gary Carsel,1
+Richmond,62065,State Senate,24,WF,Gary Carsel,8
+Richmond,62066,State Senate,24,WF,Gary Carsel,7
+Richmond,62067,State Senate,24,WF,Gary Carsel,12
+Richmond,62068,State Senate,24,WF,Gary Carsel,7
+Richmond,62069,State Senate,24,WF,Gary Carsel,8
+Richmond,62070,State Senate,24,WF,Gary Carsel,12
+Richmond,62071,State Senate,24,WF,Gary Carsel,4
+Richmond,62072,State Senate,24,WF,Gary Carsel,1
+Richmond,63001,State Senate,24,WF,Gary Carsel,5
+Richmond,63002,State Senate,24,WF,Gary Carsel,5
+Richmond,63003,State Senate,24,WF,Gary Carsel,9
+Richmond,63004,State Senate,24,WF,Gary Carsel,2
+Richmond,63005,State Senate,24,WF,Gary Carsel,8
+Richmond,63006,State Senate,24,WF,Gary Carsel,5
+Richmond,63007,State Senate,24,WF,Gary Carsel,10
+Richmond,63008,State Senate,24,WF,Gary Carsel,3
+Richmond,63009,State Senate,24,WF,Gary Carsel,1
+Richmond,63011,State Senate,24,WF,Gary Carsel,7
+Richmond,63012,State Senate,24,WF,Gary Carsel,3
+Richmond,63013,State Senate,24,WF,Gary Carsel,15
+Richmond,63014,State Senate,24,WF,Gary Carsel,4
+Richmond,63015,State Senate,24,WF,Gary Carsel,7
+Richmond,63016,State Senate,24,WF,Gary Carsel,11
+Richmond,63018,State Senate,24,WF,Gary Carsel,9
+Richmond,63019,State Senate,24,WF,Gary Carsel,3
+Richmond,63020,State Senate,24,WF,Gary Carsel,4
+Richmond,63021,State Senate,24,WF,Gary Carsel,11
+Richmond,63022,State Senate,24,WF,Gary Carsel,11
+Richmond,63023,State Senate,24,WF,Gary Carsel,12
+Richmond,63024,State Senate,24,WF,Gary Carsel,7
+Richmond,63025,State Senate,24,WF,Gary Carsel,8
+Richmond,63026,State Senate,24,WF,Gary Carsel,1
+Richmond,63027,State Senate,24,WF,Gary Carsel,6
+Richmond,63028,State Senate,24,WF,Gary Carsel,1
+Richmond,63029,State Senate,24,WF,Gary Carsel,8
+Richmond,63030,State Senate,24,WF,Gary Carsel,11
+Richmond,63031,State Senate,24,WF,Gary Carsel,5
+Richmond,63032,State Senate,24,WF,Gary Carsel,7
+Richmond,63033,State Senate,24,WF,Gary Carsel,6
+Richmond,63034,State Senate,24,WF,Gary Carsel,2
+Richmond,63035,State Senate,24,WF,Gary Carsel,6
+Richmond,63036,State Senate,24,WF,Gary Carsel,6
+Richmond,63046,State Senate,24,WF,Gary Carsel,13
+Richmond,63047,State Senate,24,WF,Gary Carsel,16
+Richmond,63048,State Senate,24,WF,Gary Carsel,2
+Richmond,63049,State Senate,24,WF,Gary Carsel,6
+Richmond,63050,State Senate,24,WF,Gary Carsel,9
+Richmond,63051,State Senate,24,WF,Gary Carsel,7
+Richmond,63052,State Senate,24,WF,Gary Carsel,2
+Richmond,63053,State Senate,24,WF,Gary Carsel,5
+Richmond,63054,State Senate,24,WF,Gary Carsel,2
+Richmond,63055,State Senate,24,WF,Gary Carsel,9
+Richmond,63056,State Senate,24,WF,Gary Carsel,10
+Richmond,63057,State Senate,24,WF,Gary Carsel,4
+Richmond,63058,State Senate,24,WF,Gary Carsel,7
+Richmond,63059,State Senate,24,WF,Gary Carsel,11
+Richmond,63060,State Senate,24,WF,Gary Carsel,15
+Richmond,63061,State Senate,24,WF,Gary Carsel,15
+Richmond,63062,State Senate,24,WF,Gary Carsel,11
+Richmond,63063,State Senate,24,WF,Gary Carsel,18
+Richmond,63064,State Senate,24,WF,Gary Carsel,4
+Richmond,63065,State Senate,24,WF,Gary Carsel,13
+Richmond,63066,State Senate,24,WF,Gary Carsel,8
+Richmond,63067,State Senate,24,WF,Gary Carsel,9
+Richmond,63068,State Senate,24,WF,Gary Carsel,8
+Richmond,63069,State Senate,24,WF,Gary Carsel,2
+Richmond,63070,State Senate,24,WF,Gary Carsel,4
+Richmond,63071,State Senate,24,WF,Gary Carsel,11
+Richmond,63072,State Senate,24,WF,Gary Carsel,12
+Richmond,63073,State Senate,24,WF,Gary Carsel,12
+Richmond,64001,State Senate,24,WF,Gary Carsel,5
+Richmond,64002,State Senate,24,WF,Gary Carsel,14
+Richmond,64003,State Senate,24,WF,Gary Carsel,4
+Richmond,64004,State Senate,24,WF,Gary Carsel,7
+Richmond,64005,State Senate,24,WF,Gary Carsel,5
+Richmond,64006,State Senate,24,WF,Gary Carsel,5
+Richmond,64007,State Senate,24,WF,Gary Carsel,9
+Richmond,64008,State Senate,24,WF,Gary Carsel,10
+Richmond,64009,State Senate,24,WF,Gary Carsel,5
+Richmond,64010,State Senate,24,WF,Gary Carsel,14
+Richmond,64011,State Senate,24,WF,Gary Carsel,12
+Richmond,64012,State Senate,24,WF,Gary Carsel,9
+Richmond,64013,State Senate,24,WF,Gary Carsel,3
+Richmond,64014,State Senate,24,WF,Gary Carsel,2
+Richmond,64015,State Senate,24,WF,Gary Carsel,1
+Richmond,64016,State Senate,24,WF,Gary Carsel,8
+Richmond,64017,State Senate,24,WF,Gary Carsel,12
+Richmond,64018,State Senate,24,WF,Gary Carsel,13
+Richmond,64019,State Senate,24,WF,Gary Carsel,17
+Richmond,64020,State Senate,24,WF,Gary Carsel,10
+Richmond,64021,State Senate,24,WF,Gary Carsel,3
+Richmond,64022,State Senate,24,WF,Gary Carsel,8
+Richmond,64023,State Senate,24,WF,Gary Carsel,9
+Richmond,64024,State Senate,24,WF,Gary Carsel,6
+Richmond,64025,State Senate,24,WF,Gary Carsel,4
+Richmond,64026,State Senate,24,WF,Gary Carsel,13
+Richmond,64027,State Senate,24,WF,Gary Carsel,7
+Richmond,64028,State Senate,24,WF,Gary Carsel,5
+Richmond,64029,State Senate,24,WF,Gary Carsel,3
+Richmond,64030,State Senate,24,WF,Gary Carsel,3
+Richmond,64031,State Senate,24,WF,Gary Carsel,9
+Richmond,64032,State Senate,24,WF,Gary Carsel,12
+Richmond,64033,State Senate,24,WF,Gary Carsel,5
+Richmond,64034,State Senate,24,WF,Gary Carsel,7
+Richmond,64035,State Senate,24,WF,Gary Carsel,7
+Richmond,64036,State Senate,24,WF,Gary Carsel,6
+Richmond,64037,State Senate,24,WF,Gary Carsel,6
+Richmond,64038,State Senate,24,WF,Gary Carsel,14
+Richmond,61034,State Senate,24,Ind,writein,0
+Richmond,61035,State Senate,24,Ind,writein,0
+Richmond,61036,State Senate,24,Ind,writein,0
+Richmond,61037,State Senate,24,Ind,writein,0
+Richmond,61038,State Senate,24,Ind,writein,1
+Richmond,61039,State Senate,24,Ind,writein,1
+Richmond,61040,State Senate,24,Ind,writein,0
+Richmond,61041,State Senate,24,Ind,writein,0
+Richmond,61042,State Senate,24,Ind,writein,2
+Richmond,61043,State Senate,24,Ind,writein,2
+Richmond,61044,State Senate,24,Ind,writein,0
+Richmond,61045,State Senate,24,Ind,writein,0
+Richmond,61046,State Senate,24,Ind,writein,1
+Richmond,61047,State Senate,24,Ind,writein,1
+Richmond,61048,State Senate,24,Ind,writein,0
+Richmond,62001,State Senate,24,Ind,writein,1
+Richmond,62002,State Senate,24,Ind,writein,1
+Richmond,62003,State Senate,24,Ind,writein,0
+Richmond,62004,State Senate,24,Ind,writein,1
+Richmond,62005,State Senate,24,Ind,writein,0
+Richmond,62006,State Senate,24,Ind,writein,1
+Richmond,62007,State Senate,24,Ind,writein,0
+Richmond,62008,State Senate,24,Ind,writein,1
+Richmond,62009,State Senate,24,Ind,writein,0
+Richmond,62010,State Senate,24,Ind,writein,0
+Richmond,62011,State Senate,24,Ind,writein,1
+Richmond,62012,State Senate,24,Ind,writein,0
+Richmond,62013,State Senate,24,Ind,writein,0
+Richmond,62014,State Senate,24,Ind,writein,1
+Richmond,62015,State Senate,24,Ind,writein,1
+Richmond,62016,State Senate,24,Ind,writein,1
+Richmond,62017,State Senate,24,Ind,writein,0
+Richmond,62018,State Senate,24,Ind,writein,1
+Richmond,62019,State Senate,24,Ind,writein,0
+Richmond,62020,State Senate,24,Ind,writein,0
+Richmond,62021,State Senate,24,Ind,writein,0
+Richmond,62022,State Senate,24,Ind,writein,0
+Richmond,62023,State Senate,24,Ind,writein,0
+Richmond,62024,State Senate,24,Ind,writein,0
+Richmond,62025,State Senate,24,Ind,writein,0
+Richmond,62026,State Senate,24,Ind,writein,2
+Richmond,62027,State Senate,24,Ind,writein,0
+Richmond,62028,State Senate,24,Ind,writein,0
+Richmond,62029,State Senate,24,Ind,writein,0
+Richmond,62030,State Senate,24,Ind,writein,0
+Richmond,62031,State Senate,24,Ind,writein,0
+Richmond,62032,State Senate,24,Ind,writein,0
+Richmond,62033,State Senate,24,Ind,writein,0
+Richmond,62034,State Senate,24,Ind,writein,1
+Richmond,62035,State Senate,24,Ind,writein,2
+Richmond,62036,State Senate,24,Ind,writein,0
+Richmond,62037,State Senate,24,Ind,writein,0
+Richmond,62038,State Senate,24,Ind,writein,0
+Richmond,62039,State Senate,24,Ind,writein,0
+Richmond,62040,State Senate,24,Ind,writein,0
+Richmond,62041,State Senate,24,Ind,writein,0
+Richmond,62042,State Senate,24,Ind,writein,0
+Richmond,62043,State Senate,24,Ind,writein,1
+Richmond,62044,State Senate,24,Ind,writein,0
+Richmond,62045,State Senate,24,Ind,writein,0
+Richmond,62046,State Senate,24,Ind,writein,1
+Richmond,62047,State Senate,24,Ind,writein,1
+Richmond,62048,State Senate,24,Ind,writein,0
+Richmond,62049,State Senate,24,Ind,writein,1
+Richmond,62050,State Senate,24,Ind,writein,1
+Richmond,62051,State Senate,24,Ind,writein,1
+Richmond,62052,State Senate,24,Ind,writein,0
+Richmond,62053,State Senate,24,Ind,writein,0
+Richmond,62054,State Senate,24,Ind,writein,0
+Richmond,62055,State Senate,24,Ind,writein,1
+Richmond,62056,State Senate,24,Ind,writein,0
+Richmond,62057,State Senate,24,Ind,writein,0
+Richmond,62058,State Senate,24,Ind,writein,0
+Richmond,62059,State Senate,24,Ind,writein,0
+Richmond,62060,State Senate,24,Ind,writein,0
+Richmond,62061,State Senate,24,Ind,writein,1
+Richmond,62062,State Senate,24,Ind,writein,0
+Richmond,62063,State Senate,24,Ind,writein,1
+Richmond,62064,State Senate,24,Ind,writein,0
+Richmond,62065,State Senate,24,Ind,writein,0
+Richmond,62066,State Senate,24,Ind,writein,0
+Richmond,62067,State Senate,24,Ind,writein,0
+Richmond,62068,State Senate,24,Ind,writein,0
+Richmond,62069,State Senate,24,Ind,writein,0
+Richmond,62070,State Senate,24,Ind,writein,0
+Richmond,62071,State Senate,24,Ind,writein,0
+Richmond,62072,State Senate,24,Ind,writein,0
+Richmond,63001,State Senate,24,Ind,writein,0
+Richmond,63002,State Senate,24,Ind,writein,0
+Richmond,63003,State Senate,24,Ind,writein,0
+Richmond,63004,State Senate,24,Ind,writein,0
+Richmond,63005,State Senate,24,Ind,writein,0
+Richmond,63006,State Senate,24,Ind,writein,0
+Richmond,63007,State Senate,24,Ind,writein,0
+Richmond,63008,State Senate,24,Ind,writein,0
+Richmond,63009,State Senate,24,Ind,writein,0
+Richmond,63011,State Senate,24,Ind,writein,1
+Richmond,63012,State Senate,24,Ind,writein,2
+Richmond,63013,State Senate,24,Ind,writein,0
+Richmond,63014,State Senate,24,Ind,writein,1
+Richmond,63015,State Senate,24,Ind,writein,1
+Richmond,63016,State Senate,24,Ind,writein,1
+Richmond,63018,State Senate,24,Ind,writein,0
+Richmond,63019,State Senate,24,Ind,writein,0
+Richmond,63020,State Senate,24,Ind,writein,1
+Richmond,63021,State Senate,24,Ind,writein,0
+Richmond,63022,State Senate,24,Ind,writein,2
+Richmond,63023,State Senate,24,Ind,writein,0
+Richmond,63024,State Senate,24,Ind,writein,2
+Richmond,63025,State Senate,24,Ind,writein,1
+Richmond,63026,State Senate,24,Ind,writein,1
+Richmond,63027,State Senate,24,Ind,writein,0
+Richmond,63028,State Senate,24,Ind,writein,1
+Richmond,63029,State Senate,24,Ind,writein,0
+Richmond,63030,State Senate,24,Ind,writein,0
+Richmond,63031,State Senate,24,Ind,writein,0
+Richmond,63032,State Senate,24,Ind,writein,0
+Richmond,63033,State Senate,24,Ind,writein,0
+Richmond,63034,State Senate,24,Ind,writein,0
+Richmond,63035,State Senate,24,Ind,writein,1
+Richmond,63036,State Senate,24,Ind,writein,0
+Richmond,63046,State Senate,24,Ind,writein,0
+Richmond,63047,State Senate,24,Ind,writein,0
+Richmond,63048,State Senate,24,Ind,writein,0
+Richmond,63049,State Senate,24,Ind,writein,0
+Richmond,63050,State Senate,24,Ind,writein,0
+Richmond,63051,State Senate,24,Ind,writein,1
+Richmond,63052,State Senate,24,Ind,writein,0
+Richmond,63053,State Senate,24,Ind,writein,0
+Richmond,63054,State Senate,24,Ind,writein,0
+Richmond,63055,State Senate,24,Ind,writein,0
+Richmond,63056,State Senate,24,Ind,writein,0
+Richmond,63057,State Senate,24,Ind,writein,2
+Richmond,63058,State Senate,24,Ind,writein,0
+Richmond,63059,State Senate,24,Ind,writein,1
+Richmond,63060,State Senate,24,Ind,writein,0
+Richmond,63061,State Senate,24,Ind,writein,3
+Richmond,63062,State Senate,24,Ind,writein,2
+Richmond,63063,State Senate,24,Ind,writein,1
+Richmond,63064,State Senate,24,Ind,writein,0
+Richmond,63065,State Senate,24,Ind,writein,1
+Richmond,63066,State Senate,24,Ind,writein,0
+Richmond,63067,State Senate,24,Ind,writein,1
+Richmond,63068,State Senate,24,Ind,writein,1
+Richmond,63069,State Senate,24,Ind,writein,0
+Richmond,63070,State Senate,24,Ind,writein,0
+Richmond,63071,State Senate,24,Ind,writein,0
+Richmond,63072,State Senate,24,Ind,writein,0
+Richmond,63073,State Senate,24,Ind,writein,0
+Richmond,64001,State Senate,24,Ind,writein,0
+Richmond,64002,State Senate,24,Ind,writein,1
+Richmond,64003,State Senate,24,Ind,writein,1
+Richmond,64004,State Senate,24,Ind,writein,1
+Richmond,64005,State Senate,24,Ind,writein,1
+Richmond,64006,State Senate,24,Ind,writein,0
+Richmond,64007,State Senate,24,Ind,writein,0
+Richmond,64008,State Senate,24,Ind,writein,0
+Richmond,64009,State Senate,24,Ind,writein,1
+Richmond,64010,State Senate,24,Ind,writein,1
+Richmond,64011,State Senate,24,Ind,writein,0
+Richmond,64012,State Senate,24,Ind,writein,0
+Richmond,64013,State Senate,24,Ind,writein,0
+Richmond,64014,State Senate,24,Ind,writein,0
+Richmond,64015,State Senate,24,Ind,writein,0
+Richmond,64016,State Senate,24,Ind,writein,1
+Richmond,64017,State Senate,24,Ind,writein,1
+Richmond,64018,State Senate,24,Ind,writein,0
+Richmond,64019,State Senate,24,Ind,writein,2
+Richmond,64020,State Senate,24,Ind,writein,0
+Richmond,64021,State Senate,24,Ind,writein,1
+Richmond,64022,State Senate,24,Ind,writein,0
+Richmond,64023,State Senate,24,Ind,writein,0
+Richmond,64024,State Senate,24,Ind,writein,0
+Richmond,64025,State Senate,24,Ind,writein,1
+Richmond,64026,State Senate,24,Ind,writein,0
+Richmond,64027,State Senate,24,Ind,writein,0
+Richmond,64028,State Senate,24,Ind,writein,0
+Richmond,64029,State Senate,24,Ind,writein,0
+Richmond,64030,State Senate,24,Ind,writein,0
+Richmond,64031,State Senate,24,Ind,writein,0
+Richmond,64032,State Senate,24,Ind,writein,0
+Richmond,64033,State Senate,24,Ind,writein,0
+Richmond,64034,State Senate,24,Ind,writein,0
+Richmond,64035,State Senate,24,Ind,writein,1
+Richmond,64036,State Senate,24,Ind,writein,1
+Richmond,64037,State Senate,24,Ind,writein,0
+Richmond,64038,State Senate,24,Ind,writein,1
 Richmond,61001,U.S. House,11,Dem,Mark Murphy,537
 Richmond,61002,U.S. House,11,Dem,Mark Murphy,438
 Richmond,61003,U.S. House,11,Dem,Mark Murphy,553


### PR DESCRIPTION
I did a VSCode find-replace on `,State Senate,SD([0-9]+),` with `,State Senate,$1,` (to remove the `SD` prefix from district numbers for some records).

I looked through several thousand lines to ensure both the RegEx was specific enough to only touch desired lines and that the replace command was crafted correctly to replace the exact district number.

Fixes Issue #73 