### PR TITLE
Fix missing precinct names in 2018 statewide file

### DIFF
--- a/statewide_generator.py
+++ b/statewide_generator.py
@@ -1,83 +1,184 @@
 import os
 import glob
 import csv
+import argparse
 
-year = '2022'
-election = '20221108'
-path = 'counties/'+election+'*precinct.csv'
-output_file = f"{election}__ny__general__precinct.csv"
+# Canonical statewide offices to keep in the consolidated file. Mirrors the
+# `validOffices` set in src/verifier.py, plus 'U.S. House - Unexpired Term'
+# (a distinct special-election contest that is intentionally kept on its own
+# label rather than folded into 'U.S. House', which would duplicate rows).
+CANONICAL_OFFICES = frozenset([
+    'President', 'U.S. Senate', 'U.S. House', 'Governor', 'State Senate',
+    'State Assembly', 'Attorney General', 'Secretary of State',
+    'State Treasurer', 'Comptroller', 'U.S. House - Unexpired Term',
+])
 
-def generate_headers(year, path):
-    os.chdir(year)
-    os.chdir('counties')
-    vote_headers = []
-    for fname in glob.glob(path):
-        with open(fname, "r") as csvfile:
+# County files use a handful of non-canonical spellings for statewide offices.
+# Map them to the canonical name. Case-insensitive matching against the
+# canonical set (below) handles the rest (e.g. 'ATTORNEY GENERAL', 'COMPTROLLER').
+OFFICE_VARIANTS = {
+    'Assembly': 'State Assembly',
+    'State House': 'State Assembly',
+    'U.S.House': 'U.S. House',
+}
+
+# Core columns always present, written in this canonical order.
+CORE_COLUMNS = ['county', 'precinct', 'office', 'district', 'candidate', 'party', 'votes']
+
+# Source columns renamed on output so a given year's statewide header stays
+# stable regardless of which county introduced the column.
+COLUMN_REMAP = {
+    'machine': 'machine_votes',
+}
+
+
+def normalize_office(raw):
+    """Return the canonical office name for `raw`, or `raw` unchanged if it is
+    not a recognized statewide office (so callers can filter it out)."""
+    o = (raw or '').strip()
+    if o in CANONICAL_OFFICES:
+        return o
+    if o in OFFICE_VARIANTS:
+        return OFFICE_VARIANTS[o]
+    lowered = o.lower()
+    for canonical in CANONICAL_OFFICES:
+        if canonical.lower() == lowered:
+            return canonical
+    return o
+
+
+def remap_column(name):
+    return COLUMN_REMAP.get(name, name)
+
+
+def county_from_filename(fname):
+    return os.path.basename(fname).split('__')[3]
+
+
+def generate_headers(year, election):
+    """Print the non-core columns each county file contributes (debug aid)."""
+    path = f'{year}/counties/{election}__*__precinct.csv'
+    for fname in sorted(glob.glob(path)):
+        with open(fname, 'r', newline='', encoding='utf-8-sig') as csvfile:
             reader = csv.reader(csvfile)
             headers = next(reader)
-            print(list(fname + ': ' + h for h in headers if h not in ['county','precinct', 'office', 'district', 'candidate', 'party', 'votes']))
-            #vote_headers.append(h for h in headers if h not in ['county','precinct', 'office', 'district', 'candidate', 'party'])
-#    with open('vote_headers.csv', "w") as csv_outfile:
-#        outfile = csv.writer(csv_outfile)
-#        outfile.writerows(vote_headers)
+            extras = [remap_column(h) for h in headers if h not in CORE_COLUMNS and h != 'notes']
+            print(os.path.basename(fname) + ': ' + str(extras))
 
-def generate_offices(year, path):
-    os.chdir(year)
-    os.chdir('counties')
+
+def generate_offices(year, election):
+    """Print the distinct office strings found across county files."""
+    path = f'{year}/counties/{election}__*__precinct.csv'
     offices = []
-    for fname in glob.glob(path):
-        with open(fname, "r") as csvfile:
-            print(fname)
+    for fname in sorted(glob.glob(path)):
+        with open(fname, 'r', newline='', encoding='utf-8-sig') as csvfile:
             reader = csv.DictReader(csvfile)
             for row in reader:
-                if not row['office'] in offices:
-                    offices.append(row['office'])
-    with open('../../offices.csv', "w") as csv_outfile:
-        outfile = csv.writer(csv_outfile)
-        outfile.writerows(offices)
+                o = (row.get('office') or '').strip()
+                if o and o not in offices:
+                    offices.append(o)
+    for o in offices:
+        print(o)
 
