### PR TITLE
Fix incorrect precincts

### DIFF
--- a/2020/counties/20201103__ny__general__suffolk__precinct.csv
+++ b/2020/counties/20201103__ny__general__suffolk__precinct.csv
@@ -7893,48 +7893,48 @@ Suffolk,Smithtown 89,President,,Joseph R. Biden,DEM,234
 Suffolk,Smithtown 90,President,,Joseph R. Biden,DEM,125
 Suffolk,Smithtown 91,President,,Joseph R. Biden,DEM,352
 Suffolk,Smithtown 92,President,,Joseph R. Biden,DEM,324
-Suffolk,Smithtown 1,President,,Joseph R. Biden,DEM,611
-Suffolk,Smithtown 2,President,,Joseph R. Biden,DEM,340
-Suffolk,Smithtown 3,President,,Joseph R. Biden,DEM,720
-Suffolk,Smithtown 4,President,,Joseph R. Biden,DEM,816
-Suffolk,Smithtown 5,President,,Joseph R. Biden,DEM,351
-Suffolk,Smithtown 6,President,,Joseph R. Biden,DEM,302
-Suffolk,Smithtown 7,President,,Joseph R. Biden,DEM,384
-Suffolk,Smithtown 8,President,,Joseph R. Biden,DEM,295
-Suffolk,Smithtown 9,President,,Joseph R. Biden,DEM,680
-Suffolk,Smithtown 10,President,,Joseph R. Biden,DEM,211
-Suffolk,Smithtown 11,President,,Joseph R. Biden,DEM,429
-Suffolk,Smithtown 12,President,,Joseph R. Biden,DEM,556
-Suffolk,Smithtown 13,President,,Joseph R. Biden,DEM,515
-Suffolk,Smithtown 14,President,,Joseph R. Biden,DEM,238
-Suffolk,Smithtown 15,President,,Joseph R. Biden,DEM,444
-Suffolk,Smithtown 16,President,,Joseph R. Biden,DEM,628
-Suffolk,Smithtown 17,President,,Joseph R. Biden,DEM,331
-Suffolk,Smithtown 18,President,,Joseph R. Biden,DEM,397
-Suffolk,Smithtown 19,President,,Joseph R. Biden,DEM,209
-Suffolk,Smithtown 20,President,,Joseph R. Biden,DEM,435
-Suffolk,Smithtown 21,President,,Joseph R. Biden,DEM,354
-Suffolk,Smithtown 22,President,,Joseph R. Biden,DEM,271
-Suffolk,Smithtown 23,President,,Joseph R. Biden,DEM,800
-Suffolk,Smithtown 24,President,,Joseph R. Biden,DEM,383
-Suffolk,Smithtown 25,President,,Joseph R. Biden,DEM,416
-Suffolk,Smithtown 26,President,,Joseph R. Biden,DEM,816
-Suffolk,Smithtown 27,President,,Joseph R. Biden,DEM,481
-Suffolk,Smithtown 28,President,,Joseph R. Biden,DEM,540
-Suffolk,Smithtown 29,President,,Joseph R. Biden,DEM,376
-Suffolk,Smithtown 30,President,,Joseph R. Biden,DEM,365
-Suffolk,Smithtown 31,President,,Joseph R. Biden,DEM,616
-Suffolk,Smithtown 32,President,,Joseph R. Biden,DEM,446
-Suffolk,Smithtown 33,President,,Joseph R. Biden,DEM,297
-Suffolk,Smithtown 34,President,,Joseph R. Biden,DEM,319
-Suffolk,Smithtown 35,President,,Joseph R. Biden,DEM,306
-Suffolk,Smithtown 36,President,,Joseph R. Biden,DEM,658
-Suffolk,Smithtown 37,President,,Joseph R. Biden,DEM,453
-Suffolk,Smithtown 38,President,,Joseph R. Biden,DEM,230
-Suffolk,Smithtown 39,President,,Joseph R. Biden,DEM,469
-Suffolk,Smithtown 40,President,,Joseph R. Biden,DEM,203
-Suffolk,Smithtown 41,President,,Joseph R. Biden,DEM,270
-Suffolk,Smithtown 42,President,,Joseph R. Biden,DEM,403
+Suffolk,Southampton 1,President,,Joseph R. Biden,DEM,611
+Suffolk,Southampton 2,President,,Joseph R. Biden,DEM,340
+Suffolk,Southampton 3,President,,Joseph R. Biden,DEM,720
+Suffolk,Southampton 4,President,,Joseph R. Biden,DEM,816
+Suffolk,Southampton 5,President,,Joseph R. Biden,DEM,351
+Suffolk,Southampton 6,President,,Joseph R. Biden,DEM,302
+Suffolk,Southampton 7,President,,Joseph R. Biden,DEM,384
+Suffolk,Southampton 8,President,,Joseph R. Biden,DEM,295
+Suffolk,Southampton 9,President,,Joseph R. Biden,DEM,680
+Suffolk,Southampton 10,President,,Joseph R. Biden,DEM,211
+Suffolk,Southampton 11,President,,Joseph R. Biden,DEM,429
+Suffolk,Southampton 12,President,,Joseph R. Biden,DEM,556
+Suffolk,Southampton 13,President,,Joseph R. Biden,DEM,515
+Suffolk,Southampton 14,President,,Joseph R. Biden,DEM,238
+Suffolk,Southampton 15,President,,Joseph R. Biden,DEM,444
+Suffolk,Southampton 16,President,,Joseph R. Biden,DEM,628
+Suffolk,Southampton 17,President,,Joseph R. Biden,DEM,331
+Suffolk,Southampton 18,President,,Joseph R. Biden,DEM,397
+Suffolk,Southampton 19,President,,Joseph R. Biden,DEM,209
+Suffolk,Southampton 20,President,,Joseph R. Biden,DEM,435
+Suffolk,Southampton 21,President,,Joseph R. Biden,DEM,354
+Suffolk,Southampton 22,President,,Joseph R. Biden,DEM,271
+Suffolk,Southampton 23,President,,Joseph R. Biden,DEM,800
+Suffolk,Southampton 24,President,,Joseph R. Biden,DEM,383
+Suffolk,Southampton 25,President,,Joseph R. Biden,DEM,416
+Suffolk,Southampton 26,President,,Joseph R. Biden,DEM,816
+Suffolk,Southampton 27,President,,Joseph R. Biden,DEM,481
+Suffolk,Southampton 28,President,,Joseph R. Biden,DEM,540
+Suffolk,Southampton 29,President,,Joseph R. Biden,DEM,376
+Suffolk,Southampton 30,President,,Joseph R. Biden,DEM,365
+Suffolk,Southampton 31,President,,Joseph R. Biden,DEM,616
+Suffolk,Southampton 32,President,,Joseph R. Biden,DEM,446
+Suffolk,Southampton 33,President,,Joseph R. Biden,DEM,297
+Suffolk,Southampton 34,President,,Joseph R. Biden,DEM,319
+Suffolk,Southampton 35,President,,Joseph R. Biden,DEM,306
+Suffolk,Southampton 36,President,,Joseph R. Biden,DEM,658
+Suffolk,Southampton 37,President,,Joseph R. Biden,DEM,453
+Suffolk,Southampton 38,President,,Joseph R. Biden,DEM,230
+Suffolk,Southampton 39,President,,Joseph R. Biden,DEM,469
+Suffolk,Southampton 40,President,,Joseph R. Biden,DEM,203
+Suffolk,Southampton 41,President,,Joseph R. Biden,DEM,270
+Suffolk,Southampton 42,President,,Joseph R. Biden,DEM,403
 Suffolk,Southold 1,President,,Joseph R. Biden,DEM,169
 Suffolk,Southold 2,President,,Joseph R. Biden,DEM,493
 Suffolk,Southold 3,President,,Joseph R. Biden,DEM,319
@@ -8298,48 +8298,48 @@ Suffolk,Smithtown 89,President,,Joseph R. Biden,WOR,8
 Suffolk,Smithtown 90,President,,Joseph R. Biden,WOR,7
 Suffolk,Smithtown 91,President,,Joseph R. Biden,WOR,18
 Suffolk,Smithtown 92,President,,Joseph R. Biden,WOR,11
