### PR TITLE
Add workflow to run data tests

### DIFF
--- a/.github/workflows/data_tests.yml
+++ b/.github/workflows/data_tests.yml
@@ -1,0 +1,31 @@
+name: Data Tests
+
+on: [push, pull_request]
+
+jobs:
+  duplicate_entries:
+    name: Duplicate entries
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+
+    - name: Check out data
+      uses: actions/checkout@v2.3.4
+      with:
+        path: data
+
+    - name: Check out data tests
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: openelections/openelections-data-tests
+        ref: v0.1.1
+        path: data_tests
+
+    - name: Run data tests
+      run: python3 ${{ github.workspace }}/data_tests/run_tests.py duplicate_entries ${{ github.workspace }}/data

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![Build Status](https://github.com/openelections/openelections-data-ny/actions/workflows/data_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-ny/actions)
-[![Build Status](https://github.com/openelections/openelections-data-ny/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-ny/actions)
+[![Build Status](https://github.com/openelections/openelections-data-ny/actions/workflows/data_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-ny/actions/workflows/data_tests.yml?query=branch%3Amaster)
+[![Build Status](https://github.com/openelections/openelections-data-ny/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-ny/actions/workflows/format_tests.yml?query=branch%3Amaster)
 
 OpenElections Data NY
 =====================

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-OpenElections Data NY [![Build Status](https://github.com/openelections/openelections-data-ny/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-ny/actions)
+[![Build Status](https://github.com/openelections/openelections-data-ny/actions/workflows/data_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-ny/actions)
+[![Build Status](https://github.com/openelections/openelections-data-ny/actions/workflows/format_tests.yml/badge.svg?branch=master)](https://github.com/openelections/openelections-data-ny/actions)
+
+OpenElections Data NY
 =====================
 
 Pre-processed election results for New York. These CSV files are converted from [original source files](https://github.com/openelections/openelections-sources-ny) from individual counties. You can see [county-specific inventories](https://github.com/openelections/openelections-data-ny/blob/master/county_matrix.csv) and refer to the below table for overall progress. Elections marked as `done` have all counties completed for that level. Those marked as `working` mean that at least one volunteer is working on this election, and this could be a good place to start if you're new. `Not started` means that this election is wide open and could use a volunteer.


### PR DESCRIPTION
This adds a workflow to run the [data validation](https://github.com/openelections/openelections-data-tests) tests. This currently consists of a single job that checks for duplicate entries in the data files.