-def generate_consolidated_file(year, path, output_file):
+
+def generate_consolidated_file(year, election, output_file):
+    """Concatenate county precinct files into one statewide precinct file.
+
+    - Keeps only rows whose office normalizes to a canonical statewide office.
+    - Drops rows with a blank precinct (county-wide candidate subtotals), which
+      do not belong in a precinct-level file. Dropped counts are logged per
+      county so anomalies (e.g. a county file with unfixed merged-cell blanks)
+      are visible.
+    - Writes core columns in canonical order plus the union of every extra
+      vote-breakdown column found across the inputs, in stable first-seen order.
+    """
+    path = f'{year}/counties/{election}__*__precinct.csv'
+    files = sorted(glob.glob(path))
+    if not files:
+        raise SystemExit(f'no county files matched {path}')
+
+    # First pass: discover the union of extra output columns, first-seen order.
+    extras = []
+    extras_seen = set()
+    for fname in files:
+        with open(fname, 'r', newline='', encoding='utf-8-sig') as csvfile:
+            headers = next(csv.reader(csvfile))
+        for h in headers:
+            out = remap_column(h)
+            if h in CORE_COLUMNS or h == 'notes':
+                continue
+            if out not in extras_seen:
+                extras_seen.add(out)
+                extras.append(out)
+
+    header = CORE_COLUMNS + extras
     results = []
-    os.chdir(year)
-    os.chdir('counties')
-    for fname in glob.glob(path):
-        print(fname)
-        with open(fname, "r") as csvfile:
-            reader = csv.DictReader(csvfile)
-            for row in reader:
-                if row['office'].strip() in ['Registered Voters', 'Ballots Cast', 'Ballots Cast Blank', 'President', 'U.S. Senate', 'U.S. House', 'Governor', 'Comptroller', 'Attorney General', 'State Senate', 'State Assembly']:
-                    if 'election_day' in row:
-                        election_day = row['election_day']
-                    else:
-                        election_day = None
-                    if 'early' in row:
-                        early_voting = row['early_voting']
-                    else:
-                        early_voting = None
-                    if 'tally' in row:
-                        hand_tally = row['hand_tally']
-                    else:
-                        hand_tally = None
-                    if 'federal' in row:
-                        federal = row['federal']
-                    else:
-                        federal = None
-                    if 'absentee' in row:
-                        absentee = row['absentee']
-                    else:
-                        absentee = None
-                    if 'military' in row:
-                        military = row['military']
-                    else:
-                        military = None
-                    if 'affidavit' in row:
-                        affidavit = row['affidavit']
-                    else:
-                        affidavit = None
-                    results.append([row['county'], row['precinct'], row['office'], row['district'], row['candidate'], row['party'], row['votes'], early_voting, election_day, absentee, military, federal, affidavit, hand_tally])
+    dropped = {}
 
-    os.chdir('..')
-    with open(output_file, "w") as csv_outfile:
-        outfile = csv.writer(csv_outfile)
-        outfile.writerow(['county','precinct', 'office', 'district', 'candidate', 'party', 'votes', 'early_voting', 'election_day', 'absentee', 'military', 'federal', 'affidavit', 'hand_tally'])
-        outfile.writerows(results)
+    for fname in files:
+        county = county_from_filename(fname)
+        with open(fname, 'r', newline='', encoding='utf-8-sig') as csvfile:
+            reader = csv.DictReader(csvfile)
+            # Map each output extra name back to this file's source column, if present.
+            src_of_out = {}
+            for src in reader.fieldnames:
+                src_of_out[remap_column(src)] = src
+            for row in reader:
+                office = normalize_office(row.get('office', ''))
+                if office not in CANONICAL_OFFICES:
+                    continue
+                precinct = (row.get('precinct') or '').strip()
+                if not precinct:
+                    dropped[county] = dropped.get(county, 0) + 1
+                    continue
+                out_row = [
+                    row.get('county', ''),
+                    precinct,
+                    office,
+                    row.get('district', ''),
+                    row.get('candidate', ''),
+                    row.get('party', ''),
+                    row.get('votes', ''),
+                ]
+                for out_name in extras:
+                    src = src_of_out.get(out_name)
+                    out_row.append(row.get(src, '') if src else '')
+                results.append(out_row)
+
+    os.makedirs(os.path.dirname(output_file) or '.', exist_ok=True)
+    with open(output_file, 'w', newline='', encoding='utf-8') as csv_outfile:
+        writer = csv.writer(csv_outfile)
+        writer.writerow(header)
+        writer.writerows(results)
+
+    total_dropped = sum(dropped.values())
+    if dropped:
+        detail = ', '.join(f'{c} {n}' for c, n in sorted(dropped.items()))
+        print(f'dropped {total_dropped} blank-precinct subtotal rows: {detail}')
+    else:
+        print('dropped 0 blank-precinct subtotal rows')
+    print(f'wrote {len(results)} rows to {output_file} ({len(header)} columns)')
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Generate a statewide NY precinct CSV from county precinct files.')
+    parser.add_argument('--year', required=True, help='e.g. 2018')
+    parser.add_argument('--election', required=True, help='e.g. 20181106')
+    parser.add_argument('--output', help='output path (default: {year}/{election}__ny__general__precinct.csv)')
+    parser.add_argument('--headers', action='store_true', help='print per-file extra columns and exit')
+    parser.add_argument('--offices', action='store_true', help='print distinct office strings and exit')
+    args = parser.parse_args()
+
+    if args.headers:
+        generate_headers(args.year, args.election)
+        return
+    if args.offices:
+        generate_offices(args.year, args.election)
+        return
+
+    output_file = args.output or f'{args.year}/{args.election}__ny__general__precinct.csv'
+    generate_consolidated_file(args.year, args.election, output_file)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Closes #123