-Suffolk,Smithtown 1,President,,Joseph R. Biden,WOR,21
-Suffolk,Smithtown 2,President,,Joseph R. Biden,WOR,19
-Suffolk,Smithtown 3,President,,Joseph R. Biden,WOR,25
-Suffolk,Smithtown 4,President,,Joseph R. Biden,WOR,31
-Suffolk,Smithtown 5,President,,Joseph R. Biden,WOR,6
-Suffolk,Smithtown 6,President,,Joseph R. Biden,WOR,9
-Suffolk,Smithtown 7,President,,Joseph R. Biden,WOR,21
-Suffolk,Smithtown 8,President,,Joseph R. Biden,WOR,21
-Suffolk,Smithtown 9,President,,Joseph R. Biden,WOR,26
-Suffolk,Smithtown 10,President,,Joseph R. Biden,WOR,6
-Suffolk,Smithtown 11,President,,Joseph R. Biden,WOR,18
-Suffolk,Smithtown 12,President,,Joseph R. Biden,WOR,19
-Suffolk,Smithtown 13,President,,Joseph R. Biden,WOR,16
-Suffolk,Smithtown 14,President,,Joseph R. Biden,WOR,11
-Suffolk,Smithtown 15,President,,Joseph R. Biden,WOR,19
-Suffolk,Smithtown 16,President,,Joseph R. Biden,WOR,34
-Suffolk,Smithtown 17,President,,Joseph R. Biden,WOR,17
-Suffolk,Smithtown 18,President,,Joseph R. Biden,WOR,27
-Suffolk,Smithtown 19,President,,Joseph R. Biden,WOR,8
-Suffolk,Smithtown 20,President,,Joseph R. Biden,WOR,20
-Suffolk,Smithtown 21,President,,Joseph R. Biden,WOR,17
-Suffolk,Smithtown 22,President,,Joseph R. Biden,WOR,13
-Suffolk,Smithtown 23,President,,Joseph R. Biden,WOR,21
-Suffolk,Smithtown 24,President,,Joseph R. Biden,WOR,10
-Suffolk,Smithtown 25,President,,Joseph R. Biden,WOR,20
-Suffolk,Smithtown 26,President,,Joseph R. Biden,WOR,33
-Suffolk,Smithtown 27,President,,Joseph R. Biden,WOR,15
-Suffolk,Smithtown 28,President,,Joseph R. Biden,WOR,16
-Suffolk,Smithtown 29,President,,Joseph R. Biden,WOR,14
-Suffolk,Smithtown 30,President,,Joseph R. Biden,WOR,16
-Suffolk,Smithtown 31,President,,Joseph R. Biden,WOR,28
-Suffolk,Smithtown 32,President,,Joseph R. Biden,WOR,23
-Suffolk,Smithtown 33,President,,Joseph R. Biden,WOR,7
-Suffolk,Smithtown 34,President,,Joseph R. Biden,WOR,13
-Suffolk,Smithtown 35,President,,Joseph R. Biden,WOR,16
-Suffolk,Smithtown 36,President,,Joseph R. Biden,WOR,37
-Suffolk,Smithtown 37,President,,Joseph R. Biden,WOR,24
-Suffolk,Smithtown 38,President,,Joseph R. Biden,WOR,12
-Suffolk,Smithtown 39,President,,Joseph R. Biden,WOR,34
-Suffolk,Smithtown 40,President,,Joseph R. Biden,WOR,12
-Suffolk,Smithtown 41,President,,Joseph R. Biden,WOR,6
-Suffolk,Smithtown 42,President,,Joseph R. Biden,WOR,11
+Suffolk,Southampton 1,President,,Joseph R. Biden,WOR,21
+Suffolk,Southampton 2,President,,Joseph R. Biden,WOR,19
+Suffolk,Southampton 3,President,,Joseph R. Biden,WOR,25
+Suffolk,Southampton 4,President,,Joseph R. Biden,WOR,31
+Suffolk,Southampton 5,President,,Joseph R. Biden,WOR,6
+Suffolk,Southampton 6,President,,Joseph R. Biden,WOR,9
+Suffolk,Southampton 7,President,,Joseph R. Biden,WOR,21
+Suffolk,Southampton 8,President,,Joseph R. Biden,WOR,21
+Suffolk,Southampton 9,President,,Joseph R. Biden,WOR,26
+Suffolk,Southampton 10,President,,Joseph R. Biden,WOR,6
+Suffolk,Southampton 11,President,,Joseph R. Biden,WOR,18
+Suffolk,Southampton 12,President,,Joseph R. Biden,WOR,19
+Suffolk,Southampton 13,President,,Joseph R. Biden,WOR,16
+Suffolk,Southampton 14,President,,Joseph R. Biden,WOR,11
+Suffolk,Southampton 15,President,,Joseph R. Biden,WOR,19
+Suffolk,Southampton 16,President,,Joseph R. Biden,WOR,34
+Suffolk,Southampton 17,President,,Joseph R. Biden,WOR,17
+Suffolk,Southampton 18,President,,Joseph R. Biden,WOR,27
+Suffolk,Southampton 19,President,,Joseph R. Biden,WOR,8
+Suffolk,Southampton 20,President,,Joseph R. Biden,WOR,20
+Suffolk,Southampton 21,President,,Joseph R. Biden,WOR,17
+Suffolk,Southampton 22,President,,Joseph R. Biden,WOR,13
+Suffolk,Southampton 23,President,,Joseph R. Biden,WOR,21
+Suffolk,Southampton 24,President,,Joseph R. Biden,WOR,10
+Suffolk,Southampton 25,President,,Joseph R. Biden,WOR,20
+Suffolk,Southampton 26,President,,Joseph R. Biden,WOR,33
+Suffolk,Southampton 27,President,,Joseph R. Biden,WOR,15
+Suffolk,Southampton 28,President,,Joseph R. Biden,WOR,16
+Suffolk,Southampton 29,President,,Joseph R. Biden,WOR,14
+Suffolk,Southampton 30,President,,Joseph R. Biden,WOR,16
+Suffolk,Southampton 31,President,,Joseph R. Biden,WOR,28
+Suffolk,Southampton 32,President,,Joseph R. Biden,WOR,23
+Suffolk,Southampton 33,President,,Joseph R. Biden,WOR,7
+Suffolk,Southampton 34,President,,Joseph R. Biden,WOR,13
+Suffolk,Southampton 35,President,,Joseph R. Biden,WOR,16
+Suffolk,Southampton 36,President,,Joseph R. Biden,WOR,37
+Suffolk,Southampton 37,President,,Joseph R. Biden,WOR,24
+Suffolk,Southampton 38,President,,Joseph R. Biden,WOR,12
+Suffolk,Southampton 39,President,,Joseph R. Biden,WOR,34
+Suffolk,Southampton 40,President,,Joseph R. Biden,WOR,12
+Suffolk,Southampton 41,President,,Joseph R. Biden,WOR,6
+Suffolk,Southampton 42,President,,Joseph R. Biden,WOR,11
 Suffolk,Southold 1,President,,Joseph R. Biden,WOR,12
 Suffolk,Southold 2,President,,Joseph R. Biden,WOR,24
 Suffolk,Southold 3,President,,Joseph R. Biden,WOR,15
@@ -8703,48 +8703,48 @@ Suffolk,Smithtown 89,President,,Donald J. Trump,REP,305
 Suffolk,Smithtown 90,President,,Donald J. Trump,REP,205
 Suffolk,Smithtown 91,President,,Donald J. Trump,REP,396
 Suffolk,Smithtown 92,President,,Donald J. Trump,REP,417
