### PR TITLE
Fix incorrect precincts in 2018 Onondaga County general file

### DIFF
--- a/2018/counties/20181106__ny__general__onondaga__precinct.csv
+++ b/2018/counties/20181106__ny__general__onondaga__precinct.csv
@@ -3419,66 +3419,66 @@ Onondaga,Geddes 20,Governor,,Stephanie A Miner/ Michael J Volpe,SAM,6
 Onondaga,Geddes 20,Governor,,Larry Sharpe/ Andrew C Hollister,LIB,6
 Onondaga,Geddes 20,Governor,,Write-ins,,0
 Onondaga,Geddes 20,Governor,,Voids/Blanks,,9
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,DEM,108
-Onondaga,Geddes 20,Governor,,Marc Molinaro/ Julie Killian,REP,167
-Onondaga,Geddes 20,Governor,,Marc Molinaro/ Julie Killian,CON,39
-Onondaga,Geddes 20,Governor,,Howie Hawkins/ Jia Lee,GRE,17
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,WOR,3
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,IND,7
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,WEP,1
-Onondaga,Geddes 20,Governor,,Marc Molinaro/ Julie Killian,REF,5
-Onondaga,Geddes 20,Governor,,Stephanie A Miner/ Michael J Volpe,SAM,10
-Onondaga,Geddes 20,Governor,,Larry Sharpe/ Andrew C Hollister,LIB,15
-Onondaga,Geddes 20,Governor,,Write-ins,,0
-Onondaga,Geddes 20,Governor,,Voids/Blanks,,9
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,DEM,108
-Onondaga,Geddes 20,Governor,,Marc Molinaro/ Julie Killian,REP,236
-Onondaga,Geddes 20,Governor,,Marc Molinaro/ Julie Killian,CON,56
-Onondaga,Geddes 20,Governor,,Howie Hawkins/ Jia Lee,GRE,10
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,WOR,2
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,IND,10
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,WEP,1
-Onondaga,Geddes 20,Governor,,Marc Molinaro/ Julie Killian,REF,5
-Onondaga,Geddes 20,Governor,,Stephanie A Miner/ Michael J Volpe,SAM,21
-Onondaga,Geddes 20,Governor,,Larry Sharpe/ Andrew C Hollister,LIB,18
-Onondaga,Geddes 20,Governor,,Write-ins,,0
-Onondaga,Geddes 20,Governor,,Voids/Blanks,,8
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,DEM,152
-Onondaga,Geddes 20,Governor,,Marc Molinaro/ Julie Killian,REP,231
-Onondaga,Geddes 20,Governor,,Marc Molinaro/ Julie Killian,CON,48
-Onondaga,Geddes 20,Governor,,Howie Hawkins/ Jia Lee,GRE,15
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,WOR,5
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,IND,14
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,WEP,4
-Onondaga,Geddes 20,Governor,,Marc Molinaro/ Julie Killian,REF,2
-Onondaga,Geddes 20,Governor,,Stephanie A Miner/ Michael J Volpe,SAM,15
-Onondaga,Geddes 20,Governor,,Larry Sharpe/ Andrew C Hollister,LIB,23
-Onondaga,Geddes 20,Governor,,Write-ins,,0
-Onondaga,Geddes 20,Governor,,Voids/Blanks,,20
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,DEM,171
-Onondaga,Geddes 20,Governor,,Marc Molinaro/ Julie Killian,REP,198
-Onondaga,Geddes 20,Governor,,Marc Molinaro/ Julie Killian,CON,44
-Onondaga,Geddes 20,Governor,,Howie Hawkins/ Jia Lee,GRE,19
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,WOR,6
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,IND,5
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,WEP,2
-Onondaga,Geddes 20,Governor,,Marc Molinaro/ Julie Killian,REF,3
-Onondaga,Geddes 20,Governor,,Stephanie A Miner/ Michael J Volpe,SAM,12
-Onondaga,Geddes 20,Governor,,Larry Sharpe/ Andrew C Hollister,LIB,7
-Onondaga,Geddes 20,Governor,,Write-ins,,0
-Onondaga,Geddes 20,Governor,,Voids/Blanks,,14
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,DEM,146
-Onondaga,Geddes 20,Governor,,Marc Molinaro/ Julie Killian,REP,235
-Onondaga,Geddes 20,Governor,,Marc Molinaro/ Julie Killian,CON,31
-Onondaga,Geddes 20,Governor,,Howie Hawkins/ Jia Lee,GRE,12
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,WOR,3
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,IND,4
-Onondaga,Geddes 20,Governor,,Andrew M Cuomo/ Kathy C Hochul,WEP,0
-Onondaga,Geddes 20,Governor,,Marc Molinaro/ Julie Killian,REF,5
-Onondaga,Geddes 20,Governor,,Stephanie A Miner/ Michael J Volpe,SAM,10
-Onondaga,Geddes 20,Governor,,Larry Sharpe/ Andrew C Hollister,LIB,16
-Onondaga,Geddes 20,Governor,,Write-ins,,0
-Onondaga,Geddes 20,Governor,,Voids/Blanks,,10
+Onondaga,Lafayette 01,Governor,,Andrew M Cuomo/ Kathy C Hochul,DEM,108
+Onondaga,Lafayette 01,Governor,,Marc Molinaro/ Julie Killian,REP,167
+Onondaga,Lafayette 01,Governor,,Marc Molinaro/ Julie Killian,CON,39
+Onondaga,Lafayette 01,Governor,,Howie Hawkins/ Jia Lee,GRE,17
+Onondaga,Lafayette 01,Governor,,Andrew M Cuomo/ Kathy C Hochul,WOR,3
+Onondaga,Lafayette 01,Governor,,Andrew M Cuomo/ Kathy C Hochul,IND,7
+Onondaga,Lafayette 01,Governor,,Andrew M Cuomo/ Kathy C Hochul,WEP,1
+Onondaga,Lafayette 01,Governor,,Marc Molinaro/ Julie Killian,REF,5
+Onondaga,Lafayette 01,Governor,,Stephanie A Miner/ Michael J Volpe,SAM,10
+Onondaga,Lafayette 01,Governor,,Larry Sharpe/ Andrew C Hollister,LIB,15
+Onondaga,Lafayette 01,Governor,,Write-ins,,0
+Onondaga,Lafayette 01,Governor,,Voids/Blanks,,9
+Onondaga,Lafayette 02,Governor,,Andrew M Cuomo/ Kathy C Hochul,DEM,108
+Onondaga,Lafayette 02,Governor,,Marc Molinaro/ Julie Killian,REP,236
+Onondaga,Lafayette 02,Governor,,Marc Molinaro/ Julie Killian,CON,56
+Onondaga,Lafayette 02,Governor,,Howie Hawkins/ Jia Lee,GRE,10
+Onondaga,Lafayette 02,Governor,,Andrew M Cuomo/ Kathy C Hochul,WOR,2
+Onondaga,Lafayette 02,Governor,,Andrew M Cuomo/ Kathy C Hochul,IND,10
+Onondaga,Lafayette 02,Governor,,Andrew M Cuomo/ Kathy C Hochul,WEP,1
+Onondaga,Lafayette 02,Governor,,Marc Molinaro/ Julie Killian,REF,5
+Onondaga,Lafayette 02,Governor,,Stephanie A Miner/ Michael J Volpe,SAM,21
+Onondaga,Lafayette 02,Governor,,Larry Sharpe/ Andrew C Hollister,LIB,18
+Onondaga,Lafayette 02,Governor,,Write-ins,,0
+Onondaga,Lafayette 02,Governor,,Voids/Blanks,,8
+Onondaga,Lafayette 03,Governor,,Andrew M Cuomo/ Kathy C Hochul,DEM,152
+Onondaga,Lafayette 03,Governor,,Marc Molinaro/ Julie Killian,REP,231
+Onondaga,Lafayette 03,Governor,,Marc Molinaro/ Julie Killian,CON,48
+Onondaga,Lafayette 03,Governor,,Howie Hawkins/ Jia Lee,GRE,15
+Onondaga,Lafayette 03,Governor,,Andrew M Cuomo/ Kathy C Hochul,WOR,5
+Onondaga,Lafayette 03,Governor,,Andrew M Cuomo/ Kathy C Hochul,IND,14
+Onondaga,Lafayette 03,Governor,,Andrew M Cuomo/ Kathy C Hochul,WEP,4
+Onondaga,Lafayette 03,Governor,,Marc Molinaro/ Julie Killian,REF,2
+Onondaga,Lafayette 03,Governor,,Stephanie A Miner/ Michael J Volpe,SAM,15
+Onondaga,Lafayette 03,Governor,,Larry Sharpe/ Andrew C Hollister,LIB,23
+Onondaga,Lafayette 03,Governor,,Write-ins,,0
+Onondaga,Lafayette 03,Governor,,Voids/Blanks,,20
+Onondaga,Lafayette 04,Governor,,Andrew M Cuomo/ Kathy C Hochul,DEM,171
+Onondaga,Lafayette 04,Governor,,Marc Molinaro/ Julie Killian,REP,198
+Onondaga,Lafayette 04,Governor,,Marc Molinaro/ Julie Killian,CON,44
+Onondaga,Lafayette 04,Governor,,Howie Hawkins/ Jia Lee,GRE,19
+Onondaga,Lafayette 04,Governor,,Andrew M Cuomo/ Kathy C Hochul,WOR,6
+Onondaga,Lafayette 04,Governor,,Andrew M Cuomo/ Kathy C Hochul,IND,5
+Onondaga,Lafayette 04,Governor,,Andrew M Cuomo/ Kathy C Hochul,WEP,2
+Onondaga,Lafayette 04,Governor,,Marc Molinaro/ Julie Killian,REF,3
+Onondaga,Lafayette 04,Governor,,Stephanie A Miner/ Michael J Volpe,SAM,12
+Onondaga,Lafayette 04,Governor,,Larry Sharpe/ Andrew C Hollister,LIB,7
+Onondaga,Lafayette 04,Governor,,Write-ins,,0
+Onondaga,Lafayette 04,Governor,,Voids/Blanks,,14
+Onondaga,Lafayette 05,Governor,,Andrew M Cuomo/ Kathy C Hochul,DEM,146
+Onondaga,Lafayette 05,Governor,,Marc Molinaro/ Julie Killian,REP,235
+Onondaga,Lafayette 05,Governor,,Marc Molinaro/ Julie Killian,CON,31
+Onondaga,Lafayette 05,Governor,,Howie Hawkins/ Jia Lee,GRE,12
+Onondaga,Lafayette 05,Governor,,Andrew M Cuomo/ Kathy C Hochul,WOR,3
+Onondaga,Lafayette 05,Governor,,Andrew M Cuomo/ Kathy C Hochul,IND,4
+Onondaga,Lafayette 05,Governor,,Andrew M Cuomo/ Kathy C Hochul,WEP,0
+Onondaga,Lafayette 05,Governor,,Marc Molinaro/ Julie Killian,REF,5
+Onondaga,Lafayette 05,Governor,,Stephanie A Miner/ Michael J Volpe,SAM,10
+Onondaga,Lafayette 05,Governor,,Larry Sharpe/ Andrew C Hollister,LIB,16
+Onondaga,Lafayette 05,Governor,,Write-ins,,0
+Onondaga,Lafayette 05,Governor,,Voids/Blanks,,10
 Onondaga,Lysander 01,Governor,,Andrew M Cuomo/ Kathy C Hochul,DEM,139
 Onondaga,Lysander 01,Governor,,Marc Molinaro/ Julie Killian,REP,247
 Onondaga,Lysander 01,Governor,,Marc Molinaro/ Julie Killian,CON,63


### PR DESCRIPTION
This fixes some incorrect precincts that resulted in [duplicate rows](https://github.com/openelections/openelections-data-tx/issues/348#issuecomment-899707487).  According to the [source file](https://github.com/openelections/openelections-sources-ny/blob/27262a1dc91f2a2ec579431148521f340136103e/2018/Onondaga%20NY%20GE18FINALRESULTS.xls), these entries belong to the Lafayette precincts.