Issue #123 reported hundreds of blank precinct names in `2018/20181106__ny__general__precinct.csv`. Investigation found **441** blank rows with two distinct causes, plus a broken generator.

### 1. Stale statewide file (384 Onondaga rows)
The Onondaga county source was fixed in `162f274` (carry-forward of merged-cell-quirk blanks), but the statewide file had not been regenerated since 2023-03-28. The source is now clean; regenerating resolves these.

### 2. County-wide candidate subtotals (57 rows: Kings 8, New York 42, Albany 7)
Each was verified to equal the per-party-line sum of that candidate's precinct rows. Per the maintainer policy in `162f274` these are legitimate structural subtotals that **stay in the county files** and are reported upstream. The **statewide** precinct file is a precinct-level file, so it now drops blank-precinct subtotal rows — giving it zero blanks.

### The generator was broken for 2018
`statewide_generator.py` was hardcoded to 2022 and silently dropped **~54,900 valid rows** on office-name mismatches (`Assembly`, `COMPTROLLER`, `ATTORNEY GENERAL`, `State House`, `U.S.House`) via a case-sensitive allowlist with no normalization. Rewrote it:

- **Parameterized** via argparse (`--year`, `--election`, `--output`).
- **`normalize_office()`** maps variant spellings to the canonical offices; `U.S. House - Unexpired Term` (Monroe special election) is kept on its own label so it isn't folded into `U.S. House` (which would duplicate rows).
- **Dynamic output schema**: core columns in canonical order plus the union of extra vote-breakdown columns across county files, with `machine` → `machine_votes` remapped. Reproduces the existing 12-column 2018 header.
- **Drops blank-precinct subtotal rows**, logging the per-county count so anomalies surface.

## Verification

Regenerated `2018/20181106__ny__general__precinct.csv`:

| Check | Result |
|---|---|
| Blank precincts | **0** (was 441) |
| Header | unchanged 12 columns ✓ |
| Offices | 8 (7 canonical + `U.S. House - Unexpired Term`); no variants remain ✓ |
| Row count vs county sources | **1,013,023 = exactly the keepable source rows** (57 subtotals dropped, 133,443 local/non-canonical offices dropped) ✓ |
| Per-(county, office) reconciliation | 2 mismatches, both = 7 rows in the Kings source file mislabeled `county=Queens` (pre-existing source quirk, faithfully passed through) ✓ |
| Onondaga blank precincts | 0 (was 384) ✓ |
| Monroe unexpired term | 5,085 rows preserved ✓ |
| Saratoga `U.S.House` | 1,224 rows normalized & included ✓ |

The new file is ~56,500 rows larger than the old 956,485 because the old 2023 build silently dropped ~54,900 variant-named office rows and excluded the Monroe unexpired term; it also predated recent county-file edits. The new file reflects current county sources with correct normalization.

## Side finding (not fixed here)
The Kings 2018 county file has **7 State Senate rows (district 17, precinct "Kings 41024") with `county` mislabeled as "Queens"** — a pre-existing source-data error worth a separate county-file fix.

## Out of scope
- County source files left untouched (Kings/NY/Albany subtotals stay, per the `162f274` policy).
- No 2022/other-year regen (the script now supports them; verification would be a separate task).
- Reporting the subtotal-schema question upstream to `openelections-data-tests` is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)