-Suffolk,Smithtown 1,President,,Donald J. Trump,REP,226
-Suffolk,Smithtown 2,President,,Donald J. Trump,REP,200
-Suffolk,Smithtown 3,President,,Donald J. Trump,REP,266
-Suffolk,Smithtown 4,President,,Donald J. Trump,REP,413
-Suffolk,Smithtown 5,President,,Donald J. Trump,REP,225
-Suffolk,Smithtown 6,President,,Donald J. Trump,REP,171
-Suffolk,Smithtown 7,President,,Donald J. Trump,REP,218
-Suffolk,Smithtown 8,President,,Donald J. Trump,REP,295
-Suffolk,Smithtown 9,President,,Donald J. Trump,REP,373
-Suffolk,Smithtown 10,President,,Donald J. Trump,REP,158
-Suffolk,Smithtown 11,President,,Donald J. Trump,REP,638
-Suffolk,Smithtown 12,President,,Donald J. Trump,REP,372
-Suffolk,Smithtown 13,President,,Donald J. Trump,REP,171
-Suffolk,Smithtown 14,President,,Donald J. Trump,REP,220
-Suffolk,Smithtown 15,President,,Donald J. Trump,REP,323
-Suffolk,Smithtown 16,President,,Donald J. Trump,REP,451
-Suffolk,Smithtown 17,President,,Donald J. Trump,REP,306
-Suffolk,Smithtown 18,President,,Donald J. Trump,REP,372
-Suffolk,Smithtown 19,President,,Donald J. Trump,REP,137
-Suffolk,Smithtown 20,President,,Donald J. Trump,REP,348
-Suffolk,Smithtown 21,President,,Donald J. Trump,REP,112
-Suffolk,Smithtown 22,President,,Donald J. Trump,REP,225
-Suffolk,Smithtown 23,President,,Donald J. Trump,REP,675
-Suffolk,Smithtown 24,President,,Donald J. Trump,REP,221
-Suffolk,Smithtown 25,President,,Donald J. Trump,REP,337
-Suffolk,Smithtown 26,President,,Donald J. Trump,REP,352
-Suffolk,Smithtown 27,President,,Donald J. Trump,REP,611
-Suffolk,Smithtown 28,President,,Donald J. Trump,REP,366
-Suffolk,Smithtown 29,President,,Donald J. Trump,REP,356
-Suffolk,Smithtown 30,President,,Donald J. Trump,REP,255
-Suffolk,Smithtown 31,President,,Donald J. Trump,REP,233
-Suffolk,Smithtown 32,President,,Donald J. Trump,REP,398
-Suffolk,Smithtown 33,President,,Donald J. Trump,REP,300
-Suffolk,Smithtown 34,President,,Donald J. Trump,REP,307
-Suffolk,Smithtown 35,President,,Donald J. Trump,REP,435
-Suffolk,Smithtown 36,President,,Donald J. Trump,REP,271
-Suffolk,Smithtown 37,President,,Donald J. Trump,REP,337
-Suffolk,Smithtown 38,President,,Donald J. Trump,REP,245
-Suffolk,Smithtown 39,President,,Donald J. Trump,REP,243
-Suffolk,Smithtown 40,President,,Donald J. Trump,REP,240
-Suffolk,Smithtown 41,President,,Donald J. Trump,REP,150
-Suffolk,Smithtown 42,President,,Donald J. Trump,REP,240
+Suffolk,Southampton 1,President,,Donald J. Trump,REP,226
+Suffolk,Southampton 2,President,,Donald J. Trump,REP,200
+Suffolk,Southampton 3,President,,Donald J. Trump,REP,266
+Suffolk,Southampton 4,President,,Donald J. Trump,REP,413
+Suffolk,Southampton 5,President,,Donald J. Trump,REP,225
+Suffolk,Southampton 6,President,,Donald J. Trump,REP,171
+Suffolk,Southampton 7,President,,Donald J. Trump,REP,218
+Suffolk,Southampton 8,President,,Donald J. Trump,REP,295
+Suffolk,Southampton 9,President,,Donald J. Trump,REP,373
+Suffolk,Southampton 10,President,,Donald J. Trump,REP,158
+Suffolk,Southampton 11,President,,Donald J. Trump,REP,638
+Suffolk,Southampton 12,President,,Donald J. Trump,REP,372
+Suffolk,Southampton 13,President,,Donald J. Trump,REP,171
+Suffolk,Southampton 14,President,,Donald J. Trump,REP,220
+Suffolk,Southampton 15,President,,Donald J. Trump,REP,323
+Suffolk,Southampton 16,President,,Donald J. Trump,REP,451
+Suffolk,Southampton 17,President,,Donald J. Trump,REP,306
+Suffolk,Southampton 18,President,,Donald J. Trump,REP,372
+Suffolk,Southampton 19,President,,Donald J. Trump,REP,137
+Suffolk,Southampton 20,President,,Donald J. Trump,REP,348
+Suffolk,Southampton 21,President,,Donald J. Trump,REP,112
+Suffolk,Southampton 22,President,,Donald J. Trump,REP,225
+Suffolk,Southampton 23,President,,Donald J. Trump,REP,675
+Suffolk,Southampton 24,President,,Donald J. Trump,REP,221
+Suffolk,Southampton 25,President,,Donald J. Trump,REP,337
+Suffolk,Southampton 26,President,,Donald J. Trump,REP,352
+Suffolk,Southampton 27,President,,Donald J. Trump,REP,611
+Suffolk,Southampton 28,President,,Donald J. Trump,REP,366
+Suffolk,Southampton 29,President,,Donald J. Trump,REP,356
+Suffolk,Southampton 30,President,,Donald J. Trump,REP,255
+Suffolk,Southampton 31,President,,Donald J. Trump,REP,233
+Suffolk,Southampton 32,President,,Donald J. Trump,REP,398
+Suffolk,Southampton 33,President,,Donald J. Trump,REP,300
+Suffolk,Southampton 34,President,,Donald J. Trump,REP,307
+Suffolk,Southampton 35,President,,Donald J. Trump,REP,435
+Suffolk,Southampton 36,President,,Donald J. Trump,REP,271
+Suffolk,Southampton 37,President,,Donald J. Trump,REP,337
+Suffolk,Southampton 38,President,,Donald J. Trump,REP,245
+Suffolk,Southampton 39,President,,Donald J. Trump,REP,243
+Suffolk,Southampton 40,President,,Donald J. Trump,REP,240
+Suffolk,Southampton 41,President,,Donald J. Trump,REP,150
+Suffolk,Southampton 42,President,,Donald J. Trump,REP,240
 Suffolk,Southold 1,President,,Donald J. Trump,REP,51
 Suffolk,Southold 2,President,,Donald J. Trump,REP,188
 Suffolk,Southold 3,President,,Donald J. Trump,REP,232
@@ -9108,48 +9108,48 @@ Suffolk,Smithtown 89,President,,Donald J. Trump,CON,25
 Suffolk,Smithtown 90,President,,Donald J. Trump,CON,21
 Suffolk,Smithtown 91,President,,Donald J. Trump,CON,34
 Suffolk,Smithtown 92,President,,Donald J. Trump,CON,32
