### PR TITLE
Fix to include empty columns for early_voting, election_day, provisiona…

### DIFF
--- a/2022/20221108__ny__general__allegany__precinct.csv
+++ b/2022/20221108__ny__general__allegany__precinct.csv
@@ -77,1232 +77,1232 @@ Allegany,Wellsville 5,Ballots Cast,,,,482,88,367,1,26
 Allegany,West Almond,Ballots Cast,,,,126,7,108,1,10
 Allegany,Willing,Ballots Cast,,,,509,43,438,4,24
 Allegany,Wirt,Ballots Cast,,,,404,16,365,3,20
-Allegany,Alfred 1,Governor,,DEM,Kathy C. Hochul,205
-Allegany,Alfred 2,Governor,,DEM,Kathy C. Hochul,210
-Allegany,Allen,Governor,,DEM,Kathy C. Hochul,28
-Allegany,Alma,Governor,,DEM,Kathy C. Hochul,37
-Allegany,Almond,Governor,,DEM,Kathy C. Hochul,152
-Allegany,Amity 1,Governor,,DEM,Kathy C. Hochul,77
-Allegany,Amity 2,Governor,,DEM,Kathy C. Hochul,123
-Allegany,Andover 1,Governor,,DEM,Kathy C. Hochul,86
-Allegany,Andover 2,Governor,,DEM,Kathy C. Hochul,47
-Allegany,Angelica 1,Governor,,DEM,Kathy C. Hochul,64
-Allegany,Angelica 2,Governor,,DEM,Kathy C. Hochul,52
-Allegany,Belfast,Governor,,DEM,Kathy C. Hochul,121
-Allegany,Birdsall,Governor,,DEM,Kathy C. Hochul,14
-Allegany,Bolivar,Governor,,DEM,Kathy C. Hochul,131
-Allegany,Burns,Governor,,DEM,Kathy C. Hochul,61
-Allegany,Caneadea 1,Governor,,DEM,Kathy C. Hochul,57
-Allegany,Caneadea 2,Governor,,DEM,Kathy C. Hochul,90
-Allegany,Centerville,Governor,,DEM,Kathy C. Hochul,34
-Allegany,Clarksville,Governor,,DEM,Kathy C. Hochul,76
-Allegany,Cuba 1,Governor,,DEM,Kathy C. Hochul,162
-Allegany,Cuba 2,Governor,,DEM,Kathy C. Hochul,159
-Allegany,Friendship,Governor,,DEM,Kathy C. Hochul,90
-Allegany,Genesee,Governor,,DEM,Kathy C. Hochul,96
-Allegany,Granger,Governor,,DEM,Kathy C. Hochul,23
-Allegany,Grove,Governor,,DEM,Kathy C. Hochul,43
-Allegany,Hume,Governor,,DEM,Kathy C. Hochul,127
-Allegany,Independence,Governor,,DEM,Kathy C. Hochul,64
-Allegany,New Hudson,Governor,,DEM,Kathy C. Hochul,38
-Allegany,Rushford,Governor,,DEM,Kathy C. Hochul,91
-Allegany,Scio,Governor,,DEM,Kathy C. Hochul,125
-Allegany,Ward,Governor,,DEM,Kathy C. Hochul,34
-Allegany,Wellsville 1,Governor,,DEM,Kathy C. Hochul,135
-Allegany,Wellsville 2,Governor,,DEM,Kathy C. Hochul,187
-Allegany,Wellsville 3,Governor,,DEM,Kathy C. Hochul,178
-Allegany,Wellsville 4,Governor,,DEM,Kathy C. Hochul,109
-Allegany,Welllsville 5,Governor,,DEM,Kathy C. Hochul,107
-Allegany,West Almond,Governor,,DEM,Kathy C. Hochul,23
-Allegany,Willing,Governor,,DEM,Kathy C. Hochul,116
-Allegany,Wirt,Governor,,DEM,Kathy C. Hochul,41
-Allegany,Alfred 1,Governor,,WOR,Kathy C. Hochul,23
-Allegany,Alfred 2,Governor,,WOR,Kathy C. Hochul,17
-Allegany,Allen,Governor,,WOR,Kathy C. Hochul,5
-Allegany,Alma,Governor,,WOR,Kathy C. Hochul,1
-Allegany,Almond,Governor,,WOR,Kathy C. Hochul,14
-Allegany,Amity 1,Governor,,WOR,Kathy C. Hochul,5
-Allegany,Amity 2,Governor,,WOR,Kathy C. Hochul,5
-Allegany,Andover 1,Governor,,WOR,Kathy C. Hochul,5
-Allegany,Andover 2,Governor,,WOR,Kathy C. Hochul,6
-Allegany,Angelica 1,Governor,,WOR,Kathy C. Hochul,5
-Allegany,Angelica 2,Governor,,WOR,Kathy C. Hochul,0
-Allegany,Belfast,Governor,,WOR,Kathy C. Hochul,5
-Allegany,Birdsall,Governor,,WOR,Kathy C. Hochul,1
-Allegany,Bolivar,Governor,,WOR,Kathy C. Hochul,8
-Allegany,Burns,Governor,,WOR,Kathy C. Hochul,5
-Allegany,Caneadea 1,Governor,,WOR,Kathy C. Hochul,8
-Allegany,Caneadea 2,Governor,,WOR,Kathy C. Hochul,2
-Allegany,Centerville,Governor,,WOR,Kathy C. Hochul,3
-Allegany,Clarksville,Governor,,WOR,Kathy C. Hochul,2
-Allegany,Cuba 1,Governor,,WOR,Kathy C. Hochul,16
-Allegany,Cuba 2,Governor,,WOR,Kathy C. Hochul,16
-Allegany,Friendship,Governor,,WOR,Kathy C. Hochul,2
-Allegany,Genesee,Governor,,WOR,Kathy C. Hochul,4
-Allegany,Granger,Governor,,WOR,Kathy C. Hochul,1
-Allegany,Grove,Governor,,WOR,Kathy C. Hochul,6
-Allegany,Hume,Governor,,WOR,Kathy C. Hochul,9
-Allegany,Independence,Governor,,WOR,Kathy C. Hochul,3
-Allegany,New Hudson,Governor,,WOR,Kathy C. Hochul,4
-Allegany,Rushford,Governor,,WOR,Kathy C. Hochul,9
-Allegany,Scio,Governor,,WOR,Kathy C. Hochul,6
-Allegany,Ward,Governor,,WOR,Kathy C. Hochul,6
-Allegany,Wellsville 1,Governor,,WOR,Kathy C. Hochul,9
-Allegany,Wellsville 2,Governor,,WOR,Kathy C. Hochul,7
-Allegany,Wellsville 3,Governor,,WOR,Kathy C. Hochul,12
-Allegany,Wellsville 4,Governor,,WOR,Kathy C. Hochul,3
-Allegany,Welllsville 5,Governor,,WOR,Kathy C. Hochul,7
-Allegany,West Almond,Governor,,WOR,Kathy C. Hochul,2
-Allegany,Willing,Governor,,WOR,Kathy C. Hochul,8
-Allegany,Wirt,Governor,,WOR,Kathy C. Hochul,5
-Allegany,Alfred 1,Governor,,REP,Lee Zeldin,39
-Allegany,Alfred 2,Governor,,REP,Lee Zeldin,223
-Allegany,Allen,Governor,,REP,Lee Zeldin,144
-Allegany,Alma,Governor,,REP,Lee Zeldin,252
-Allegany,Almond,Governor,,REP,Lee Zeldin,418
-Allegany,Amity 1,Governor,,REP,Lee Zeldin,222
-Allegany,Amity 2,Governor,,REP,Lee Zeldin,344
-Allegany,Andover 1,Governor,,REP,Lee Zeldin,270
-Allegany,Andover 2,Governor,,REP,Lee Zeldin,246
-Allegany,Angelica 1,Governor,,REP,Lee Zeldin,219
-Allegany,Angelica 2,Governor,,REP,Lee Zeldin,174
-Allegany,Belfast,Governor,,REP,Lee Zeldin,422
-Allegany,Birdsall,Governor,,REP,Lee Zeldin,63
-Allegany,Bolivar,Governor,,REP,Lee Zeldin,499
-Allegany,Burns,Governor,,REP,Lee Zeldin,328
-Allegany,Caneadea 1,Governor,,REP,Lee Zeldin,189
-Allegany,Caneadea 2,Governor,,REP,Lee Zeldin,177
-Allegany,Centerville,Governor,,REP,Lee Zeldin,197
-Allegany,Clarksville,Governor,,REP,Lee Zeldin,258
-Allegany,Cuba 1,Governor,,REP,Lee Zeldin,276
-Allegany,Cuba 2,Governor,,REP,Lee Zeldin,442
-Allegany,Friendship,Governor,,REP,Lee Zeldin,451
-Allegany,Genesee,Governor,,REP,Lee Zeldin,464
-Allegany,Granger,Governor,,REP,Lee Zeldin,188
-Allegany,Grove,Governor,,REP,Lee Zeldin,179
-Allegany,Hume,Governor,,REP,Lee Zeldin,511
-Allegany,Independence,Governor,,REP,Lee Zeldin,287
-Allegany,New Hudson,Governor,,REP,Lee Zeldin,194
-Allegany,Rushford,Governor,,REP,Lee Zeldin,333
-Allegany,Scio,Governor,,REP,Lee Zeldin,447
-Allegany,Ward,Governor,,REP,Lee Zeldin,118
-Allegany,Wellsville 1,Governor,,REP,Lee Zeldin,282
-Allegany,Wellsville 2,Governor,,REP,Lee Zeldin,270
-Allegany,Wellsville 3,Governor,,REP,Lee Zeldin,325
-Allegany,Wellsville 4,Governor,,REP,Lee Zeldin,285
-Allegany,Welllsville 5,Governor,,REP,Lee Zeldin,338
-Allegany,West Almond,Governor,,REP,Lee Zeldin,84
-Allegany,Willing,Governor,,REP,Lee Zeldin,369
-Allegany,Wirt,Governor,,REP,Lee Zeldin,335
-Allegany,Alfred 1,Governor,,CON,Lee Zeldin,14
-Allegany,Alfred 2,Governor,,CON,Lee Zeldin,45
-Allegany,Allen,Governor,,CON,Lee Zeldin,13
-Allegany,Alma,Governor,,CON,Lee Zeldin,24
-Allegany,Almond,Governor,,CON,Lee Zeldin,76
-Allegany,Amity 1,Governor,,CON,Lee Zeldin,25
-Allegany,Amity 2,Governor,,CON,Lee Zeldin,32
-Allegany,Andover 1,Governor,,CON,Lee Zeldin,28
-Allegany,Andover 2,Governor,,CON,Lee Zeldin,10
-Allegany,Angelica 1,Governor,,CON,Lee Zeldin,19
-Allegany,Angelica 2,Governor,,CON,Lee Zeldin,19
-Allegany,Belfast,Governor,,CON,Lee Zeldin,44
-Allegany,Birdsall,Governor,,CON,Lee Zeldin,10
-Allegany,Bolivar,Governor,,CON,Lee Zeldin,41
-Allegany,Burns,Governor,,CON,Lee Zeldin,43
-Allegany,Caneadea 1,Governor,,CON,Lee Zeldin,28
-Allegany,Caneadea 2,Governor,,CON,Lee Zeldin,36
-Allegany,Centerville,Governor,,CON,Lee Zeldin,32
-Allegany,Clarksville,Governor,,CON,Lee Zeldin,28
-Allegany,Cuba 1,Governor,,CON,Lee Zeldin,26
-Allegany,Cuba 2,Governor,,CON,Lee Zeldin,29
-Allegany,Friendship,Governor,,CON,Lee Zeldin,42
-Allegany,Genesee,Governor,,CON,Lee Zeldin,36
-Allegany,Granger,Governor,,CON,Lee Zeldin,21
-Allegany,Grove,Governor,,CON,Lee Zeldin,28
-Allegany,Hume,Governor,,CON,Lee Zeldin,54
-Allegany,Independence,Governor,,CON,Lee Zeldin,15
-Allegany,New Hudson,Governor,,CON,Lee Zeldin,19
-Allegany,Rushford,Governor,,CON,Lee Zeldin,57
-Allegany,Scio,Governor,,CON,Lee Zeldin,43
-Allegany,Ward,Governor,,CON,Lee Zeldin,11
-Allegany,Wellsville 1,Governor,,CON,Lee Zeldin,16
-Allegany,Wellsville 2,Governor,,CON,Lee Zeldin,23
-Allegany,Wellsville 3,Governor,,CON,Lee Zeldin,32
-Allegany,Wellsville 4,Governor,,CON,Lee Zeldin,15
-Allegany,Welllsville 5,Governor,,CON,Lee Zeldin,27
-Allegany,West Almond,Governor,,CON,Lee Zeldin,15
-Allegany,Willing,Governor,,CON,Lee Zeldin,15
-Allegany,Wirt,Governor,,CON,Lee Zeldin,21
-Allegany,Alfred 1,Governor,,,WRITE-IN,5
-Allegany,Alfred 2,Governor,,,WRITE-IN,7
-Allegany,Allen,Governor,,,WRITE-IN,2
-Allegany,Alma,Governor,,,WRITE-IN,1
-Allegany,Almond,Governor,,,WRITE-IN,3
-Allegany,Amity 1,Governor,,,WRITE-IN,0
-Allegany,Amity 2,Governor,,,WRITE-IN,0
-Allegany,Andover 1,Governor,,,WRITE-IN,1
-Allegany,Andover 2,Governor,,,WRITE-IN,0
-Allegany,Angelica 1,Governor,,,WRITE-IN,0
-Allegany,Angelica 2,Governor,,,WRITE-IN,1
-Allegany,Belfast,Governor,,,WRITE-IN,1
-Allegany,Birdsall,Governor,,,WRITE-IN,1
-Allegany,Bolivar,Governor,,,WRITE-IN,0
-Allegany,Burns,Governor,,,WRITE-IN,0
-Allegany,Caneadea 1,Governor,,,WRITE-IN,1
-Allegany,Caneadea 2,Governor,,,WRITE-IN,4
-Allegany,Centerville,Governor,,,WRITE-IN,1
-Allegany,Clarksville,Governor,,,WRITE-IN,0
-Allegany,Cuba 1,Governor,,,WRITE-IN,3
-Allegany,Cuba 2,Governor,,,WRITE-IN,0
-Allegany,Friendship,Governor,,,WRITE-IN,1
-Allegany,Genesee,Governor,,,WRITE-IN,0
-Allegany,Granger,Governor,,,WRITE-IN,0
-Allegany,Grove,Governor,,,WRITE-IN,1
-Allegany,Hume,Governor,,,WRITE-IN,2
-Allegany,Independence,Governor,,,WRITE-IN,2
-Allegany,New Hudson,Governor,,,WRITE-IN,0
-Allegany,Rushford,Governor,,,WRITE-IN,1
-Allegany,Scio,Governor,,,WRITE-IN,2
-Allegany,Ward,Governor,,,WRITE-IN,0
-Allegany,Wellsville 1,Governor,,,WRITE-IN,0
-Allegany,Wellsville 2,Governor,,,WRITE-IN,0
-Allegany,Wellsville 3,Governor,,,WRITE-IN,0
-Allegany,Wellsville 4,Governor,,,WRITE-IN,1
-Allegany,Welllsville 5,Governor,,,WRITE-IN,0
-Allegany,West Almond,Governor,,,WRITE-IN,0
-Allegany,Willing,Governor,,,WRITE-IN,3
-Allegany,Wirt,Governor,,,WRITE-IN,2
-Allegany,Alfred 1,Attorney General,,DEM,Letitia A. James,197
-Allegany,Alfred 2,Attorney General,,DEM,Letitia A. James,209
-Allegany,Allen,Attorney General,,DEM,Letitia A. James,30
-Allegany,Alma,Attorney General,,DEM,Letitia A. James,34
-Allegany,Almond,Attorney General,,DEM,Letitia A. James,152
-Allegany,Amity 1,Attorney General,,DEM,Letitia A. James,77
-Allegany,Amity 2,Attorney General,,DEM,Letitia A. James,121
-Allegany,Andover 1,Attorney General,,DEM,Letitia A. James,95
-Allegany,Andover 2,Attorney General,,DEM,Letitia A. James,47
-Allegany,Angelica 1,Attorney General,,DEM,Letitia A. James,65
-Allegany,Angelica 2,Attorney General,,DEM,Letitia A. James,52
-Allegany,Belfast,Attorney General,,DEM,Letitia A. James,121
-Allegany,Birdsall,Attorney General,,DEM,Letitia A. James,17
-Allegany,Bolivar,Attorney General,,DEM,Letitia A. James,139
-Allegany,Burns,Attorney General,,DEM,Letitia A. James,63
-Allegany,Caneadea 1,Attorney General,,DEM,Letitia A. James,61
-Allegany,Caneadea 2,Attorney General,,DEM,Letitia A. James,91
-Allegany,Centerville,Attorney General,,DEM,Letitia A. James,33
-Allegany,Clarksville,Attorney General,,DEM,Letitia A. James,77
-Allegany,Cuba 1,Attorney General,,DEM,Letitia A. James,170
-Allegany,Cuba 2,Attorney General,,DEM,Letitia A. James,163
-Allegany,Friendship,Attorney General,,DEM,Letitia A. James,94
-Allegany,Genesee,Attorney General,,DEM,Letitia A. James,99
-Allegany,Granger,Attorney General,,DEM,Letitia A. James,25
-Allegany,Grove,Attorney General,,DEM,Letitia A. James,45
-Allegany,Hume,Attorney General,,DEM,Letitia A. James,131
-Allegany,Independence,Attorney General,,DEM,Letitia A. James,70
-Allegany,New Hudson,Attorney General,,DEM,Letitia A. James,41
-Allegany,Rushford,Attorney General,,DEM,Letitia A. James,84
-Allegany,Scio,Attorney General,,DEM,Letitia A. James,133
-Allegany,Ward,Attorney General,,DEM,Letitia A. James,36
-Allegany,Wellsville 1,Attorney General,,DEM,Letitia A. James,134
-Allegany,Wellsville 2,Attorney General,,DEM,Letitia A. James,177
-Allegany,Wellsville 3,Attorney General,,DEM,Letitia A. James,174
-Allegany,Wellsville 4,Attorney General,,DEM,Letitia A. James,100
-Allegany,Welllsville 5,Attorney General,,DEM,Letitia A. James,114
-Allegany,West Almond,Attorney General,,DEM,Letitia A. James,25
-Allegany,Willing,Attorney General,,DEM,Letitia A. James,117
-Allegany,Wirt,Attorney General,,DEM,Letitia A. James,43
-Allegany,Alfred 1,Attorney General,,WOR,Letitia A. James,24
-Allegany,Alfred 2,Attorney General,,WOR,Letitia A. James,20
-Allegany,Allen,Attorney General,,WOR,Letitia A. James,6
-Allegany,Alma,Attorney General,,WOR,Letitia A. James,2
-Allegany,Almond,Attorney General,,WOR,Letitia A. James,18
-Allegany,Amity 1,Attorney General,,WOR,Letitia A. James,10
-Allegany,Amity 2,Attorney General,,WOR,Letitia A. James,8
-Allegany,Andover 1,Attorney General,,WOR,Letitia A. James,9
-Allegany,Andover 2,Attorney General,,WOR,Letitia A. James,9
-Allegany,Angelica 1,Attorney General,,WOR,Letitia A. James,10
-Allegany,Angelica 2,Attorney General,,WOR,Letitia A. James,2
-Allegany,Belfast,Attorney General,,WOR,Letitia A. James,13
-Allegany,Birdsall,Attorney General,,WOR,Letitia A. James,1
-Allegany,Bolivar,Attorney General,,WOR,Letitia A. James,11
-Allegany,Burns,Attorney General,,WOR,Letitia A. James,6
-Allegany,Caneadea 1,Attorney General,,WOR,Letitia A. James,9
-Allegany,Caneadea 2,Attorney General,,WOR,Letitia A. James,6
-Allegany,Centerville,Attorney General,,WOR,Letitia A. James,5
-Allegany,Clarksville,Attorney General,,WOR,Letitia A. James,4
-Allegany,Cuba 1,Attorney General,,WOR,Letitia A. James,17
-Allegany,Cuba 2,Attorney General,,WOR,Letitia A. James,21
-Allegany,Friendship,Attorney General,,WOR,Letitia A. James,4
-Allegany,Genesee,Attorney General,,WOR,Letitia A. James,7
-Allegany,Granger,Attorney General,,WOR,Letitia A. James,3
-Allegany,Grove,Attorney General,,WOR,Letitia A. James,6
-Allegany,Hume,Attorney General,,WOR,Letitia A. James,11
-Allegany,Independence,Attorney General,,WOR,Letitia A. James,5
-Allegany,New Hudson,Attorney General,,WOR,Letitia A. James,8
-Allegany,Rushford,Attorney General,,WOR,Letitia A. James,14
-Allegany,Scio,Attorney General,,WOR,Letitia A. James,8
-Allegany,Ward,Attorney General,,WOR,Letitia A. James,8
-Allegany,Wellsville 1,Attorney General,,WOR,Letitia A. James,7
-Allegany,Wellsville 2,Attorney General,,WOR,Letitia A. James,9
-Allegany,Wellsville 3,Attorney General,,WOR,Letitia A. James,13
-Allegany,Wellsville 4,Attorney General,,WOR,Letitia A. James,9
-Allegany,Welllsville 5,Attorney General,,WOR,Letitia A. James,11
-Allegany,West Almond,Attorney General,,WOR,Letitia A. James,1
-Allegany,Willing,Attorney General,,WOR,Letitia A. James,6
-Allegany,Wirt,Attorney General,,WOR,Letitia A. James,4
-Allegany,Alfred 1,Attorney General,,REP,Michael Henry,46
-Allegany,Alfred 2,Attorney General,,REP,Michael Henry,212
-Allegany,Allen,Attorney General,,REP,Michael Henry,140
-Allegany,Alma,Attorney General,,REP,Michael Henry,244
-Allegany,Almond,Attorney General,,REP,Michael Henry,405
-Allegany,Amity 1,Attorney General,,REP,Michael Henry,216
-Allegany,Amity 2,Attorney General,,REP,Michael Henry,337
-Allegany,Andover 1,Attorney General,,REP,Michael Henry,258
-Allegany,Andover 2,Attorney General,,REP,Michael Henry,235
-Allegany,Angelica 1,Attorney General,,REP,Michael Henry,214
-Allegany,Angelica 2,Attorney General,,REP,Michael Henry,168
-Allegany,Belfast,Attorney General,,REP,Michael Henry,406
-Allegany,Birdsall,Attorney General,,REP,Michael Henry,58
-Allegany,Bolivar,Attorney General,,REP,Michael Henry,469
-Allegany,Burns,Attorney General,,REP,Michael Henry,310
-Allegany,Caneadea 1,Attorney General,,REP,Michael Henry,183
-Allegany,Caneadea 2,Attorney General,,REP,Michael Henry,175
-Allegany,Centerville,Attorney General,,REP,Michael Henry,194
-Allegany,Clarksville,Attorney General,,REP,Michael Henry,247
-Allegany,Cuba 1,Attorney General,,REP,Michael Henry,259
-Allegany,Cuba 2,Attorney General,,REP,Michael Henry,425
-Allegany,Friendship,Attorney General,,REP,Michael Henry,428
-Allegany,Genesee,Attorney General,,REP,Michael Henry,443
-Allegany,Granger,Attorney General,,REP,Michael Henry,180
-Allegany,Grove,Attorney General,,REP,Michael Henry,172
-Allegany,Hume,Attorney General,,REP,Michael Henry,483
-Allegany,Independence,Attorney General,,REP,Michael Henry,274
-Allegany,New Hudson,Attorney General,,REP,Michael Henry,180
-Allegany,Rushford,Attorney General,,REP,Michael Henry,326
-Allegany,Scio,Attorney General,,REP,Michael Henry,429
-Allegany,Ward,Attorney General,,REP,Michael Henry,115
-Allegany,Wellsville 1,Attorney General,,REP,Michael Henry,274
-Allegany,Wellsville 2,Attorney General,,REP,Michael Henry,270
-Allegany,Wellsville 3,Attorney General,,REP,Michael Henry,315
-Allegany,Wellsville 4,Attorney General,,REP,Michael Henry,280
-Allegany,Welllsville 5,Attorney General,,REP,Michael Henry,325
-Allegany,West Almond,Attorney General,,REP,Michael Henry,84
-Allegany,Willing,Attorney General,,REP,Michael Henry,363
-Allegany,Wirt,Attorney General,,REP,Michael Henry,319
-Allegany,Alfred 1,Attorney General,,CON,Michael Henry,14
-Allegany,Alfred 2,Attorney General,,CON,Michael Henry,49
-Allegany,Allen,Attorney General,,CON,Michael Henry,10
-Allegany,Alma,Attorney General,,CON,Michael Henry,23
-Allegany,Almond,Attorney General,,CON,Michael Henry,77
-Allegany,Amity 1,Attorney General,,CON,Michael Henry,19
-Allegany,Amity 2,Attorney General,,CON,Michael Henry,29
-Allegany,Andover 1,Attorney General,,CON,Michael Henry,24
-Allegany,Andover 2,Attorney General,,CON,Michael Henry,13
-Allegany,Angelica 1,Attorney General,,CON,Michael Henry,13
-Allegany,Angelica 2,Attorney General,,CON,Michael Henry,17
-Allegany,Belfast,Attorney General,,CON,Michael Henry,46
-Allegany,Birdsall,Attorney General,,CON,Michael Henry,10
-Allegany,Bolivar,Attorney General,,CON,Michael Henry,41
-Allegany,Burns,Attorney General,,CON,Michael Henry,43
-Allegany,Caneadea 1,Attorney General,,CON,Michael Henry,22
-Allegany,Caneadea 2,Attorney General,,CON,Michael Henry,34
-Allegany,Centerville,Attorney General,,CON,Michael Henry,34
-Allegany,Clarksville,Attorney General,,CON,Michael Henry,27
-Allegany,Cuba 1,Attorney General,,CON,Michael Henry,29
-Allegany,Cuba 2,Attorney General,,CON,Michael Henry,29
-Allegany,Friendship,Attorney General,,CON,Michael Henry,43
-Allegany,Genesee,Attorney General,,CON,Michael Henry,38
-Allegany,Granger,Attorney General,,CON,Michael Henry,21
-Allegany,Grove,Attorney General,,CON,Michael Henry,32
-Allegany,Hume,Attorney General,,CON,Michael Henry,58
-Allegany,Independence,Attorney General,,CON,Michael Henry,13
-Allegany,New Hudson,Attorney General,,CON,Michael Henry,22
-Allegany,Rushford,Attorney General,,CON,Michael Henry,58
-Allegany,Scio,Attorney General,,CON,Michael Henry,41
-Allegany,Ward,Attorney General,,CON,Michael Henry,10
-Allegany,Wellsville 1,Attorney General,,CON,Michael Henry,22
-Allegany,Wellsville 2,Attorney General,,CON,Michael Henry,21
-Allegany,Wellsville 3,Attorney General,,CON,Michael Henry,35
-Allegany,Wellsville 4,Attorney General,,CON,Michael Henry,14
-Allegany,Welllsville 5,Attorney General,,CON,Michael Henry,22
-Allegany,West Almond,Attorney General,,CON,Michael Henry,12
-Allegany,Willing,Attorney General,,CON,Michael Henry,15
-Allegany,Wirt,Attorney General,,CON,Michael Henry,20
-Allegany,Alfred 1,Attorney General,,,WRITE-IN,1
-Allegany,Alfred 2,Attorney General,,,WRITE-IN,2
-Allegany,Allen,Attorney General,,,WRITE-IN,0
-Allegany,Alma,Attorney General,,,WRITE-IN,1
-Allegany,Almond,Attorney General,,,WRITE-IN,0
-Allegany,Amity 1,Attorney General,,,WRITE-IN,0
-Allegany,Amity 2,Attorney General,,,WRITE-IN,0
-Allegany,Andover 1,Attorney General,,,WRITE-IN,0
-Allegany,Andover 2,Attorney General,,,WRITE-IN,0
-Allegany,Angelica 1,Attorney General,,,WRITE-IN,0
-Allegany,Angelica 2,Attorney General,,,WRITE-IN,0
-Allegany,Belfast,Attorney General,,,WRITE-IN,0
-Allegany,Birdsall,Attorney General,,,WRITE-IN,0
-Allegany,Bolivar,Attorney General,,,WRITE-IN,0
-Allegany,Burns,Attorney General,,,WRITE-IN,0
-Allegany,Caneadea 1,Attorney General,,,WRITE-IN,1
-Allegany,Caneadea 2,Attorney General,,,WRITE-IN,1
-Allegany,Centerville,Attorney General,,,WRITE-IN,0
-Allegany,Clarksville,Attorney General,,,WRITE-IN,0
-Allegany,Cuba 1,Attorney General,,,WRITE-IN,0
-Allegany,Cuba 2,Attorney General,,,WRITE-IN,0
-Allegany,Friendship,Attorney General,,,WRITE-IN,0
-Allegany,Genesee,Attorney General,,,WRITE-IN,0
-Allegany,Granger,Attorney General,,,WRITE-IN,0
-Allegany,Grove,Attorney General,,,WRITE-IN,0
-Allegany,Hume,Attorney General,,,WRITE-IN,0
-Allegany,Independence,Attorney General,,,WRITE-IN,0
-Allegany,New Hudson,Attorney General,,,WRITE-IN,0
-Allegany,Rushford,Attorney General,,,WRITE-IN,0
-Allegany,Scio,Attorney General,,,WRITE-IN,1
-Allegany,Ward,Attorney General,,,WRITE-IN,0
-Allegany,Wellsville 1,Attorney General,,,WRITE-IN,0
-Allegany,Wellsville 2,Attorney General,,,WRITE-IN,0
-Allegany,Wellsville 3,Attorney General,,,WRITE-IN,0
-Allegany,Wellsville 4,Attorney General,,,WRITE-IN,0
-Allegany,Welllsville 5,Attorney General,,,WRITE-IN,0
-Allegany,West Almond,Attorney General,,,WRITE-IN,0
-Allegany,Willing,Attorney General,,,WRITE-IN,1
-Allegany,Wirt,Attorney General,,,WRITE-IN,0
-Allegany,Alfred 1,Comptroller,,DEM,Thomas P. DiNapoli,198
-Allegany,Alfred 2,Comptroller,,DEM,Thomas P. DiNapoli,216
-Allegany,Allen,Comptroller,,DEM,Thomas P. DiNapoli,35
-Allegany,Alma,Comptroller,,DEM,Thomas P. DiNapoli,40
-Allegany,Almond,Comptroller,,DEM,Thomas P. DiNapoli,172
-Allegany,Amity 1,Comptroller,,DEM,Thomas P. DiNapoli,90
-Allegany,Amity 2,Comptroller,,DEM,Thomas P. DiNapoli,144
-Allegany,Andover 1,Comptroller,,DEM,Thomas P. DiNapoli,95
-Allegany,Andover 2,Comptroller,,DEM,Thomas P. DiNapoli,57
-Allegany,Angelica 1,Comptroller,,DEM,Thomas P. DiNapoli,80
-Allegany,Angelica 2,Comptroller,,DEM,Thomas P. DiNapoli,58
-Allegany,Belfast,Comptroller,,DEM,Thomas P. DiNapoli,138
-Allegany,Birdsall,Comptroller,,DEM,Thomas P. DiNapoli,17
-Allegany,Bolivar,Comptroller,,DEM,Thomas P. DiNapoli,158
-Allegany,Burns,Comptroller,,DEM,Thomas P. DiNapoli,83
-Allegany,Caneadea 1,Comptroller,,DEM,Thomas P. DiNapoli,67
-Allegany,Caneadea 2,Comptroller,,DEM,Thomas P. DiNapoli,87
-Allegany,Centerville,Comptroller,,DEM,Thomas P. DiNapoli,41
-Allegany,Clarksville,Comptroller,,DEM,Thomas P. DiNapoli,84
-Allegany,Cuba 1,Comptroller,,DEM,Thomas P. DiNapoli,183
-Allegany,Cuba 2,Comptroller,,DEM,Thomas P. DiNapoli,175
-Allegany,Friendship,Comptroller,,DEM,Thomas P. DiNapoli,116
-Allegany,Genesee,Comptroller,,DEM,Thomas P. DiNapoli,112
-Allegany,Granger,Comptroller,,DEM,Thomas P. DiNapoli,26
-Allegany,Grove,Comptroller,,DEM,Thomas P. DiNapoli,56
-Allegany,Hume,Comptroller,,DEM,Thomas P. DiNapoli,136
-Allegany,Independence,Comptroller,,DEM,Thomas P. DiNapoli,78
-Allegany,New Hudson,Comptroller,,DEM,Thomas P. DiNapoli,51
-Allegany,Rushford,Comptroller,,DEM,Thomas P. DiNapoli,92
-Allegany,Scio,Comptroller,,DEM,Thomas P. DiNapoli,145
-Allegany,Ward,Comptroller,,DEM,Thomas P. DiNapoli,45
-Allegany,Wellsville 1,Comptroller,,DEM,Thomas P. DiNapoli,142
-Allegany,Wellsville 2,Comptroller,,DEM,Thomas P. DiNapoli,188
-Allegany,Wellsville 3,Comptroller,,DEM,Thomas P. DiNapoli,187
-Allegany,Wellsville 4,Comptroller,,DEM,Thomas P. DiNapoli,110
-Allegany,Welllsville 5,Comptroller,,DEM,Thomas P. DiNapoli,127
-Allegany,West Almond,Comptroller,,DEM,Thomas P. DiNapoli,27
-Allegany,Willing,Comptroller,,DEM,Thomas P. DiNapoli,141
-Allegany,Wirt,Comptroller,,DEM,Thomas P. DiNapoli,45
-Allegany,Alfred 1,Comptroller,,WOR,Thomas P. DiNapoli,26
-Allegany,Alfred 2,Comptroller,,WOR,Thomas P. DiNapoli,21
-Allegany,Allen,Comptroller,,WOR,Thomas P. DiNapoli,7
-Allegany,Alma,Comptroller,,WOR,Thomas P. DiNapoli,6
-Allegany,Almond,Comptroller,,WOR,Thomas P. DiNapoli,24
-Allegany,Amity 1,Comptroller,,WOR,Thomas P. DiNapoli,16
-Allegany,Amity 2,Comptroller,,WOR,Thomas P. DiNapoli,9
-Allegany,Andover 1,Comptroller,,WOR,Thomas P. DiNapoli,9
-Allegany,Andover 2,Comptroller,,WOR,Thomas P. DiNapoli,10
-Allegany,Angelica 1,Comptroller,,WOR,Thomas P. DiNapoli,11
-Allegany,Angelica 2,Comptroller,,WOR,Thomas P. DiNapoli,3
-Allegany,Belfast,Comptroller,,WOR,Thomas P. DiNapoli,10
-Allegany,Birdsall,Comptroller,,WOR,Thomas P. DiNapoli,3
-Allegany,Bolivar,Comptroller,,WOR,Thomas P. DiNapoli,12
-Allegany,Burns,Comptroller,,WOR,Thomas P. DiNapoli,13
-Allegany,Caneadea 1,Comptroller,,WOR,Thomas P. DiNapoli,12
-Allegany,Caneadea 2,Comptroller,,WOR,Thomas P. DiNapoli,3
-Allegany,Centerville,Comptroller,,WOR,Thomas P. DiNapoli,8
-Allegany,Clarksville,Comptroller,,WOR,Thomas P. DiNapoli,7
-Allegany,Cuba 1,Comptroller,,WOR,Thomas P. DiNapoli,20
-Allegany,Cuba 2,Comptroller,,WOR,Thomas P. DiNapoli,25
-Allegany,Friendship,Comptroller,,WOR,Thomas P. DiNapoli,12
-Allegany,Genesee,Comptroller,,WOR,Thomas P. DiNapoli,9
-Allegany,Granger,Comptroller,,WOR,Thomas P. DiNapoli,5
-Allegany,Grove,Comptroller,,WOR,Thomas P. DiNapoli,13
-Allegany,Hume,Comptroller,,WOR,Thomas P. DiNapoli,19
-Allegany,Independence,Comptroller,,WOR,Thomas P. DiNapoli,7
-Allegany,New Hudson,Comptroller,,WOR,Thomas P. DiNapoli,10
-Allegany,Rushford,Comptroller,,WOR,Thomas P. DiNapoli,18
-Allegany,Scio,Comptroller,,WOR,Thomas P. DiNapoli,19
-Allegany,Ward,Comptroller,,WOR,Thomas P. DiNapoli,10
-Allegany,Wellsville 1,Comptroller,,WOR,Thomas P. DiNapoli,12
-Allegany,Wellsville 2,Comptroller,,WOR,Thomas P. DiNapoli,15
-Allegany,Wellsville 3,Comptroller,,WOR,Thomas P. DiNapoli,20
-Allegany,Wellsville 4,Comptroller,,WOR,Thomas P. DiNapoli,9
-Allegany,Welllsville 5,Comptroller,,WOR,Thomas P. DiNapoli,15
-Allegany,West Almond,Comptroller,,WOR,Thomas P. DiNapoli,1
-Allegany,Willing,Comptroller,,WOR,Thomas P. DiNapoli,14
-Allegany,Wirt,Comptroller,,WOR,Thomas P. DiNapoli,10
-Allegany,Alfred 1,Comptroller,,REP,Paul Rodriguez,40
-Allegany,Alfred 2,Comptroller,,REP,Paul Rodriguez,205
-Allegany,Allen,Comptroller,,REP,Paul Rodriguez,127
-Allegany,Alma,Comptroller,,REP,Paul Rodriguez,238
-Allegany,Almond,Comptroller,,REP,Paul Rodriguez,385
-Allegany,Amity 1,Comptroller,,REP,Paul Rodriguez,200
-Allegany,Amity 2,Comptroller,,REP,Paul Rodriguez,313
-Allegany,Andover 1,Comptroller,,REP,Paul Rodriguez,253
-Allegany,Andover 2,Comptroller,,REP,Paul Rodriguez,226
-Allegany,Angelica 1,Comptroller,,REP,Paul Rodriguez,202
-Allegany,Angelica 2,Comptroller,,REP,Paul Rodriguez,162
-Allegany,Belfast,Comptroller,,REP,Paul Rodriguez,391
-Allegany,Birdsall,Comptroller,,REP,Paul Rodriguez,58
-Allegany,Bolivar,Comptroller,,REP,Paul Rodriguez,457
-Allegany,Burns,Comptroller,,REP,Paul Rodriguez,288
-Allegany,Caneadea 1,Comptroller,,REP,Paul Rodriguez,172
-Allegany,Caneadea 2,Comptroller,,REP,Paul Rodriguez,180
-Allegany,Centerville,Comptroller,,REP,Paul Rodriguez,182
-Allegany,Clarksville,Comptroller,,REP,Paul Rodriguez,236
-Allegany,Cuba 1,Comptroller,,REP,Paul Rodriguez,241
-Allegany,Cuba 2,Comptroller,,REP,Paul Rodriguez,406
-Allegany,Friendship,Comptroller,,REP,Paul Rodriguez,393
-Allegany,Genesee,Comptroller,,REP,Paul Rodriguez,434
-Allegany,Granger,Comptroller,,REP,Paul Rodriguez,173
-Allegany,Grove,Comptroller,,REP,Paul Rodriguez,160
-Allegany,Hume,Comptroller,,REP,Paul Rodriguez,472
-Allegany,Independence,Comptroller,,REP,Paul Rodriguez,262
-Allegany,New Hudson,Comptroller,,REP,Paul Rodriguez,172
-Allegany,Rushford,Comptroller,,REP,Paul Rodriguez,310
-Allegany,Scio,Comptroller,,REP,Paul Rodriguez,408
-Allegany,Ward,Comptroller,,REP,Paul Rodriguez,102
-Allegany,Wellsville 1,Comptroller,,REP,Paul Rodriguez,258
-Allegany,Wellsville 2,Comptroller,,REP,Paul Rodriguez,257
-Allegany,Wellsville 3,Comptroller,,REP,Paul Rodriguez,293
-Allegany,Wellsville 4,Comptroller,,REP,Paul Rodriguez,276
-Allegany,Welllsville 5,Comptroller,,REP,Paul Rodriguez,312
-Allegany,West Almond,Comptroller,,REP,Paul Rodriguez,81
-Allegany,Willing,Comptroller,,REP,Paul Rodriguez,334
-Allegany,Wirt,Comptroller,,REP,Paul Rodriguez,305
-Allegany,Alfred 1,Comptroller,,CON,Paul Rodriguez,14
-Allegany,Alfred 2,Comptroller,,CON,Paul Rodriguez,47
-Allegany,Allen,Comptroller,,CON,Paul Rodriguez,13
-Allegany,Alma,Comptroller,,CON,Paul Rodriguez,21
-Allegany,Almond,Comptroller,,CON,Paul Rodriguez,72
-Allegany,Amity 1,Comptroller,,CON,Paul Rodriguez,21
-Allegany,Amity 2,Comptroller,,CON,Paul Rodriguez,26
-Allegany,Andover 1,Comptroller,,CON,Paul Rodriguez,27
-Allegany,Andover 2,Comptroller,,CON,Paul Rodriguez,13
-Allegany,Angelica 1,Comptroller,,CON,Paul Rodriguez,11
-Allegany,Angelica 2,Comptroller,,CON,Paul Rodriguez,19
-Allegany,Belfast,Comptroller,,CON,Paul Rodriguez,44
-Allegany,Birdsall,Comptroller,,CON,Paul Rodriguez,8
-Allegany,Bolivar,Comptroller,,CON,Paul Rodriguez,40
-Allegany,Burns,Comptroller,,CON,Paul Rodriguez,38
-Allegany,Caneadea 1,Comptroller,,CON,Paul Rodriguez,24
-Allegany,Caneadea 2,Comptroller,,CON,Paul Rodriguez,36
-Allegany,Centerville,Comptroller,,CON,Paul Rodriguez,30
-Allegany,Clarksville,Comptroller,,CON,Paul Rodriguez,26
-Allegany,Cuba 1,Comptroller,,CON,Paul Rodriguez,28
-Allegany,Cuba 2,Comptroller,,CON,Paul Rodriguez,28
-Allegany,Friendship,Comptroller,,CON,Paul Rodriguez,45
-Allegany,Genesee,Comptroller,,CON,Paul Rodriguez,37
-Allegany,Granger,Comptroller,,CON,Paul Rodriguez,22
-Allegany,Grove,Comptroller,,CON,Paul Rodriguez,27
-Allegany,Hume,Comptroller,,CON,Paul Rodriguez,55
-Allegany,Independence,Comptroller,,CON,Paul Rodriguez,12
-Allegany,New Hudson,Comptroller,,CON,Paul Rodriguez,17
-Allegany,Rushford,Comptroller,,CON,Paul Rodriguez,58
-Allegany,Scio,Comptroller,,CON,Paul Rodriguez,36
-Allegany,Ward,Comptroller,,CON,Paul Rodriguez,11
-Allegany,Wellsville 1,Comptroller,,CON,Paul Rodriguez,17
-Allegany,Wellsville 2,Comptroller,,CON,Paul Rodriguez,19
-Allegany,Wellsville 3,Comptroller,,CON,Paul Rodriguez,33
-Allegany,Wellsville 4,Comptroller,,CON,Paul Rodriguez,14
-Allegany,Welllsville 5,Comptroller,,CON,Paul Rodriguez,20
-Allegany,West Almond,Comptroller,,CON,Paul Rodriguez,13
-Allegany,Willing,Comptroller,,CON,Paul Rodriguez,15
-Allegany,Wirt,Comptroller,,CON,Paul Rodriguez,22
-Allegany,Alfred 1,Comptroller,,,WRITE-IN,1
-Allegany,Alfred 2,Comptroller,,,WRITE-IN,2
-Allegany,Allen,Comptroller,,,WRITE-IN,1
-Allegany,Alma,Comptroller,,,WRITE-IN,0
-Allegany,Almond,Comptroller,,,WRITE-IN,0
-Allegany,Amity 1,Comptroller,,,WRITE-IN,0
-Allegany,Amity 2,Comptroller,,,WRITE-IN,0
-Allegany,Andover 1,Comptroller,,,WRITE-IN,0
-Allegany,Andover 2,Comptroller,,,WRITE-IN,0
-Allegany,Angelica 1,Comptroller,,,WRITE-IN,0
-Allegany,Angelica 2,Comptroller,,,WRITE-IN,0
-Allegany,Belfast,Comptroller,,,WRITE-IN,0
-Allegany,Birdsall,Comptroller,,,WRITE-IN,0
-Allegany,Bolivar,Comptroller,,,WRITE-IN,0
-Allegany,Burns,Comptroller,,,WRITE-IN,0
-Allegany,Caneadea 1,Comptroller,,,WRITE-IN,1
-Allegany,Caneadea 2,Comptroller,,,WRITE-IN,1
-Allegany,Centerville,Comptroller,,,WRITE-IN,0
-Allegany,Clarksville,Comptroller,,,WRITE-IN,0
-Allegany,Cuba 1,Comptroller,,,WRITE-IN,0
-Allegany,Cuba 2,Comptroller,,,WRITE-IN,0
-Allegany,Friendship,Comptroller,,,WRITE-IN,0
-Allegany,Genesee,Comptroller,,,WRITE-IN,0
-Allegany,Granger,Comptroller,,,WRITE-IN,0
-Allegany,Grove,Comptroller,,,WRITE-IN,0
-Allegany,Hume,Comptroller,,,WRITE-IN,0
-Allegany,Independence,Comptroller,,,WRITE-IN,0
-Allegany,New Hudson,Comptroller,,,WRITE-IN,0
-Allegany,Rushford,Comptroller,,,WRITE-IN,0
-Allegany,Scio,Comptroller,,,WRITE-IN,0
-Allegany,Ward,Comptroller,,,WRITE-IN,0
-Allegany,Wellsville 1,Comptroller,,,WRITE-IN,0
-Allegany,Wellsville 2,Comptroller,,,WRITE-IN,0
-Allegany,Wellsville 3,Comptroller,,,WRITE-IN,0
-Allegany,Wellsville 4,Comptroller,,,WRITE-IN,0
-Allegany,Welllsville 5,Comptroller,,,WRITE-IN,0
-Allegany,West Almond,Comptroller,,,WRITE-IN,0
-Allegany,Willing,Comptroller,,,WRITE-IN,2
-Allegany,Wirt,Comptroller,,,WRITE-IN,0
-Allegany,Alfred 1,U.S. Senate,,DEM,Charles E. Schumer,204
-Allegany,Alfred 2,U.S. Senate,,DEM,Charles E. Schumer,221
-Allegany,Allen,U.S. Senate,,DEM,Charles E. Schumer,32
-Allegany,Alma,U.S. Senate,,DEM,Charles E. Schumer,39
-Allegany,Almond,U.S. Senate,,DEM,Charles E. Schumer,160
-Allegany,Amity 1,U.S. Senate,,DEM,Charles E. Schumer,80
-Allegany,Amity 2,U.S. Senate,,DEM,Charles E. Schumer,129
-Allegany,Andover 1,U.S. Senate,,DEM,Charles E. Schumer,97
-Allegany,Andover 2,U.S. Senate,,DEM,Charles E. Schumer,54
-Allegany,Angelica 1,U.S. Senate,,DEM,Charles E. Schumer,71
-Allegany,Angelica 2,U.S. Senate,,DEM,Charles E. Schumer,55
-Allegany,Belfast,U.S. Senate,,DEM,Charles E. Schumer,136
-Allegany,Birdsall,U.S. Senate,,DEM,Charles E. Schumer,16
-Allegany,Bolivar,U.S. Senate,,DEM,Charles E. Schumer,143
-Allegany,Burns,U.S. Senate,,DEM,Charles E. Schumer,75
-Allegany,Caneadea 1,U.S. Senate,,DEM,Charles E. Schumer,65
-Allegany,Caneadea 2,U.S. Senate,,DEM,Charles E. Schumer,94
-Allegany,Centerville,U.S. Senate,,DEM,Charles E. Schumer,37
-Allegany,Clarksville,U.S. Senate,,DEM,Charles E. Schumer,89
-Allegany,Cuba 1,U.S. Senate,,DEM,Charles E. Schumer,181
-Allegany,Cuba 2,U.S. Senate,,DEM,Charles E. Schumer,171
-Allegany,Friendship,U.S. Senate,,DEM,Charles E. Schumer,108
-Allegany,Genesee,U.S. Senate,,DEM,Charles E. Schumer,110
-Allegany,Granger,U.S. Senate,,DEM,Charles E. Schumer,26
-Allegany,Grove,U.S. Senate,,DEM,Charles E. Schumer,48
-Allegany,Hume,U.S. Senate,,DEM,Charles E. Schumer,133
-Allegany,Independence,U.S. Senate,,DEM,Charles E. Schumer,70
-Allegany,New Hudson,U.S. Senate,,DEM,Charles E. Schumer,44
-Allegany,Rushford,U.S. Senate,,DEM,Charles E. Schumer,93
-Allegany,Scio,U.S. Senate,,DEM,Charles E. Schumer,140
-Allegany,Ward,U.S. Senate,,DEM,Charles E. Schumer,36
-Allegany,Wellsville 1,U.S. Senate,,DEM,Charles E. Schumer,143
-Allegany,Wellsville 2,U.S. Senate,,DEM,Charles E. Schumer,196
-Allegany,Wellsville 3,U.S. Senate,,DEM,Charles E. Schumer,189
-Allegany,Wellsville 4,U.S. Senate,,DEM,Charles E. Schumer,110
-Allegany,Welllsville 5,U.S. Senate,,DEM,Charles E. Schumer,128
-Allegany,West Almond,U.S. Senate,,DEM,Charles E. Schumer,22
-Allegany,Willing,U.S. Senate,,DEM,Charles E. Schumer,131
-Allegany,Wirt,U.S. Senate,,DEM,Charles E. Schumer,47
-Allegany,Alfred 1,U.S. Senate,,WOR,Charles E. Schumer,26
-Allegany,Alfred 2,U.S. Senate,,WOR,Charles E. Schumer,21
-Allegany,Allen,U.S. Senate,,WOR,Charles E. Schumer,7
-Allegany,Alma,U.S. Senate,,WOR,Charles E. Schumer,4
-Allegany,Almond,U.S. Senate,,WOR,Charles E. Schumer,17
-Allegany,Amity 1,U.S. Senate,,WOR,Charles E. Schumer,10
-Allegany,Amity 2,U.S. Senate,,WOR,Charles E. Schumer,10
-Allegany,Andover 1,U.S. Senate,,WOR,Charles E. Schumer,9
-Allegany,Andover 2,U.S. Senate,,WOR,Charles E. Schumer,7
-Allegany,Angelica 1,U.S. Senate,,WOR,Charles E. Schumer,8
-Allegany,Angelica 2,U.S. Senate,,WOR,Charles E. Schumer,2
-Allegany,Belfast,U.S. Senate,,WOR,Charles E. Schumer,13
-Allegany,Birdsall,U.S. Senate,,WOR,Charles E. Schumer,1
-Allegany,Bolivar,U.S. Senate,,WOR,Charles E. Schumer,13
-Allegany,Burns,U.S. Senate,,WOR,Charles E. Schumer,8
-Allegany,Caneadea 1,U.S. Senate,,WOR,Charles E. Schumer,10
-Allegany,Caneadea 2,U.S. Senate,,WOR,Charles E. Schumer,3
-Allegany,Centerville,U.S. Senate,,WOR,Charles E. Schumer,2
-Allegany,Clarksville,U.S. Senate,,WOR,Charles E. Schumer,6
-Allegany,Cuba 1,U.S. Senate,,WOR,Charles E. Schumer,19
-Allegany,Cuba 2,U.S. Senate,,WOR,Charles E. Schumer,24
-Allegany,Friendship,U.S. Senate,,WOR,Charles E. Schumer,8
-Allegany,Genesee,U.S. Senate,,WOR,Charles E. Schumer,5
-Allegany,Granger,U.S. Senate,,WOR,Charles E. Schumer,3
-Allegany,Grove,U.S. Senate,,WOR,Charles E. Schumer,5
-Allegany,Hume,U.S. Senate,,WOR,Charles E. Schumer,21
-Allegany,Independence,U.S. Senate,,WOR,Charles E. Schumer,5
-Allegany,New Hudson,U.S. Senate,,WOR,Charles E. Schumer,9
-Allegany,Rushford,U.S. Senate,,WOR,Charles E. Schumer,13
-Allegany,Scio,U.S. Senate,,WOR,Charles E. Schumer,9
-Allegany,Ward,U.S. Senate,,WOR,Charles E. Schumer,10
-Allegany,Wellsville 1,U.S. Senate,,WOR,Charles E. Schumer,12
-Allegany,Wellsville 2,U.S. Senate,,WOR,Charles E. Schumer,9
-Allegany,Wellsville 3,U.S. Senate,,WOR,Charles E. Schumer,18
-Allegany,Wellsville 4,U.S. Senate,,WOR,Charles E. Schumer,10
-Allegany,Welllsville 5,U.S. Senate,,WOR,Charles E. Schumer,11
-Allegany,West Almond,U.S. Senate,,WOR,Charles E. Schumer,0
-Allegany,Willing,U.S. Senate,,WOR,Charles E. Schumer,7
-Allegany,Wirt,U.S. Senate,,WOR,Charles E. Schumer,8
-Allegany,Alfred 1,U.S. Senate,,REP,Joe Pinion,44
-Allegany,Alfred 2,U.S. Senate,,REP,Joe Pinion,207
-Allegany,Allen,U.S. Senate,,REP,Joe Pinion,134
-Allegany,Alma,U.S. Senate,,REP,Joe Pinion,242
-Allegany,Almond,U.S. Senate,,REP,Joe Pinion,399
-Allegany,Amity 1,U.S. Senate,,REP,Joe Pinion,210
-Allegany,Amity 2,U.S. Senate,,REP,Joe Pinion,327
-Allegany,Andover 1,U.S. Senate,,REP,Joe Pinion,253
-Allegany,Andover 2,U.S. Senate,,REP,Joe Pinion,225
-Allegany,Angelica 1,U.S. Senate,,REP,Joe Pinion,207
-Allegany,Angelica 2,U.S. Senate,,REP,Joe Pinion,166
-Allegany,Belfast,U.S. Senate,,REP,Joe Pinion,393
-Allegany,Birdsall,U.S. Senate,,REP,Joe Pinion,58
-Allegany,Bolivar,U.S. Senate,,REP,Joe Pinion,457
-Allegany,Burns,U.S. Senate,,REP,Joe Pinion,302
-Allegany,Caneadea 1,U.S. Senate,,REP,Joe Pinion,178
-Allegany,Caneadea 2,U.S. Senate,,REP,Joe Pinion,172
-Allegany,Centerville,U.S. Senate,,REP,Joe Pinion,189
-Allegany,Clarksville,U.S. Senate,,REP,Joe Pinion,235
-Allegany,Cuba 1,U.S. Senate,,REP,Joe Pinion,248
-Allegany,Cuba 2,U.S. Senate,,REP,Joe Pinion,411
-Allegany,Friendship,U.S. Senate,,REP,Joe Pinion,417
-Allegany,Genesee,U.S. Senate,,REP,Joe Pinion,438
-Allegany,Granger,U.S. Senate,,REP,Joe Pinion,179
-Allegany,Grove,U.S. Senate,,REP,Joe Pinion,173
-Allegany,Hume,U.S. Senate,,REP,Joe Pinion,477
-Allegany,Independence,U.S. Senate,,REP,Joe Pinion,276
-Allegany,New Hudson,U.S. Senate,,REP,Joe Pinion,177
-Allegany,Rushford,U.S. Senate,,REP,Joe Pinion,315
-Allegany,Scio,U.S. Senate,,REP,Joe Pinion,428
-Allegany,Ward,U.S. Senate,,REP,Joe Pinion,111
-Allegany,Wellsville 1,U.S. Senate,,REP,Joe Pinion,255
-Allegany,Wellsville 2,U.S. Senate,,REP,Joe Pinion,259
-Allegany,Wellsville 3,U.S. Senate,,REP,Joe Pinion,308
-Allegany,Wellsville 4,U.S. Senate,,REP,Joe Pinion,265
-Allegany,Welllsville 5,U.S. Senate,,REP,Joe Pinion,312
-Allegany,West Almond,U.S. Senate,,REP,Joe Pinion,87
-Allegany,Willing,U.S. Senate,,REP,Joe Pinion,352
-Allegany,Wirt,U.S. Senate,,REP,Joe Pinion,310
-Allegany,Alfred 1,U.S. Senate,,CON,Joe Pinion,12
-Allegany,Alfred 2,U.S. Senate,,CON,Joe Pinion,43
-Allegany,Allen,U.S. Senate,,CON,Joe Pinion,11
-Allegany,Alma,U.S. Senate,,CON,Joe Pinion,22
-Allegany,Almond,U.S. Senate,,CON,Joe Pinion,76
-Allegany,Amity 1,U.S. Senate,,CON,Joe Pinion,20
-Allegany,Amity 2,U.S. Senate,,CON,Joe Pinion,28
-Allegany,Andover 1,U.S. Senate,,CON,Joe Pinion,24
-Allegany,Andover 2,U.S. Senate,,CON,Joe Pinion,15
-Allegany,Angelica 1,U.S. Senate,,CON,Joe Pinion,13
-Allegany,Angelica 2,U.S. Senate,,CON,Joe Pinion,21
-Allegany,Belfast,U.S. Senate,,CON,Joe Pinion,45
-Allegany,Birdsall,U.S. Senate,,CON,Joe Pinion,10
-Allegany,Bolivar,U.S. Senate,,CON,Joe Pinion,46
-Allegany,Burns,U.S. Senate,,CON,Joe Pinion,38
-Allegany,Caneadea 1,U.S. Senate,,CON,Joe Pinion,25
-Allegany,Caneadea 2,U.S. Senate,,CON,Joe Pinion,37
-Allegany,Centerville,U.S. Senate,,CON,Joe Pinion,32
-Allegany,Clarksville,U.S. Senate,,CON,Joe Pinion,27
-Allegany,Cuba 1,U.S. Senate,,CON,Joe Pinion,25
-Allegany,Cuba 2,U.S. Senate,,CON,Joe Pinion,30
-Allegany,Friendship,U.S. Senate,,CON,Joe Pinion,42
-Allegany,Genesee,U.S. Senate,,CON,Joe Pinion,37
-Allegany,Granger,U.S. Senate,,CON,Joe Pinion,22
-Allegany,Grove,U.S. Senate,,CON,Joe Pinion,29
-Allegany,Hume,U.S. Senate,,CON,Joe Pinion,56
-Allegany,Independence,U.S. Senate,,CON,Joe Pinion,11
-Allegany,New Hudson,U.S. Senate,,CON,Joe Pinion,17
-Allegany,Rushford,U.S. Senate,,CON,Joe Pinion,61
-Allegany,Scio,U.S. Senate,,CON,Joe Pinion,35
-Allegany,Ward,U.S. Senate,,CON,Joe Pinion,10
-Allegany,Wellsville 1,U.S. Senate,,CON,Joe Pinion,22
-Allegany,Wellsville 2,U.S. Senate,,CON,Joe Pinion,20
-Allegany,Wellsville 3,U.S. Senate,,CON,Joe Pinion,33
-Allegany,Wellsville 4,U.S. Senate,,CON,Joe Pinion,14
-Allegany,Welllsville 5,U.S. Senate,,CON,Joe Pinion,22
-Allegany,West Almond,U.S. Senate,,CON,Joe Pinion,14
-Allegany,Willing,U.S. Senate,,CON,Joe Pinion,14
-Allegany,Wirt,U.S. Senate,,CON,Joe Pinion,22
-Allegany,Alfred 1,U.S. Senate,,LaRouche,Diane Sare,1
-Allegany,Alfred 2,U.S. Senate,,LaRouche,Diane Sare,4
-Allegany,Allen,U.S. Senate,,LaRouche,Diane Sare,0
-Allegany,Alma,U.S. Senate,,LaRouche,Diane Sare,1
-Allegany,Almond,U.S. Senate,,LaRouche,Diane Sare,6
-Allegany,Amity 1,U.S. Senate,,LaRouche,Diane Sare,2
-Allegany,Amity 2,U.S. Senate,,LaRouche,Diane Sare,1
-Allegany,Andover 1,U.S. Senate,,LaRouche,Diane Sare,2
-Allegany,Andover 2,U.S. Senate,,LaRouche,Diane Sare,3
-Allegany,Angelica 1,U.S. Senate,,LaRouche,Diane Sare,3
-Allegany,Angelica 2,U.S. Senate,,LaRouche,Diane Sare,1
-Allegany,Belfast,U.S. Senate,,LaRouche,Diane Sare,1
-Allegany,Birdsall,U.S. Senate,,LaRouche,Diane Sare,0
-Allegany,Bolivar,U.S. Senate,,LaRouche,Diane Sare,0
-Allegany,Burns,U.S. Senate,,LaRouche,Diane Sare,2
-Allegany,Caneadea 1,U.S. Senate,,LaRouche,Diane Sare,1
-Allegany,Caneadea 2,U.S. Senate,,LaRouche,Diane Sare,3
-Allegany,Centerville,U.S. Senate,,LaRouche,Diane Sare,4
-Allegany,Clarksville,U.S. Senate,,LaRouche,Diane Sare,0
-Allegany,Cuba 1,U.S. Senate,,LaRouche,Diane Sare,1
-Allegany,Cuba 2,U.S. Senate,,LaRouche,Diane Sare,2
-Allegany,Friendship,U.S. Senate,,LaRouche,Diane Sare,1
-Allegany,Genesee,U.S. Senate,,LaRouche,Diane Sare,2
-Allegany,Granger,U.S. Senate,,LaRouche,Diane Sare,0
-Allegany,Grove,U.S. Senate,,LaRouche,Diane Sare,4
-Allegany,Hume,U.S. Senate,,LaRouche,Diane Sare,4
-Allegany,Independence,U.S. Senate,,LaRouche,Diane Sare,2
-Allegany,New Hudson,U.S. Senate,,LaRouche,Diane Sare,2
-Allegany,Rushford,U.S. Senate,,LaRouche,Diane Sare,5
-Allegany,Scio,U.S. Senate,,LaRouche,Diane Sare,5
-Allegany,Ward,U.S. Senate,,LaRouche,Diane Sare,2
-Allegany,Wellsville 1,U.S. Senate,,LaRouche,Diane Sare,4
-Allegany,Wellsville 2,U.S. Senate,,LaRouche,Diane Sare,1
-Allegany,Wellsville 3,U.S. Senate,,LaRouche,Diane Sare,1
-Allegany,Wellsville 4,U.S. Senate,,LaRouche,Diane Sare,3
-Allegany,Welllsville 5,U.S. Senate,,LaRouche,Diane Sare,1
-Allegany,West Almond,U.S. Senate,,LaRouche,Diane Sare,0
-Allegany,Willing,U.S. Senate,,LaRouche,Diane Sare,0
-Allegany,Wirt,U.S. Senate,,LaRouche,Diane Sare,2
-Allegany,Alfred 1,U.S. Senate,,,WRITE-IN,1
-Allegany,Alfred 2,U.S. Senate,,,WRITE-IN,2
-Allegany,Allen,U.S. Senate,,,WRITE-IN,1
-Allegany,Alma,U.S. Senate,,,WRITE-IN,0
-Allegany,Almond,U.S. Senate,,,WRITE-IN,0
-Allegany,Amity 1,U.S. Senate,,,WRITE-IN,0
-Allegany,Amity 2,U.S. Senate,,,WRITE-IN,0
-Allegany,Andover 1,U.S. Senate,,,WRITE-IN,0
-Allegany,Andover 2,U.S. Senate,,,WRITE-IN,0
-Allegany,Angelica 1,U.S. Senate,,,WRITE-IN,0
-Allegany,Angelica 2,U.S. Senate,,,WRITE-IN,0
-Allegany,Belfast,U.S. Senate,,,WRITE-IN,0
-Allegany,Birdsall,U.S. Senate,,,WRITE-IN,0
-Allegany,Bolivar,U.S. Senate,,,WRITE-IN,0
-Allegany,Burns,U.S. Senate,,,WRITE-IN,0
-Allegany,Caneadea 1,U.S. Senate,,,WRITE-IN,1
-Allegany,Caneadea 2,U.S. Senate,,,WRITE-IN,1
-Allegany,Centerville,U.S. Senate,,,WRITE-IN,0
-Allegany,Clarksville,U.S. Senate,,,WRITE-IN,0
-Allegany,Cuba 1,U.S. Senate,,,WRITE-IN,0
-Allegany,Cuba 2,U.S. Senate,,,WRITE-IN,0
-Allegany,Friendship,U.S. Senate,,,WRITE-IN,0
-Allegany,Genesee,U.S. Senate,,,WRITE-IN,0
-Allegany,Granger,U.S. Senate,,,WRITE-IN,0
-Allegany,Grove,U.S. Senate,,,WRITE-IN,0
-Allegany,Hume,U.S. Senate,,,WRITE-IN,0
-Allegany,Independence,U.S. Senate,,,WRITE-IN,0
-Allegany,New Hudson,U.S. Senate,,,WRITE-IN,0
-Allegany,Rushford,U.S. Senate,,,WRITE-IN,0
-Allegany,Scio,U.S. Senate,,,WRITE-IN,1
-Allegany,Ward,U.S. Senate,,,WRITE-IN,0
-Allegany,Wellsville 1,U.S. Senate,,,WRITE-IN,0
-Allegany,Wellsville 2,U.S. Senate,,,WRITE-IN,0
-Allegany,Wellsville 3,U.S. Senate,,,WRITE-IN,0
-Allegany,Wellsville 4,U.S. Senate,,,WRITE-IN,0
-Allegany,Welllsville 5,U.S. Senate,,,WRITE-IN,0
-Allegany,West Almond,U.S. Senate,,,WRITE-IN,0
-Allegany,Willing,U.S. Senate,,,WRITE-IN,0
-Allegany,Wirt,U.S. Senate,,,WRITE-IN,0
-Allegany,Alfred 1,U.S. House,23,DEM,Max Della Pia,224
-Allegany,Alfred 2,U.S. House,23,DEM,Max Della Pia,226
-Allegany,Allen,U.S. House,23,DEM,Max Della Pia,28
-Allegany,Alma,U.S. House,23,DEM,Max Della Pia,21
-Allegany,Almond,U.S. House,23,DEM,Max Della Pia,156
-Allegany,Amity 1,U.S. House,23,DEM,Max Della Pia,73
-Allegany,Amity 2,U.S. House,23,DEM,Max Della Pia,125
-Allegany,Andover 1,U.S. House,23,DEM,Max Della Pia,95
-Allegany,Andover 2,U.S. House,23,DEM,Max Della Pia,53
-Allegany,Angelica 1,U.S. House,23,DEM,Max Della Pia,64
-Allegany,Angelica 2,U.S. House,23,DEM,Max Della Pia,50
-Allegany,Belfast,U.S. House,23,DEM,Max Della Pia,121
-Allegany,Birdsall,U.S. House,23,DEM,Max Della Pia,15
-Allegany,Bolivar,U.S. House,23,DEM,Max Della Pia,134
-Allegany,Burns,U.S. House,23,DEM,Max Della Pia,66
-Allegany,Caneadea 1,U.S. House,23,DEM,Max Della Pia,59
-Allegany,Caneadea 2,U.S. House,23,DEM,Max Della Pia,95
-Allegany,Centerville,U.S. House,23,DEM,Max Della Pia,29
-Allegany,Clarksville,U.S. House,23,DEM,Max Della Pia,79
-Allegany,Cuba 1,U.S. House,23,DEM,Max Della Pia,173
-Allegany,Cuba 2,U.S. House,23,DEM,Max Della Pia,165
-Allegany,Friendship,U.S. House,23,DEM,Max Della Pia,78
-Allegany,Genesee,U.S. House,23,DEM,Max Della Pia,99
-Allegany,Granger,U.S. House,23,DEM,Max Della Pia,25
-Allegany,Grove,U.S. House,23,DEM,Max Della Pia,52
-Allegany,Hume,U.S. House,23,DEM,Max Della Pia,130
-Allegany,Independence,U.S. House,23,DEM,Max Della Pia,65
-Allegany,New Hudson,U.S. House,23,DEM,Max Della Pia,40
-Allegany,Rushford,U.S. House,23,DEM,Max Della Pia,84
-Allegany,Scio,U.S. House,23,DEM,Max Della Pia,124
-Allegany,Ward,U.S. House,23,DEM,Max Della Pia,38
-Allegany,Wellsville 1,U.S. House,23,DEM,Max Della Pia,138
-Allegany,Wellsville 2,U.S. House,23,DEM,Max Della Pia,170
-Allegany,Wellsville 3,U.S. House,23,DEM,Max Della Pia,175
-Allegany,Wellsville 4,U.S. House,23,DEM,Max Della Pia,100
-Allegany,Welllsville 5,U.S. House,23,DEM,Max Della Pia,112
-Allegany,West Almond,U.S. House,23,DEM,Max Della Pia,20
-Allegany,Willing,U.S. House,23,DEM,Max Della Pia,106
-Allegany,Wirt,U.S. House,23,DEM,Max Della Pia,36
-Allegany,Alfred 1,U.S. House,23,REP,Nicholas A. Langworthy,48
-Allegany,Alfred 2,U.S. House,23,REP,Nicholas A. Langworthy,212
-Allegany,Allen,U.S. House,23,REP,Nicholas A. Langworthy,140
-Allegany,Alma,U.S. House,23,REP,Nicholas A. Langworthy,246
-Allegany,Almond,U.S. House,23,REP,Nicholas A. Langworthy,416
-Allegany,Amity 1,U.S. House,23,REP,Nicholas A. Langworthy,216
-Allegany,Amity 2,U.S. House,23,REP,Nicholas A. Langworthy,342
-Allegany,Andover 1,U.S. House,23,REP,Nicholas A. Langworthy,260
-Allegany,Andover 2,U.S. House,23,REP,Nicholas A. Langworthy,240
-Allegany,Angelica 1,U.S. House,23,REP,Nicholas A. Langworthy,214
-Allegany,Angelica 2,U.S. House,23,REP,Nicholas A. Langworthy,173
-Allegany,Belfast,U.S. House,23,REP,Nicholas A. Langworthy,413
-Allegany,Birdsall,U.S. House,23,REP,Nicholas A. Langworthy,59
-Allegany,Bolivar,U.S. House,23,REP,Nicholas A. Langworthy,485
-Allegany,Burns,U.S. House,23,REP,Nicholas A. Langworthy,310
-Allegany,Caneadea 1,U.S. House,23,REP,Nicholas A. Langworthy,186
-Allegany,Caneadea 2,U.S. House,23,REP,Nicholas A. Langworthy,179
-Allegany,Centerville,U.S. House,23,REP,Nicholas A. Langworthy,197
-Allegany,Clarksville,U.S. House,23,REP,Nicholas A. Langworthy,237
-Allegany,Cuba 1,U.S. House,23,REP,Nicholas A. Langworthy,276
-Allegany,Cuba 2,U.S. House,23,REP,Nicholas A. Langworthy,441
-Allegany,Friendship,U.S. House,23,REP,Nicholas A. Langworthy,451
-Allegany,Genesee,U.S. House,23,REP,Nicholas A. Langworthy,462
-Allegany,Granger,U.S. House,23,REP,Nicholas A. Langworthy,178
-Allegany,Grove,U.S. House,23,REP,Nicholas A. Langworthy,173
-Allegany,Hume,U.S. House,23,REP,Nicholas A. Langworthy,502
-Allegany,Independence,U.S. House,23,REP,Nicholas A. Langworthy,282
-Allegany,New Hudson,U.S. House,23,REP,Nicholas A. Langworthy,188
-Allegany,Rushford,U.S. House,23,REP,Nicholas A. Langworthy,335
-Allegany,Scio,U.S. House,23,REP,Nicholas A. Langworthy,442
-Allegany,Ward,U.S. House,23,REP,Nicholas A. Langworthy,116
-Allegany,Wellsville 1,U.S. House,23,REP,Nicholas A. Langworthy,272
-Allegany,Wellsville 2,U.S. House,23,REP,Nicholas A. Langworthy,285
-Allegany,Wellsville 3,U.S. House,23,REP,Nicholas A. Langworthy,282
-Allegany,Wellsville 4,U.S. House,23,REP,Nicholas A. Langworthy,288
-Allegany,Welllsville 5,U.S. House,23,REP,Nicholas A. Langworthy,330
-Allegany,West Almond,U.S. House,23,REP,Nicholas A. Langworthy,90
-Allegany,Willing,U.S. House,23,REP,Nicholas A. Langworthy,376
-Allegany,Wirt,U.S. House,23,REP,Nicholas A. Langworthy,328
-Allegany,Alfred 1,U.S. House,23,CON,Nicholas A. Langworthy,15
-Allegany,Alfred 2,U.S. House,23,CON,Nicholas A. Langworthy,44
-Allegany,Allen,U.S. House,23,CON,Nicholas A. Langworthy,15
-Allegany,Alma,U.S. House,23,CON,Nicholas A. Langworthy,19
-Allegany,Almond,U.S. House,23,CON,Nicholas A. Langworthy,77
-Allegany,Amity 1,U.S. House,23,CON,Nicholas A. Langworthy,23
-Allegany,Amity 2,U.S. House,23,CON,Nicholas A. Langworthy,33
-Allegany,Andover 1,U.S. House,23,CON,Nicholas A. Langworthy,28
-Allegany,Andover 2,U.S. House,23,CON,Nicholas A. Langworthy,14
-Allegany,Angelica 1,U.S. House,23,CON,Nicholas A. Langworthy,16
-Allegany,Angelica 2,U.S. House,23,CON,Nicholas A. Langworthy,22
-Allegany,Belfast,U.S. House,23,CON,Nicholas A. Langworthy,48
-Allegany,Birdsall,U.S. House,23,CON,Nicholas A. Langworthy,12
-Allegany,Bolivar,U.S. House,23,CON,Nicholas A. Langworthy,38
-Allegany,Burns,U.S. House,23,CON,Nicholas A. Langworthy,43
-Allegany,Caneadea 1,U.S. House,23,CON,Nicholas A. Langworthy,24
-Allegany,Caneadea 2,U.S. House,23,CON,Nicholas A. Langworthy,36
-Allegany,Centerville,U.S. House,23,CON,Nicholas A. Langworthy,35
-Allegany,Clarksville,U.S. House,23,CON,Nicholas A. Langworthy,32
-Allegany,Cuba 1,U.S. House,23,CON,Nicholas A. Langworthy,29
-Allegany,Cuba 2,U.S. House,23,CON,Nicholas A. Langworthy,29
-Allegany,Friendship,U.S. House,23,CON,Nicholas A. Langworthy,46
-Allegany,Genesee,U.S. House,23,CON,Nicholas A. Langworthy,36
-Allegany,Granger,U.S. House,23,CON,Nicholas A. Langworthy,20
-Allegany,Grove,U.S. House,23,CON,Nicholas A. Langworthy,28
-Allegany,Hume,U.S. House,23,CON,Nicholas A. Langworthy,48
-Allegany,Independence,U.S. House,23,CON,Nicholas A. Langworthy,15
-Allegany,New Hudson,U.S. House,23,CON,Nicholas A. Langworthy,19
-Allegany,Rushford,U.S. House,23,CON,Nicholas A. Langworthy,63
-Allegany,Scio,U.S. House,23,CON,Nicholas A. Langworthy,44
-Allegany,Ward,U.S. House,23,CON,Nicholas A. Langworthy,12
-Allegany,Wellsville 1,U.S. House,23,CON,Nicholas A. Langworthy,25
-Allegany,Wellsville 2,U.S. House,23,CON,Nicholas A. Langworthy,24
-Allegany,Wellsville 3,U.S. House,23,CON,Nicholas A. Langworthy,36
-Allegany,Wellsville 4,U.S. House,23,CON,Nicholas A. Langworthy,19
-Allegany,Welllsville 5,U.S. House,23,CON,Nicholas A. Langworthy,25
-Allegany,West Almond,U.S. House,23,CON,Nicholas A. Langworthy,15
-Allegany,Willing,U.S. House,23,CON,Nicholas A. Langworthy,14
-Allegany,Wirt,U.S. House,23,CON,Nicholas A. Langworthy,21
-Allegany,Alfred 1,U.S. House,23,,WRITE-IN,1
-Allegany,Alfred 2,U.S. House,23,,WRITE-IN,1
-Allegany,Allen,U.S. House,23,,WRITE-IN,0
-Allegany,Alma,U.S. House,23,,WRITE-IN,0
-Allegany,Almond,U.S. House,23,,WRITE-IN,0
-Allegany,Amity 1,U.S. House,23,,WRITE-IN,0
-Allegany,Amity 2,U.S. House,23,,WRITE-IN,0
-Allegany,Andover 1,U.S. House,23,,WRITE-IN,0
-Allegany,Andover 2,U.S. House,23,,WRITE-IN,0
-Allegany,Angelica 1,U.S. House,23,,WRITE-IN,0
-Allegany,Angelica 2,U.S. House,23,,WRITE-IN,0
-Allegany,Belfast,U.S. House,23,,WRITE-IN,0
-Allegany,Birdsall,U.S. House,23,,WRITE-IN,0
-Allegany,Bolivar,U.S. House,23,,WRITE-IN,0
-Allegany,Burns,U.S. House,23,,WRITE-IN,0
-Allegany,Caneadea 1,U.S. House,23,,WRITE-IN,2
-Allegany,Caneadea 2,U.S. House,23,,WRITE-IN,2
-Allegany,Centerville,U.S. House,23,,WRITE-IN,0
-Allegany,Clarksville,U.S. House,23,,WRITE-IN,0
-Allegany,Cuba 1,U.S. House,23,,WRITE-IN,0
-Allegany,Cuba 2,U.S. House,23,,WRITE-IN,0
-Allegany,Friendship,U.S. House,23,,WRITE-IN,0
-Allegany,Genesee,U.S. House,23,,WRITE-IN,0
-Allegany,Granger,U.S. House,23,,WRITE-IN,0
-Allegany,Grove,U.S. House,23,,WRITE-IN,0
-Allegany,Hume,U.S. House,23,,WRITE-IN,0
-Allegany,Independence,U.S. House,23,,WRITE-IN,0
-Allegany,New Hudson,U.S. House,23,,WRITE-IN,0
-Allegany,Rushford,U.S. House,23,,WRITE-IN,0
-Allegany,Scio,U.S. House,23,,WRITE-IN,0
-Allegany,Ward,U.S. House,23,,WRITE-IN,0
-Allegany,Wellsville 1,U.S. House,23,,WRITE-IN,0
-Allegany,Wellsville 2,U.S. House,23,,WRITE-IN,0
-Allegany,Wellsville 3,U.S. House,23,,WRITE-IN,1
-Allegany,Wellsville 4,U.S. House,23,,WRITE-IN,0
-Allegany,Welllsville 5,U.S. House,23,,WRITE-IN,0
-Allegany,West Almond,U.S. House,23,,WRITE-IN,0
-Allegany,Willing,U.S. House,23,,WRITE-IN,0
-Allegany,Wirt,U.S. House,23,,WRITE-IN,1
-Allegany,Allen,State Senate,57,DEM,Daniel Brown,32
-Allegany,Alma,State Senate,57,DEM,Daniel Brown,31
-Allegany,Angelica 1,State Senate,57,DEM,Daniel Brown,57
-Allegany,Angelica 2,State Senate,57,DEM,Daniel Brown,49
-Allegany,Belfast,State Senate,57,DEM,Daniel Brown,108
-Allegany,Bolivar,State Senate,57,DEM,Daniel Brown,123
-Allegany,Caneadea 1,State Senate,57,DEM,Daniel Brown,58
-Allegany,Caneadea 2,State Senate,57,DEM,Daniel Brown,80
-Allegany,Centerville,State Senate,57,DEM,Daniel Brown,39
-Allegany,Clarksville,State Senate,57,DEM,Daniel Brown,78
-Allegany,Cuba 1,State Senate,57,DEM,Daniel Brown,159
-Allegany,Cuba 2,State Senate,57,DEM,Daniel Brown,152
-Allegany,Friendship,State Senate,57,DEM,Daniel Brown,86
-Allegany,Genesee,State Senate,57,DEM,Daniel Brown,93
-Allegany,Granger,State Senate,57,DEM,Daniel Brown,27
-Allegany,Hume,State Senate,57,DEM,Daniel Brown,125
-Allegany,New Hudson,State Senate,57,DEM,Daniel Brown,35
-Allegany,Rushford,State Senate,57,DEM,Daniel Brown,83
-Allegany,West Almond,State Senate,57,DEM,Daniel Brown,24
-Allegany,Wirt,State Senate,57,DEM,Daniel Brown,35
-Allegany,Allen,State Senate,57,REP,George Borrello,135
-Allegany,Alma,State Senate,57,REP,George Borrello,246
-Allegany,Angelica 1,State Senate,57,REP,George Borrello,218
-Allegany,Angelica 2,State Senate,57,REP,George Borrello,172
-Allegany,Belfast,State Senate,57,REP,George Borrello,427
-Allegany,Bolivar,State Senate,57,REP,George Borrello,488
-Allegany,Caneadea 1,State Senate,57,REP,George Borrello,191
-Allegany,Caneadea 2,State Senate,57,REP,George Borrello,193
-Allegany,Centerville,State Senate,57,REP,George Borrello,193
-Allegany,Clarksville,State Senate,57,REP,George Borrello,240
-Allegany,Cuba 1,State Senate,57,REP,George Borrello,285
-Allegany,Cuba 2,State Senate,57,REP,George Borrello,451
-Allegany,Friendship,State Senate,57,REP,George Borrello,439
-Allegany,Genesee,State Senate,57,REP,George Borrello,463
-Allegany,Granger,State Senate,57,REP,George Borrello,178
-Allegany,Hume,State Senate,57,REP,George Borrello,499
-Allegany,New Hudson,State Senate,57,REP,George Borrello,191
-Allegany,Rushford,State Senate,57,REP,George Borrello,342
-Allegany,West Almond,State Senate,57,REP,George Borrello,84
-Allegany,Wirt,State Senate,57,REP,George Borrello,323
-Allegany,Allen,State Senate,57,CON,George Borrello,12
-Allegany,Alma,State Senate,57,CON,George Borrello,22
-Allegany,Angelica 1,State Senate,57,CON,George Borrello,19
-Allegany,Angelica 2,State Senate,57,CON,George Borrello,21
-Allegany,Belfast,State Senate,57,CON,George Borrello,46
-Allegany,Bolivar,State Senate,57,CON,George Borrello,43
-Allegany,Caneadea 1,State Senate,57,CON,George Borrello,24
-Allegany,Caneadea 2,State Senate,57,CON,George Borrello,33
-Allegany,Centerville,State Senate,57,CON,George Borrello,32
-Allegany,Clarksville,State Senate,57,CON,George Borrello,33
-Allegany,Cuba 1,State Senate,57,CON,George Borrello,29
-Allegany,Cuba 2,State Senate,57,CON,George Borrello,35
-Allegany,Friendship,State Senate,57,CON,George Borrello,42
-Allegany,Genesee,State Senate,57,CON,George Borrello,32
-Allegany,Granger,State Senate,57,CON,George Borrello,20
-Allegany,Hume,State Senate,57,CON,George Borrello,49
-Allegany,New Hudson,State Senate,57,CON,George Borrello,19
-Allegany,Rushford,State Senate,57,CON,George Borrello,52
-Allegany,West Almond,State Senate,57,CON,George Borrello,15
-Allegany,Wirt,State Senate,57,CON,George Borrello,25
-Allegany,Allen,State Senate,57,,WRITE-IN,1
-Allegany,Alma,State Senate,57,,WRITE-IN,0
-Allegany,Angelica 1,State Senate,57,,WRITE-IN,0
-Allegany,Angelica 2,State Senate,57,,WRITE-IN,0
-Allegany,Belfast,State Senate,57,,WRITE-IN,0
-Allegany,Bolivar,State Senate,57,,WRITE-IN,0
-Allegany,Caneadea 1,State Senate,57,,WRITE-IN,0
-Allegany,Caneadea 2,State Senate,57,,WRITE-IN,0
-Allegany,Centerville,State Senate,57,,WRITE-IN,0
-Allegany,Clarksville,State Senate,57,,WRITE-IN,0
-Allegany,Cuba 1,State Senate,57,,WRITE-IN,0
-Allegany,Cuba 2,State Senate,57,,WRITE-IN,0
-Allegany,Friendship,State Senate,57,,WRITE-IN,0
-Allegany,Genesee,State Senate,57,,WRITE-IN,0
-Allegany,Granger,State Senate,57,,WRITE-IN,0
-Allegany,Hume,State Senate,57,,WRITE-IN,1
-Allegany,New Hudson,State Senate,57,,WRITE-IN,0
-Allegany,Rushford,State Senate,57,,WRITE-IN,0
-Allegany,West Almond,State Senate,57,,WRITE-IN,0
-Allegany,Wirt,State Senate,57,,WRITE-IN,0
-Allegany,Alfred 1,State Senate,58,REP,Thomas O'Mara,95
-Allegany,Alfred 2,State Senate,58,REP,Thomas O'Mara,245
-Allegany,Almond,State Senate,58,REP,Thomas O'Mara,448
-Allegany,Amity 1,State Senate,58,REP,Thomas O'Mara,223
-Allegany,Amity 2,State Senate,58,REP,Thomas O'Mara,354
-Allegany,Andover 1,State Senate,58,REP,Thomas O'Mara,294
-Allegany,Andover 2,State Senate,58,REP,Thomas O'Mara,244
-Allegany,Birdsall,State Senate,58,REP,Thomas O'Mara,59
-Allegany,Burns,State Senate,58,REP,Thomas O'Mara,321
-Allegany,Grove,State Senate,58,REP,Thomas O'Mara,189
-Allegany,Independence,State Senate,58,REP,Thomas O'Mara,280
-Allegany,Scio,State Senate,58,REP,Thomas O'Mara,461
-Allegany,Ward,State Senate,58,REP,Thomas O'Mara,111
-Allegany,Wellsville 1,State Senate,58,REP,Thomas O'Mara,306
-Allegany,Wellsville 2,State Senate,58,REP,Thomas O'Mara,325
-Allegany,Wellsville 3,State Senate,58,REP,Thomas O'Mara,370
-Allegany,Wellsville 4,State Senate,58,REP,Thomas O'Mara,306
-Allegany,Welllsville 5,State Senate,58,REP,Thomas O'Mara,359
-Allegany,Willing,State Senate,58,REP,Thomas O'Mara,403
-Allegany,Alfred 1,State Senate,58,CON,Thomas O'Mara,24
-Allegany,Alfred 2,State Senate,58,CON,Thomas O'Mara,55
-Allegany,Almond,State Senate,58,CON,Thomas O'Mara,91
-Allegany,Amity 1,State Senate,58,CON,Thomas O'Mara,25
-Allegany,Amity 2,State Senate,58,CON,Thomas O'Mara,46
-Allegany,Andover 1,State Senate,58,CON,Thomas O'Mara,34
-Allegany,Andover 2,State Senate,58,CON,Thomas O'Mara,13
-Allegany,Birdsall,State Senate,58,CON,Thomas O'Mara,12
-Allegany,Burns,State Senate,58,CON,Thomas O'Mara,49
-Allegany,Grove,State Senate,58,CON,Thomas O'Mara,36
-Allegany,Independence,State Senate,58,CON,Thomas O'Mara,23
-Allegany,Scio,State Senate,58,CON,Thomas O'Mara,56
-Allegany,Ward,State Senate,58,CON,Thomas O'Mara,19
-Allegany,Wellsville 1,State Senate,58,CON,Thomas O'Mara,37
-Allegany,Wellsville 2,State Senate,58,CON,Thomas O'Mara,39
-Allegany,Wellsville 3,State Senate,58,CON,Thomas O'Mara,47
-Allegany,Wellsville 4,State Senate,58,CON,Thomas O'Mara,25
-Allegany,Welllsville 5,State Senate,58,CON,Thomas O'Mara,36
-Allegany,Willing,State Senate,58,CON,Thomas O'Mara,22
-Allegany,Alfred 1,State Senate,58,,WRITE-IN,7
-Allegany,Alfred 2,State Senate,58,,WRITE-IN,4
-Allegany,Almond,State Senate,58,,WRITE-IN,5
-Allegany,Amity 1,State Senate,58,,WRITE-IN,1
-Allegany,Amity 2,State Senate,58,,WRITE-IN,1
-Allegany,Andover 1,State Senate,58,,WRITE-IN,0
-Allegany,Andover 2,State Senate,58,,WRITE-IN,0
-Allegany,Birdsall,State Senate,58,,WRITE-IN,0
-Allegany,Burns,State Senate,58,,WRITE-IN,1
-Allegany,Grove,State Senate,58,,WRITE-IN,0
-Allegany,Independence,State Senate,58,,WRITE-IN,0
-Allegany,Scio,State Senate,58,,WRITE-IN,2
-Allegany,Ward,State Senate,58,,WRITE-IN,1
-Allegany,Wellsville 1,State Senate,58,,WRITE-IN,3
-Allegany,Wellsville 2,State Senate,58,,WRITE-IN,0
-Allegany,Wellsville 3,State Senate,58,,WRITE-IN,2
-Allegany,Wellsville 4,State Senate,58,,WRITE-IN,1
-Allegany,Welllsville 5,State Senate,58,,WRITE-IN,2
-Allegany,Willing,State Senate,58,,WRITE-IN,0
-Allegany,Alfred 1,State Assembly,148,REP,Joseph Giglio,89
-Allegany,Alfred 2,State Assembly,148,REP,Joseph Giglio,248
-Allegany,Allen,State Assembly,148,REP,Joseph Giglio,135
-Allegany,Alma,State Assembly,148,REP,Joseph Giglio,246
-Allegany,Almond,State Assembly,148,REP,Joseph Giglio,452
-Allegany,Amity 1,State Assembly,148,REP,Joseph Giglio,228
-Allegany,Amity 2,State Assembly,148,REP,Joseph Giglio,355
-Allegany,Andover 1,State Assembly,148,REP,Joseph Giglio,295
-Allegany,Andover 2,State Assembly,148,REP,Joseph Giglio,245
-Allegany,Angelica 1,State Assembly,148,REP,Joseph Giglio,224
-Allegany,Angelica 2,State Assembly,148,REP,Joseph Giglio,180
-Allegany,Belfast,State Assembly,148,REP,Joseph Giglio,450
-Allegany,Birdsall,State Assembly,148,REP,Joseph Giglio,61
-Allegany,Bolivar,State Assembly,148,REP,Joseph Giglio,522
-Allegany,Burns,State Assembly,148,REP,Joseph Giglio,315
-Allegany,Caneadea 1,State Assembly,148,REP,Joseph Giglio,205
-Allegany,Caneadea 2,State Assembly,148,REP,Joseph Giglio,218
-Allegany,Centerville,State Assembly,148,REP,Joseph Giglio,199
-Allegany,Clarksville,State Assembly,148,REP,Joseph Giglio,258
-Allegany,Cuba 1,State Assembly,148,REP,Joseph Giglio,323
-Allegany,Cuba 2,State Assembly,148,REP,Joseph Giglio,504
-Allegany,Friendship,State Assembly,148,REP,Joseph Giglio,460
-Allegany,Genesee,State Assembly,148,REP,Joseph Giglio,488
-Allegany,Granger,State Assembly,148,REP,Joseph Giglio,180
-Allegany,Grove,State Assembly,148,REP,Joseph Giglio,187
-Allegany,Hume,State Assembly,148,REP,Joseph Giglio,528
-Allegany,Independence,State Assembly,148,REP,Joseph Giglio,281
-Allegany,New Hudson,State Assembly,148,REP,Joseph Giglio,195
-Allegany,Rushford,State Assembly,148,REP,Joseph Giglio,364
-Allegany,Scio,State Assembly,148,REP,Joseph Giglio,470
-Allegany,Ward,State Assembly,148,REP,Joseph Giglio,116
-Allegany,Wellsville 1,State Assembly,148,REP,Joseph Giglio,310
-Allegany,Wellsville 2,State Assembly,148,REP,Joseph Giglio,326
-Allegany,Wellsville 3,State Assembly,148,REP,Joseph Giglio,374
-Allegany,Wellsville 4,State Assembly,148,REP,Joseph Giglio,309
-Allegany,Welllsville 5,State Assembly,148,REP,Joseph Giglio,360
-Allegany,West Almond,State Assembly,148,REP,Joseph Giglio,86
-Allegany,Willing,State Assembly,148,REP,Joseph Giglio,405
-Allegany,Wirt,State Assembly,148,REP,Joseph Giglio,332
-Allegany,Alfred 1,State Assembly,148,CON,Joseph Giglio,26
-Allegany,Alfred 2,State Assembly,148,CON,Joseph Giglio,55
-Allegany,Allen,State Assembly,148,CON,Joseph Giglio,13
-Allegany,Alma,State Assembly,148,CON,Joseph Giglio,24
-Allegany,Almond,State Assembly,148,CON,Joseph Giglio,89
-Allegany,Amity 1,State Assembly,148,CON,Joseph Giglio,25
-Allegany,Amity 2,State Assembly,148,CON,Joseph Giglio,47
-Allegany,Andover 1,State Assembly,148,CON,Joseph Giglio,34
-Allegany,Andover 2,State Assembly,148,CON,Joseph Giglio,16
-Allegany,Angelica 1,State Assembly,148,CON,Joseph Giglio,22
-Allegany,Angelica 2,State Assembly,148,CON,Joseph Giglio,24
-Allegany,Belfast,State Assembly,148,CON,Joseph Giglio,60
-Allegany,Birdsall,State Assembly,148,CON,Joseph Giglio,12
-Allegany,Bolivar,State Assembly,148,CON,Joseph Giglio,56
-Allegany,Burns,State Assembly,148,CON,Joseph Giglio,51
-Allegany,Caneadea 1,State Assembly,148,CON,Joseph Giglio,26
-Allegany,Caneadea 2,State Assembly,148,CON,Joseph Giglio,41
-Allegany,Centerville,State Assembly,148,CON,Joseph Giglio,37
-Allegany,Clarksville,State Assembly,148,CON,Joseph Giglio,35
-Allegany,Cuba 1,State Assembly,148,CON,Joseph Giglio,51
-Allegany,Cuba 2,State Assembly,148,CON,Joseph Giglio,45
-Allegany,Friendship,State Assembly,148,CON,Joseph Giglio,44
-Allegany,Genesee,State Assembly,148,CON,Joseph Giglio,39
-Allegany,Granger,State Assembly,148,CON,Joseph Giglio,22
-Allegany,Grove,State Assembly,148,CON,Joseph Giglio,33
-Allegany,Hume,State Assembly,148,CON,Joseph Giglio,65
-Allegany,Independence,State Assembly,148,CON,Joseph Giglio,24
-Allegany,New Hudson,State Assembly,148,CON,Joseph Giglio,26
-Allegany,Rushford,State Assembly,148,CON,Joseph Giglio,66
-Allegany,Scio,State Assembly,148,CON,Joseph Giglio,55
-Allegany,Ward,State Assembly,148,CON,Joseph Giglio,14
-Allegany,Wellsville 1,State Assembly,148,CON,Joseph Giglio,41
-Allegany,Wellsville 2,State Assembly,148,CON,Joseph Giglio,39
-Allegany,Wellsville 3,State Assembly,148,CON,Joseph Giglio,44
-Allegany,Wellsville 4,State Assembly,148,CON,Joseph Giglio,23
-Allegany,Welllsville 5,State Assembly,148,CON,Joseph Giglio,39
-Allegany,West Almond,State Assembly,148,CON,Joseph Giglio,14
-Allegany,Willing,State Assembly,148,CON,Joseph Giglio,22
-Allegany,Wirt,State Assembly,148,CON,Joseph Giglio,27
-Allegany,Alfred 1,State Assembly,148,,WRITE-IN,5
-Allegany,Alfred 2,State Assembly,148,,WRITE-IN,4
-Allegany,Allen,State Assembly,148,,WRITE-IN,2
-Allegany,Alma,State Assembly,148,,WRITE-IN,0
-Allegany,Almond,State Assembly,148,,WRITE-IN,4
-Allegany,Amity 1,State Assembly,148,,WRITE-IN,1
-Allegany,Amity 2,State Assembly,148,,WRITE-IN,1
-Allegany,Andover 1,State Assembly,148,,WRITE-IN,0
-Allegany,Andover 2,State Assembly,148,,WRITE-IN,0
-Allegany,Angelica 1,State Assembly,148,,WRITE-IN,0
-Allegany,Angelica 2,State Assembly,148,,WRITE-IN,1
-Allegany,Belfast,State Assembly,148,,WRITE-IN,1
-Allegany,Birdsall,State Assembly,148,,WRITE-IN,0
-Allegany,Bolivar,State Assembly,148,,WRITE-IN,1
-Allegany,Burns,State Assembly,148,,WRITE-IN,1
-Allegany,Caneadea 1,State Assembly,148,,WRITE-IN,1
-Allegany,Caneadea 2,State Assembly,148,,WRITE-IN,0
-Allegany,Centerville,State Assembly,148,,WRITE-IN,0
-Allegany,Clarksville,State Assembly,148,,WRITE-IN,0
-Allegany,Cuba 1,State Assembly,148,,WRITE-IN,2
-Allegany,Cuba 2,State Assembly,148,,WRITE-IN,3
-Allegany,Friendship,State Assembly,148,,WRITE-IN,0
-Allegany,Genesee,State Assembly,148,,WRITE-IN,0
-Allegany,Granger,State Assembly,148,,WRITE-IN,0
-Allegany,Grove,State Assembly,148,,WRITE-IN,0
-Allegany,Hume,State Assembly,148,,WRITE-IN,4
-Allegany,Independence,State Assembly,148,,WRITE-IN,0
-Allegany,New Hudson,State Assembly,148,,WRITE-IN,2
-Allegany,Rushford,State Assembly,148,,WRITE-IN,2
-Allegany,Scio,State Assembly,148,,WRITE-IN,2
-Allegany,Ward,State Assembly,148,,WRITE-IN,1
-Allegany,Wellsville 1,State Assembly,148,,WRITE-IN,3
-Allegany,Wellsville 2,State Assembly,148,,WRITE-IN,0
-Allegany,Wellsville 3,State Assembly,148,,WRITE-IN,2
-Allegany,Wellsville 4,State Assembly,148,,WRITE-IN,1
-Allegany,Welllsville 5,State Assembly,148,,WRITE-IN,1
-Allegany,West Almond,State Assembly,148,,WRITE-IN,0
-Allegany,Willing,State Assembly,148,,WRITE-IN,0
-Allegany,Wirt,State Assembly,148,,WRITE-IN,1
+Allegany,Alfred 1,Governor,,DEM,Kathy C. Hochul,205,,,,
+Allegany,Alfred 2,Governor,,DEM,Kathy C. Hochul,210,,,,
+Allegany,Allen,Governor,,DEM,Kathy C. Hochul,28,,,,
+Allegany,Alma,Governor,,DEM,Kathy C. Hochul,37,,,,
+Allegany,Almond,Governor,,DEM,Kathy C. Hochul,152,,,,
+Allegany,Amity 1,Governor,,DEM,Kathy C. Hochul,77,,,,
+Allegany,Amity 2,Governor,,DEM,Kathy C. Hochul,123,,,,
+Allegany,Andover 1,Governor,,DEM,Kathy C. Hochul,86,,,,
+Allegany,Andover 2,Governor,,DEM,Kathy C. Hochul,47,,,,
+Allegany,Angelica 1,Governor,,DEM,Kathy C. Hochul,64,,,,
+Allegany,Angelica 2,Governor,,DEM,Kathy C. Hochul,52,,,,
+Allegany,Belfast,Governor,,DEM,Kathy C. Hochul,121,,,,
+Allegany,Birdsall,Governor,,DEM,Kathy C. Hochul,14,,,,
+Allegany,Bolivar,Governor,,DEM,Kathy C. Hochul,131,,,,
+Allegany,Burns,Governor,,DEM,Kathy C. Hochul,61,,,,
+Allegany,Caneadea 1,Governor,,DEM,Kathy C. Hochul,57,,,,
+Allegany,Caneadea 2,Governor,,DEM,Kathy C. Hochul,90,,,,
+Allegany,Centerville,Governor,,DEM,Kathy C. Hochul,34,,,,
+Allegany,Clarksville,Governor,,DEM,Kathy C. Hochul,76,,,,
+Allegany,Cuba 1,Governor,,DEM,Kathy C. Hochul,162,,,,
+Allegany,Cuba 2,Governor,,DEM,Kathy C. Hochul,159,,,,
+Allegany,Friendship,Governor,,DEM,Kathy C. Hochul,90,,,,
+Allegany,Genesee,Governor,,DEM,Kathy C. Hochul,96,,,,
+Allegany,Granger,Governor,,DEM,Kathy C. Hochul,23,,,,
+Allegany,Grove,Governor,,DEM,Kathy C. Hochul,43,,,,
+Allegany,Hume,Governor,,DEM,Kathy C. Hochul,127,,,,
+Allegany,Independence,Governor,,DEM,Kathy C. Hochul,64,,,,
+Allegany,New Hudson,Governor,,DEM,Kathy C. Hochul,38,,,,
+Allegany,Rushford,Governor,,DEM,Kathy C. Hochul,91,,,,
+Allegany,Scio,Governor,,DEM,Kathy C. Hochul,125,,,,
+Allegany,Ward,Governor,,DEM,Kathy C. Hochul,34,,,,
+Allegany,Wellsville 1,Governor,,DEM,Kathy C. Hochul,135,,,,
+Allegany,Wellsville 2,Governor,,DEM,Kathy C. Hochul,187,,,,
+Allegany,Wellsville 3,Governor,,DEM,Kathy C. Hochul,178,,,,
+Allegany,Wellsville 4,Governor,,DEM,Kathy C. Hochul,109,,,,
+Allegany,Welllsville 5,Governor,,DEM,Kathy C. Hochul,107,,,,
+Allegany,West Almond,Governor,,DEM,Kathy C. Hochul,23,,,,
+Allegany,Willing,Governor,,DEM,Kathy C. Hochul,116,,,,
+Allegany,Wirt,Governor,,DEM,Kathy C. Hochul,41,,,,
+Allegany,Alfred 1,Governor,,WOR,Kathy C. Hochul,23,,,,
+Allegany,Alfred 2,Governor,,WOR,Kathy C. Hochul,17,,,,
+Allegany,Allen,Governor,,WOR,Kathy C. Hochul,5,,,,
+Allegany,Alma,Governor,,WOR,Kathy C. Hochul,1,,,,
+Allegany,Almond,Governor,,WOR,Kathy C. Hochul,14,,,,
+Allegany,Amity 1,Governor,,WOR,Kathy C. Hochul,5,,,,
+Allegany,Amity 2,Governor,,WOR,Kathy C. Hochul,5,,,,
+Allegany,Andover 1,Governor,,WOR,Kathy C. Hochul,5,,,,
+Allegany,Andover 2,Governor,,WOR,Kathy C. Hochul,6,,,,
+Allegany,Angelica 1,Governor,,WOR,Kathy C. Hochul,5,,,,
+Allegany,Angelica 2,Governor,,WOR,Kathy C. Hochul,0,,,,
+Allegany,Belfast,Governor,,WOR,Kathy C. Hochul,5,,,,
+Allegany,Birdsall,Governor,,WOR,Kathy C. Hochul,1,,,,
+Allegany,Bolivar,Governor,,WOR,Kathy C. Hochul,8,,,,
+Allegany,Burns,Governor,,WOR,Kathy C. Hochul,5,,,,
+Allegany,Caneadea 1,Governor,,WOR,Kathy C. Hochul,8,,,,
+Allegany,Caneadea 2,Governor,,WOR,Kathy C. Hochul,2,,,,
+Allegany,Centerville,Governor,,WOR,Kathy C. Hochul,3,,,,
+Allegany,Clarksville,Governor,,WOR,Kathy C. Hochul,2,,,,
+Allegany,Cuba 1,Governor,,WOR,Kathy C. Hochul,16,,,,
+Allegany,Cuba 2,Governor,,WOR,Kathy C. Hochul,16,,,,
+Allegany,Friendship,Governor,,WOR,Kathy C. Hochul,2,,,,
+Allegany,Genesee,Governor,,WOR,Kathy C. Hochul,4,,,,
+Allegany,Granger,Governor,,WOR,Kathy C. Hochul,1,,,,
+Allegany,Grove,Governor,,WOR,Kathy C. Hochul,6,,,,
+Allegany,Hume,Governor,,WOR,Kathy C. Hochul,9,,,,
+Allegany,Independence,Governor,,WOR,Kathy C. Hochul,3,,,,
+Allegany,New Hudson,Governor,,WOR,Kathy C. Hochul,4,,,,
+Allegany,Rushford,Governor,,WOR,Kathy C. Hochul,9,,,,
+Allegany,Scio,Governor,,WOR,Kathy C. Hochul,6,,,,
+Allegany,Ward,Governor,,WOR,Kathy C. Hochul,6,,,,
+Allegany,Wellsville 1,Governor,,WOR,Kathy C. Hochul,9,,,,
+Allegany,Wellsville 2,Governor,,WOR,Kathy C. Hochul,7,,,,
+Allegany,Wellsville 3,Governor,,WOR,Kathy C. Hochul,12,,,,
+Allegany,Wellsville 4,Governor,,WOR,Kathy C. Hochul,3,,,,
+Allegany,Welllsville 5,Governor,,WOR,Kathy C. Hochul,7,,,,
+Allegany,West Almond,Governor,,WOR,Kathy C. Hochul,2,,,,
+Allegany,Willing,Governor,,WOR,Kathy C. Hochul,8,,,,
+Allegany,Wirt,Governor,,WOR,Kathy C. Hochul,5,,,,
+Allegany,Alfred 1,Governor,,REP,Lee Zeldin,39,,,,
+Allegany,Alfred 2,Governor,,REP,Lee Zeldin,223,,,,
+Allegany,Allen,Governor,,REP,Lee Zeldin,144,,,,
+Allegany,Alma,Governor,,REP,Lee Zeldin,252,,,,
+Allegany,Almond,Governor,,REP,Lee Zeldin,418,,,,
+Allegany,Amity 1,Governor,,REP,Lee Zeldin,222,,,,
+Allegany,Amity 2,Governor,,REP,Lee Zeldin,344,,,,
+Allegany,Andover 1,Governor,,REP,Lee Zeldin,270,,,,
+Allegany,Andover 2,Governor,,REP,Lee Zeldin,246,,,,
+Allegany,Angelica 1,Governor,,REP,Lee Zeldin,219,,,,
+Allegany,Angelica 2,Governor,,REP,Lee Zeldin,174,,,,
+Allegany,Belfast,Governor,,REP,Lee Zeldin,422,,,,
+Allegany,Birdsall,Governor,,REP,Lee Zeldin,63,,,,
+Allegany,Bolivar,Governor,,REP,Lee Zeldin,499,,,,
+Allegany,Burns,Governor,,REP,Lee Zeldin,328,,,,
+Allegany,Caneadea 1,Governor,,REP,Lee Zeldin,189,,,,
+Allegany,Caneadea 2,Governor,,REP,Lee Zeldin,177,,,,
+Allegany,Centerville,Governor,,REP,Lee Zeldin,197,,,,
+Allegany,Clarksville,Governor,,REP,Lee Zeldin,258,,,,
+Allegany,Cuba 1,Governor,,REP,Lee Zeldin,276,,,,
+Allegany,Cuba 2,Governor,,REP,Lee Zeldin,442,,,,
+Allegany,Friendship,Governor,,REP,Lee Zeldin,451,,,,
+Allegany,Genesee,Governor,,REP,Lee Zeldin,464,,,,
+Allegany,Granger,Governor,,REP,Lee Zeldin,188,,,,
+Allegany,Grove,Governor,,REP,Lee Zeldin,179,,,,
+Allegany,Hume,Governor,,REP,Lee Zeldin,511,,,,
+Allegany,Independence,Governor,,REP,Lee Zeldin,287,,,,
+Allegany,New Hudson,Governor,,REP,Lee Zeldin,194,,,,
+Allegany,Rushford,Governor,,REP,Lee Zeldin,333,,,,
+Allegany,Scio,Governor,,REP,Lee Zeldin,447,,,,
+Allegany,Ward,Governor,,REP,Lee Zeldin,118,,,,
+Allegany,Wellsville 1,Governor,,REP,Lee Zeldin,282,,,,
+Allegany,Wellsville 2,Governor,,REP,Lee Zeldin,270,,,,
+Allegany,Wellsville 3,Governor,,REP,Lee Zeldin,325,,,,
+Allegany,Wellsville 4,Governor,,REP,Lee Zeldin,285,,,,
+Allegany,Welllsville 5,Governor,,REP,Lee Zeldin,338,,,,
+Allegany,West Almond,Governor,,REP,Lee Zeldin,84,,,,
+Allegany,Willing,Governor,,REP,Lee Zeldin,369,,,,
+Allegany,Wirt,Governor,,REP,Lee Zeldin,335,,,,
+Allegany,Alfred 1,Governor,,CON,Lee Zeldin,14,,,,
+Allegany,Alfred 2,Governor,,CON,Lee Zeldin,45,,,,
+Allegany,Allen,Governor,,CON,Lee Zeldin,13,,,,
+Allegany,Alma,Governor,,CON,Lee Zeldin,24,,,,
+Allegany,Almond,Governor,,CON,Lee Zeldin,76,,,,
+Allegany,Amity 1,Governor,,CON,Lee Zeldin,25,,,,
+Allegany,Amity 2,Governor,,CON,Lee Zeldin,32,,,,
+Allegany,Andover 1,Governor,,CON,Lee Zeldin,28,,,,
+Allegany,Andover 2,Governor,,CON,Lee Zeldin,10,,,,
+Allegany,Angelica 1,Governor,,CON,Lee Zeldin,19,,,,
+Allegany,Angelica 2,Governor,,CON,Lee Zeldin,19,,,,
+Allegany,Belfast,Governor,,CON,Lee Zeldin,44,,,,
+Allegany,Birdsall,Governor,,CON,Lee Zeldin,10,,,,
+Allegany,Bolivar,Governor,,CON,Lee Zeldin,41,,,,
+Allegany,Burns,Governor,,CON,Lee Zeldin,43,,,,
+Allegany,Caneadea 1,Governor,,CON,Lee Zeldin,28,,,,
+Allegany,Caneadea 2,Governor,,CON,Lee Zeldin,36,,,,
+Allegany,Centerville,Governor,,CON,Lee Zeldin,32,,,,
+Allegany,Clarksville,Governor,,CON,Lee Zeldin,28,,,,
+Allegany,Cuba 1,Governor,,CON,Lee Zeldin,26,,,,
+Allegany,Cuba 2,Governor,,CON,Lee Zeldin,29,,,,
+Allegany,Friendship,Governor,,CON,Lee Zeldin,42,,,,
+Allegany,Genesee,Governor,,CON,Lee Zeldin,36,,,,
+Allegany,Granger,Governor,,CON,Lee Zeldin,21,,,,
+Allegany,Grove,Governor,,CON,Lee Zeldin,28,,,,
+Allegany,Hume,Governor,,CON,Lee Zeldin,54,,,,
+Allegany,Independence,Governor,,CON,Lee Zeldin,15,,,,
+Allegany,New Hudson,Governor,,CON,Lee Zeldin,19,,,,
+Allegany,Rushford,Governor,,CON,Lee Zeldin,57,,,,
+Allegany,Scio,Governor,,CON,Lee Zeldin,43,,,,
+Allegany,Ward,Governor,,CON,Lee Zeldin,11,,,,
+Allegany,Wellsville 1,Governor,,CON,Lee Zeldin,16,,,,
+Allegany,Wellsville 2,Governor,,CON,Lee Zeldin,23,,,,
+Allegany,Wellsville 3,Governor,,CON,Lee Zeldin,32,,,,
+Allegany,Wellsville 4,Governor,,CON,Lee Zeldin,15,,,,
+Allegany,Welllsville 5,Governor,,CON,Lee Zeldin,27,,,,
+Allegany,West Almond,Governor,,CON,Lee Zeldin,15,,,,
+Allegany,Willing,Governor,,CON,Lee Zeldin,15,,,,
+Allegany,Wirt,Governor,,CON,Lee Zeldin,21,,,,
+Allegany,Alfred 1,Governor,,,WRITE-IN,5,,,,
+Allegany,Alfred 2,Governor,,,WRITE-IN,7,,,,
+Allegany,Allen,Governor,,,WRITE-IN,2,,,,
+Allegany,Alma,Governor,,,WRITE-IN,1,,,,
+Allegany,Almond,Governor,,,WRITE-IN,3,,,,
+Allegany,Amity 1,Governor,,,WRITE-IN,0,,,,
+Allegany,Amity 2,Governor,,,WRITE-IN,0,,,,
+Allegany,Andover 1,Governor,,,WRITE-IN,1,,,,
+Allegany,Andover 2,Governor,,,WRITE-IN,0,,,,
+Allegany,Angelica 1,Governor,,,WRITE-IN,0,,,,
+Allegany,Angelica 2,Governor,,,WRITE-IN,1,,,,
+Allegany,Belfast,Governor,,,WRITE-IN,1,,,,
+Allegany,Birdsall,Governor,,,WRITE-IN,1,,,,
+Allegany,Bolivar,Governor,,,WRITE-IN,0,,,,
+Allegany,Burns,Governor,,,WRITE-IN,0,,,,
+Allegany,Caneadea 1,Governor,,,WRITE-IN,1,,,,
+Allegany,Caneadea 2,Governor,,,WRITE-IN,4,,,,
+Allegany,Centerville,Governor,,,WRITE-IN,1,,,,
+Allegany,Clarksville,Governor,,,WRITE-IN,0,,,,
+Allegany,Cuba 1,Governor,,,WRITE-IN,3,,,,
+Allegany,Cuba 2,Governor,,,WRITE-IN,0,,,,
+Allegany,Friendship,Governor,,,WRITE-IN,1,,,,
+Allegany,Genesee,Governor,,,WRITE-IN,0,,,,
+Allegany,Granger,Governor,,,WRITE-IN,0,,,,
+Allegany,Grove,Governor,,,WRITE-IN,1,,,,
+Allegany,Hume,Governor,,,WRITE-IN,2,,,,
+Allegany,Independence,Governor,,,WRITE-IN,2,,,,
+Allegany,New Hudson,Governor,,,WRITE-IN,0,,,,
+Allegany,Rushford,Governor,,,WRITE-IN,1,,,,
+Allegany,Scio,Governor,,,WRITE-IN,2,,,,
+Allegany,Ward,Governor,,,WRITE-IN,0,,,,
+Allegany,Wellsville 1,Governor,,,WRITE-IN,0,,,,
+Allegany,Wellsville 2,Governor,,,WRITE-IN,0,,,,
+Allegany,Wellsville 3,Governor,,,WRITE-IN,0,,,,
+Allegany,Wellsville 4,Governor,,,WRITE-IN,1,,,,
+Allegany,Welllsville 5,Governor,,,WRITE-IN,0,,,,
+Allegany,West Almond,Governor,,,WRITE-IN,0,,,,
+Allegany,Willing,Governor,,,WRITE-IN,3,,,,
+Allegany,Wirt,Governor,,,WRITE-IN,2,,,,
+Allegany,Alfred 1,Attorney General,,DEM,Letitia A. James,197,,,,
+Allegany,Alfred 2,Attorney General,,DEM,Letitia A. James,209,,,,
+Allegany,Allen,Attorney General,,DEM,Letitia A. James,30,,,,
+Allegany,Alma,Attorney General,,DEM,Letitia A. James,34,,,,
+Allegany,Almond,Attorney General,,DEM,Letitia A. James,152,,,,
+Allegany,Amity 1,Attorney General,,DEM,Letitia A. James,77,,,,
+Allegany,Amity 2,Attorney General,,DEM,Letitia A. James,121,,,,
+Allegany,Andover 1,Attorney General,,DEM,Letitia A. James,95,,,,
+Allegany,Andover 2,Attorney General,,DEM,Letitia A. James,47,,,,
+Allegany,Angelica 1,Attorney General,,DEM,Letitia A. James,65,,,,
+Allegany,Angelica 2,Attorney General,,DEM,Letitia A. James,52,,,,
+Allegany,Belfast,Attorney General,,DEM,Letitia A. James,121,,,,
+Allegany,Birdsall,Attorney General,,DEM,Letitia A. James,17,,,,
+Allegany,Bolivar,Attorney General,,DEM,Letitia A. James,139,,,,
+Allegany,Burns,Attorney General,,DEM,Letitia A. James,63,,,,
+Allegany,Caneadea 1,Attorney General,,DEM,Letitia A. James,61,,,,
+Allegany,Caneadea 2,Attorney General,,DEM,Letitia A. James,91,,,,
+Allegany,Centerville,Attorney General,,DEM,Letitia A. James,33,,,,
+Allegany,Clarksville,Attorney General,,DEM,Letitia A. James,77,,,,
+Allegany,Cuba 1,Attorney General,,DEM,Letitia A. James,170,,,,
+Allegany,Cuba 2,Attorney General,,DEM,Letitia A. James,163,,,,
+Allegany,Friendship,Attorney General,,DEM,Letitia A. James,94,,,,
+Allegany,Genesee,Attorney General,,DEM,Letitia A. James,99,,,,
+Allegany,Granger,Attorney General,,DEM,Letitia A. James,25,,,,
+Allegany,Grove,Attorney General,,DEM,Letitia A. James,45,,,,
+Allegany,Hume,Attorney General,,DEM,Letitia A. James,131,,,,
+Allegany,Independence,Attorney General,,DEM,Letitia A. James,70,,,,
+Allegany,New Hudson,Attorney General,,DEM,Letitia A. James,41,,,,
+Allegany,Rushford,Attorney General,,DEM,Letitia A. James,84,,,,
+Allegany,Scio,Attorney General,,DEM,Letitia A. James,133,,,,
+Allegany,Ward,Attorney General,,DEM,Letitia A. James,36,,,,
+Allegany,Wellsville 1,Attorney General,,DEM,Letitia A. James,134,,,,
+Allegany,Wellsville 2,Attorney General,,DEM,Letitia A. James,177,,,,
+Allegany,Wellsville 3,Attorney General,,DEM,Letitia A. James,174,,,,
+Allegany,Wellsville 4,Attorney General,,DEM,Letitia A. James,100,,,,
+Allegany,Welllsville 5,Attorney General,,DEM,Letitia A. James,114,,,,
+Allegany,West Almond,Attorney General,,DEM,Letitia A. James,25,,,,
+Allegany,Willing,Attorney General,,DEM,Letitia A. James,117,,,,
+Allegany,Wirt,Attorney General,,DEM,Letitia A. James,43,,,,
+Allegany,Alfred 1,Attorney General,,WOR,Letitia A. James,24,,,,
+Allegany,Alfred 2,Attorney General,,WOR,Letitia A. James,20,,,,
+Allegany,Allen,Attorney General,,WOR,Letitia A. James,6,,,,
+Allegany,Alma,Attorney General,,WOR,Letitia A. James,2,,,,
+Allegany,Almond,Attorney General,,WOR,Letitia A. James,18,,,,
+Allegany,Amity 1,Attorney General,,WOR,Letitia A. James,10,,,,
+Allegany,Amity 2,Attorney General,,WOR,Letitia A. James,8,,,,
+Allegany,Andover 1,Attorney General,,WOR,Letitia A. James,9,,,,
+Allegany,Andover 2,Attorney General,,WOR,Letitia A. James,9,,,,
+Allegany,Angelica 1,Attorney General,,WOR,Letitia A. James,10,,,,
+Allegany,Angelica 2,Attorney General,,WOR,Letitia A. James,2,,,,
+Allegany,Belfast,Attorney General,,WOR,Letitia A. James,13,,,,
+Allegany,Birdsall,Attorney General,,WOR,Letitia A. James,1,,,,
+Allegany,Bolivar,Attorney General,,WOR,Letitia A. James,11,,,,
+Allegany,Burns,Attorney General,,WOR,Letitia A. James,6,,,,
+Allegany,Caneadea 1,Attorney General,,WOR,Letitia A. James,9,,,,
+Allegany,Caneadea 2,Attorney General,,WOR,Letitia A. James,6,,,,
+Allegany,Centerville,Attorney General,,WOR,Letitia A. James,5,,,,
+Allegany,Clarksville,Attorney General,,WOR,Letitia A. James,4,,,,
+Allegany,Cuba 1,Attorney General,,WOR,Letitia A. James,17,,,,
+Allegany,Cuba 2,Attorney General,,WOR,Letitia A. James,21,,,,
+Allegany,Friendship,Attorney General,,WOR,Letitia A. James,4,,,,
+Allegany,Genesee,Attorney General,,WOR,Letitia A. James,7,,,,
+Allegany,Granger,Attorney General,,WOR,Letitia A. James,3,,,,
+Allegany,Grove,Attorney General,,WOR,Letitia A. James,6,,,,
+Allegany,Hume,Attorney General,,WOR,Letitia A. James,11,,,,
+Allegany,Independence,Attorney General,,WOR,Letitia A. James,5,,,,
+Allegany,New Hudson,Attorney General,,WOR,Letitia A. James,8,,,,
+Allegany,Rushford,Attorney General,,WOR,Letitia A. James,14,,,,
+Allegany,Scio,Attorney General,,WOR,Letitia A. James,8,,,,
+Allegany,Ward,Attorney General,,WOR,Letitia A. James,8,,,,
+Allegany,Wellsville 1,Attorney General,,WOR,Letitia A. James,7,,,,
+Allegany,Wellsville 2,Attorney General,,WOR,Letitia A. James,9,,,,
+Allegany,Wellsville 3,Attorney General,,WOR,Letitia A. James,13,,,,
+Allegany,Wellsville 4,Attorney General,,WOR,Letitia A. James,9,,,,
+Allegany,Welllsville 5,Attorney General,,WOR,Letitia A. James,11,,,,
+Allegany,West Almond,Attorney General,,WOR,Letitia A. James,1,,,,
+Allegany,Willing,Attorney General,,WOR,Letitia A. James,6,,,,
+Allegany,Wirt,Attorney General,,WOR,Letitia A. James,4,,,,
+Allegany,Alfred 1,Attorney General,,REP,Michael Henry,46,,,,
+Allegany,Alfred 2,Attorney General,,REP,Michael Henry,212,,,,
+Allegany,Allen,Attorney General,,REP,Michael Henry,140,,,,
+Allegany,Alma,Attorney General,,REP,Michael Henry,244,,,,
+Allegany,Almond,Attorney General,,REP,Michael Henry,405,,,,
+Allegany,Amity 1,Attorney General,,REP,Michael Henry,216,,,,
+Allegany,Amity 2,Attorney General,,REP,Michael Henry,337,,,,
+Allegany,Andover 1,Attorney General,,REP,Michael Henry,258,,,,
+Allegany,Andover 2,Attorney General,,REP,Michael Henry,235,,,,
+Allegany,Angelica 1,Attorney General,,REP,Michael Henry,214,,,,
+Allegany,Angelica 2,Attorney General,,REP,Michael Henry,168,,,,
+Allegany,Belfast,Attorney General,,REP,Michael Henry,406,,,,
+Allegany,Birdsall,Attorney General,,REP,Michael Henry,58,,,,
+Allegany,Bolivar,Attorney General,,REP,Michael Henry,469,,,,
+Allegany,Burns,Attorney General,,REP,Michael Henry,310,,,,
+Allegany,Caneadea 1,Attorney General,,REP,Michael Henry,183,,,,
+Allegany,Caneadea 2,Attorney General,,REP,Michael Henry,175,,,,
+Allegany,Centerville,Attorney General,,REP,Michael Henry,194,,,,
+Allegany,Clarksville,Attorney General,,REP,Michael Henry,247,,,,
+Allegany,Cuba 1,Attorney General,,REP,Michael Henry,259,,,,
+Allegany,Cuba 2,Attorney General,,REP,Michael Henry,425,,,,
+Allegany,Friendship,Attorney General,,REP,Michael Henry,428,,,,
+Allegany,Genesee,Attorney General,,REP,Michael Henry,443,,,,
+Allegany,Granger,Attorney General,,REP,Michael Henry,180,,,,
+Allegany,Grove,Attorney General,,REP,Michael Henry,172,,,,
+Allegany,Hume,Attorney General,,REP,Michael Henry,483,,,,
+Allegany,Independence,Attorney General,,REP,Michael Henry,274,,,,
+Allegany,New Hudson,Attorney General,,REP,Michael Henry,180,,,,
+Allegany,Rushford,Attorney General,,REP,Michael Henry,326,,,,
+Allegany,Scio,Attorney General,,REP,Michael Henry,429,,,,
+Allegany,Ward,Attorney General,,REP,Michael Henry,115,,,,
+Allegany,Wellsville 1,Attorney General,,REP,Michael Henry,274,,,,
+Allegany,Wellsville 2,Attorney General,,REP,Michael Henry,270,,,,
+Allegany,Wellsville 3,Attorney General,,REP,Michael Henry,315,,,,
+Allegany,Wellsville 4,Attorney General,,REP,Michael Henry,280,,,,
+Allegany,Welllsville 5,Attorney General,,REP,Michael Henry,325,,,,
+Allegany,West Almond,Attorney General,,REP,Michael Henry,84,,,,
+Allegany,Willing,Attorney General,,REP,Michael Henry,363,,,,
+Allegany,Wirt,Attorney General,,REP,Michael Henry,319,,,,
+Allegany,Alfred 1,Attorney General,,CON,Michael Henry,14,,,,
+Allegany,Alfred 2,Attorney General,,CON,Michael Henry,49,,,,
+Allegany,Allen,Attorney General,,CON,Michael Henry,10,,,,
+Allegany,Alma,Attorney General,,CON,Michael Henry,23,,,,
+Allegany,Almond,Attorney General,,CON,Michael Henry,77,,,,
+Allegany,Amity 1,Attorney General,,CON,Michael Henry,19,,,,
+Allegany,Amity 2,Attorney General,,CON,Michael Henry,29,,,,
+Allegany,Andover 1,Attorney General,,CON,Michael Henry,24,,,,
+Allegany,Andover 2,Attorney General,,CON,Michael Henry,13,,,,
+Allegany,Angelica 1,Attorney General,,CON,Michael Henry,13,,,,
+Allegany,Angelica 2,Attorney General,,CON,Michael Henry,17,,,,
+Allegany,Belfast,Attorney General,,CON,Michael Henry,46,,,,
+Allegany,Birdsall,Attorney General,,CON,Michael Henry,10,,,,
+Allegany,Bolivar,Attorney General,,CON,Michael Henry,41,,,,
+Allegany,Burns,Attorney General,,CON,Michael Henry,43,,,,
+Allegany,Caneadea 1,Attorney General,,CON,Michael Henry,22,,,,
+Allegany,Caneadea 2,Attorney General,,CON,Michael Henry,34,,,,
+Allegany,Centerville,Attorney General,,CON,Michael Henry,34,,,,
+Allegany,Clarksville,Attorney General,,CON,Michael Henry,27,,,,
+Allegany,Cuba 1,Attorney General,,CON,Michael Henry,29,,,,
+Allegany,Cuba 2,Attorney General,,CON,Michael Henry,29,,,,
+Allegany,Friendship,Attorney General,,CON,Michael Henry,43,,,,
+Allegany,Genesee,Attorney General,,CON,Michael Henry,38,,,,
+Allegany,Granger,Attorney General,,CON,Michael Henry,21,,,,
+Allegany,Grove,Attorney General,,CON,Michael Henry,32,,,,
+Allegany,Hume,Attorney General,,CON,Michael Henry,58,,,,
+Allegany,Independence,Attorney General,,CON,Michael Henry,13,,,,
+Allegany,New Hudson,Attorney General,,CON,Michael Henry,22,,,,
+Allegany,Rushford,Attorney General,,CON,Michael Henry,58,,,,
+Allegany,Scio,Attorney General,,CON,Michael Henry,41,,,,
+Allegany,Ward,Attorney General,,CON,Michael Henry,10,,,,
+Allegany,Wellsville 1,Attorney General,,CON,Michael Henry,22,,,,
+Allegany,Wellsville 2,Attorney General,,CON,Michael Henry,21,,,,
+Allegany,Wellsville 3,Attorney General,,CON,Michael Henry,35,,,,
+Allegany,Wellsville 4,Attorney General,,CON,Michael Henry,14,,,,
+Allegany,Welllsville 5,Attorney General,,CON,Michael Henry,22,,,,
+Allegany,West Almond,Attorney General,,CON,Michael Henry,12,,,,
+Allegany,Willing,Attorney General,,CON,Michael Henry,15,,,,
+Allegany,Wirt,Attorney General,,CON,Michael Henry,20,,,,
+Allegany,Alfred 1,Attorney General,,,WRITE-IN,1,,,,
+Allegany,Alfred 2,Attorney General,,,WRITE-IN,2,,,,
+Allegany,Allen,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Alma,Attorney General,,,WRITE-IN,1,,,,
+Allegany,Almond,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Amity 1,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Amity 2,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Andover 1,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Andover 2,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Angelica 1,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Angelica 2,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Belfast,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Birdsall,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Bolivar,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Burns,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Caneadea 1,Attorney General,,,WRITE-IN,1,,,,
+Allegany,Caneadea 2,Attorney General,,,WRITE-IN,1,,,,
+Allegany,Centerville,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Clarksville,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Cuba 1,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Cuba 2,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Friendship,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Genesee,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Granger,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Grove,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Hume,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Independence,Attorney General,,,WRITE-IN,0,,,,
+Allegany,New Hudson,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Rushford,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Scio,Attorney General,,,WRITE-IN,1,,,,
+Allegany,Ward,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Wellsville 1,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Wellsville 2,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Wellsville 3,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Wellsville 4,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Welllsville 5,Attorney General,,,WRITE-IN,0,,,,
+Allegany,West Almond,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Willing,Attorney General,,,WRITE-IN,1,,,,
+Allegany,Wirt,Attorney General,,,WRITE-IN,0,,,,
+Allegany,Alfred 1,Comptroller,,DEM,Thomas P. DiNapoli,198,,,,
+Allegany,Alfred 2,Comptroller,,DEM,Thomas P. DiNapoli,216,,,,
+Allegany,Allen,Comptroller,,DEM,Thomas P. DiNapoli,35,,,,
+Allegany,Alma,Comptroller,,DEM,Thomas P. DiNapoli,40,,,,
+Allegany,Almond,Comptroller,,DEM,Thomas P. DiNapoli,172,,,,
+Allegany,Amity 1,Comptroller,,DEM,Thomas P. DiNapoli,90,,,,
+Allegany,Amity 2,Comptroller,,DEM,Thomas P. DiNapoli,144,,,,
+Allegany,Andover 1,Comptroller,,DEM,Thomas P. DiNapoli,95,,,,
+Allegany,Andover 2,Comptroller,,DEM,Thomas P. DiNapoli,57,,,,
+Allegany,Angelica 1,Comptroller,,DEM,Thomas P. DiNapoli,80,,,,
+Allegany,Angelica 2,Comptroller,,DEM,Thomas P. DiNapoli,58,,,,
+Allegany,Belfast,Comptroller,,DEM,Thomas P. DiNapoli,138,,,,
+Allegany,Birdsall,Comptroller,,DEM,Thomas P. DiNapoli,17,,,,
+Allegany,Bolivar,Comptroller,,DEM,Thomas P. DiNapoli,158,,,,
+Allegany,Burns,Comptroller,,DEM,Thomas P. DiNapoli,83,,,,
+Allegany,Caneadea 1,Comptroller,,DEM,Thomas P. DiNapoli,67,,,,
+Allegany,Caneadea 2,Comptroller,,DEM,Thomas P. DiNapoli,87,,,,
+Allegany,Centerville,Comptroller,,DEM,Thomas P. DiNapoli,41,,,,
+Allegany,Clarksville,Comptroller,,DEM,Thomas P. DiNapoli,84,,,,
+Allegany,Cuba 1,Comptroller,,DEM,Thomas P. DiNapoli,183,,,,
+Allegany,Cuba 2,Comptroller,,DEM,Thomas P. DiNapoli,175,,,,
+Allegany,Friendship,Comptroller,,DEM,Thomas P. DiNapoli,116,,,,
+Allegany,Genesee,Comptroller,,DEM,Thomas P. DiNapoli,112,,,,
+Allegany,Granger,Comptroller,,DEM,Thomas P. DiNapoli,26,,,,
+Allegany,Grove,Comptroller,,DEM,Thomas P. DiNapoli,56,,,,
+Allegany,Hume,Comptroller,,DEM,Thomas P. DiNapoli,136,,,,
+Allegany,Independence,Comptroller,,DEM,Thomas P. DiNapoli,78,,,,
+Allegany,New Hudson,Comptroller,,DEM,Thomas P. DiNapoli,51,,,,
+Allegany,Rushford,Comptroller,,DEM,Thomas P. DiNapoli,92,,,,
+Allegany,Scio,Comptroller,,DEM,Thomas P. DiNapoli,145,,,,
+Allegany,Ward,Comptroller,,DEM,Thomas P. DiNapoli,45,,,,
+Allegany,Wellsville 1,Comptroller,,DEM,Thomas P. DiNapoli,142,,,,
+Allegany,Wellsville 2,Comptroller,,DEM,Thomas P. DiNapoli,188,,,,
+Allegany,Wellsville 3,Comptroller,,DEM,Thomas P. DiNapoli,187,,,,
+Allegany,Wellsville 4,Comptroller,,DEM,Thomas P. DiNapoli,110,,,,
+Allegany,Welllsville 5,Comptroller,,DEM,Thomas P. DiNapoli,127,,,,
+Allegany,West Almond,Comptroller,,DEM,Thomas P. DiNapoli,27,,,,
+Allegany,Willing,Comptroller,,DEM,Thomas P. DiNapoli,141,,,,
+Allegany,Wirt,Comptroller,,DEM,Thomas P. DiNapoli,45,,,,
+Allegany,Alfred 1,Comptroller,,WOR,Thomas P. DiNapoli,26,,,,
+Allegany,Alfred 2,Comptroller,,WOR,Thomas P. DiNapoli,21,,,,
+Allegany,Allen,Comptroller,,WOR,Thomas P. DiNapoli,7,,,,
+Allegany,Alma,Comptroller,,WOR,Thomas P. DiNapoli,6,,,,
+Allegany,Almond,Comptroller,,WOR,Thomas P. DiNapoli,24,,,,
+Allegany,Amity 1,Comptroller,,WOR,Thomas P. DiNapoli,16,,,,
+Allegany,Amity 2,Comptroller,,WOR,Thomas P. DiNapoli,9,,,,
+Allegany,Andover 1,Comptroller,,WOR,Thomas P. DiNapoli,9,,,,
+Allegany,Andover 2,Comptroller,,WOR,Thomas P. DiNapoli,10,,,,
+Allegany,Angelica 1,Comptroller,,WOR,Thomas P. DiNapoli,11,,,,
+Allegany,Angelica 2,Comptroller,,WOR,Thomas P. DiNapoli,3,,,,
+Allegany,Belfast,Comptroller,,WOR,Thomas P. DiNapoli,10,,,,
+Allegany,Birdsall,Comptroller,,WOR,Thomas P. DiNapoli,3,,,,
+Allegany,Bolivar,Comptroller,,WOR,Thomas P. DiNapoli,12,,,,
+Allegany,Burns,Comptroller,,WOR,Thomas P. DiNapoli,13,,,,
+Allegany,Caneadea 1,Comptroller,,WOR,Thomas P. DiNapoli,12,,,,
+Allegany,Caneadea 2,Comptroller,,WOR,Thomas P. DiNapoli,3,,,,
+Allegany,Centerville,Comptroller,,WOR,Thomas P. DiNapoli,8,,,,
+Allegany,Clarksville,Comptroller,,WOR,Thomas P. DiNapoli,7,,,,
+Allegany,Cuba 1,Comptroller,,WOR,Thomas P. DiNapoli,20,,,,
+Allegany,Cuba 2,Comptroller,,WOR,Thomas P. DiNapoli,25,,,,
+Allegany,Friendship,Comptroller,,WOR,Thomas P. DiNapoli,12,,,,
+Allegany,Genesee,Comptroller,,WOR,Thomas P. DiNapoli,9,,,,
+Allegany,Granger,Comptroller,,WOR,Thomas P. DiNapoli,5,,,,
+Allegany,Grove,Comptroller,,WOR,Thomas P. DiNapoli,13,,,,
+Allegany,Hume,Comptroller,,WOR,Thomas P. DiNapoli,19,,,,
+Allegany,Independence,Comptroller,,WOR,Thomas P. DiNapoli,7,,,,
+Allegany,New Hudson,Comptroller,,WOR,Thomas P. DiNapoli,10,,,,
+Allegany,Rushford,Comptroller,,WOR,Thomas P. DiNapoli,18,,,,
+Allegany,Scio,Comptroller,,WOR,Thomas P. DiNapoli,19,,,,
+Allegany,Ward,Comptroller,,WOR,Thomas P. DiNapoli,10,,,,
+Allegany,Wellsville 1,Comptroller,,WOR,Thomas P. DiNapoli,12,,,,
+Allegany,Wellsville 2,Comptroller,,WOR,Thomas P. DiNapoli,15,,,,
+Allegany,Wellsville 3,Comptroller,,WOR,Thomas P. DiNapoli,20,,,,
+Allegany,Wellsville 4,Comptroller,,WOR,Thomas P. DiNapoli,9,,,,
+Allegany,Welllsville 5,Comptroller,,WOR,Thomas P. DiNapoli,15,,,,
+Allegany,West Almond,Comptroller,,WOR,Thomas P. DiNapoli,1,,,,
+Allegany,Willing,Comptroller,,WOR,Thomas P. DiNapoli,14,,,,
+Allegany,Wirt,Comptroller,,WOR,Thomas P. DiNapoli,10,,,,
+Allegany,Alfred 1,Comptroller,,REP,Paul Rodriguez,40,,,,
+Allegany,Alfred 2,Comptroller,,REP,Paul Rodriguez,205,,,,
+Allegany,Allen,Comptroller,,REP,Paul Rodriguez,127,,,,
+Allegany,Alma,Comptroller,,REP,Paul Rodriguez,238,,,,
+Allegany,Almond,Comptroller,,REP,Paul Rodriguez,385,,,,
+Allegany,Amity 1,Comptroller,,REP,Paul Rodriguez,200,,,,
+Allegany,Amity 2,Comptroller,,REP,Paul Rodriguez,313,,,,
+Allegany,Andover 1,Comptroller,,REP,Paul Rodriguez,253,,,,
+Allegany,Andover 2,Comptroller,,REP,Paul Rodriguez,226,,,,
+Allegany,Angelica 1,Comptroller,,REP,Paul Rodriguez,202,,,,
+Allegany,Angelica 2,Comptroller,,REP,Paul Rodriguez,162,,,,
+Allegany,Belfast,Comptroller,,REP,Paul Rodriguez,391,,,,
+Allegany,Birdsall,Comptroller,,REP,Paul Rodriguez,58,,,,
+Allegany,Bolivar,Comptroller,,REP,Paul Rodriguez,457,,,,
+Allegany,Burns,Comptroller,,REP,Paul Rodriguez,288,,,,
+Allegany,Caneadea 1,Comptroller,,REP,Paul Rodriguez,172,,,,
+Allegany,Caneadea 2,Comptroller,,REP,Paul Rodriguez,180,,,,
+Allegany,Centerville,Comptroller,,REP,Paul Rodriguez,182,,,,
+Allegany,Clarksville,Comptroller,,REP,Paul Rodriguez,236,,,,
+Allegany,Cuba 1,Comptroller,,REP,Paul Rodriguez,241,,,,
+Allegany,Cuba 2,Comptroller,,REP,Paul Rodriguez,406,,,,
+Allegany,Friendship,Comptroller,,REP,Paul Rodriguez,393,,,,
+Allegany,Genesee,Comptroller,,REP,Paul Rodriguez,434,,,,
+Allegany,Granger,Comptroller,,REP,Paul Rodriguez,173,,,,
+Allegany,Grove,Comptroller,,REP,Paul Rodriguez,160,,,,
+Allegany,Hume,Comptroller,,REP,Paul Rodriguez,472,,,,
+Allegany,Independence,Comptroller,,REP,Paul Rodriguez,262,,,,
+Allegany,New Hudson,Comptroller,,REP,Paul Rodriguez,172,,,,
+Allegany,Rushford,Comptroller,,REP,Paul Rodriguez,310,,,,
+Allegany,Scio,Comptroller,,REP,Paul Rodriguez,408,,,,
+Allegany,Ward,Comptroller,,REP,Paul Rodriguez,102,,,,
+Allegany,Wellsville 1,Comptroller,,REP,Paul Rodriguez,258,,,,
+Allegany,Wellsville 2,Comptroller,,REP,Paul Rodriguez,257,,,,
+Allegany,Wellsville 3,Comptroller,,REP,Paul Rodriguez,293,,,,
+Allegany,Wellsville 4,Comptroller,,REP,Paul Rodriguez,276,,,,
+Allegany,Welllsville 5,Comptroller,,REP,Paul Rodriguez,312,,,,
+Allegany,West Almond,Comptroller,,REP,Paul Rodriguez,81,,,,
+Allegany,Willing,Comptroller,,REP,Paul Rodriguez,334,,,,
+Allegany,Wirt,Comptroller,,REP,Paul Rodriguez,305,,,,
+Allegany,Alfred 1,Comptroller,,CON,Paul Rodriguez,14,,,,
+Allegany,Alfred 2,Comptroller,,CON,Paul Rodriguez,47,,,,
+Allegany,Allen,Comptroller,,CON,Paul Rodriguez,13,,,,
+Allegany,Alma,Comptroller,,CON,Paul Rodriguez,21,,,,
+Allegany,Almond,Comptroller,,CON,Paul Rodriguez,72,,,,
+Allegany,Amity 1,Comptroller,,CON,Paul Rodriguez,21,,,,
+Allegany,Amity 2,Comptroller,,CON,Paul Rodriguez,26,,,,
+Allegany,Andover 1,Comptroller,,CON,Paul Rodriguez,27,,,,
+Allegany,Andover 2,Comptroller,,CON,Paul Rodriguez,13,,,,
+Allegany,Angelica 1,Comptroller,,CON,Paul Rodriguez,11,,,,
+Allegany,Angelica 2,Comptroller,,CON,Paul Rodriguez,19,,,,
+Allegany,Belfast,Comptroller,,CON,Paul Rodriguez,44,,,,
+Allegany,Birdsall,Comptroller,,CON,Paul Rodriguez,8,,,,
+Allegany,Bolivar,Comptroller,,CON,Paul Rodriguez,40,,,,
+Allegany,Burns,Comptroller,,CON,Paul Rodriguez,38,,,,
+Allegany,Caneadea 1,Comptroller,,CON,Paul Rodriguez,24,,,,
+Allegany,Caneadea 2,Comptroller,,CON,Paul Rodriguez,36,,,,
+Allegany,Centerville,Comptroller,,CON,Paul Rodriguez,30,,,,
+Allegany,Clarksville,Comptroller,,CON,Paul Rodriguez,26,,,,
+Allegany,Cuba 1,Comptroller,,CON,Paul Rodriguez,28,,,,
+Allegany,Cuba 2,Comptroller,,CON,Paul Rodriguez,28,,,,
+Allegany,Friendship,Comptroller,,CON,Paul Rodriguez,45,,,,
+Allegany,Genesee,Comptroller,,CON,Paul Rodriguez,37,,,,
+Allegany,Granger,Comptroller,,CON,Paul Rodriguez,22,,,,
+Allegany,Grove,Comptroller,,CON,Paul Rodriguez,27,,,,
+Allegany,Hume,Comptroller,,CON,Paul Rodriguez,55,,,,
+Allegany,Independence,Comptroller,,CON,Paul Rodriguez,12,,,,
+Allegany,New Hudson,Comptroller,,CON,Paul Rodriguez,17,,,,
+Allegany,Rushford,Comptroller,,CON,Paul Rodriguez,58,,,,
+Allegany,Scio,Comptroller,,CON,Paul Rodriguez,36,,,,
+Allegany,Ward,Comptroller,,CON,Paul Rodriguez,11,,,,
+Allegany,Wellsville 1,Comptroller,,CON,Paul Rodriguez,17,,,,
+Allegany,Wellsville 2,Comptroller,,CON,Paul Rodriguez,19,,,,
+Allegany,Wellsville 3,Comptroller,,CON,Paul Rodriguez,33,,,,
+Allegany,Wellsville 4,Comptroller,,CON,Paul Rodriguez,14,,,,
+Allegany,Welllsville 5,Comptroller,,CON,Paul Rodriguez,20,,,,
+Allegany,West Almond,Comptroller,,CON,Paul Rodriguez,13,,,,
+Allegany,Willing,Comptroller,,CON,Paul Rodriguez,15,,,,
+Allegany,Wirt,Comptroller,,CON,Paul Rodriguez,22,,,,
+Allegany,Alfred 1,Comptroller,,,WRITE-IN,1,,,,
+Allegany,Alfred 2,Comptroller,,,WRITE-IN,2,,,,
+Allegany,Allen,Comptroller,,,WRITE-IN,1,,,,
+Allegany,Alma,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Almond,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Amity 1,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Amity 2,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Andover 1,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Andover 2,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Angelica 1,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Angelica 2,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Belfast,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Birdsall,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Bolivar,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Burns,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Caneadea 1,Comptroller,,,WRITE-IN,1,,,,
+Allegany,Caneadea 2,Comptroller,,,WRITE-IN,1,,,,
+Allegany,Centerville,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Clarksville,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Cuba 1,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Cuba 2,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Friendship,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Genesee,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Granger,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Grove,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Hume,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Independence,Comptroller,,,WRITE-IN,0,,,,
+Allegany,New Hudson,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Rushford,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Scio,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Ward,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Wellsville 1,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Wellsville 2,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Wellsville 3,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Wellsville 4,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Welllsville 5,Comptroller,,,WRITE-IN,0,,,,
+Allegany,West Almond,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Willing,Comptroller,,,WRITE-IN,2,,,,
+Allegany,Wirt,Comptroller,,,WRITE-IN,0,,,,
+Allegany,Alfred 1,U.S. Senate,,DEM,Charles E. Schumer,204,,,,
+Allegany,Alfred 2,U.S. Senate,,DEM,Charles E. Schumer,221,,,,
+Allegany,Allen,U.S. Senate,,DEM,Charles E. Schumer,32,,,,
+Allegany,Alma,U.S. Senate,,DEM,Charles E. Schumer,39,,,,
+Allegany,Almond,U.S. Senate,,DEM,Charles E. Schumer,160,,,,
+Allegany,Amity 1,U.S. Senate,,DEM,Charles E. Schumer,80,,,,
+Allegany,Amity 2,U.S. Senate,,DEM,Charles E. Schumer,129,,,,
+Allegany,Andover 1,U.S. Senate,,DEM,Charles E. Schumer,97,,,,
+Allegany,Andover 2,U.S. Senate,,DEM,Charles E. Schumer,54,,,,
+Allegany,Angelica 1,U.S. Senate,,DEM,Charles E. Schumer,71,,,,
+Allegany,Angelica 2,U.S. Senate,,DEM,Charles E. Schumer,55,,,,
+Allegany,Belfast,U.S. Senate,,DEM,Charles E. Schumer,136,,,,
+Allegany,Birdsall,U.S. Senate,,DEM,Charles E. Schumer,16,,,,
+Allegany,Bolivar,U.S. Senate,,DEM,Charles E. Schumer,143,,,,
+Allegany,Burns,U.S. Senate,,DEM,Charles E. Schumer,75,,,,
+Allegany,Caneadea 1,U.S. Senate,,DEM,Charles E. Schumer,65,,,,
+Allegany,Caneadea 2,U.S. Senate,,DEM,Charles E. Schumer,94,,,,
+Allegany,Centerville,U.S. Senate,,DEM,Charles E. Schumer,37,,,,
+Allegany,Clarksville,U.S. Senate,,DEM,Charles E. Schumer,89,,,,
+Allegany,Cuba 1,U.S. Senate,,DEM,Charles E. Schumer,181,,,,
+Allegany,Cuba 2,U.S. Senate,,DEM,Charles E. Schumer,171,,,,
+Allegany,Friendship,U.S. Senate,,DEM,Charles E. Schumer,108,,,,
+Allegany,Genesee,U.S. Senate,,DEM,Charles E. Schumer,110,,,,
+Allegany,Granger,U.S. Senate,,DEM,Charles E. Schumer,26,,,,
+Allegany,Grove,U.S. Senate,,DEM,Charles E. Schumer,48,,,,
+Allegany,Hume,U.S. Senate,,DEM,Charles E. Schumer,133,,,,
+Allegany,Independence,U.S. Senate,,DEM,Charles E. Schumer,70,,,,
+Allegany,New Hudson,U.S. Senate,,DEM,Charles E. Schumer,44,,,,
+Allegany,Rushford,U.S. Senate,,DEM,Charles E. Schumer,93,,,,
+Allegany,Scio,U.S. Senate,,DEM,Charles E. Schumer,140,,,,
+Allegany,Ward,U.S. Senate,,DEM,Charles E. Schumer,36,,,,
+Allegany,Wellsville 1,U.S. Senate,,DEM,Charles E. Schumer,143,,,,
+Allegany,Wellsville 2,U.S. Senate,,DEM,Charles E. Schumer,196,,,,
+Allegany,Wellsville 3,U.S. Senate,,DEM,Charles E. Schumer,189,,,,
+Allegany,Wellsville 4,U.S. Senate,,DEM,Charles E. Schumer,110,,,,
+Allegany,Welllsville 5,U.S. Senate,,DEM,Charles E. Schumer,128,,,,
+Allegany,West Almond,U.S. Senate,,DEM,Charles E. Schumer,22,,,,
+Allegany,Willing,U.S. Senate,,DEM,Charles E. Schumer,131,,,,
+Allegany,Wirt,U.S. Senate,,DEM,Charles E. Schumer,47,,,,
+Allegany,Alfred 1,U.S. Senate,,WOR,Charles E. Schumer,26,,,,
+Allegany,Alfred 2,U.S. Senate,,WOR,Charles E. Schumer,21,,,,
+Allegany,Allen,U.S. Senate,,WOR,Charles E. Schumer,7,,,,
+Allegany,Alma,U.S. Senate,,WOR,Charles E. Schumer,4,,,,
+Allegany,Almond,U.S. Senate,,WOR,Charles E. Schumer,17,,,,
+Allegany,Amity 1,U.S. Senate,,WOR,Charles E. Schumer,10,,,,
+Allegany,Amity 2,U.S. Senate,,WOR,Charles E. Schumer,10,,,,
+Allegany,Andover 1,U.S. Senate,,WOR,Charles E. Schumer,9,,,,
+Allegany,Andover 2,U.S. Senate,,WOR,Charles E. Schumer,7,,,,
+Allegany,Angelica 1,U.S. Senate,,WOR,Charles E. Schumer,8,,,,
+Allegany,Angelica 2,U.S. Senate,,WOR,Charles E. Schumer,2,,,,
+Allegany,Belfast,U.S. Senate,,WOR,Charles E. Schumer,13,,,,
+Allegany,Birdsall,U.S. Senate,,WOR,Charles E. Schumer,1,,,,
+Allegany,Bolivar,U.S. Senate,,WOR,Charles E. Schumer,13,,,,
+Allegany,Burns,U.S. Senate,,WOR,Charles E. Schumer,8,,,,
+Allegany,Caneadea 1,U.S. Senate,,WOR,Charles E. Schumer,10,,,,
+Allegany,Caneadea 2,U.S. Senate,,WOR,Charles E. Schumer,3,,,,
+Allegany,Centerville,U.S. Senate,,WOR,Charles E. Schumer,2,,,,
+Allegany,Clarksville,U.S. Senate,,WOR,Charles E. Schumer,6,,,,
+Allegany,Cuba 1,U.S. Senate,,WOR,Charles E. Schumer,19,,,,
+Allegany,Cuba 2,U.S. Senate,,WOR,Charles E. Schumer,24,,,,
+Allegany,Friendship,U.S. Senate,,WOR,Charles E. Schumer,8,,,,
+Allegany,Genesee,U.S. Senate,,WOR,Charles E. Schumer,5,,,,
+Allegany,Granger,U.S. Senate,,WOR,Charles E. Schumer,3,,,,
+Allegany,Grove,U.S. Senate,,WOR,Charles E. Schumer,5,,,,
+Allegany,Hume,U.S. Senate,,WOR,Charles E. Schumer,21,,,,
+Allegany,Independence,U.S. Senate,,WOR,Charles E. Schumer,5,,,,
+Allegany,New Hudson,U.S. Senate,,WOR,Charles E. Schumer,9,,,,
+Allegany,Rushford,U.S. Senate,,WOR,Charles E. Schumer,13,,,,
+Allegany,Scio,U.S. Senate,,WOR,Charles E. Schumer,9,,,,
+Allegany,Ward,U.S. Senate,,WOR,Charles E. Schumer,10,,,,
+Allegany,Wellsville 1,U.S. Senate,,WOR,Charles E. Schumer,12,,,,
+Allegany,Wellsville 2,U.S. Senate,,WOR,Charles E. Schumer,9,,,,
+Allegany,Wellsville 3,U.S. Senate,,WOR,Charles E. Schumer,18,,,,
+Allegany,Wellsville 4,U.S. Senate,,WOR,Charles E. Schumer,10,,,,
+Allegany,Welllsville 5,U.S. Senate,,WOR,Charles E. Schumer,11,,,,
+Allegany,West Almond,U.S. Senate,,WOR,Charles E. Schumer,0,,,,
+Allegany,Willing,U.S. Senate,,WOR,Charles E. Schumer,7,,,,
+Allegany,Wirt,U.S. Senate,,WOR,Charles E. Schumer,8,,,,
+Allegany,Alfred 1,U.S. Senate,,REP,Joe Pinion,44,,,,
+Allegany,Alfred 2,U.S. Senate,,REP,Joe Pinion,207,,,,
+Allegany,Allen,U.S. Senate,,REP,Joe Pinion,134,,,,
+Allegany,Alma,U.S. Senate,,REP,Joe Pinion,242,,,,
+Allegany,Almond,U.S. Senate,,REP,Joe Pinion,399,,,,
+Allegany,Amity 1,U.S. Senate,,REP,Joe Pinion,210,,,,
+Allegany,Amity 2,U.S. Senate,,REP,Joe Pinion,327,,,,
+Allegany,Andover 1,U.S. Senate,,REP,Joe Pinion,253,,,,
+Allegany,Andover 2,U.S. Senate,,REP,Joe Pinion,225,,,,
+Allegany,Angelica 1,U.S. Senate,,REP,Joe Pinion,207,,,,
+Allegany,Angelica 2,U.S. Senate,,REP,Joe Pinion,166,,,,
+Allegany,Belfast,U.S. Senate,,REP,Joe Pinion,393,,,,
+Allegany,Birdsall,U.S. Senate,,REP,Joe Pinion,58,,,,
+Allegany,Bolivar,U.S. Senate,,REP,Joe Pinion,457,,,,
+Allegany,Burns,U.S. Senate,,REP,Joe Pinion,302,,,,
+Allegany,Caneadea 1,U.S. Senate,,REP,Joe Pinion,178,,,,
+Allegany,Caneadea 2,U.S. Senate,,REP,Joe Pinion,172,,,,
+Allegany,Centerville,U.S. Senate,,REP,Joe Pinion,189,,,,
+Allegany,Clarksville,U.S. Senate,,REP,Joe Pinion,235,,,,
+Allegany,Cuba 1,U.S. Senate,,REP,Joe Pinion,248,,,,
+Allegany,Cuba 2,U.S. Senate,,REP,Joe Pinion,411,,,,
+Allegany,Friendship,U.S. Senate,,REP,Joe Pinion,417,,,,
+Allegany,Genesee,U.S. Senate,,REP,Joe Pinion,438,,,,
+Allegany,Granger,U.S. Senate,,REP,Joe Pinion,179,,,,
+Allegany,Grove,U.S. Senate,,REP,Joe Pinion,173,,,,
+Allegany,Hume,U.S. Senate,,REP,Joe Pinion,477,,,,
+Allegany,Independence,U.S. Senate,,REP,Joe Pinion,276,,,,
+Allegany,New Hudson,U.S. Senate,,REP,Joe Pinion,177,,,,
+Allegany,Rushford,U.S. Senate,,REP,Joe Pinion,315,,,,
+Allegany,Scio,U.S. Senate,,REP,Joe Pinion,428,,,,
+Allegany,Ward,U.S. Senate,,REP,Joe Pinion,111,,,,
+Allegany,Wellsville 1,U.S. Senate,,REP,Joe Pinion,255,,,,
+Allegany,Wellsville 2,U.S. Senate,,REP,Joe Pinion,259,,,,
+Allegany,Wellsville 3,U.S. Senate,,REP,Joe Pinion,308,,,,
+Allegany,Wellsville 4,U.S. Senate,,REP,Joe Pinion,265,,,,
+Allegany,Welllsville 5,U.S. Senate,,REP,Joe Pinion,312,,,,
+Allegany,West Almond,U.S. Senate,,REP,Joe Pinion,87,,,,
+Allegany,Willing,U.S. Senate,,REP,Joe Pinion,352,,,,
+Allegany,Wirt,U.S. Senate,,REP,Joe Pinion,310,,,,
+Allegany,Alfred 1,U.S. Senate,,CON,Joe Pinion,12,,,,
+Allegany,Alfred 2,U.S. Senate,,CON,Joe Pinion,43,,,,
+Allegany,Allen,U.S. Senate,,CON,Joe Pinion,11,,,,
+Allegany,Alma,U.S. Senate,,CON,Joe Pinion,22,,,,
+Allegany,Almond,U.S. Senate,,CON,Joe Pinion,76,,,,
+Allegany,Amity 1,U.S. Senate,,CON,Joe Pinion,20,,,,
+Allegany,Amity 2,U.S. Senate,,CON,Joe Pinion,28,,,,
+Allegany,Andover 1,U.S. Senate,,CON,Joe Pinion,24,,,,
+Allegany,Andover 2,U.S. Senate,,CON,Joe Pinion,15,,,,
+Allegany,Angelica 1,U.S. Senate,,CON,Joe Pinion,13,,,,
+Allegany,Angelica 2,U.S. Senate,,CON,Joe Pinion,21,,,,
+Allegany,Belfast,U.S. Senate,,CON,Joe Pinion,45,,,,
+Allegany,Birdsall,U.S. Senate,,CON,Joe Pinion,10,,,,
+Allegany,Bolivar,U.S. Senate,,CON,Joe Pinion,46,,,,
+Allegany,Burns,U.S. Senate,,CON,Joe Pinion,38,,,,
+Allegany,Caneadea 1,U.S. Senate,,CON,Joe Pinion,25,,,,
+Allegany,Caneadea 2,U.S. Senate,,CON,Joe Pinion,37,,,,
+Allegany,Centerville,U.S. Senate,,CON,Joe Pinion,32,,,,
+Allegany,Clarksville,U.S. Senate,,CON,Joe Pinion,27,,,,
+Allegany,Cuba 1,U.S. Senate,,CON,Joe Pinion,25,,,,
+Allegany,Cuba 2,U.S. Senate,,CON,Joe Pinion,30,,,,
+Allegany,Friendship,U.S. Senate,,CON,Joe Pinion,42,,,,
+Allegany,Genesee,U.S. Senate,,CON,Joe Pinion,37,,,,
+Allegany,Granger,U.S. Senate,,CON,Joe Pinion,22,,,,
+Allegany,Grove,U.S. Senate,,CON,Joe Pinion,29,,,,
+Allegany,Hume,U.S. Senate,,CON,Joe Pinion,56,,,,
+Allegany,Independence,U.S. Senate,,CON,Joe Pinion,11,,,,
+Allegany,New Hudson,U.S. Senate,,CON,Joe Pinion,17,,,,
+Allegany,Rushford,U.S. Senate,,CON,Joe Pinion,61,,,,
+Allegany,Scio,U.S. Senate,,CON,Joe Pinion,35,,,,
+Allegany,Ward,U.S. Senate,,CON,Joe Pinion,10,,,,
+Allegany,Wellsville 1,U.S. Senate,,CON,Joe Pinion,22,,,,
+Allegany,Wellsville 2,U.S. Senate,,CON,Joe Pinion,20,,,,
+Allegany,Wellsville 3,U.S. Senate,,CON,Joe Pinion,33,,,,
+Allegany,Wellsville 4,U.S. Senate,,CON,Joe Pinion,14,,,,
+Allegany,Welllsville 5,U.S. Senate,,CON,Joe Pinion,22,,,,
+Allegany,West Almond,U.S. Senate,,CON,Joe Pinion,14,,,,
+Allegany,Willing,U.S. Senate,,CON,Joe Pinion,14,,,,
+Allegany,Wirt,U.S. Senate,,CON,Joe Pinion,22,,,,
+Allegany,Alfred 1,U.S. Senate,,LaRouche,Diane Sare,1,,,,
+Allegany,Alfred 2,U.S. Senate,,LaRouche,Diane Sare,4,,,,
+Allegany,Allen,U.S. Senate,,LaRouche,Diane Sare,0,,,,
+Allegany,Alma,U.S. Senate,,LaRouche,Diane Sare,1,,,,
+Allegany,Almond,U.S. Senate,,LaRouche,Diane Sare,6,,,,
+Allegany,Amity 1,U.S. Senate,,LaRouche,Diane Sare,2,,,,
+Allegany,Amity 2,U.S. Senate,,LaRouche,Diane Sare,1,,,,
+Allegany,Andover 1,U.S. Senate,,LaRouche,Diane Sare,2,,,,
+Allegany,Andover 2,U.S. Senate,,LaRouche,Diane Sare,3,,,,
+Allegany,Angelica 1,U.S. Senate,,LaRouche,Diane Sare,3,,,,
+Allegany,Angelica 2,U.S. Senate,,LaRouche,Diane Sare,1,,,,
+Allegany,Belfast,U.S. Senate,,LaRouche,Diane Sare,1,,,,
+Allegany,Birdsall,U.S. Senate,,LaRouche,Diane Sare,0,,,,
+Allegany,Bolivar,U.S. Senate,,LaRouche,Diane Sare,0,,,,
+Allegany,Burns,U.S. Senate,,LaRouche,Diane Sare,2,,,,
+Allegany,Caneadea 1,U.S. Senate,,LaRouche,Diane Sare,1,,,,
+Allegany,Caneadea 2,U.S. Senate,,LaRouche,Diane Sare,3,,,,
+Allegany,Centerville,U.S. Senate,,LaRouche,Diane Sare,4,,,,
+Allegany,Clarksville,U.S. Senate,,LaRouche,Diane Sare,0,,,,
+Allegany,Cuba 1,U.S. Senate,,LaRouche,Diane Sare,1,,,,
+Allegany,Cuba 2,U.S. Senate,,LaRouche,Diane Sare,2,,,,
+Allegany,Friendship,U.S. Senate,,LaRouche,Diane Sare,1,,,,
+Allegany,Genesee,U.S. Senate,,LaRouche,Diane Sare,2,,,,
+Allegany,Granger,U.S. Senate,,LaRouche,Diane Sare,0,,,,
+Allegany,Grove,U.S. Senate,,LaRouche,Diane Sare,4,,,,
+Allegany,Hume,U.S. Senate,,LaRouche,Diane Sare,4,,,,
+Allegany,Independence,U.S. Senate,,LaRouche,Diane Sare,2,,,,
+Allegany,New Hudson,U.S. Senate,,LaRouche,Diane Sare,2,,,,
+Allegany,Rushford,U.S. Senate,,LaRouche,Diane Sare,5,,,,
+Allegany,Scio,U.S. Senate,,LaRouche,Diane Sare,5,,,,
+Allegany,Ward,U.S. Senate,,LaRouche,Diane Sare,2,,,,
+Allegany,Wellsville 1,U.S. Senate,,LaRouche,Diane Sare,4,,,,
+Allegany,Wellsville 2,U.S. Senate,,LaRouche,Diane Sare,1,,,,
+Allegany,Wellsville 3,U.S. Senate,,LaRouche,Diane Sare,1,,,,
+Allegany,Wellsville 4,U.S. Senate,,LaRouche,Diane Sare,3,,,,
+Allegany,Welllsville 5,U.S. Senate,,LaRouche,Diane Sare,1,,,,
+Allegany,West Almond,U.S. Senate,,LaRouche,Diane Sare,0,,,,
+Allegany,Willing,U.S. Senate,,LaRouche,Diane Sare,0,,,,
+Allegany,Wirt,U.S. Senate,,LaRouche,Diane Sare,2,,,,
+Allegany,Alfred 1,U.S. Senate,,,WRITE-IN,1,,,,
+Allegany,Alfred 2,U.S. Senate,,,WRITE-IN,2,,,,
+Allegany,Allen,U.S. Senate,,,WRITE-IN,1,,,,
+Allegany,Alma,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Almond,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Amity 1,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Amity 2,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Andover 1,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Andover 2,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Angelica 1,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Angelica 2,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Belfast,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Birdsall,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Bolivar,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Burns,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Caneadea 1,U.S. Senate,,,WRITE-IN,1,,,,
+Allegany,Caneadea 2,U.S. Senate,,,WRITE-IN,1,,,,
+Allegany,Centerville,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Clarksville,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Cuba 1,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Cuba 2,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Friendship,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Genesee,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Granger,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Grove,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Hume,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Independence,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,New Hudson,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Rushford,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Scio,U.S. Senate,,,WRITE-IN,1,,,,
+Allegany,Ward,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Wellsville 1,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Wellsville 2,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Wellsville 3,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Wellsville 4,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Welllsville 5,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,West Almond,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Willing,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Wirt,U.S. Senate,,,WRITE-IN,0,,,,
+Allegany,Alfred 1,U.S. House,23,DEM,Max Della Pia,224,,,,
+Allegany,Alfred 2,U.S. House,23,DEM,Max Della Pia,226,,,,
+Allegany,Allen,U.S. House,23,DEM,Max Della Pia,28,,,,
+Allegany,Alma,U.S. House,23,DEM,Max Della Pia,21,,,,
+Allegany,Almond,U.S. House,23,DEM,Max Della Pia,156,,,,
+Allegany,Amity 1,U.S. House,23,DEM,Max Della Pia,73,,,,
+Allegany,Amity 2,U.S. House,23,DEM,Max Della Pia,125,,,,
+Allegany,Andover 1,U.S. House,23,DEM,Max Della Pia,95,,,,
+Allegany,Andover 2,U.S. House,23,DEM,Max Della Pia,53,,,,
+Allegany,Angelica 1,U.S. House,23,DEM,Max Della Pia,64,,,,
+Allegany,Angelica 2,U.S. House,23,DEM,Max Della Pia,50,,,,
+Allegany,Belfast,U.S. House,23,DEM,Max Della Pia,121,,,,
+Allegany,Birdsall,U.S. House,23,DEM,Max Della Pia,15,,,,
+Allegany,Bolivar,U.S. House,23,DEM,Max Della Pia,134,,,,
+Allegany,Burns,U.S. House,23,DEM,Max Della Pia,66,,,,
+Allegany,Caneadea 1,U.S. House,23,DEM,Max Della Pia,59,,,,
+Allegany,Caneadea 2,U.S. House,23,DEM,Max Della Pia,95,,,,
+Allegany,Centerville,U.S. House,23,DEM,Max Della Pia,29,,,,
+Allegany,Clarksville,U.S. House,23,DEM,Max Della Pia,79,,,,
+Allegany,Cuba 1,U.S. House,23,DEM,Max Della Pia,173,,,,
+Allegany,Cuba 2,U.S. House,23,DEM,Max Della Pia,165,,,,
+Allegany,Friendship,U.S. House,23,DEM,Max Della Pia,78,,,,
+Allegany,Genesee,U.S. House,23,DEM,Max Della Pia,99,,,,
+Allegany,Granger,U.S. House,23,DEM,Max Della Pia,25,,,,
+Allegany,Grove,U.S. House,23,DEM,Max Della Pia,52,,,,
+Allegany,Hume,U.S. House,23,DEM,Max Della Pia,130,,,,
+Allegany,Independence,U.S. House,23,DEM,Max Della Pia,65,,,,
+Allegany,New Hudson,U.S. House,23,DEM,Max Della Pia,40,,,,
+Allegany,Rushford,U.S. House,23,DEM,Max Della Pia,84,,,,
+Allegany,Scio,U.S. House,23,DEM,Max Della Pia,124,,,,
+Allegany,Ward,U.S. House,23,DEM,Max Della Pia,38,,,,
+Allegany,Wellsville 1,U.S. House,23,DEM,Max Della Pia,138,,,,
+Allegany,Wellsville 2,U.S. House,23,DEM,Max Della Pia,170,,,,
+Allegany,Wellsville 3,U.S. House,23,DEM,Max Della Pia,175,,,,
+Allegany,Wellsville 4,U.S. House,23,DEM,Max Della Pia,100,,,,
+Allegany,Welllsville 5,U.S. House,23,DEM,Max Della Pia,112,,,,
+Allegany,West Almond,U.S. House,23,DEM,Max Della Pia,20,,,,
+Allegany,Willing,U.S. House,23,DEM,Max Della Pia,106,,,,
+Allegany,Wirt,U.S. House,23,DEM,Max Della Pia,36,,,,
+Allegany,Alfred 1,U.S. House,23,REP,Nicholas A. Langworthy,48,,,,
+Allegany,Alfred 2,U.S. House,23,REP,Nicholas A. Langworthy,212,,,,
+Allegany,Allen,U.S. House,23,REP,Nicholas A. Langworthy,140,,,,
+Allegany,Alma,U.S. House,23,REP,Nicholas A. Langworthy,246,,,,
+Allegany,Almond,U.S. House,23,REP,Nicholas A. Langworthy,416,,,,
+Allegany,Amity 1,U.S. House,23,REP,Nicholas A. Langworthy,216,,,,
+Allegany,Amity 2,U.S. House,23,REP,Nicholas A. Langworthy,342,,,,
+Allegany,Andover 1,U.S. House,23,REP,Nicholas A. Langworthy,260,,,,
+Allegany,Andover 2,U.S. House,23,REP,Nicholas A. Langworthy,240,,,,
+Allegany,Angelica 1,U.S. House,23,REP,Nicholas A. Langworthy,214,,,,
+Allegany,Angelica 2,U.S. House,23,REP,Nicholas A. Langworthy,173,,,,
+Allegany,Belfast,U.S. House,23,REP,Nicholas A. Langworthy,413,,,,
+Allegany,Birdsall,U.S. House,23,REP,Nicholas A. Langworthy,59,,,,
+Allegany,Bolivar,U.S. House,23,REP,Nicholas A. Langworthy,485,,,,
+Allegany,Burns,U.S. House,23,REP,Nicholas A. Langworthy,310,,,,
+Allegany,Caneadea 1,U.S. House,23,REP,Nicholas A. Langworthy,186,,,,
+Allegany,Caneadea 2,U.S. House,23,REP,Nicholas A. Langworthy,179,,,,
+Allegany,Centerville,U.S. House,23,REP,Nicholas A. Langworthy,197,,,,
+Allegany,Clarksville,U.S. House,23,REP,Nicholas A. Langworthy,237,,,,
+Allegany,Cuba 1,U.S. House,23,REP,Nicholas A. Langworthy,276,,,,
+Allegany,Cuba 2,U.S. House,23,REP,Nicholas A. Langworthy,441,,,,
+Allegany,Friendship,U.S. House,23,REP,Nicholas A. Langworthy,451,,,,
+Allegany,Genesee,U.S. House,23,REP,Nicholas A. Langworthy,462,,,,
+Allegany,Granger,U.S. House,23,REP,Nicholas A. Langworthy,178,,,,
+Allegany,Grove,U.S. House,23,REP,Nicholas A. Langworthy,173,,,,
+Allegany,Hume,U.S. House,23,REP,Nicholas A. Langworthy,502,,,,
+Allegany,Independence,U.S. House,23,REP,Nicholas A. Langworthy,282,,,,
+Allegany,New Hudson,U.S. House,23,REP,Nicholas A. Langworthy,188,,,,
+Allegany,Rushford,U.S. House,23,REP,Nicholas A. Langworthy,335,,,,
+Allegany,Scio,U.S. House,23,REP,Nicholas A. Langworthy,442,,,,
+Allegany,Ward,U.S. House,23,REP,Nicholas A. Langworthy,116,,,,
+Allegany,Wellsville 1,U.S. House,23,REP,Nicholas A. Langworthy,272,,,,
+Allegany,Wellsville 2,U.S. House,23,REP,Nicholas A. Langworthy,285,,,,
+Allegany,Wellsville 3,U.S. House,23,REP,Nicholas A. Langworthy,282,,,,
+Allegany,Wellsville 4,U.S. House,23,REP,Nicholas A. Langworthy,288,,,,
+Allegany,Welllsville 5,U.S. House,23,REP,Nicholas A. Langworthy,330,,,,
+Allegany,West Almond,U.S. House,23,REP,Nicholas A. Langworthy,90,,,,
+Allegany,Willing,U.S. House,23,REP,Nicholas A. Langworthy,376,,,,
+Allegany,Wirt,U.S. House,23,REP,Nicholas A. Langworthy,328,,,,
+Allegany,Alfred 1,U.S. House,23,CON,Nicholas A. Langworthy,15,,,,
+Allegany,Alfred 2,U.S. House,23,CON,Nicholas A. Langworthy,44,,,,
+Allegany,Allen,U.S. House,23,CON,Nicholas A. Langworthy,15,,,,
+Allegany,Alma,U.S. House,23,CON,Nicholas A. Langworthy,19,,,,
+Allegany,Almond,U.S. House,23,CON,Nicholas A. Langworthy,77,,,,
+Allegany,Amity 1,U.S. House,23,CON,Nicholas A. Langworthy,23,,,,
+Allegany,Amity 2,U.S. House,23,CON,Nicholas A. Langworthy,33,,,,
+Allegany,Andover 1,U.S. House,23,CON,Nicholas A. Langworthy,28,,,,
+Allegany,Andover 2,U.S. House,23,CON,Nicholas A. Langworthy,14,,,,
+Allegany,Angelica 1,U.S. House,23,CON,Nicholas A. Langworthy,16,,,,
+Allegany,Angelica 2,U.S. House,23,CON,Nicholas A. Langworthy,22,,,,
+Allegany,Belfast,U.S. House,23,CON,Nicholas A. Langworthy,48,,,,
+Allegany,Birdsall,U.S. House,23,CON,Nicholas A. Langworthy,12,,,,
+Allegany,Bolivar,U.S. House,23,CON,Nicholas A. Langworthy,38,,,,
+Allegany,Burns,U.S. House,23,CON,Nicholas A. Langworthy,43,,,,
+Allegany,Caneadea 1,U.S. House,23,CON,Nicholas A. Langworthy,24,,,,
+Allegany,Caneadea 2,U.S. House,23,CON,Nicholas A. Langworthy,36,,,,
+Allegany,Centerville,U.S. House,23,CON,Nicholas A. Langworthy,35,,,,
+Allegany,Clarksville,U.S. House,23,CON,Nicholas A. Langworthy,32,,,,
+Allegany,Cuba 1,U.S. House,23,CON,Nicholas A. Langworthy,29,,,,
+Allegany,Cuba 2,U.S. House,23,CON,Nicholas A. Langworthy,29,,,,
+Allegany,Friendship,U.S. House,23,CON,Nicholas A. Langworthy,46,,,,
+Allegany,Genesee,U.S. House,23,CON,Nicholas A. Langworthy,36,,,,
+Allegany,Granger,U.S. House,23,CON,Nicholas A. Langworthy,20,,,,
+Allegany,Grove,U.S. House,23,CON,Nicholas A. Langworthy,28,,,,
+Allegany,Hume,U.S. House,23,CON,Nicholas A. Langworthy,48,,,,
+Allegany,Independence,U.S. House,23,CON,Nicholas A. Langworthy,15,,,,
+Allegany,New Hudson,U.S. House,23,CON,Nicholas A. Langworthy,19,,,,
+Allegany,Rushford,U.S. House,23,CON,Nicholas A. Langworthy,63,,,,
+Allegany,Scio,U.S. House,23,CON,Nicholas A. Langworthy,44,,,,
+Allegany,Ward,U.S. House,23,CON,Nicholas A. Langworthy,12,,,,
+Allegany,Wellsville 1,U.S. House,23,CON,Nicholas A. Langworthy,25,,,,
+Allegany,Wellsville 2,U.S. House,23,CON,Nicholas A. Langworthy,24,,,,
+Allegany,Wellsville 3,U.S. House,23,CON,Nicholas A. Langworthy,36,,,,
+Allegany,Wellsville 4,U.S. House,23,CON,Nicholas A. Langworthy,19,,,,
+Allegany,Welllsville 5,U.S. House,23,CON,Nicholas A. Langworthy,25,,,,
+Allegany,West Almond,U.S. House,23,CON,Nicholas A. Langworthy,15,,,,
+Allegany,Willing,U.S. House,23,CON,Nicholas A. Langworthy,14,,,,
+Allegany,Wirt,U.S. House,23,CON,Nicholas A. Langworthy,21,,,,
+Allegany,Alfred 1,U.S. House,23,,WRITE-IN,1,,,,
+Allegany,Alfred 2,U.S. House,23,,WRITE-IN,1,,,,
+Allegany,Allen,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Alma,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Almond,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Amity 1,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Amity 2,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Andover 1,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Andover 2,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Angelica 1,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Angelica 2,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Belfast,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Birdsall,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Bolivar,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Burns,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Caneadea 1,U.S. House,23,,WRITE-IN,2,,,,
+Allegany,Caneadea 2,U.S. House,23,,WRITE-IN,2,,,,
+Allegany,Centerville,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Clarksville,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Cuba 1,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Cuba 2,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Friendship,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Genesee,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Granger,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Grove,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Hume,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Independence,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,New Hudson,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Rushford,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Scio,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Ward,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Wellsville 1,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Wellsville 2,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Wellsville 3,U.S. House,23,,WRITE-IN,1,,,,
+Allegany,Wellsville 4,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Welllsville 5,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,West Almond,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Willing,U.S. House,23,,WRITE-IN,0,,,,
+Allegany,Wirt,U.S. House,23,,WRITE-IN,1,,,,
+Allegany,Allen,State Senate,57,DEM,Daniel Brown,32,,,,
+Allegany,Alma,State Senate,57,DEM,Daniel Brown,31,,,,
+Allegany,Angelica 1,State Senate,57,DEM,Daniel Brown,57,,,,
+Allegany,Angelica 2,State Senate,57,DEM,Daniel Brown,49,,,,
+Allegany,Belfast,State Senate,57,DEM,Daniel Brown,108,,,,
+Allegany,Bolivar,State Senate,57,DEM,Daniel Brown,123,,,,
+Allegany,Caneadea 1,State Senate,57,DEM,Daniel Brown,58,,,,
+Allegany,Caneadea 2,State Senate,57,DEM,Daniel Brown,80,,,,
+Allegany,Centerville,State Senate,57,DEM,Daniel Brown,39,,,,
+Allegany,Clarksville,State Senate,57,DEM,Daniel Brown,78,,,,
+Allegany,Cuba 1,State Senate,57,DEM,Daniel Brown,159,,,,
+Allegany,Cuba 2,State Senate,57,DEM,Daniel Brown,152,,,,
+Allegany,Friendship,State Senate,57,DEM,Daniel Brown,86,,,,
+Allegany,Genesee,State Senate,57,DEM,Daniel Brown,93,,,,
+Allegany,Granger,State Senate,57,DEM,Daniel Brown,27,,,,
+Allegany,Hume,State Senate,57,DEM,Daniel Brown,125,,,,
+Allegany,New Hudson,State Senate,57,DEM,Daniel Brown,35,,,,
+Allegany,Rushford,State Senate,57,DEM,Daniel Brown,83,,,,
+Allegany,West Almond,State Senate,57,DEM,Daniel Brown,24,,,,
+Allegany,Wirt,State Senate,57,DEM,Daniel Brown,35,,,,
+Allegany,Allen,State Senate,57,REP,George Borrello,135,,,,
+Allegany,Alma,State Senate,57,REP,George Borrello,246,,,,
+Allegany,Angelica 1,State Senate,57,REP,George Borrello,218,,,,
+Allegany,Angelica 2,State Senate,57,REP,George Borrello,172,,,,
+Allegany,Belfast,State Senate,57,REP,George Borrello,427,,,,
+Allegany,Bolivar,State Senate,57,REP,George Borrello,488,,,,
+Allegany,Caneadea 1,State Senate,57,REP,George Borrello,191,,,,
+Allegany,Caneadea 2,State Senate,57,REP,George Borrello,193,,,,
+Allegany,Centerville,State Senate,57,REP,George Borrello,193,,,,
+Allegany,Clarksville,State Senate,57,REP,George Borrello,240,,,,
+Allegany,Cuba 1,State Senate,57,REP,George Borrello,285,,,,
+Allegany,Cuba 2,State Senate,57,REP,George Borrello,451,,,,
+Allegany,Friendship,State Senate,57,REP,George Borrello,439,,,,
+Allegany,Genesee,State Senate,57,REP,George Borrello,463,,,,
+Allegany,Granger,State Senate,57,REP,George Borrello,178,,,,
+Allegany,Hume,State Senate,57,REP,George Borrello,499,,,,
+Allegany,New Hudson,State Senate,57,REP,George Borrello,191,,,,
+Allegany,Rushford,State Senate,57,REP,George Borrello,342,,,,
+Allegany,West Almond,State Senate,57,REP,George Borrello,84,,,,
+Allegany,Wirt,State Senate,57,REP,George Borrello,323,,,,
+Allegany,Allen,State Senate,57,CON,George Borrello,12,,,,
+Allegany,Alma,State Senate,57,CON,George Borrello,22,,,,
+Allegany,Angelica 1,State Senate,57,CON,George Borrello,19,,,,
+Allegany,Angelica 2,State Senate,57,CON,George Borrello,21,,,,
+Allegany,Belfast,State Senate,57,CON,George Borrello,46,,,,
+Allegany,Bolivar,State Senate,57,CON,George Borrello,43,,,,
+Allegany,Caneadea 1,State Senate,57,CON,George Borrello,24,,,,
+Allegany,Caneadea 2,State Senate,57,CON,George Borrello,33,,,,
+Allegany,Centerville,State Senate,57,CON,George Borrello,32,,,,
+Allegany,Clarksville,State Senate,57,CON,George Borrello,33,,,,
+Allegany,Cuba 1,State Senate,57,CON,George Borrello,29,,,,
+Allegany,Cuba 2,State Senate,57,CON,George Borrello,35,,,,
+Allegany,Friendship,State Senate,57,CON,George Borrello,42,,,,
+Allegany,Genesee,State Senate,57,CON,George Borrello,32,,,,
+Allegany,Granger,State Senate,57,CON,George Borrello,20,,,,
+Allegany,Hume,State Senate,57,CON,George Borrello,49,,,,
+Allegany,New Hudson,State Senate,57,CON,George Borrello,19,,,,
+Allegany,Rushford,State Senate,57,CON,George Borrello,52,,,,
+Allegany,West Almond,State Senate,57,CON,George Borrello,15,,,,
+Allegany,Wirt,State Senate,57,CON,George Borrello,25,,,,
+Allegany,Allen,State Senate,57,,WRITE-IN,1,,,,
+Allegany,Alma,State Senate,57,,WRITE-IN,0,,,,
+Allegany,Angelica 1,State Senate,57,,WRITE-IN,0,,,,
+Allegany,Angelica 2,State Senate,57,,WRITE-IN,0,,,,
+Allegany,Belfast,State Senate,57,,WRITE-IN,0,,,,
+Allegany,Bolivar,State Senate,57,,WRITE-IN,0,,,,
+Allegany,Caneadea 1,State Senate,57,,WRITE-IN,0,,,,
+Allegany,Caneadea 2,State Senate,57,,WRITE-IN,0,,,,
+Allegany,Centerville,State Senate,57,,WRITE-IN,0,,,,
+Allegany,Clarksville,State Senate,57,,WRITE-IN,0,,,,
+Allegany,Cuba 1,State Senate,57,,WRITE-IN,0,,,,
+Allegany,Cuba 2,State Senate,57,,WRITE-IN,0,,,,
+Allegany,Friendship,State Senate,57,,WRITE-IN,0,,,,
+Allegany,Genesee,State Senate,57,,WRITE-IN,0,,,,
+Allegany,Granger,State Senate,57,,WRITE-IN,0,,,,
+Allegany,Hume,State Senate,57,,WRITE-IN,1,,,,
+Allegany,New Hudson,State Senate,57,,WRITE-IN,0,,,,
+Allegany,Rushford,State Senate,57,,WRITE-IN,0,,,,
+Allegany,West Almond,State Senate,57,,WRITE-IN,0,,,,
+Allegany,Wirt,State Senate,57,,WRITE-IN,0,,,,
+Allegany,Alfred 1,State Senate,58,REP,Thomas O'Mara,95,,,,
+Allegany,Alfred 2,State Senate,58,REP,Thomas O'Mara,245,,,,
+Allegany,Almond,State Senate,58,REP,Thomas O'Mara,448,,,,
+Allegany,Amity 1,State Senate,58,REP,Thomas O'Mara,223,,,,
+Allegany,Amity 2,State Senate,58,REP,Thomas O'Mara,354,,,,
+Allegany,Andover 1,State Senate,58,REP,Thomas O'Mara,294,,,,
+Allegany,Andover 2,State Senate,58,REP,Thomas O'Mara,244,,,,
+Allegany,Birdsall,State Senate,58,REP,Thomas O'Mara,59,,,,
+Allegany,Burns,State Senate,58,REP,Thomas O'Mara,321,,,,
+Allegany,Grove,State Senate,58,REP,Thomas O'Mara,189,,,,
+Allegany,Independence,State Senate,58,REP,Thomas O'Mara,280,,,,
+Allegany,Scio,State Senate,58,REP,Thomas O'Mara,461,,,,
+Allegany,Ward,State Senate,58,REP,Thomas O'Mara,111,,,,
+Allegany,Wellsville 1,State Senate,58,REP,Thomas O'Mara,306,,,,
+Allegany,Wellsville 2,State Senate,58,REP,Thomas O'Mara,325,,,,
+Allegany,Wellsville 3,State Senate,58,REP,Thomas O'Mara,370,,,,
+Allegany,Wellsville 4,State Senate,58,REP,Thomas O'Mara,306,,,,
+Allegany,Welllsville 5,State Senate,58,REP,Thomas O'Mara,359,,,,
+Allegany,Willing,State Senate,58,REP,Thomas O'Mara,403,,,,
+Allegany,Alfred 1,State Senate,58,CON,Thomas O'Mara,24,,,,
+Allegany,Alfred 2,State Senate,58,CON,Thomas O'Mara,55,,,,
+Allegany,Almond,State Senate,58,CON,Thomas O'Mara,91,,,,
+Allegany,Amity 1,State Senate,58,CON,Thomas O'Mara,25,,,,
+Allegany,Amity 2,State Senate,58,CON,Thomas O'Mara,46,,,,
+Allegany,Andover 1,State Senate,58,CON,Thomas O'Mara,34,,,,
+Allegany,Andover 2,State Senate,58,CON,Thomas O'Mara,13,,,,
+Allegany,Birdsall,State Senate,58,CON,Thomas O'Mara,12,,,,
+Allegany,Burns,State Senate,58,CON,Thomas O'Mara,49,,,,
+Allegany,Grove,State Senate,58,CON,Thomas O'Mara,36,,,,
+Allegany,Independence,State Senate,58,CON,Thomas O'Mara,23,,,,
+Allegany,Scio,State Senate,58,CON,Thomas O'Mara,56,,,,
+Allegany,Ward,State Senate,58,CON,Thomas O'Mara,19,,,,
+Allegany,Wellsville 1,State Senate,58,CON,Thomas O'Mara,37,,,,
+Allegany,Wellsville 2,State Senate,58,CON,Thomas O'Mara,39,,,,
+Allegany,Wellsville 3,State Senate,58,CON,Thomas O'Mara,47,,,,
+Allegany,Wellsville 4,State Senate,58,CON,Thomas O'Mara,25,,,,
+Allegany,Welllsville 5,State Senate,58,CON,Thomas O'Mara,36,,,,
+Allegany,Willing,State Senate,58,CON,Thomas O'Mara,22,,,,
+Allegany,Alfred 1,State Senate,58,,WRITE-IN,7,,,,
+Allegany,Alfred 2,State Senate,58,,WRITE-IN,4,,,,
+Allegany,Almond,State Senate,58,,WRITE-IN,5,,,,
+Allegany,Amity 1,State Senate,58,,WRITE-IN,1,,,,
+Allegany,Amity 2,State Senate,58,,WRITE-IN,1,,,,
+Allegany,Andover 1,State Senate,58,,WRITE-IN,0,,,,
+Allegany,Andover 2,State Senate,58,,WRITE-IN,0,,,,
+Allegany,Birdsall,State Senate,58,,WRITE-IN,0,,,,
+Allegany,Burns,State Senate,58,,WRITE-IN,1,,,,
+Allegany,Grove,State Senate,58,,WRITE-IN,0,,,,
+Allegany,Independence,State Senate,58,,WRITE-IN,0,,,,
+Allegany,Scio,State Senate,58,,WRITE-IN,2,,,,
+Allegany,Ward,State Senate,58,,WRITE-IN,1,,,,
+Allegany,Wellsville 1,State Senate,58,,WRITE-IN,3,,,,
+Allegany,Wellsville 2,State Senate,58,,WRITE-IN,0,,,,
+Allegany,Wellsville 3,State Senate,58,,WRITE-IN,2,,,,
+Allegany,Wellsville 4,State Senate,58,,WRITE-IN,1,,,,
+Allegany,Welllsville 5,State Senate,58,,WRITE-IN,2,,,,
+Allegany,Willing,State Senate,58,,WRITE-IN,0,,,,
+Allegany,Alfred 1,State Assembly,148,REP,Joseph Giglio,89,,,,
+Allegany,Alfred 2,State Assembly,148,REP,Joseph Giglio,248,,,,
+Allegany,Allen,State Assembly,148,REP,Joseph Giglio,135,,,,
+Allegany,Alma,State Assembly,148,REP,Joseph Giglio,246,,,,
+Allegany,Almond,State Assembly,148,REP,Joseph Giglio,452,,,,
+Allegany,Amity 1,State Assembly,148,REP,Joseph Giglio,228,,,,
+Allegany,Amity 2,State Assembly,148,REP,Joseph Giglio,355,,,,
+Allegany,Andover 1,State Assembly,148,REP,Joseph Giglio,295,,,,
+Allegany,Andover 2,State Assembly,148,REP,Joseph Giglio,245,,,,
+Allegany,Angelica 1,State Assembly,148,REP,Joseph Giglio,224,,,,
+Allegany,Angelica 2,State Assembly,148,REP,Joseph Giglio,180,,,,
+Allegany,Belfast,State Assembly,148,REP,Joseph Giglio,450,,,,
+Allegany,Birdsall,State Assembly,148,REP,Joseph Giglio,61,,,,
+Allegany,Bolivar,State Assembly,148,REP,Joseph Giglio,522,,,,
+Allegany,Burns,State Assembly,148,REP,Joseph Giglio,315,,,,
+Allegany,Caneadea 1,State Assembly,148,REP,Joseph Giglio,205,,,,
+Allegany,Caneadea 2,State Assembly,148,REP,Joseph Giglio,218,,,,
+Allegany,Centerville,State Assembly,148,REP,Joseph Giglio,199,,,,
+Allegany,Clarksville,State Assembly,148,REP,Joseph Giglio,258,,,,
+Allegany,Cuba 1,State Assembly,148,REP,Joseph Giglio,323,,,,
+Allegany,Cuba 2,State Assembly,148,REP,Joseph Giglio,504,,,,
+Allegany,Friendship,State Assembly,148,REP,Joseph Giglio,460,,,,
+Allegany,Genesee,State Assembly,148,REP,Joseph Giglio,488,,,,
+Allegany,Granger,State Assembly,148,REP,Joseph Giglio,180,,,,
+Allegany,Grove,State Assembly,148,REP,Joseph Giglio,187,,,,
+Allegany,Hume,State Assembly,148,REP,Joseph Giglio,528,,,,
+Allegany,Independence,State Assembly,148,REP,Joseph Giglio,281,,,,
+Allegany,New Hudson,State Assembly,148,REP,Joseph Giglio,195,,,,
+Allegany,Rushford,State Assembly,148,REP,Joseph Giglio,364,,,,
+Allegany,Scio,State Assembly,148,REP,Joseph Giglio,470,,,,
+Allegany,Ward,State Assembly,148,REP,Joseph Giglio,116,,,,
+Allegany,Wellsville 1,State Assembly,148,REP,Joseph Giglio,310,,,,
+Allegany,Wellsville 2,State Assembly,148,REP,Joseph Giglio,326,,,,
+Allegany,Wellsville 3,State Assembly,148,REP,Joseph Giglio,374,,,,
+Allegany,Wellsville 4,State Assembly,148,REP,Joseph Giglio,309,,,,
+Allegany,Welllsville 5,State Assembly,148,REP,Joseph Giglio,360,,,,
+Allegany,West Almond,State Assembly,148,REP,Joseph Giglio,86,,,,
+Allegany,Willing,State Assembly,148,REP,Joseph Giglio,405,,,,
+Allegany,Wirt,State Assembly,148,REP,Joseph Giglio,332,,,,
+Allegany,Alfred 1,State Assembly,148,CON,Joseph Giglio,26,,,,
+Allegany,Alfred 2,State Assembly,148,CON,Joseph Giglio,55,,,,
+Allegany,Allen,State Assembly,148,CON,Joseph Giglio,13,,,,
+Allegany,Alma,State Assembly,148,CON,Joseph Giglio,24,,,,
+Allegany,Almond,State Assembly,148,CON,Joseph Giglio,89,,,,
+Allegany,Amity 1,State Assembly,148,CON,Joseph Giglio,25,,,,
+Allegany,Amity 2,State Assembly,148,CON,Joseph Giglio,47,,,,
+Allegany,Andover 1,State Assembly,148,CON,Joseph Giglio,34,,,,
+Allegany,Andover 2,State Assembly,148,CON,Joseph Giglio,16,,,,
+Allegany,Angelica 1,State Assembly,148,CON,Joseph Giglio,22,,,,
+Allegany,Angelica 2,State Assembly,148,CON,Joseph Giglio,24,,,,
+Allegany,Belfast,State Assembly,148,CON,Joseph Giglio,60,,,,
+Allegany,Birdsall,State Assembly,148,CON,Joseph Giglio,12,,,,
+Allegany,Bolivar,State Assembly,148,CON,Joseph Giglio,56,,,,
+Allegany,Burns,State Assembly,148,CON,Joseph Giglio,51,,,,
+Allegany,Caneadea 1,State Assembly,148,CON,Joseph Giglio,26,,,,
+Allegany,Caneadea 2,State Assembly,148,CON,Joseph Giglio,41,,,,
+Allegany,Centerville,State Assembly,148,CON,Joseph Giglio,37,,,,
+Allegany,Clarksville,State Assembly,148,CON,Joseph Giglio,35,,,,
+Allegany,Cuba 1,State Assembly,148,CON,Joseph Giglio,51,,,,
+Allegany,Cuba 2,State Assembly,148,CON,Joseph Giglio,45,,,,
+Allegany,Friendship,State Assembly,148,CON,Joseph Giglio,44,,,,
+Allegany,Genesee,State Assembly,148,CON,Joseph Giglio,39,,,,
+Allegany,Granger,State Assembly,148,CON,Joseph Giglio,22,,,,
+Allegany,Grove,State Assembly,148,CON,Joseph Giglio,33,,,,
+Allegany,Hume,State Assembly,148,CON,Joseph Giglio,65,,,,
+Allegany,Independence,State Assembly,148,CON,Joseph Giglio,24,,,,
+Allegany,New Hudson,State Assembly,148,CON,Joseph Giglio,26,,,,
+Allegany,Rushford,State Assembly,148,CON,Joseph Giglio,66,,,,
+Allegany,Scio,State Assembly,148,CON,Joseph Giglio,55,,,,
+Allegany,Ward,State Assembly,148,CON,Joseph Giglio,14,,,,
+Allegany,Wellsville 1,State Assembly,148,CON,Joseph Giglio,41,,,,
+Allegany,Wellsville 2,State Assembly,148,CON,Joseph Giglio,39,,,,
+Allegany,Wellsville 3,State Assembly,148,CON,Joseph Giglio,44,,,,
+Allegany,Wellsville 4,State Assembly,148,CON,Joseph Giglio,23,,,,
+Allegany,Welllsville 5,State Assembly,148,CON,Joseph Giglio,39,,,,
+Allegany,West Almond,State Assembly,148,CON,Joseph Giglio,14,,,,
+Allegany,Willing,State Assembly,148,CON,Joseph Giglio,22,,,,
+Allegany,Wirt,State Assembly,148,CON,Joseph Giglio,27,,,,
+Allegany,Alfred 1,State Assembly,148,,WRITE-IN,5,,,,
+Allegany,Alfred 2,State Assembly,148,,WRITE-IN,4,,,,
+Allegany,Allen,State Assembly,148,,WRITE-IN,2,,,,
+Allegany,Alma,State Assembly,148,,WRITE-IN,0,,,,
+Allegany,Almond,State Assembly,148,,WRITE-IN,4,,,,
+Allegany,Amity 1,State Assembly,148,,WRITE-IN,1,,,,
+Allegany,Amity 2,State Assembly,148,,WRITE-IN,1,,,,
+Allegany,Andover 1,State Assembly,148,,WRITE-IN,0,,,,
+Allegany,Andover 2,State Assembly,148,,WRITE-IN,0,,,,
+Allegany,Angelica 1,State Assembly,148,,WRITE-IN,0,,,,
+Allegany,Angelica 2,State Assembly,148,,WRITE-IN,1,,,,
+Allegany,Belfast,State Assembly,148,,WRITE-IN,1,,,,
+Allegany,Birdsall,State Assembly,148,,WRITE-IN,0,,,,
+Allegany,Bolivar,State Assembly,148,,WRITE-IN,1,,,,
+Allegany,Burns,State Assembly,148,,WRITE-IN,1,,,,
+Allegany,Caneadea 1,State Assembly,148,,WRITE-IN,1,,,,
+Allegany,Caneadea 2,State Assembly,148,,WRITE-IN,0,,,,
+Allegany,Centerville,State Assembly,148,,WRITE-IN,0,,,,
+Allegany,Clarksville,State Assembly,148,,WRITE-IN,0,,,,
+Allegany,Cuba 1,State Assembly,148,,WRITE-IN,2,,,,
+Allegany,Cuba 2,State Assembly,148,,WRITE-IN,3,,,,
+Allegany,Friendship,State Assembly,148,,WRITE-IN,0,,,,
+Allegany,Genesee,State Assembly,148,,WRITE-IN,0,,,,
+Allegany,Granger,State Assembly,148,,WRITE-IN,0,,,,
+Allegany,Grove,State Assembly,148,,WRITE-IN,0,,,,
+Allegany,Hume,State Assembly,148,,WRITE-IN,4,,,,
+Allegany,Independence,State Assembly,148,,WRITE-IN,0,,,,
+Allegany,New Hudson,State Assembly,148,,WRITE-IN,2,,,,
+Allegany,Rushford,State Assembly,148,,WRITE-IN,2,,,,
+Allegany,Scio,State Assembly,148,,WRITE-IN,2,,,,
+Allegany,Ward,State Assembly,148,,WRITE-IN,1,,,,
+Allegany,Wellsville 1,State Assembly,148,,WRITE-IN,3,,,,
+Allegany,Wellsville 2,State Assembly,148,,WRITE-IN,0,,,,
+Allegany,Wellsville 3,State Assembly,148,,WRITE-IN,2,,,,
+Allegany,Wellsville 4,State Assembly,148,,WRITE-IN,1,,,,
+Allegany,Welllsville 5,State Assembly,148,,WRITE-IN,1,,,,
+Allegany,West Almond,State Assembly,148,,WRITE-IN,0,,,,
+Allegany,Willing,State Assembly,148,,WRITE-IN,0,,,,
+Allegany,Wirt,State Assembly,148,,WRITE-IN,1,,,,


### PR DESCRIPTION
Noticed that rows for candidates were missing (empty) columns for the extended counting methods. This cleans that up to make various csv tools happier when handling the data.