### PR TITLE
Narrow bare excepts to Exception in el30 / ulster parsers

### DIFF
--- a/el30.py
+++ b/el30.py
@@ -55,7 +55,7 @@ for line in lines:
             party = party.replace(')','')
         try:
             votes, pct = line.split('\t')[1:]
-        except:
+        except Exception:
             votes = line.split('\t')[1:][0]
         results.append(['Rockland', precinct, office, None, party, candidate, votes.replace(',','').strip()])
 

--- a/ulster_parser.py
+++ b/ulster_parser.py
@@ -36,7 +36,7 @@ for sheet in SHEETS:
         try:
             c, p = candidate.value.split('\n')
             total_cands.append(c)
-        except:
+        except Exception:
             c = candidate.value
         if p:
             candidates_with_party.append([c.strip(), p])
@@ -78,5 +78,5 @@ with open("20201103__ny__general__ulster__precinct.csv", "wt") as output_file:
     for result in results:
         try:
             csvfile.writerow(['Ulster', result['precinct'], result['office'], result['district'], result['party'], result['candidate'], result['votes'], result['election_day'], result['absentee']])
-        except:
+        except Exception:
             raise


### PR DESCRIPTION
flake8 E722. Narrows three bare `except:` blocks to `Exception` so KeyboardInterrupt isn't swallowed mid-parse.