-Suffolk,Smithtown 1,President,,Donald J. Trump,CON,23
-Suffolk,Smithtown 2,President,,Donald J. Trump,CON,19
-Suffolk,Smithtown 3,President,,Donald J. Trump,CON,20
-Suffolk,Smithtown 4,President,,Donald J. Trump,CON,42
-Suffolk,Smithtown 5,President,,Donald J. Trump,CON,12
-Suffolk,Smithtown 6,President,,Donald J. Trump,CON,16
-Suffolk,Smithtown 7,President,,Donald J. Trump,CON,12
-Suffolk,Smithtown 8,President,,Donald J. Trump,CON,47
-Suffolk,Smithtown 9,President,,Donald J. Trump,CON,35
-Suffolk,Smithtown 10,President,,Donald J. Trump,CON,17
-Suffolk,Smithtown 11,President,,Donald J. Trump,CON,87
-Suffolk,Smithtown 12,President,,Donald J. Trump,CON,48
-Suffolk,Smithtown 13,President,,Donald J. Trump,CON,7
-Suffolk,Smithtown 14,President,,Donald J. Trump,CON,19
-Suffolk,Smithtown 15,President,,Donald J. Trump,CON,39
-Suffolk,Smithtown 16,President,,Donald J. Trump,CON,46
-Suffolk,Smithtown 17,President,,Donald J. Trump,CON,34
-Suffolk,Smithtown 18,President,,Donald J. Trump,CON,30
-Suffolk,Smithtown 19,President,,Donald J. Trump,CON,15
-Suffolk,Smithtown 20,President,,Donald J. Trump,CON,35
-Suffolk,Smithtown 21,President,,Donald J. Trump,CON,11
-Suffolk,Smithtown 22,President,,Donald J. Trump,CON,26
-Suffolk,Smithtown 23,President,,Donald J. Trump,CON,96
-Suffolk,Smithtown 24,President,,Donald J. Trump,CON,20
-Suffolk,Smithtown 25,President,,Donald J. Trump,CON,35
-Suffolk,Smithtown 26,President,,Donald J. Trump,CON,44
-Suffolk,Smithtown 27,President,,Donald J. Trump,CON,55
-Suffolk,Smithtown 28,President,,Donald J. Trump,CON,49
-Suffolk,Smithtown 29,President,,Donald J. Trump,CON,27
-Suffolk,Smithtown 30,President,,Donald J. Trump,CON,22
-Suffolk,Smithtown 31,President,,Donald J. Trump,CON,39
-Suffolk,Smithtown 32,President,,Donald J. Trump,CON,45
-Suffolk,Smithtown 33,President,,Donald J. Trump,CON,34
-Suffolk,Smithtown 34,President,,Donald J. Trump,CON,28
-Suffolk,Smithtown 35,President,,Donald J. Trump,CON,31
-Suffolk,Smithtown 36,President,,Donald J. Trump,CON,39
-Suffolk,Smithtown 37,President,,Donald J. Trump,CON,38
-Suffolk,Smithtown 38,President,,Donald J. Trump,CON,27
-Suffolk,Smithtown 39,President,,Donald J. Trump,CON,35
-Suffolk,Smithtown 40,President,,Donald J. Trump,CON,23
-Suffolk,Smithtown 41,President,,Donald J. Trump,CON,16
-Suffolk,Smithtown 42,President,,Donald J. Trump,CON,35
+Suffolk,Southampton 1,President,,Donald J. Trump,CON,23
+Suffolk,Southampton 2,President,,Donald J. Trump,CON,19
+Suffolk,Southampton 3,President,,Donald J. Trump,CON,20
+Suffolk,Southampton 4,President,,Donald J. Trump,CON,42
+Suffolk,Southampton 5,President,,Donald J. Trump,CON,12
+Suffolk,Southampton 6,President,,Donald J. Trump,CON,16
+Suffolk,Southampton 7,President,,Donald J. Trump,CON,12
+Suffolk,Southampton 8,President,,Donald J. Trump,CON,47
+Suffolk,Southampton 9,President,,Donald J. Trump,CON,35
+Suffolk,Southampton 10,President,,Donald J. Trump,CON,17
+Suffolk,Southampton 11,President,,Donald J. Trump,CON,87
+Suffolk,Southampton 12,President,,Donald J. Trump,CON,48
+Suffolk,Southampton 13,President,,Donald J. Trump,CON,7
+Suffolk,Southampton 14,President,,Donald J. Trump,CON,19
+Suffolk,Southampton 15,President,,Donald J. Trump,CON,39
+Suffolk,Southampton 16,President,,Donald J. Trump,CON,46
+Suffolk,Southampton 17,President,,Donald J. Trump,CON,34
+Suffolk,Southampton 18,President,,Donald J. Trump,CON,30
+Suffolk,Southampton 19,President,,Donald J. Trump,CON,15
+Suffolk,Southampton 20,President,,Donald J. Trump,CON,35
+Suffolk,Southampton 21,President,,Donald J. Trump,CON,11
+Suffolk,Southampton 22,President,,Donald J. Trump,CON,26
+Suffolk,Southampton 23,President,,Donald J. Trump,CON,96
+Suffolk,Southampton 24,President,,Donald J. Trump,CON,20
+Suffolk,Southampton 25,President,,Donald J. Trump,CON,35
+Suffolk,Southampton 26,President,,Donald J. Trump,CON,44
+Suffolk,Southampton 27,President,,Donald J. Trump,CON,55
+Suffolk,Southampton 28,President,,Donald J. Trump,CON,49
+Suffolk,Southampton 29,President,,Donald J. Trump,CON,27
+Suffolk,Southampton 30,President,,Donald J. Trump,CON,22
+Suffolk,Southampton 31,President,,Donald J. Trump,CON,39
+Suffolk,Southampton 32,President,,Donald J. Trump,CON,45
+Suffolk,Southampton 33,President,,Donald J. Trump,CON,34
+Suffolk,Southampton 34,President,,Donald J. Trump,CON,28
+Suffolk,Southampton 35,President,,Donald J. Trump,CON,31
+Suffolk,Southampton 36,President,,Donald J. Trump,CON,39
+Suffolk,Southampton 37,President,,Donald J. Trump,CON,38
+Suffolk,Southampton 38,President,,Donald J. Trump,CON,27
+Suffolk,Southampton 39,President,,Donald J. Trump,CON,35
+Suffolk,Southampton 40,President,,Donald J. Trump,CON,23
+Suffolk,Southampton 41,President,,Donald J. Trump,CON,16
+Suffolk,Southampton 42,President,,Donald J. Trump,CON,35
 Suffolk,Southold 1,President,,Donald J. Trump,CON,2
 Suffolk,Southold 2,President,,Donald J. Trump,CON,28
 Suffolk,Southold 3,President,,Donald J. Trump,CON,27
@@ -9513,48 +9513,48 @@ Suffolk,Smithtown 89,President,,Howie Hawkins,GRE,0
 Suffolk,Smithtown 90,President,,Howie Hawkins,GRE,1
 Suffolk,Smithtown 91,President,,Howie Hawkins,GRE,1
 Suffolk,Smithtown 92,President,,Howie Hawkins,GRE,0
-Suffolk,Smithtown 1,President,,Howie Hawkins,GRE,3
-Suffolk,Smithtown 2,President,,Howie Hawkins,GRE,0
-Suffolk,Smithtown 3,President,,Howie Hawkins,GRE,3
-Suffolk,Smithtown 4,President,,Howie Hawkins,GRE,5
-Suffolk,Smithtown 5,President,,Howie Hawkins,GRE,0
-Suffolk,Smithtown 6,President,,Howie Hawkins,GRE,1
-Suffolk,Smithtown 7,President,,Howie Hawkins,GRE,2
-Suffolk,Smithtown 8,President,,Howie Hawkins,GRE,6
-Suffolk,Smithtown 9,President,,Howie Hawkins,GRE,1
-Suffolk,Smithtown 10,President,,Howie Hawkins,GRE,0
-Suffolk,Smithtown 11,President,,Howie Hawkins,GRE,1
-Suffolk,Smithtown 12,President,,Howie Hawkins,GRE,5
-Suffolk,Smithtown 13,President,,Howie Hawkins,GRE,1
-Suffolk,Smithtown 14,President,,Howie Hawkins,GRE,0
-Suffolk,Smithtown 15,President,,Howie Hawkins,GRE,2
-Suffolk,Smithtown 16,President,,Howie Hawkins,GRE,0
-Suffolk,Smithtown 17,President,,Howie Hawkins,GRE,1
-Suffolk,Smithtown 18,President,,Howie Hawkins,GRE,1
-Suffolk,Smithtown 19,President,,Howie Hawkins,GRE,3
-Suffolk,Smithtown 20,President,,Howie Hawkins,GRE,3
-Suffolk,Smithtown 21,President,,Howie Hawkins,GRE,1
-Suffolk,Smithtown 22,President,,Howie Hawkins,GRE,1
-Suffolk,Smithtown 23,President,,Howie Hawkins,GRE,3
-Suffolk,Smithtown 24,President,,Howie Hawkins,GRE,0
-Suffolk,Smithtown 25,President,,Howie Hawkins,GRE,5
-Suffolk,Smithtown 26,President,,Howie Hawkins,GRE,2
-Suffolk,Smithtown 27,President,,Howie Hawkins,GRE,4
-Suffolk,Smithtown 28,President,,Howie Hawkins,GRE,2
-Suffolk,Smithtown 29,President,,Howie Hawkins,GRE,0
-Suffolk,Smithtown 30,President,,Howie Hawkins,GRE,4
-Suffolk,Smithtown 31,President,,Howie Hawkins,GRE,3
-Suffolk,Smithtown 32,President,,Howie Hawkins,GRE,7
-Suffolk,Smithtown 33,President,,Howie Hawkins,GRE,0
-Suffolk,Smithtown 34,President,,Howie Hawkins,GRE,2
-Suffolk,Smithtown 35,President,,Howie Hawkins,GRE,1
-Suffolk,Smithtown 36,President,,Howie Hawkins,GRE,1
-Suffolk,Smithtown 37,President,,Howie Hawkins,GRE,2
-Suffolk,Smithtown 38,President,,Howie Hawkins,GRE,4
-Suffolk,Smithtown 39,President,,Howie Hawkins,GRE,2
-Suffolk,Smithtown 40,President,,Howie Hawkins,GRE,4
-Suffolk,Smithtown 41,President,,Howie Hawkins,GRE,0
-Suffolk,Smithtown 42,President,,Howie Hawkins,GRE,1
+Suffolk,Southampton 1,President,,Howie Hawkins,GRE,3
+Suffolk,Southampton 2,President,,Howie Hawkins,GRE,0
+Suffolk,Southampton 3,President,,Howie Hawkins,GRE,3
+Suffolk,Southampton 4,President,,Howie Hawkins,GRE,5
+Suffolk,Southampton 5,President,,Howie Hawkins,GRE,0
+Suffolk,Southampton 6,President,,Howie Hawkins,GRE,1
+Suffolk,Southampton 7,President,,Howie Hawkins,GRE,2
+Suffolk,Southampton 8,President,,Howie Hawkins,GRE,6
+Suffolk,Southampton 9,President,,Howie Hawkins,GRE,1
+Suffolk,Southampton 10,President,,Howie Hawkins,GRE,0
+Suffolk,Southampton 11,President,,Howie Hawkins,GRE,1
+Suffolk,Southampton 12,President,,Howie Hawkins,GRE,5
+Suffolk,Southampton 13,President,,Howie Hawkins,GRE,1
+Suffolk,Southampton 14,President,,Howie Hawkins,GRE,0
+Suffolk,Southampton 15,President,,Howie Hawkins,GRE,2
+Suffolk,Southampton 16,President,,Howie Hawkins,GRE,0
+Suffolk,Southampton 17,President,,Howie Hawkins,GRE,1
+Suffolk,Southampton 18,President,,Howie Hawkins,GRE,1
+Suffolk,Southampton 19,President,,Howie Hawkins,GRE,3
+Suffolk,Southampton 20,President,,Howie Hawkins,GRE,3
+Suffolk,Southampton 21,President,,Howie Hawkins,GRE,1
+Suffolk,Southampton 22,President,,Howie Hawkins,GRE,1
+Suffolk,Southampton 23,President,,Howie Hawkins,GRE,3
+Suffolk,Southampton 24,President,,Howie Hawkins,GRE,0
+Suffolk,Southampton 25,President,,Howie Hawkins,GRE,5
+Suffolk,Southampton 26,President,,Howie Hawkins,GRE,2
+Suffolk,Southampton 27,President,,Howie Hawkins,GRE,4
+Suffolk,Southampton 28,President,,Howie Hawkins,GRE,2
+Suffolk,Southampton 29,President,,Howie Hawkins,GRE,0
+Suffolk,Southampton 30,President,,Howie Hawkins,GRE,4
+Suffolk,Southampton 31,President,,Howie Hawkins,GRE,3
+Suffolk,Southampton 32,President,,Howie Hawkins,GRE,7
+Suffolk,Southampton 33,President,,Howie Hawkins,GRE,0
+Suffolk,Southampton 34,President,,Howie Hawkins,GRE,2
+Suffolk,Southampton 35,President,,Howie Hawkins,GRE,1
+Suffolk,Southampton 36,President,,Howie Hawkins,GRE,1
+Suffolk,Southampton 37,President,,Howie Hawkins,GRE,2
+Suffolk,Southampton 38,President,,Howie Hawkins,GRE,4
+Suffolk,Southampton 39,President,,Howie Hawkins,GRE,2
+Suffolk,Southampton 40,President,,Howie Hawkins,GRE,4
+Suffolk,Southampton 41,President,,Howie Hawkins,GRE,0
+Suffolk,Southampton 42,President,,Howie Hawkins,GRE,1
 Suffolk,Southold 1,President,,Howie Hawkins,GRE,0
 Suffolk,Southold 2,President,,Howie Hawkins,GRE,1
 Suffolk,Southold 3,President,,Howie Hawkins,GRE,2
@@ -9918,48 +9918,48 @@ Suffolk,Smithtown 89,President,,Jo Jorgensen,LBT,2
 Suffolk,Smithtown 90,President,,Jo Jorgensen,LBT,3
 Suffolk,Smithtown 91,President,,Jo Jorgensen,LBT,4
 Suffolk,Smithtown 92,President,,Jo Jorgensen,LBT,5
-Suffolk,Smithtown 1,President,,Jo Jorgensen,LBT,6
-Suffolk,Smithtown 2,President,,Jo Jorgensen,LBT,4
-Suffolk,Smithtown 3,President,,Jo Jorgensen,LBT,5
-Suffolk,Smithtown 4,President,,Jo Jorgensen,LBT,9
-Suffolk,Smithtown 5,President,,Jo Jorgensen,LBT,2
-Suffolk,Smithtown 6,President,,Jo Jorgensen,LBT,4
-Suffolk,Smithtown 7,President,,Jo Jorgensen,LBT,0
-Suffolk,Smithtown 8,President,,Jo Jorgensen,LBT,8
-Suffolk,Smithtown 9,President,,Jo Jorgensen,LBT,6
-Suffolk,Smithtown 10,President,,Jo Jorgensen,LBT,0
-Suffolk,Smithtown 11,President,,Jo Jorgensen,LBT,7
-Suffolk,Smithtown 12,President,,Jo Jorgensen,LBT,7
-Suffolk,Smithtown 13,President,,Jo Jorgensen,LBT,6
-Suffolk,Smithtown 14,President,,Jo Jorgensen,LBT,0
-Suffolk,Smithtown 15,President,,Jo Jorgensen,LBT,4
-Suffolk,Smithtown 16,President,,Jo Jorgensen,LBT,2
-Suffolk,Smithtown 17,President,,Jo Jorgensen,LBT,1
-Suffolk,Smithtown 18,President,,Jo Jorgensen,LBT,5
-Suffolk,Smithtown 19,President,,Jo Jorgensen,LBT,2
-Suffolk,Smithtown 20,President,,Jo Jorgensen,LBT,3
-Suffolk,Smithtown 21,President,,Jo Jorgensen,LBT,5
-Suffolk,Smithtown 22,President,,Jo Jorgensen,LBT,3
-Suffolk,Smithtown 23,President,,Jo Jorgensen,LBT,9
-Suffolk,Smithtown 24,President,,Jo Jorgensen,LBT,6
-Suffolk,Smithtown 25,President,,Jo Jorgensen,LBT,10
-Suffolk,Smithtown 26,President,,Jo Jorgensen,LBT,2
-Suffolk,Smithtown 27,President,,Jo Jorgensen,LBT,4
-Suffolk,Smithtown 28,President,,Jo Jorgensen,LBT,9
-Suffolk,Smithtown 29,President,,Jo Jorgensen,LBT,1
-Suffolk,Smithtown 30,President,,Jo Jorgensen,LBT,8
-Suffolk,Smithtown 31,President,,Jo Jorgensen,LBT,7
-Suffolk,Smithtown 32,President,,Jo Jorgensen,LBT,2
-Suffolk,Smithtown 33,President,,Jo Jorgensen,LBT,3
-Suffolk,Smithtown 34,President,,Jo Jorgensen,LBT,2
-Suffolk,Smithtown 35,President,,Jo Jorgensen,LBT,4
-Suffolk,Smithtown 36,President,,Jo Jorgensen,LBT,4
-Suffolk,Smithtown 37,President,,Jo Jorgensen,LBT,3
-Suffolk,Smithtown 38,President,,Jo Jorgensen,LBT,3
-Suffolk,Smithtown 39,President,,Jo Jorgensen,LBT,3
-Suffolk,Smithtown 40,President,,Jo Jorgensen,LBT,5
-Suffolk,Smithtown 41,President,,Jo Jorgensen,LBT,0
-Suffolk,Smithtown 42,President,,Jo Jorgensen,LBT,4
+Suffolk,Southampton 1,President,,Jo Jorgensen,LBT,6
+Suffolk,Southampton 2,President,,Jo Jorgensen,LBT,4
+Suffolk,Southampton 3,President,,Jo Jorgensen,LBT,5
+Suffolk,Southampton 4,President,,Jo Jorgensen,LBT,9
+Suffolk,Southampton 5,President,,Jo Jorgensen,LBT,2
+Suffolk,Southampton 6,President,,Jo Jorgensen,LBT,4
+Suffolk,Southampton 7,President,,Jo Jorgensen,LBT,0
+Suffolk,Southampton 8,President,,Jo Jorgensen,LBT,8
+Suffolk,Southampton 9,President,,Jo Jorgensen,LBT,6
+Suffolk,Southampton 10,President,,Jo Jorgensen,LBT,0
+Suffolk,Southampton 11,President,,Jo Jorgensen,LBT,7
+Suffolk,Southampton 12,President,,Jo Jorgensen,LBT,7
+Suffolk,Southampton 13,President,,Jo Jorgensen,LBT,6
+Suffolk,Southampton 14,President,,Jo Jorgensen,LBT,0
+Suffolk,Southampton 15,President,,Jo Jorgensen,LBT,4
+Suffolk,Southampton 16,President,,Jo Jorgensen,LBT,2
+Suffolk,Southampton 17,President,,Jo Jorgensen,LBT,1
+Suffolk,Southampton 18,President,,Jo Jorgensen,LBT,5
+Suffolk,Southampton 19,President,,Jo Jorgensen,LBT,2
+Suffolk,Southampton 20,President,,Jo Jorgensen,LBT,3
+Suffolk,Southampton 21,President,,Jo Jorgensen,LBT,5
+Suffolk,Southampton 22,President,,Jo Jorgensen,LBT,3
+Suffolk,Southampton 23,President,,Jo Jorgensen,LBT,9
+Suffolk,Southampton 24,President,,Jo Jorgensen,LBT,6
+Suffolk,Southampton 25,President,,Jo Jorgensen,LBT,10
+Suffolk,Southampton 26,President,,Jo Jorgensen,LBT,2
+Suffolk,Southampton 27,President,,Jo Jorgensen,LBT,4
+Suffolk,Southampton 28,President,,Jo Jorgensen,LBT,9
+Suffolk,Southampton 29,President,,Jo Jorgensen,LBT,1
+Suffolk,Southampton 30,President,,Jo Jorgensen,LBT,8
+Suffolk,Southampton 31,President,,Jo Jorgensen,LBT,7
+Suffolk,Southampton 32,President,,Jo Jorgensen,LBT,2
+Suffolk,Southampton 33,President,,Jo Jorgensen,LBT,3
+Suffolk,Southampton 34,President,,Jo Jorgensen,LBT,2
+Suffolk,Southampton 35,President,,Jo Jorgensen,LBT,4
+Suffolk,Southampton 36,President,,Jo Jorgensen,LBT,4
+Suffolk,Southampton 37,President,,Jo Jorgensen,LBT,3
+Suffolk,Southampton 38,President,,Jo Jorgensen,LBT,3
+Suffolk,Southampton 39,President,,Jo Jorgensen,LBT,3
+Suffolk,Southampton 40,President,,Jo Jorgensen,LBT,5
+Suffolk,Southampton 41,President,,Jo Jorgensen,LBT,0
+Suffolk,Southampton 42,President,,Jo Jorgensen,LBT,4
 Suffolk,Southold 1,President,,Jo Jorgensen,LBT,1
 Suffolk,Southold 2,President,,Jo Jorgensen,LBT,2
 Suffolk,Southold 3,President,,Jo Jorgensen,LBT,5
@@ -10323,48 +10323,48 @@ Suffolk,Smithtown 89,President,,Brock Pierce,IND,1
 Suffolk,Smithtown 90,President,,Brock Pierce,IND,1
 Suffolk,Smithtown 91,President,,Brock Pierce,IND,5
 Suffolk,Smithtown 92,President,,Brock Pierce,IND,0
-Suffolk,Smithtown 1,President,,Brock Pierce,IND,2
-Suffolk,Smithtown 2,President,,Brock Pierce,IND,0
-Suffolk,Smithtown 3,President,,Brock Pierce,IND,3
-Suffolk,Smithtown 4,President,,Brock Pierce,IND,5
-Suffolk,Smithtown 5,President,,Brock Pierce,IND,1
-Suffolk,Smithtown 6,President,,Brock Pierce,IND,1
-Suffolk,Smithtown 7,President,,Brock Pierce,IND,2
-Suffolk,Smithtown 8,President,,Brock Pierce,IND,3
-Suffolk,Smithtown 9,President,,Brock Pierce,IND,5
-Suffolk,Smithtown 10,President,,Brock Pierce,IND,1
-Suffolk,Smithtown 11,President,,Brock Pierce,IND,3
-Suffolk,Smithtown 12,President,,Brock Pierce,IND,1
-Suffolk,Smithtown 13,President,,Brock Pierce,IND,0
-Suffolk,Smithtown 14,President,,Brock Pierce,IND,3
-Suffolk,Smithtown 15,President,,Brock Pierce,IND,2
-Suffolk,Smithtown 16,President,,Brock Pierce,IND,4
-Suffolk,Smithtown 17,President,,Brock Pierce,IND,4
-Suffolk,Smithtown 18,President,,Brock Pierce,IND,3
-Suffolk,Smithtown 19,President,,Brock Pierce,IND,1
-Suffolk,Smithtown 20,President,,Brock Pierce,IND,2
-Suffolk,Smithtown 21,President,,Brock Pierce,IND,2
-Suffolk,Smithtown 22,President,,Brock Pierce,IND,1
-Suffolk,Smithtown 23,President,,Brock Pierce,IND,13
-Suffolk,Smithtown 24,President,,Brock Pierce,IND,1
-Suffolk,Smithtown 25,President,,Brock Pierce,IND,4
-Suffolk,Smithtown 26,President,,Brock Pierce,IND,7
-Suffolk,Smithtown 27,President,,Brock Pierce,IND,5
-Suffolk,Smithtown 28,President,,Brock Pierce,IND,2
-Suffolk,Smithtown 29,President,,Brock Pierce,IND,2
-Suffolk,Smithtown 30,President,,Brock Pierce,IND,1
-Suffolk,Smithtown 31,President,,Brock Pierce,IND,3
-Suffolk,Smithtown 32,President,,Brock Pierce,IND,5
-Suffolk,Smithtown 33,President,,Brock Pierce,IND,4
-Suffolk,Smithtown 34,President,,Brock Pierce,IND,6
-Suffolk,Smithtown 35,President,,Brock Pierce,IND,3
-Suffolk,Smithtown 36,President,,Brock Pierce,IND,1
-Suffolk,Smithtown 37,President,,Brock Pierce,IND,3
-Suffolk,Smithtown 38,President,,Brock Pierce,IND,2
-Suffolk,Smithtown 39,President,,Brock Pierce,IND,9
-Suffolk,Smithtown 40,President,,Brock Pierce,IND,1
-Suffolk,Smithtown 41,President,,Brock Pierce,IND,1
-Suffolk,Smithtown 42,President,,Brock Pierce,IND,4
+Suffolk,Southampton 1,President,,Brock Pierce,IND,2
+Suffolk,Southampton 2,President,,Brock Pierce,IND,0
+Suffolk,Southampton 3,President,,Brock Pierce,IND,3
+Suffolk,Southampton 4,President,,Brock Pierce,IND,5
+Suffolk,Southampton 5,President,,Brock Pierce,IND,1
+Suffolk,Southampton 6,President,,Brock Pierce,IND,1
+Suffolk,Southampton 7,President,,Brock Pierce,IND,2
+Suffolk,Southampton 8,President,,Brock Pierce,IND,3
+Suffolk,Southampton 9,President,,Brock Pierce,IND,5
+Suffolk,Southampton 10,President,,Brock Pierce,IND,1
+Suffolk,Southampton 11,President,,Brock Pierce,IND,3
+Suffolk,Southampton 12,President,,Brock Pierce,IND,1
+Suffolk,Southampton 13,President,,Brock Pierce,IND,0
+Suffolk,Southampton 14,President,,Brock Pierce,IND,3
+Suffolk,Southampton 15,President,,Brock Pierce,IND,2
+Suffolk,Southampton 16,President,,Brock Pierce,IND,4
+Suffolk,Southampton 17,President,,Brock Pierce,IND,4
+Suffolk,Southampton 18,President,,Brock Pierce,IND,3
+Suffolk,Southampton 19,President,,Brock Pierce,IND,1
+Suffolk,Southampton 20,President,,Brock Pierce,IND,2
+Suffolk,Southampton 21,President,,Brock Pierce,IND,2
+Suffolk,Southampton 22,President,,Brock Pierce,IND,1
+Suffolk,Southampton 23,President,,Brock Pierce,IND,13
+Suffolk,Southampton 24,President,,Brock Pierce,IND,1
+Suffolk,Southampton 25,President,,Brock Pierce,IND,4
+Suffolk,Southampton 26,President,,Brock Pierce,IND,7
+Suffolk,Southampton 27,President,,Brock Pierce,IND,5
+Suffolk,Southampton 28,President,,Brock Pierce,IND,2
+Suffolk,Southampton 29,President,,Brock Pierce,IND,2
+Suffolk,Southampton 30,President,,Brock Pierce,IND,1
+Suffolk,Southampton 31,President,,Brock Pierce,IND,3
+Suffolk,Southampton 32,President,,Brock Pierce,IND,5
+Suffolk,Southampton 33,President,,Brock Pierce,IND,4
+Suffolk,Southampton 34,President,,Brock Pierce,IND,6
+Suffolk,Southampton 35,President,,Brock Pierce,IND,3
+Suffolk,Southampton 36,President,,Brock Pierce,IND,1
+Suffolk,Southampton 37,President,,Brock Pierce,IND,3
+Suffolk,Southampton 38,President,,Brock Pierce,IND,2
+Suffolk,Southampton 39,President,,Brock Pierce,IND,9
+Suffolk,Southampton 40,President,,Brock Pierce,IND,1
+Suffolk,Southampton 41,President,,Brock Pierce,IND,1
+Suffolk,Southampton 42,President,,Brock Pierce,IND,4
 Suffolk,Southold 1,President,,Brock Pierce,IND,1
 Suffolk,Southold 2,President,,Brock Pierce,IND,3
 Suffolk,Southold 3,President,,Brock Pierce,IND,1
@@ -10728,48 +10728,48 @@ Suffolk,Smithtown 89,President,,Scattering,,1
 Suffolk,Smithtown 90,President,,Scattering,,1
 Suffolk,Smithtown 91,President,,Scattering,,1
 Suffolk,Smithtown 92,President,,Scattering,,3
-Suffolk,Smithtown 1,President,,Scattering,,1
-Suffolk,Smithtown 2,President,,Scattering,,0
-Suffolk,Smithtown 3,President,,Scattering,,3
-Suffolk,Smithtown 4,President,,Scattering,,6
-Suffolk,Smithtown 5,President,,Scattering,,7
-Suffolk,Smithtown 6,President,,Scattering,,2
-Suffolk,Smithtown 7,President,,Scattering,,2
-Suffolk,Smithtown 8,President,,Scattering,,1
-Suffolk,Smithtown 9,President,,Scattering,,2
-Suffolk,Smithtown 10,President,,Scattering,,3
-Suffolk,Smithtown 11,President,,Scattering,,3
-Suffolk,Smithtown 12,President,,Scattering,,0
-Suffolk,Smithtown 13,President,,Scattering,,5
-Suffolk,Smithtown 14,President,,Scattering,,3
-Suffolk,Smithtown 15,President,,Scattering,,1
-Suffolk,Smithtown 16,President,,Scattering,,3
-Suffolk,Smithtown 17,President,,Scattering,,3
-Suffolk,Smithtown 18,President,,Scattering,,3
-Suffolk,Smithtown 19,President,,Scattering,,1
-Suffolk,Smithtown 20,President,,Scattering,,1
-Suffolk,Smithtown 21,President,,Scattering,,2
-Suffolk,Smithtown 22,President,,Scattering,,4
-Suffolk,Smithtown 23,President,,Scattering,,4
-Suffolk,Smithtown 24,President,,Scattering,,3
-Suffolk,Smithtown 25,President,,Scattering,,0
-Suffolk,Smithtown 26,President,,Scattering,,2
-Suffolk,Smithtown 27,President,,Scattering,,4
-Suffolk,Smithtown 28,President,,Scattering,,3
-Suffolk,Smithtown 29,President,,Scattering,,2
-Suffolk,Smithtown 30,President,,Scattering,,2
-Suffolk,Smithtown 31,President,,Scattering,,0
-Suffolk,Smithtown 32,President,,Scattering,,4
-Suffolk,Smithtown 33,President,,Scattering,,0
-Suffolk,Smithtown 34,President,,Scattering,,2
-Suffolk,Smithtown 35,President,,Scattering,,1
-Suffolk,Smithtown 36,President,,Scattering,,1
-Suffolk,Smithtown 37,President,,Scattering,,2
-Suffolk,Smithtown 38,President,,Scattering,,3
-Suffolk,Smithtown 39,President,,Scattering,,1
-Suffolk,Smithtown 40,President,,Scattering,,0
-Suffolk,Smithtown 41,President,,Scattering,,0
-Suffolk,Smithtown 42,President,,Scattering,,0
+Suffolk,Southampton 1,President,,Scattering,,1
+Suffolk,Southampton 2,President,,Scattering,,0
+Suffolk,Southampton 3,President,,Scattering,,3
+Suffolk,Southampton 4,President,,Scattering,,6
+Suffolk,Southampton 5,President,,Scattering,,7
+Suffolk,Southampton 6,President,,Scattering,,2
+Suffolk,Southampton 7,President,,Scattering,,2
+Suffolk,Southampton 8,President,,Scattering,,1
+Suffolk,Southampton 9,President,,Scattering,,2
+Suffolk,Southampton 10,President,,Scattering,,3
+Suffolk,Southampton 11,President,,Scattering,,3
+Suffolk,Southampton 12,President,,Scattering,,0
+Suffolk,Southampton 13,President,,Scattering,,5
+Suffolk,Southampton 14,President,,Scattering,,3
+Suffolk,Southampton 15,President,,Scattering,,1
+Suffolk,Southampton 16,President,,Scattering,,3
+Suffolk,Southampton 17,President,,Scattering,,3
+Suffolk,Southampton 18,President,,Scattering,,3
+Suffolk,Southampton 19,President,,Scattering,,1
+Suffolk,Southampton 20,President,,Scattering,,1
+Suffolk,Southampton 21,President,,Scattering,,2
+Suffolk,Southampton 22,President,,Scattering,,4
+Suffolk,Southampton 23,President,,Scattering,,4
+Suffolk,Southampton 24,President,,Scattering,,3
+Suffolk,Southampton 25,President,,Scattering,,0
+Suffolk,Southampton 26,President,,Scattering,,2
+Suffolk,Southampton 27,President,,Scattering,,4
+Suffolk,Southampton 28,President,,Scattering,,3
+Suffolk,Southampton 29,President,,Scattering,,2
+Suffolk,Southampton 30,President,,Scattering,,2
+Suffolk,Southampton 31,President,,Scattering,,0
+Suffolk,Southampton 32,President,,Scattering,,4
+Suffolk,Southampton 33,President,,Scattering,,0
+Suffolk,Southampton 34,President,,Scattering,,2
+Suffolk,Southampton 35,President,,Scattering,,1
+Suffolk,Southampton 36,President,,Scattering,,1
+Suffolk,Southampton 37,President,,Scattering,,2
+Suffolk,Southampton 38,President,,Scattering,,3
+Suffolk,Southampton 39,President,,Scattering,,1
+Suffolk,Southampton 40,President,,Scattering,,0
+Suffolk,Southampton 41,President,,Scattering,,0
+Suffolk,Southampton 42,President,,Scattering,,0
 Suffolk,Southold 1,President,,Scattering,,0
 Suffolk,Southold 2,President,,Scattering,,2
 Suffolk,Southold 3,President,,Scattering,,2
@@ -11133,48 +11133,48 @@ Suffolk,Smithtown 89,President,,Voids,,0
 Suffolk,Smithtown 90,President,,Voids,,0
 Suffolk,Smithtown 91,President,,Voids,,0
 Suffolk,Smithtown 92,President,,Voids,,0
-Suffolk,Smithtown 1,President,,Voids,,0
-Suffolk,Smithtown 2,President,,Voids,,0
-Suffolk,Smithtown 3,President,,Voids,,0
-Suffolk,Smithtown 4,President,,Voids,,0
-Suffolk,Smithtown 5,President,,Voids,,0
-Suffolk,Smithtown 6,President,,Voids,,0
-Suffolk,Smithtown 7,President,,Voids,,0
-Suffolk,Smithtown 8,President,,Voids,,0
-Suffolk,Smithtown 9,President,,Voids,,0
-Suffolk,Smithtown 10,President,,Voids,,0
-Suffolk,Smithtown 11,President,,Voids,,1
-Suffolk,Smithtown 12,President,,Voids,,0
-Suffolk,Smithtown 13,President,,Voids,,1
-Suffolk,Smithtown 14,President,,Voids,,0
-Suffolk,Smithtown 15,President,,Voids,,2
-Suffolk,Smithtown 16,President,,Voids,,0
-Suffolk,Smithtown 17,President,,Voids,,0
-Suffolk,Smithtown 18,President,,Voids,,1
-Suffolk,Smithtown 19,President,,Voids,,1
-Suffolk,Smithtown 20,President,,Voids,,1
-Suffolk,Smithtown 21,President,,Voids,,0
-Suffolk,Smithtown 22,President,,Voids,,1
-Suffolk,Smithtown 23,President,,Voids,,0
-Suffolk,Smithtown 24,President,,Voids,,0
-Suffolk,Smithtown 25,President,,Voids,,1
-Suffolk,Smithtown 26,President,,Voids,,0
-Suffolk,Smithtown 27,President,,Voids,,1
-Suffolk,Smithtown 28,President,,Voids,,2
-Suffolk,Smithtown 29,President,,Voids,,0
-Suffolk,Smithtown 30,President,,Voids,,1
-Suffolk,Smithtown 31,President,,Voids,,0
-Suffolk,Smithtown 32,President,,Voids,,1
-Suffolk,Smithtown 33,President,,Voids,,0
-Suffolk,Smithtown 34,President,,Voids,,1
-Suffolk,Smithtown 35,President,,Voids,,0
-Suffolk,Smithtown 36,President,,Voids,,0
-Suffolk,Smithtown 37,President,,Voids,,0
-Suffolk,Smithtown 38,President,,Voids,,0
-Suffolk,Smithtown 39,President,,Voids,,0
-Suffolk,Smithtown 40,President,,Voids,,0
-Suffolk,Smithtown 41,President,,Voids,,0
-Suffolk,Smithtown 42,President,,Voids,,0
+Suffolk,Southampton 1,President,,Voids,,0
+Suffolk,Southampton 2,President,,Voids,,0
+Suffolk,Southampton 3,President,,Voids,,0
+Suffolk,Southampton 4,President,,Voids,,0
+Suffolk,Southampton 5,President,,Voids,,0
+Suffolk,Southampton 6,President,,Voids,,0
+Suffolk,Southampton 7,President,,Voids,,0
+Suffolk,Southampton 8,President,,Voids,,0
+Suffolk,Southampton 9,President,,Voids,,0
+Suffolk,Southampton 10,President,,Voids,,0
+Suffolk,Southampton 11,President,,Voids,,1
+Suffolk,Southampton 12,President,,Voids,,0
+Suffolk,Southampton 13,President,,Voids,,1
+Suffolk,Southampton 14,President,,Voids,,0
+Suffolk,Southampton 15,President,,Voids,,2
+Suffolk,Southampton 16,President,,Voids,,0
+Suffolk,Southampton 17,President,,Voids,,0
+Suffolk,Southampton 18,President,,Voids,,1
+Suffolk,Southampton 19,President,,Voids,,1
+Suffolk,Southampton 20,President,,Voids,,1
+Suffolk,Southampton 21,President,,Voids,,0
+Suffolk,Southampton 22,President,,Voids,,1
+Suffolk,Southampton 23,President,,Voids,,0
+Suffolk,Southampton 24,President,,Voids,,0
+Suffolk,Southampton 25,President,,Voids,,1
+Suffolk,Southampton 26,President,,Voids,,0
+Suffolk,Southampton 27,President,,Voids,,1
+Suffolk,Southampton 28,President,,Voids,,2
+Suffolk,Southampton 29,President,,Voids,,0
+Suffolk,Southampton 30,President,,Voids,,1
+Suffolk,Southampton 31,President,,Voids,,0
+Suffolk,Southampton 32,President,,Voids,,1
+Suffolk,Southampton 33,President,,Voids,,0
+Suffolk,Southampton 34,President,,Voids,,1
+Suffolk,Southampton 35,President,,Voids,,0
+Suffolk,Southampton 36,President,,Voids,,0
+Suffolk,Southampton 37,President,,Voids,,0
+Suffolk,Southampton 38,President,,Voids,,0
+Suffolk,Southampton 39,President,,Voids,,0
+Suffolk,Southampton 40,President,,Voids,,0
+Suffolk,Southampton 41,President,,Voids,,0
+Suffolk,Southampton 42,President,,Voids,,0
 Suffolk,Southold 1,President,,Voids,,0
 Suffolk,Southold 2,President,,Voids,,0
 Suffolk,Southold 3,President,,Voids,,0
@@ -11538,48 +11538,48 @@ Suffolk,Smithtown 89,President,,Blanks,,2
 Suffolk,Smithtown 90,President,,Blanks,,5
 Suffolk,Smithtown 91,President,,Blanks,,1
 Suffolk,Smithtown 92,President,,Blanks,,3
-Suffolk,Smithtown 1,President,,Blanks,,5
-Suffolk,Smithtown 2,President,,Blanks,,1
-Suffolk,Smithtown 3,President,,Blanks,,6
-Suffolk,Smithtown 4,President,,Blanks,,13
-Suffolk,Smithtown 5,President,,Blanks,,9
-Suffolk,Smithtown 6,President,,Blanks,,4
-Suffolk,Smithtown 7,President,,Blanks,,3
-Suffolk,Smithtown 8,President,,Blanks,,3
-Suffolk,Smithtown 9,President,,Blanks,,9
-Suffolk,Smithtown 10,President,,Blanks,,4
-Suffolk,Smithtown 11,President,,Blanks,,4
-Suffolk,Smithtown 12,President,,Blanks,,3
-Suffolk,Smithtown 13,President,,Blanks,,2
-Suffolk,Smithtown 14,President,,Blanks,,0
-Suffolk,Smithtown 15,President,,Blanks,,3
-Suffolk,Smithtown 16,President,,Blanks,,7
-Suffolk,Smithtown 17,President,,Blanks,,1
-Suffolk,Smithtown 18,President,,Blanks,,3
-Suffolk,Smithtown 19,President,,Blanks,,0
-Suffolk,Smithtown 20,President,,Blanks,,4
-Suffolk,Smithtown 21,President,,Blanks,,2
-Suffolk,Smithtown 22,President,,Blanks,,3
-Suffolk,Smithtown 23,President,,Blanks,,13
-Suffolk,Smithtown 24,President,,Blanks,,4
-Suffolk,Smithtown 25,President,,Blanks,,8
-Suffolk,Smithtown 26,President,,Blanks,,6
-Suffolk,Smithtown 27,President,,Blanks,,4
-Suffolk,Smithtown 28,President,,Blanks,,2
-Suffolk,Smithtown 29,President,,Blanks,,4
-Suffolk,Smithtown 30,President,,Blanks,,2
-Suffolk,Smithtown 31,President,,Blanks,,3
-Suffolk,Smithtown 32,President,,Blanks,,7
-Suffolk,Smithtown 33,President,,Blanks,,0
-Suffolk,Smithtown 34,President,,Blanks,,3
-Suffolk,Smithtown 35,President,,Blanks,,4
-Suffolk,Smithtown 36,President,,Blanks,,3
-Suffolk,Smithtown 37,President,,Blanks,,5
-Suffolk,Smithtown 38,President,,Blanks,,1
-Suffolk,Smithtown 39,President,,Blanks,,4
-Suffolk,Smithtown 40,President,,Blanks,,1
-Suffolk,Smithtown 41,President,,Blanks,,3
-Suffolk,Smithtown 42,President,,Blanks,,7
+Suffolk,Southampton 1,President,,Blanks,,5
+Suffolk,Southampton 2,President,,Blanks,,1
+Suffolk,Southampton 3,President,,Blanks,,6
+Suffolk,Southampton 4,President,,Blanks,,13
+Suffolk,Southampton 5,President,,Blanks,,9
+Suffolk,Southampton 6,President,,Blanks,,4
+Suffolk,Southampton 7,President,,Blanks,,3
+Suffolk,Southampton 8,President,,Blanks,,3
+Suffolk,Southampton 9,President,,Blanks,,9
+Suffolk,Southampton 10,President,,Blanks,,4
+Suffolk,Southampton 11,President,,Blanks,,4
+Suffolk,Southampton 12,President,,Blanks,,3
+Suffolk,Southampton 13,President,,Blanks,,2
+Suffolk,Southampton 14,President,,Blanks,,0
+Suffolk,Southampton 15,President,,Blanks,,3
+Suffolk,Southampton 16,President,,Blanks,,7
+Suffolk,Southampton 17,President,,Blanks,,1
+Suffolk,Southampton 18,President,,Blanks,,3
+Suffolk,Southampton 19,President,,Blanks,,0
+Suffolk,Southampton 20,President,,Blanks,,4
+Suffolk,Southampton 21,President,,Blanks,,2
+Suffolk,Southampton 22,President,,Blanks,,3
+Suffolk,Southampton 23,President,,Blanks,,13
+Suffolk,Southampton 24,President,,Blanks,,4
+Suffolk,Southampton 25,President,,Blanks,,8
+Suffolk,Southampton 26,President,,Blanks,,6
+Suffolk,Southampton 27,President,,Blanks,,4
+Suffolk,Southampton 28,President,,Blanks,,2
+Suffolk,Southampton 29,President,,Blanks,,4
+Suffolk,Southampton 30,President,,Blanks,,2
+Suffolk,Southampton 31,President,,Blanks,,3
+Suffolk,Southampton 32,President,,Blanks,,7
+Suffolk,Southampton 33,President,,Blanks,,0
+Suffolk,Southampton 34,President,,Blanks,,3
+Suffolk,Southampton 35,President,,Blanks,,4
+Suffolk,Southampton 36,President,,Blanks,,3
+Suffolk,Southampton 37,President,,Blanks,,5
+Suffolk,Southampton 38,President,,Blanks,,1
+Suffolk,Southampton 39,President,,Blanks,,4
+Suffolk,Southampton 40,President,,Blanks,,1
+Suffolk,Southampton 41,President,,Blanks,,3
+Suffolk,Southampton 42,President,,Blanks,,7
 Suffolk,Southold 1,President,,Blanks,,2
 Suffolk,Southold 2,President,,Blanks,,9
 Suffolk,Southold 3,President,,Blanks,,3


### PR DESCRIPTION
There were several entries for Smithtown precincts that should be associated with Southampton precincts.  These can be verified with the [original source file](https://github.com/openelections/openelections-sources-ny/blob/27262a1dc91f2a2ec579431148521f340136103e/2020/Suffolk%20NY%202020%20General%20-%20Final%20Results%20by%20ED.pdf).

This fixes #91.