### PR TITLE
Fix Cattaraugus 2020 absentee column from source PDF

### DIFF
--- a/2020/counties/20201103__ny__general__cattaraugus__precinct.csv
+++ b/2020/counties/20201103__ny__general__cattaraugus__precinct.csv
@@ -1,473 +1,473 @@
 county,precinct,office,district,candidate,party,votes,absentee
-Cattaraugus,Allegany District 1,Ballots Cast,,,,518,129
-Cattaraugus,Allegany District 2,Ballots Cast,,,,196,109
-Cattaraugus,Allegany District 3,Ballots Cast,,,,414,89
-Cattaraugus,Allegany District 4,Ballots Cast,,,,515,83
-Cattaraugus,Allegany District 5,Ballots Cast,,,,484,95
-Cattaraugus,Ashford District 1,Ballots Cast,,,,295,47
-Cattaraugus,Ashford District 2,Ballots Cast,,,,594,106
-Cattaraugus,Carrollton,Ballots Cast,,,,515,26
-Cattaraugus,City of Olean - Ward 1,Ballots Cast,,,,573,48
-Cattaraugus,City of Olean - Ward 2,Ballots Cast,,,,519,57
-Cattaraugus,City of Olean - Ward 3,Ballots Cast,,,,340,101
-Cattaraugus,City of Olean - Ward 4,Ballots Cast,,,,262,139
-Cattaraugus,City of Olean - Ward 5,Ballots Cast,,,,388,66
-Cattaraugus,City of Olean - Ward 6,Ballots Cast,,,,389,70
-Cattaraugus,City of Olean - Ward 7,Ballots Cast,,,,505,125
-Cattaraugus,City of Salamanca - Ward 1,Ballots Cast,,,,206,88
-Cattaraugus,City of Salamanca - Ward 2,Ballots Cast,,,,441,62
-Cattaraugus,City of Salamanca - Ward 3,Ballots Cast,,,,226,43
-Cattaraugus,City of Salamanca - Ward 4,Ballots Cast,,,,334,88
-Cattaraugus,City of Salamanca - Ward 5,Ballots Cast,,,,302,100
-Cattaraugus,Coldspring,Ballots Cast,,,,352,21
-Cattaraugus,Conewango,Ballots Cast,,,,351,61
-Cattaraugus,Dayton,Ballots Cast,,,,565,25
-Cattaraugus,East Otto,Ballots Cast,,,,395,103
-Cattaraugus,Ellicottville,Ballots Cast,,,,503,31
-Cattaraugus,Farmersville,Ballots Cast,,,,442,63
-Cattaraugus,Franklinville District 1,Ballots Cast,,,,547,156
-Cattaraugus,Franklinville District 2,Ballots Cast,,,,436,100
-Cattaraugus,Freedom,Ballots Cast,,,,947,59
-Cattaraugus,Great Valley 1,Ballots Cast,,,,317,47
-Cattaraugus,Great Valley 2,Ballots Cast,,,,523,198
-Cattaraugus,Hinsdale,Ballots Cast,,,,720,141
-Cattaraugus,Humphrey,Ballots Cast,,,,274,130
-Cattaraugus,Ischua,Ballots Cast,,,,309,122
-Cattaraugus,Leon,Ballots Cast,,,,281,143
-Cattaraugus,Little Valley,Ballots Cast,,,,414,155
-Cattaraugus,Lyndon,Ballots Cast,,,,293,114
-Cattaraugus,Machias,Ballots Cast,,,,782,160
-Cattaraugus,Mansfield,Ballots Cast,,,,262,115
-Cattaraugus,Napoli,Ballots Cast,,,,393,104
-Cattaraugus,New Albion,Ballots Cast,,,,641,100
-Cattaraugus,Otto,Ballots Cast,,,,314,88
-Cattaraugus,Perrysburg,Ballots Cast,,,,712,70
-Cattaraugus,Persia,Ballots Cast,,,,719,5
-Cattaraugus,Portville 1,Ballots Cast,,,,650,11
-Cattaraugus,Portville 2,Ballots Cast,,,,636,47
-Cattaraugus,Randolph District 1,Ballots Cast,,,,432,114
-Cattaraugus,Randolph District 2,Ballots Cast,,,,494,33
-Cattaraugus,Red House,Ballots Cast,,,,21,63
-Cattaraugus,South Valley,Ballots Cast,,,,130,121
-Cattaraugus,Town of Olean 1,Ballots Cast,,,,248,38
-Cattaraugus,Town of Olean 2,Ballots Cast,,,,372,121
-Cattaraugus,Town of Salamanca,Ballots Cast,,,,275,42
-Cattaraugus,Yorkshire 1,Ballots Cast,,,,643,93
-Cattaraugus,Yorkshire 2,Ballots Cast,,,,655,116
-Cattaraugus,Early Voting - Little Valley 1,Ballots Cast,,,,1168,
-Cattaraugus,Early Voting - Little Valley 2,Ballots Cast,,,,1102,
-Cattaraugus,Early Voting - Olean 1,Ballots Cast,,,,2528,
-Cattaraugus,Early Voting - Olean 2,Ballots Cast,,,,1375,
-Cattaraugus,Allegany District 1,President,,Joseph R. Biden,DEM,157,86
-Cattaraugus,Allegany District 2,President,,Joseph R. Biden,DEM,57,79
-Cattaraugus,Allegany District 3,President,,Joseph R. Biden,DEM,86,56
-Cattaraugus,Allegany District 4,President,,Joseph R. Biden,DEM,104,44
-Cattaraugus,Allegany District 5,President,,Joseph R. Biden,DEM,108,68
-Cattaraugus,Ashford District 1,President,,Joseph R. Biden,DEM,68,24
-Cattaraugus,Ashford District 2,President,,Joseph R. Biden,DEM,161,57
-Cattaraugus,Carrollton,President,,Joseph R. Biden,DEM,95,8
-Cattaraugus,City of Olean - Ward 1,President,,Joseph R. Biden,DEM,169,23
-Cattaraugus,City of Olean - Ward 2,President,,Joseph R. Biden,DEM,127,36
-Cattaraugus,City of Olean - Ward 3,President,,Joseph R. Biden,DEM,111,42
-Cattaraugus,City of Olean - Ward 4,President,,Joseph R. Biden,DEM,85,84
-Cattaraugus,City of Olean - Ward 5,President,,Joseph R. Biden,DEM,122,27
-Cattaraugus,City of Olean - Ward 6,President,,Joseph R. Biden,DEM,122,28
-Cattaraugus,City of Olean - Ward 7,President,,Joseph R. Biden,DEM,107,61
-Cattaraugus,City of Salamanca - Ward 1,President,,Joseph R. Biden,DEM,67,44
-Cattaraugus,City of Salamanca - Ward 2,President,,Joseph R. Biden,DEM,193,33
-Cattaraugus,City of Salamanca - Ward 3,President,,Joseph R. Biden,DEM,92,27
-Cattaraugus,City of Salamanca - Ward 4,President,,Joseph R. Biden,DEM,145,50
-Cattaraugus,City of Salamanca - Ward 5,President,,Joseph R. Biden,DEM,95,45
-Cattaraugus,Coldspring,President,,Joseph R. Biden,DEM,60,10
-Cattaraugus,Conewango,President,,Joseph R. Biden,DEM,70,33
-Cattaraugus,Dayton,President,,Joseph R. Biden,DEM,87,9
-Cattaraugus,Early Voting - Little Valley 1,President,,Joseph R. Biden,DEM,579,
-Cattaraugus,Early Voting - Little Valley 2,President,,Joseph R. Biden,DEM,479,
-Cattaraugus,Early Voting - Olean 1,President,,Joseph R. Biden,DEM,1340,
-Cattaraugus,Early Voting - Olean 2,President,,Joseph R. Biden,DEM,720,
-Cattaraugus,East Otto,President,,Joseph R. Biden,DEM,71,41
-Cattaraugus,Ellicottville,President,,Joseph R. Biden,DEM,184,13
-Cattaraugus,Farmersville,President,,Joseph R. Biden,DEM,62,41
-Cattaraugus,Franklinville District 1,President,,Joseph R. Biden,DEM,95,62
-Cattaraugus,Franklinville District 2,President,,Joseph R. Biden,DEM,95,44
-Cattaraugus,Freedom,President,,Joseph R. Biden,DEM,156,17
-Cattaraugus,Great Valley 1,President,,Joseph R. Biden,DEM,102,24
-Cattaraugus,Great Valley 2,President,,Joseph R. Biden,DEM,115,116
-Cattaraugus,Hinsdale,President,,Joseph R. Biden,DEM,136,94
-Cattaraugus,Humphrey,President,,Joseph R. Biden,DEM,62,76
-Cattaraugus,Ischua,President,,Joseph R. Biden,DEM,62,86
-Cattaraugus,Leon,President,,Joseph R. Biden,DEM,37,85
-Cattaraugus,Little Valley,President,,Joseph R. Biden,DEM,74,85
-Cattaraugus,Lyndon,President,,Joseph R. Biden,DEM,65,61
-Cattaraugus,Machias,President,,Joseph R. Biden,DEM,139,99
-Cattaraugus,Mansfield,President,,Joseph R. Biden,DEM,49,62
-Cattaraugus,Napoli,President,,Joseph R. Biden,DEM,60,48
-Cattaraugus,New Albion,President,,Joseph R. Biden,DEM,132,62
-Cattaraugus,Otto,President,,Joseph R. Biden,DEM,64,44
-Cattaraugus,Perrysburg,President,,Joseph R. Biden,DEM,194,31
-Cattaraugus,Persia,President,,Joseph R. Biden,DEM,172,3
-Cattaraugus,Portville 1,President,,Joseph R. Biden,DEM,137,6
-Cattaraugus,Portville 2,President,,Joseph R. Biden,DEM,111,30
-Cattaraugus,Randolph District 1,President,,Joseph R. Biden,DEM,75,62
-Cattaraugus,Randolph District 2,President,,Joseph R. Biden,DEM,85,19
-Cattaraugus,Red House,President,,Joseph R. Biden,DEM,4,39
-Cattaraugus,South Valley,President,,Joseph R. Biden,DEM,50,60
-Cattaraugus,Town of Olean 1,President,,Joseph R. Biden,DEM,50,21
-Cattaraugus,Town of Olean 2,President,,Joseph R. Biden,DEM,67,73
-Cattaraugus,Town of Salamanca,President,,Joseph R. Biden,DEM,99,30
-Cattaraugus,Yorkshire 1,President,,Joseph R. Biden,DEM,152,38
-Cattaraugus,Yorkshire 2,President,,Joseph R. Biden,DEM,130,72
-Cattaraugus,Allegany District 1,President,,Donald R. Trump,REP,313,27
-Cattaraugus,Allegany District 2,President,,Donald R. Trump,REP,121,21
-Cattaraugus,Allegany District 3,President,,Donald R. Trump,REP,288,22
-Cattaraugus,Allegany District 4,President,,Donald R. Trump,REP,365,31
-Cattaraugus,Allegany District 5,President,,Donald R. Trump,REP,334,22
-Cattaraugus,Ashford District 1,President,,Donald R. Trump,REP,192,16
-Cattaraugus,Ashford District 2,President,,Donald R. Trump,REP,375,39
-Cattaraugus,Carrollton,President,,Donald R. Trump,REP,381,14
-Cattaraugus,City of Olean - Ward 1,President,,Donald R. Trump,REP,351,15
-Cattaraugus,City of Olean - Ward 2,President,,Donald R. Trump,REP,337,17
-Cattaraugus,City of Olean - Ward 3,President,,Donald R. Trump,REP,195,50
-Cattaraugus,City of Olean - Ward 4,President,,Donald R. Trump,REP,140,43
-Cattaraugus,City of Olean - Ward 5,President,,Donald R. Trump,REP,224,34
-Cattaraugus,City of Olean - Ward 6,President,,Donald R. Trump,REP,222,33
-Cattaraugus,City of Olean - Ward 7,President,,Donald R. Trump,REP,346,49
-Cattaraugus,City of Salamanca - Ward 1,President,,Donald R. Trump,REP,126,38
-Cattaraugus,City of Salamanca - Ward 2,President,,Donald R. Trump,REP,197,23
-Cattaraugus,City of Salamanca - Ward 3,President,,Donald R. Trump,REP,118,12
-Cattaraugus,City of Salamanca - Ward 4,President,,Donald R. Trump,REP,153,28
-Cattaraugus,City of Salamanca - Ward 5,President,,Donald R. Trump,REP,183,46
-Cattaraugus,Coldspring,President,,Donald R. Trump,REP,260,5
-Cattaraugus,Conewango,President,,Donald R. Trump,REP,234,24
-Cattaraugus,Dayton,President,,Donald R. Trump,REP,419,15
-Cattaraugus,Early Voting - Little Valley 1,President,,Donald R. Trump,REP,485,
-Cattaraugus,Early Voting - Little Valley 2,President,,Donald R. Trump,REP,522,
-Cattaraugus,Early Voting - Olean 1,President,,Donald R. Trump,REP,988,
-Cattaraugus,Early Voting - Olean 2,President,,Donald R. Trump,REP,559,
-Cattaraugus,East Otto,President,,Donald R. Trump,REP,272,51
-Cattaraugus,Ellicottville,President,,Donald R. Trump,REP,275,13
-Cattaraugus,Farmersville,President,,Donald R. Trump,REP,344,20
-Cattaraugus,Franklinville District 1,President,,Donald R. Trump,REP,394,83
-Cattaraugus,Franklinville District 2,President,,Donald R. Trump,REP,307,39
-Cattaraugus,Freedom,President,,Donald R. Trump,REP,704,34
-Cattaraugus,Great Valley 1,President,,Donald R. Trump,REP,180,17
-Cattaraugus,Great Valley 2,President,,Donald R. Trump,REP,359,60
-Cattaraugus,Hinsdale,President,,Donald R. Trump,REP,507,43
-Cattaraugus,Humphrey,President,,Donald R. Trump,REP,181,32
-Cattaraugus,Ischua,President,,Donald R. Trump,REP,221,23
-Cattaraugus,Leon,President,,Donald R. Trump,REP,205,45
-Cattaraugus,Little Valley,President,,Donald R. Trump,REP,294,51
-Cattaraugus,Lyndon,President,,Donald R. Trump,REP,202,45
-Cattaraugus,Machias,President,,Donald R. Trump,REP,558,48
-Cattaraugus,Mansfield,President,,Donald R. Trump,REP,194,42
-Cattaraugus,Napoli,President,,Donald R. Trump,REP,292,45
-Cattaraugus,New Albion,President,,Donald R. Trump,REP,434,28
-Cattaraugus,Otto,President,,Donald R. Trump,REP,219,35
-Cattaraugus,Perrysburg,President,,Donald R. Trump,REP,440,32
-Cattaraugus,Persia,President,,Donald R. Trump,REP,462,2
-Cattaraugus,Portville 1,President,,Donald R. Trump,REP,453,5
-Cattaraugus,Portville 2,President,,Donald R. Trump,REP,458,13
-Cattaraugus,Randolph District 1,President,,Donald R. Trump,REP,304,44
-Cattaraugus,Randolph District 2,President,,Donald R. Trump,REP,371,10
-Cattaraugus,Red House,President,,Donald R. Trump,REP,14,20
-Cattaraugus,South Valley,President,,Donald R. Trump,REP,68,44
-Cattaraugus,Town of Olean 1,President,,Donald R. Trump,REP,175,17
-Cattaraugus,Town of Olean 2,President,,Donald R. Trump,REP,287,37
-Cattaraugus,Town of Salamanca,President,,Donald R. Trump,REP,148,6
-Cattaraugus,Yorkshire 1,President,,Donald R. Trump,REP,422,43
-Cattaraugus,Yorkshire 2,President,,Donald R. Trump,REP,431,37
-Cattaraugus,Allegany District 1,President,,Donald R. Trump,CON,22,9
-Cattaraugus,Allegany District 2,President,,Donald R. Trump,CON,6,3
-Cattaraugus,Allegany District 3,President,,Donald R. Trump,CON,24,4
-Cattaraugus,Allegany District 4,President,,Donald R. Trump,CON,32,2
-Cattaraugus,Allegany District 5,President,,Donald R. Trump,CON,21,2
-Cattaraugus,Ashford District 1,President,,Donald R. Trump,CON,22,2
-Cattaraugus,Ashford District 2,President,,Donald R. Trump,CON,40,4
-Cattaraugus,Carrollton,President,,Donald R. Trump,CON,19,1
-Cattaraugus,City of Olean - Ward 1,President,,Donald R. Trump,CON,19,5
-Cattaraugus,City of Olean - Ward 2,President,,Donald R. Trump,CON,29,1
-Cattaraugus,City of Olean - Ward 3,President,,Donald R. Trump,CON,14,5
-Cattaraugus,City of Olean - Ward 4,President,,Donald R. Trump,CON,17,5
-Cattaraugus,City of Olean - Ward 5,President,,Donald R. Trump,CON,19,1
-Cattaraugus,City of Olean - Ward 6,President,,Donald R. Trump,CON,21,2
-Cattaraugus,City of Olean - Ward 7,President,,Donald R. Trump,CON,33,8
-Cattaraugus,City of Salamanca - Ward 1,President,,Donald R. Trump,CON,9,2
-Cattaraugus,City of Salamanca - Ward 2,President,,Donald R. Trump,CON,28,2
-Cattaraugus,City of Salamanca - Ward 3,President,,Donald R. Trump,CON,9,0
-Cattaraugus,City of Salamanca - Ward 4,President,,Donald R. Trump,CON,18,3
-Cattaraugus,City of Salamanca - Ward 5,President,,Donald R. Trump,CON,11,4
-Cattaraugus,Coldspring,President,,Donald R. Trump,CON,24,2
-Cattaraugus,Conewango,President,,Donald R. Trump,CON,20,2
-Cattaraugus,Dayton,President,,Donald R. Trump,CON,40,0
-Cattaraugus,Early Voting - Little Valley 1,President,,Donald R. Trump,CON,48,
-Cattaraugus,Early Voting - Little Valley 2,President,,Donald R. Trump,CON,58,
-Cattaraugus,Early Voting - Olean 1,President,,Donald R. Trump,CON,74,
-Cattaraugus,Early Voting - Olean 2,President,,Donald R. Trump,CON,37,
-Cattaraugus,East Otto,President,,Donald R. Trump,CON,40,2
-Cattaraugus,Ellicottville,President,,Donald R. Trump,CON,21,2
-Cattaraugus,Farmersville,President,,Donald R. Trump,CON,28,0
-Cattaraugus,Franklinville District 1,President,,Donald R. Trump,CON,38,5
-Cattaraugus,Franklinville District 2,President,,Donald R. Trump,CON,17,7
-Cattaraugus,Freedom,President,,Donald R. Trump,CON,62,4
+Cattaraugus,Allegany District 1,Ballots Cast,,,,647,129
+Cattaraugus,Allegany District 2,Ballots Cast,,,,305,109
+Cattaraugus,Allegany District 3,Ballots Cast,,,,503,89
+Cattaraugus,Allegany District 4,Ballots Cast,,,,598,83
+Cattaraugus,Allegany District 5,Ballots Cast,,,,579,95
+Cattaraugus,Ashford District 1,Ballots Cast,,,,342,47
+Cattaraugus,Ashford District 2,Ballots Cast,,,,700,106
+Cattaraugus,Carrollton,Ballots Cast,,,,572,57
+Cattaraugus,City of Olean - Ward 1,Ballots Cast,,,,771,198
+Cattaraugus,City of Olean - Ward 2,Ballots Cast,,,,660,141
+Cattaraugus,City of Olean - Ward 3,Ballots Cast,,,,470,130
+Cattaraugus,City of Olean - Ward 4,Ballots Cast,,,,384,122
+Cattaraugus,City of Olean - Ward 5,Ballots Cast,,,,531,143
+Cattaraugus,City of Olean - Ward 6,Ballots Cast,,,,544,155
+Cattaraugus,City of Olean - Ward 7,Ballots Cast,,,,619,114
+Cattaraugus,City of Salamanca - Ward 1,Ballots Cast,,,,253,47
+Cattaraugus,City of Salamanca - Ward 2,Ballots Cast,,,,555,114
+Cattaraugus,City of Salamanca - Ward 3,Ballots Cast,,,,259,33
+Cattaraugus,City of Salamanca - Ward 4,Ballots Cast,,,,397,63
+Cattaraugus,City of Salamanca - Ward 5,Ballots Cast,,,,423,121
+Cattaraugus,Coldspring,Ballots Cast,,,,378,26
+Cattaraugus,Conewango,Ballots Cast,,,,399,48
+Cattaraugus,Dayton,Ballots Cast,,,,666,101
+Cattaraugus,East Otto,Ballots Cast,,,,461,66
+Cattaraugus,Ellicottville,Ballots Cast,,,,642,139
+Cattaraugus,Farmersville,Ballots Cast,,,,512,70
+Cattaraugus,Franklinville District 1,Ballots Cast,,,,635,88
+Cattaraugus,Franklinville District 2,Ballots Cast,,,,498,62
+Cattaraugus,Freedom,Ballots Cast,,,,1072,125
+Cattaraugus,Great Valley 1,Ballots Cast,,,,360,43
+Cattaraugus,Great Valley 2,Ballots Cast,,,,611,88
+Cattaraugus,Hinsdale,Ballots Cast,,,,820,100
+Cattaraugus,Humphrey,Ballots Cast,,,,295,21
+Cattaraugus,Ischua,Ballots Cast,,,,370,61
+Cattaraugus,Leon,Ballots Cast,,,,306,25
+Cattaraugus,Little Valley,Ballots Cast,,,,517,103
+Cattaraugus,Lyndon,Ballots Cast,,,,324,31
+Cattaraugus,Machias,Ballots Cast,,,,938,156
+Cattaraugus,Mansfield,Ballots Cast,,,,325,63
+Cattaraugus,Napoli,Ballots Cast,,,,452,59
+Cattaraugus,New Albion,Ballots Cast,,,,741,100
+Cattaraugus,Otto,Ballots Cast,,,,361,47
+Cattaraugus,Perrysburg,Ballots Cast,,,,812,100
+Cattaraugus,Persia,Ballots Cast,,,,879,160
+Cattaraugus,Portville 1,Ballots Cast,,,,765,115
+Cattaraugus,Portville 2,Ballots Cast,,,,740,104
+Cattaraugus,Randolph District 1,Ballots Cast,,,,520,88
+Cattaraugus,Randolph District 2,Ballots Cast,,,,564,70
+Cattaraugus,Red House,Ballots Cast,,,,26,5
+Cattaraugus,South Valley,Ballots Cast,,,,141,11
+Cattaraugus,Town of Olean 1,Ballots Cast,,,,286,38
+Cattaraugus,Town of Olean 2,Ballots Cast,,,,493,121
+Cattaraugus,Town of Salamanca,Ballots Cast,,,,317,42
+Cattaraugus,Yorkshire 1,Ballots Cast,,,,736,93
+Cattaraugus,Yorkshire 2,Ballots Cast,,,,771,116
+Cattaraugus,Early Voting - Little Valley 1,Ballots Cast,,,,1168,0
+Cattaraugus,Early Voting - Little Valley 2,Ballots Cast,,,,1102,0
+Cattaraugus,Early Voting - Olean 1,Ballots Cast,,,,2528,0
+Cattaraugus,Early Voting - Olean 2,Ballots Cast,,,,1375,0
+Cattaraugus,Allegany District 1,President,,Joseph R. Biden,DEM,243,86
+Cattaraugus,Allegany District 2,President,,Joseph R. Biden,DEM,136,79
+Cattaraugus,Allegany District 3,President,,Joseph R. Biden,DEM,142,56
+Cattaraugus,Allegany District 4,President,,Joseph R. Biden,DEM,148,44
+Cattaraugus,Allegany District 5,President,,Joseph R. Biden,DEM,176,68
+Cattaraugus,Ashford District 1,President,,Joseph R. Biden,DEM,92,24
+Cattaraugus,Ashford District 2,President,,Joseph R. Biden,DEM,218,57
+Cattaraugus,Carrollton,President,,Joseph R. Biden,DEM,131,36
+Cattaraugus,City of Olean - Ward 1,President,,Joseph R. Biden,DEM,285,116
+Cattaraugus,City of Olean - Ward 2,President,,Joseph R. Biden,DEM,221,94
+Cattaraugus,City of Olean - Ward 3,President,,Joseph R. Biden,DEM,187,76
+Cattaraugus,City of Olean - Ward 4,President,,Joseph R. Biden,DEM,171,86
+Cattaraugus,City of Olean - Ward 5,President,,Joseph R. Biden,DEM,207,85
+Cattaraugus,City of Olean - Ward 6,President,,Joseph R. Biden,DEM,207,85
+Cattaraugus,City of Olean - Ward 7,President,,Joseph R. Biden,DEM,168,61
+Cattaraugus,City of Salamanca - Ward 1,President,,Joseph R. Biden,DEM,97,30
+Cattaraugus,City of Salamanca - Ward 2,President,,Joseph R. Biden,DEM,255,62
+Cattaraugus,City of Salamanca - Ward 3,President,,Joseph R. Biden,DEM,111,19
+Cattaraugus,City of Salamanca - Ward 4,President,,Joseph R. Biden,DEM,184,39
+Cattaraugus,City of Salamanca - Ward 5,President,,Joseph R. Biden,DEM,155,60
+Cattaraugus,Coldspring,President,,Joseph R. Biden,DEM,68,8
+Cattaraugus,Conewango,President,,Joseph R. Biden,DEM,93,23
+Cattaraugus,Dayton,President,,Joseph R. Biden,DEM,129,42
+Cattaraugus,Early Voting - Little Valley 1,President,,Joseph R. Biden,DEM,579,0
+Cattaraugus,Early Voting - Little Valley 2,President,,Joseph R. Biden,DEM,479,0
+Cattaraugus,Early Voting - Olean 1,President,,Joseph R. Biden,DEM,1340,0
+Cattaraugus,Early Voting - Olean 2,President,,Joseph R. Biden,DEM,720,0
+Cattaraugus,East Otto,President,,Joseph R. Biden,DEM,98,27
+Cattaraugus,Ellicottville,President,,Joseph R. Biden,DEM,268,84
+Cattaraugus,Farmersville,President,,Joseph R. Biden,DEM,90,28
+Cattaraugus,Franklinville District 1,President,,Joseph R. Biden,DEM,139,44
+Cattaraugus,Franklinville District 2,President,,Joseph R. Biden,DEM,128,33
+Cattaraugus,Freedom,President,,Joseph R. Biden,DEM,217,61
+Cattaraugus,Great Valley 1,President,,Joseph R. Biden,DEM,129,27
+Cattaraugus,Great Valley 2,President,,Joseph R. Biden,DEM,165,50
+Cattaraugus,Hinsdale,President,,Joseph R. Biden,DEM,181,45
+Cattaraugus,Humphrey,President,,Joseph R. Biden,DEM,72,10
+Cattaraugus,Ischua,President,,Joseph R. Biden,DEM,95,33
+Cattaraugus,Leon,President,,Joseph R. Biden,DEM,46,9
+Cattaraugus,Little Valley,President,,Joseph R. Biden,DEM,115,41
+Cattaraugus,Lyndon,President,,Joseph R. Biden,DEM,78,13
+Cattaraugus,Machias,President,,Joseph R. Biden,DEM,201,62
+Cattaraugus,Mansfield,President,,Joseph R. Biden,DEM,90,41
+Cattaraugus,Napoli,President,,Joseph R. Biden,DEM,77,17
+Cattaraugus,New Albion,President,,Joseph R. Biden,DEM,176,44
+Cattaraugus,Otto,President,,Joseph R. Biden,DEM,88,24
+Cattaraugus,Perrysburg,President,,Joseph R. Biden,DEM,256,62
+Cattaraugus,Persia,President,,Joseph R. Biden,DEM,271,99
+Cattaraugus,Portville 1,President,,Joseph R. Biden,DEM,199,62
+Cattaraugus,Portville 2,President,,Joseph R. Biden,DEM,159,48
+Cattaraugus,Randolph District 1,President,,Joseph R. Biden,DEM,119,44
+Cattaraugus,Randolph District 2,President,,Joseph R. Biden,DEM,116,31
+Cattaraugus,Red House,President,,Joseph R. Biden,DEM,7,3
+Cattaraugus,South Valley,President,,Joseph R. Biden,DEM,56,6
+Cattaraugus,Town of Olean 1,President,,Joseph R. Biden,DEM,71,21
+Cattaraugus,Town of Olean 2,President,,Joseph R. Biden,DEM,140,73
+Cattaraugus,Town of Salamanca,President,,Joseph R. Biden,DEM,129,30
+Cattaraugus,Yorkshire 1,President,,Joseph R. Biden,DEM,190,38
+Cattaraugus,Yorkshire 2,President,,Joseph R. Biden,DEM,202,72
+Cattaraugus,Allegany District 1,President,,Donald R. Trump,REP,340,27
+Cattaraugus,Allegany District 2,President,,Donald R. Trump,REP,142,21
+Cattaraugus,Allegany District 3,President,,Donald R. Trump,REP,310,22
+Cattaraugus,Allegany District 4,President,,Donald R. Trump,REP,396,31
+Cattaraugus,Allegany District 5,President,,Donald R. Trump,REP,356,22
+Cattaraugus,Ashford District 1,President,,Donald R. Trump,REP,208,16
+Cattaraugus,Ashford District 2,President,,Donald R. Trump,REP,414,39
+Cattaraugus,Carrollton,President,,Donald R. Trump,REP,398,17
+Cattaraugus,City of Olean - Ward 1,President,,Donald R. Trump,REP,411,60
+Cattaraugus,City of Olean - Ward 2,President,,Donald R. Trump,REP,380,43
+Cattaraugus,City of Olean - Ward 3,President,,Donald R. Trump,REP,227,32
+Cattaraugus,City of Olean - Ward 4,President,,Donald R. Trump,REP,163,23
+Cattaraugus,City of Olean - Ward 5,President,,Donald R. Trump,REP,269,45
+Cattaraugus,City of Olean - Ward 6,President,,Donald R. Trump,REP,273,51
+Cattaraugus,City of Olean - Ward 7,President,,Donald R. Trump,REP,391,45
+Cattaraugus,City of Salamanca - Ward 1,President,,Donald R. Trump,REP,139,13
+Cattaraugus,City of Salamanca - Ward 2,President,,Donald R. Trump,REP,241,44
+Cattaraugus,City of Salamanca - Ward 3,President,,Donald R. Trump,REP,128,10
+Cattaraugus,City of Salamanca - Ward 4,President,,Donald R. Trump,REP,173,20
+Cattaraugus,City of Salamanca - Ward 5,President,,Donald R. Trump,REP,227,44
+Cattaraugus,Coldspring,President,,Donald R. Trump,REP,274,14
+Cattaraugus,Conewango,President,,Donald R. Trump,REP,249,15
+Cattaraugus,Dayton,President,,Donald R. Trump,REP,469,50
+Cattaraugus,Early Voting - Little Valley 1,President,,Donald R. Trump,REP,485,0
+Cattaraugus,Early Voting - Little Valley 2,President,,Donald R. Trump,REP,522,0
+Cattaraugus,Early Voting - Olean 1,President,,Donald R. Trump,REP,988,0
+Cattaraugus,Early Voting - Olean 2,President,,Donald R. Trump,REP,559,0
+Cattaraugus,East Otto,President,,Donald R. Trump,REP,306,34
+Cattaraugus,Ellicottville,President,,Donald R. Trump,REP,318,43
+Cattaraugus,Farmersville,President,,Donald R. Trump,REP,377,33
+Cattaraugus,Franklinville District 1,President,,Donald R. Trump,REP,432,38
+Cattaraugus,Franklinville District 2,President,,Donald R. Trump,REP,330,23
+Cattaraugus,Freedom,President,,Donald R. Trump,REP,753,49
+Cattaraugus,Great Valley 1,President,,Donald R. Trump,REP,192,12
+Cattaraugus,Great Valley 2,President,,Donald R. Trump,REP,387,28
+Cattaraugus,Hinsdale,President,,Donald R. Trump,REP,553,46
+Cattaraugus,Humphrey,President,,Donald R. Trump,REP,186,5
+Cattaraugus,Ischua,President,,Donald R. Trump,REP,245,24
+Cattaraugus,Leon,President,,Donald R. Trump,REP,220,15
+Cattaraugus,Little Valley,President,,Donald R. Trump,REP,345,51
+Cattaraugus,Lyndon,President,,Donald R. Trump,REP,215,13
+Cattaraugus,Machias,President,,Donald R. Trump,REP,641,83
+Cattaraugus,Mansfield,President,,Donald R. Trump,REP,214,20
+Cattaraugus,Napoli,President,,Donald R. Trump,REP,326,34
+Cattaraugus,New Albion,President,,Donald R. Trump,REP,473,39
+Cattaraugus,Otto,President,,Donald R. Trump,REP,236,17
+Cattaraugus,Perrysburg,President,,Donald R. Trump,REP,468,28
+Cattaraugus,Persia,President,,Donald R. Trump,REP,510,48
+Cattaraugus,Portville 1,President,,Donald R. Trump,REP,495,42
+Cattaraugus,Portville 2,President,,Donald R. Trump,REP,503,45
+Cattaraugus,Randolph District 1,President,,Donald R. Trump,REP,339,35
+Cattaraugus,Randolph District 2,President,,Donald R. Trump,REP,403,32
+Cattaraugus,Red House,President,,Donald R. Trump,REP,16,2
+Cattaraugus,South Valley,President,,Donald R. Trump,REP,73,5
+Cattaraugus,Town of Olean 1,President,,Donald R. Trump,REP,192,17
+Cattaraugus,Town of Olean 2,President,,Donald R. Trump,REP,324,37
+Cattaraugus,Town of Salamanca,President,,Donald R. Trump,REP,154,6
+Cattaraugus,Yorkshire 1,President,,Donald R. Trump,REP,465,43
+Cattaraugus,Yorkshire 2,President,,Donald R. Trump,REP,468,37
+Cattaraugus,Allegany District 1,President,,Donald R. Trump,CON,31,9
+Cattaraugus,Allegany District 2,President,,Donald R. Trump,CON,9,3
+Cattaraugus,Allegany District 3,President,,Donald R. Trump,CON,28,4
+Cattaraugus,Allegany District 4,President,,Donald R. Trump,CON,34,2
+Cattaraugus,Allegany District 5,President,,Donald R. Trump,CON,23,2
+Cattaraugus,Ashford District 1,President,,Donald R. Trump,CON,24,2
+Cattaraugus,Ashford District 2,President,,Donald R. Trump,CON,44,4
+Cattaraugus,Carrollton,President,,Donald R. Trump,CON,20,1
+Cattaraugus,City of Olean - Ward 1,President,,Donald R. Trump,CON,28,9
+Cattaraugus,City of Olean - Ward 2,President,,Donald R. Trump,CON,30,1
+Cattaraugus,City of Olean - Ward 3,President,,Donald R. Trump,CON,18,4
+Cattaraugus,City of Olean - Ward 4,President,,Donald R. Trump,CON,21,4
+Cattaraugus,City of Olean - Ward 5,President,,Donald R. Trump,CON,23,4
+Cattaraugus,City of Olean - Ward 6,President,,Donald R. Trump,CON,26,5
+Cattaraugus,City of Olean - Ward 7,President,,Donald R. Trump,CON,37,4
+Cattaraugus,City of Salamanca - Ward 1,President,,Donald R. Trump,CON,10,1
+Cattaraugus,City of Salamanca - Ward 2,President,,Donald R. Trump,CON,31,3
+Cattaraugus,City of Salamanca - Ward 3,President,,Donald R. Trump,CON,10,1
+Cattaraugus,City of Salamanca - Ward 4,President,,Donald R. Trump,CON,19,1
+Cattaraugus,City of Salamanca - Ward 5,President,,Donald R. Trump,CON,14,3
+Cattaraugus,Coldspring,President,,Donald R. Trump,CON,25,1
+Cattaraugus,Conewango,President,,Donald R. Trump,CON,25,5
+Cattaraugus,Dayton,President,,Donald R. Trump,CON,45,5
+Cattaraugus,Early Voting - Little Valley 1,President,,Donald R. Trump,CON,48,0
+Cattaraugus,Early Voting - Little Valley 2,President,,Donald R. Trump,CON,58,0
+Cattaraugus,Early Voting - Olean 1,President,,Donald R. Trump,CON,74,0
+Cattaraugus,Early Voting - Olean 2,President,,Donald R. Trump,CON,37,0
+Cattaraugus,East Otto,President,,Donald R. Trump,CON,41,1
+Cattaraugus,Ellicottville,President,,Donald R. Trump,CON,26,5
+Cattaraugus,Farmersville,President,,Donald R. Trump,CON,30,2
+Cattaraugus,Franklinville District 1,President,,Donald R. Trump,CON,40,2
+Cattaraugus,Franklinville District 2,President,,Donald R. Trump,CON,19,2
+Cattaraugus,Freedom,President,,Donald R. Trump,CON,70,8
 Cattaraugus,Great Valley 1,President,,Donald R. Trump,CON,26,0
-Cattaraugus,Great Valley 2,President,,Donald R. Trump,CON,30,9
-Cattaraugus,Hinsdale,President,,Donald R. Trump,CON,54,1
-Cattaraugus,Humphrey,President,,Donald R. Trump,CON,20,4
-Cattaraugus,Ischua,President,,Donald R. Trump,CON,16,4
-Cattaraugus,Leon,President,,Donald R. Trump,CON,26,4
-Cattaraugus,Little Valley,President,,Donald R. Trump,CON,21,5
-Cattaraugus,Lyndon,President,,Donald R. Trump,CON,13,4
-Cattaraugus,Machias,President,,Donald R. Trump,CON,54,6
-Cattaraugus,Mansfield,President,,Donald R. Trump,CON,12,3
-Cattaraugus,Napoli,President,,Donald R. Trump,CON,33,4
-Cattaraugus,New Albion,President,,Donald R. Trump,CON,50,4
-Cattaraugus,Otto,President,,Donald R. Trump,CON,23,4
-Cattaraugus,Perrysburg,President,,Donald R. Trump,CON,50,3
-Cattaraugus,Persia,President,,Donald R. Trump,CON,58,0
-Cattaraugus,Portville 1,President,,Donald R. Trump,CON,32,0
-Cattaraugus,Portville 2,President,,Donald R. Trump,CON,46,1
-Cattaraugus,Randolph District 1,President,,Donald R. Trump,CON,35,3
-Cattaraugus,Randolph District 2,President,,Donald R. Trump,CON,19,1
-Cattaraugus,Red House,President,,Donald R. Trump,CON,2,1
-Cattaraugus,South Valley,President,,Donald R. Trump,CON,8,3
+Cattaraugus,Great Valley 2,President,,Donald R. Trump,CON,33,3
+Cattaraugus,Hinsdale,President,,Donald R. Trump,CON,58,4
+Cattaraugus,Humphrey,President,,Donald R. Trump,CON,22,2
+Cattaraugus,Ischua,President,,Donald R. Trump,CON,18,2
+Cattaraugus,Leon,President,,Donald R. Trump,CON,26,0
+Cattaraugus,Little Valley,President,,Donald R. Trump,CON,23,2
+Cattaraugus,Lyndon,President,,Donald R. Trump,CON,15,2
+Cattaraugus,Machias,President,,Donald R. Trump,CON,59,5
+Cattaraugus,Mansfield,President,,Donald R. Trump,CON,12,0
+Cattaraugus,Napoli,President,,Donald R. Trump,CON,37,4
+Cattaraugus,New Albion,President,,Donald R. Trump,CON,57,7
+Cattaraugus,Otto,President,,Donald R. Trump,CON,23,0
+Cattaraugus,Perrysburg,President,,Donald R. Trump,CON,54,4
+Cattaraugus,Persia,President,,Donald R. Trump,CON,64,6
+Cattaraugus,Portville 1,President,,Donald R. Trump,CON,35,3
+Cattaraugus,Portville 2,President,,Donald R. Trump,CON,50,4
+Cattaraugus,Randolph District 1,President,,Donald R. Trump,CON,39,4
+Cattaraugus,Randolph District 2,President,,Donald R. Trump,CON,22,3
+Cattaraugus,Red House,President,,Donald R. Trump,CON,2,0
+Cattaraugus,South Valley,President,,Donald R. Trump,CON,8,0
 Cattaraugus,Town of Olean 1,President,,Donald R. Trump,CON,15,0
-Cattaraugus,Town of Olean 2,President,,Donald R. Trump,CON,9,5
-Cattaraugus,Town of Salamanca,President,,Donald R. Trump,CON,18,1
-Cattaraugus,Yorkshire 1,President,,Donald R. Trump,CON,50,5
-Cattaraugus,Yorkshire 2,President,,Donald R. Trump,CON,58,2
-Cattaraugus,Allegany District 1,President,,Joseph R. Biden,WOR,6,4
-Cattaraugus,Allegany District 2,President,,Joseph R. Biden,WOR,5,2
-Cattaraugus,Allegany District 3,President,,Joseph R. Biden,WOR,4,4
-Cattaraugus,Allegany District 4,President,,Joseph R. Biden,WOR,7,4
-Cattaraugus,Allegany District 5,President,,Joseph R. Biden,WOR,10,1
-Cattaraugus,Ashford District 1,President,,Joseph R. Biden,WOR,4,2
-Cattaraugus,Ashford District 2,President,,Joseph R. Biden,WOR,8,1
-Cattaraugus,Carrollton,President,,Joseph R. Biden,WOR,8,1
-Cattaraugus,City of Olean - Ward 1,President,,Joseph R. Biden,WOR,10,3
-Cattaraugus,City of Olean - Ward 2,President,,Joseph R. Biden,WOR,9,1
-Cattaraugus,City of Olean - Ward 3,President,,Joseph R. Biden,WOR,7,2
-Cattaraugus,City of Olean - Ward 4,President,,Joseph R. Biden,WOR,6,4
-Cattaraugus,City of Olean - Ward 5,President,,Joseph R. Biden,WOR,8,2
-Cattaraugus,City of Olean - Ward 6,President,,Joseph R. Biden,WOR,10,2
-Cattaraugus,City of Olean - Ward 7,President,,Joseph R. Biden,WOR,6,4
-Cattaraugus,City of Salamanca - Ward 1,President,,Joseph R. Biden,WOR,2,2
-Cattaraugus,City of Salamanca - Ward 2,President,,Joseph R. Biden,WOR,4,3
-Cattaraugus,City of Salamanca - Ward 3,President,,Joseph R. Biden,WOR,4,0
-Cattaraugus,City of Salamanca - Ward 4,President,,Joseph R. Biden,WOR,5,5
-Cattaraugus,City of Salamanca - Ward 5,President,,Joseph R. Biden,WOR,7,2
-Cattaraugus,Coldspring,President,,Joseph R. Biden,WOR,1,3
-Cattaraugus,Conewango,President,,Joseph R. Biden,WOR,6,0
-Cattaraugus,Dayton,President,,Joseph R. Biden,WOR,4,0
-Cattaraugus,Early Voting - Little Valley 1,President,,Joseph R. Biden,WOR,37,
-Cattaraugus,Early Voting - Little Valley 2,President,,Joseph R. Biden,WOR,25,
-Cattaraugus,Early Voting - Olean 1,President,,Joseph R. Biden,WOR,63,
-Cattaraugus,Early Voting - Olean 2,President,,Joseph R. Biden,WOR,35,
-Cattaraugus,East Otto,President,,Joseph R. Biden,WOR,4,4
-Cattaraugus,Ellicottville,President,,Joseph R. Biden,WOR,6,2
-Cattaraugus,Farmersville,President,,Joseph R. Biden,WOR,2,1
-Cattaraugus,Franklinville District 1,President,,Joseph R. Biden,WOR,8,1
-Cattaraugus,Franklinville District 2,President,,Joseph R. Biden,WOR,6,0
-Cattaraugus,Freedom,President,,Joseph R. Biden,WOR,4,3
-Cattaraugus,Great Valley 1,President,,Joseph R. Biden,WOR,3,3
-Cattaraugus,Great Valley 2,President,,Joseph R. Biden,WOR,6,7
-Cattaraugus,Hinsdale,President,,Joseph R. Biden,WOR,6,0
-Cattaraugus,Humphrey,President,,Joseph R. Biden,WOR,4,5
-Cattaraugus,Ischua,President,,Joseph R. Biden,WOR,2,6
-Cattaraugus,Leon,President,,Joseph R. Biden,WOR,4,4
-Cattaraugus,Little Valley,President,,Joseph R. Biden,WOR,4,5
-Cattaraugus,Lyndon,President,,Joseph R. Biden,WOR,4,1
-Cattaraugus,Machias,President,,Joseph R. Biden,WOR,13,2
-Cattaraugus,Mansfield,President,,Joseph R. Biden,WOR,1,2
-Cattaraugus,Napoli,President,,Joseph R. Biden,WOR,2,0
-Cattaraugus,New Albion,President,,Joseph R. Biden,WOR,10,2
-Cattaraugus,Otto,President,,Joseph R. Biden,WOR,3,0
-Cattaraugus,Perrysburg,President,,Joseph R. Biden,WOR,11,1
-Cattaraugus,Persia,President,,Joseph R. Biden,WOR,9,0
-Cattaraugus,Portville 1,President,,Joseph R. Biden,WOR,3,0
+Cattaraugus,Town of Olean 2,President,,Donald R. Trump,CON,14,5
+Cattaraugus,Town of Salamanca,President,,Donald R. Trump,CON,19,1
+Cattaraugus,Yorkshire 1,President,,Donald R. Trump,CON,55,5
+Cattaraugus,Yorkshire 2,President,,Donald R. Trump,CON,60,2
+Cattaraugus,Allegany District 1,President,,Joseph R. Biden,WOR,10,4
+Cattaraugus,Allegany District 2,President,,Joseph R. Biden,WOR,7,2
+Cattaraugus,Allegany District 3,President,,Joseph R. Biden,WOR,8,4
+Cattaraugus,Allegany District 4,President,,Joseph R. Biden,WOR,11,4
+Cattaraugus,Allegany District 5,President,,Joseph R. Biden,WOR,11,1
+Cattaraugus,Ashford District 1,President,,Joseph R. Biden,WOR,6,2
+Cattaraugus,Ashford District 2,President,,Joseph R. Biden,WOR,9,1
+Cattaraugus,Carrollton,President,,Joseph R. Biden,WOR,9,1
+Cattaraugus,City of Olean - Ward 1,President,,Joseph R. Biden,WOR,17,7
+Cattaraugus,City of Olean - Ward 2,President,,Joseph R. Biden,WOR,9,0
+Cattaraugus,City of Olean - Ward 3,President,,Joseph R. Biden,WOR,12,5
+Cattaraugus,City of Olean - Ward 4,President,,Joseph R. Biden,WOR,12,6
+Cattaraugus,City of Olean - Ward 5,President,,Joseph R. Biden,WOR,12,4
+Cattaraugus,City of Olean - Ward 6,President,,Joseph R. Biden,WOR,15,5
+Cattaraugus,City of Olean - Ward 7,President,,Joseph R. Biden,WOR,7,1
+Cattaraugus,City of Salamanca - Ward 1,President,,Joseph R. Biden,WOR,2,0
+Cattaraugus,City of Salamanca - Ward 2,President,,Joseph R. Biden,WOR,4,0
+Cattaraugus,City of Salamanca - Ward 3,President,,Joseph R. Biden,WOR,5,1
+Cattaraugus,City of Salamanca - Ward 4,President,,Joseph R. Biden,WOR,6,1
+Cattaraugus,City of Salamanca - Ward 5,President,,Joseph R. Biden,WOR,8,1
+Cattaraugus,Coldspring,President,,Joseph R. Biden,WOR,2,1
+Cattaraugus,Conewango,President,,Joseph R. Biden,WOR,9,3
+Cattaraugus,Dayton,President,,Joseph R. Biden,WOR,6,2
+Cattaraugus,Early Voting - Little Valley 1,President,,Joseph R. Biden,WOR,37,0
+Cattaraugus,Early Voting - Little Valley 2,President,,Joseph R. Biden,WOR,25,0
+Cattaraugus,Early Voting - Olean 1,President,,Joseph R. Biden,WOR,63,0
+Cattaraugus,Early Voting - Olean 2,President,,Joseph R. Biden,WOR,35,0
+Cattaraugus,East Otto,President,,Joseph R. Biden,WOR,6,2
+Cattaraugus,Ellicottville,President,,Joseph R. Biden,WOR,10,4
+Cattaraugus,Farmersville,President,,Joseph R. Biden,WOR,4,2
+Cattaraugus,Franklinville District 1,President,,Joseph R. Biden,WOR,10,2
+Cattaraugus,Franklinville District 2,President,,Joseph R. Biden,WOR,9,3
+Cattaraugus,Freedom,President,,Joseph R. Biden,WOR,8,4
+Cattaraugus,Great Valley 1,President,,Joseph R. Biden,WOR,3,0
+Cattaraugus,Great Valley 2,President,,Joseph R. Biden,WOR,11,5
+Cattaraugus,Hinsdale,President,,Joseph R. Biden,WOR,8,2
+Cattaraugus,Humphrey,President,,Joseph R. Biden,WOR,7,3
+Cattaraugus,Ischua,President,,Joseph R. Biden,WOR,2,0
+Cattaraugus,Leon,President,,Joseph R. Biden,WOR,4,0
+Cattaraugus,Little Valley,President,,Joseph R. Biden,WOR,8,4
+Cattaraugus,Lyndon,President,,Joseph R. Biden,WOR,6,2
+Cattaraugus,Machias,President,,Joseph R. Biden,WOR,14,1
+Cattaraugus,Mansfield,President,,Joseph R. Biden,WOR,2,1
+Cattaraugus,Napoli,President,,Joseph R. Biden,WOR,5,3
+Cattaraugus,New Albion,President,,Joseph R. Biden,WOR,10,0
+Cattaraugus,Otto,President,,Joseph R. Biden,WOR,6,3
+Cattaraugus,Perrysburg,President,,Joseph R. Biden,WOR,13,2
+Cattaraugus,Persia,President,,Joseph R. Biden,WOR,11,2
+Cattaraugus,Portville 1,President,,Joseph R. Biden,WOR,5,2
 Cattaraugus,Portville 2,President,,Joseph R. Biden,WOR,2,0
 Cattaraugus,Randolph District 1,President,,Joseph R. Biden,WOR,3,0
-Cattaraugus,Randolph District 2,President,,Joseph R. Biden,WOR,4,1
-Cattaraugus,Red House,President,,Joseph R. Biden,WOR,0,1
-Cattaraugus,South Valley,President,,Joseph R. Biden,WOR,2,1
+Cattaraugus,Randolph District 2,President,,Joseph R. Biden,WOR,5,1
+Cattaraugus,Red House,President,,Joseph R. Biden,WOR,0,0
+Cattaraugus,South Valley,President,,Joseph R. Biden,WOR,2,0
 Cattaraugus,Town of Olean 1,President,,Joseph R. Biden,WOR,4,0
-Cattaraugus,Town of Olean 2,President,,Joseph R. Biden,WOR,3,2
-Cattaraugus,Town of Salamanca,President,,Joseph R. Biden,WOR,3,5
-Cattaraugus,Yorkshire 1,President,,Joseph R. Biden,WOR,6,1
-Cattaraugus,Yorkshire 2,President,,Joseph R. Biden,WOR,11,3
+Cattaraugus,Town of Olean 2,President,,Joseph R. Biden,WOR,5,2
+Cattaraugus,Town of Salamanca,President,,Joseph R. Biden,WOR,8,5
+Cattaraugus,Yorkshire 1,President,,Joseph R. Biden,WOR,7,1
+Cattaraugus,Yorkshire 2,President,,Joseph R. Biden,WOR,14,3
 Cattaraugus,Allegany District 1,President,,Howie Hawkins,GRE,5,0
 Cattaraugus,Allegany District 2,President,,Howie Hawkins,GRE,0,0
-Cattaraugus,Allegany District 3,President,,Howie Hawkins,GRE,1,1
+Cattaraugus,Allegany District 3,President,,Howie Hawkins,GRE,2,1
 Cattaraugus,Allegany District 4,President,,Howie Hawkins,GRE,2,0
 Cattaraugus,Allegany District 5,President,,Howie Hawkins,GRE,3,0
-Cattaraugus,Ashford District 1,President,,Howie Hawkins,GRE,0,1
+Cattaraugus,Ashford District 1,President,,Howie Hawkins,GRE,1,1
 Cattaraugus,Ashford District 2,President,,Howie Hawkins,GRE,0,0
 Cattaraugus,Carrollton,President,,Howie Hawkins,GRE,2,0
 Cattaraugus,City of Olean - Ward 1,President,,Howie Hawkins,GRE,1,0
-Cattaraugus,City of Olean - Ward 2,President,,Howie Hawkins,GRE,3,0
-Cattaraugus,City of Olean - Ward 3,President,,Howie Hawkins,GRE,3,0
+Cattaraugus,City of Olean - Ward 2,President,,Howie Hawkins,GRE,4,1
+Cattaraugus,City of Olean - Ward 3,President,,Howie Hawkins,GRE,4,1
 Cattaraugus,City of Olean - Ward 4,President,,Howie Hawkins,GRE,2,0
-Cattaraugus,City of Olean - Ward 5,President,,Howie Hawkins,GRE,1,1
-Cattaraugus,City of Olean - Ward 6,President,,Howie Hawkins,GRE,1,2
-Cattaraugus,City of Olean - Ward 7,President,,Howie Hawkins,GRE,1,1
-Cattaraugus,City of Salamanca - Ward 1,President,,Howie Hawkins,GRE,1,0
+Cattaraugus,City of Olean - Ward 5,President,,Howie Hawkins,GRE,3,2
+Cattaraugus,City of Olean - Ward 6,President,,Howie Hawkins,GRE,2,1
+Cattaraugus,City of Olean - Ward 7,President,,Howie Hawkins,GRE,1,0
+Cattaraugus,City of Salamanca - Ward 1,President,,Howie Hawkins,GRE,2,1
 Cattaraugus,City of Salamanca - Ward 2,President,,Howie Hawkins,GRE,3,0
 Cattaraugus,City of Salamanca - Ward 3,President,,Howie Hawkins,GRE,0,0
-Cattaraugus,City of Salamanca - Ward 4,President,,Howie Hawkins,GRE,0,0
-Cattaraugus,City of Salamanca - Ward 5,President,,Howie Hawkins,GRE,0,1
-Cattaraugus,Coldspring,President,,Howie Hawkins,GRE,0,1
+Cattaraugus,City of Salamanca - Ward 4,President,,Howie Hawkins,GRE,1,1
+Cattaraugus,City of Salamanca - Ward 5,President,,Howie Hawkins,GRE,1,1
+Cattaraugus,Coldspring,President,,Howie Hawkins,GRE,0,0
 Cattaraugus,Conewango,President,,Howie Hawkins,GRE,2,0
 Cattaraugus,Dayton,President,,Howie Hawkins,GRE,3,0
-Cattaraugus,Early Voting - Little Valley 1,President,,Howie Hawkins,GRE,6,
-Cattaraugus,Early Voting - Little Valley 2,President,,Howie Hawkins,GRE,2,
-Cattaraugus,Early Voting - Olean 1,President,,Howie Hawkins,GRE,13,
-Cattaraugus,Early Voting - Olean 2,President,,Howie Hawkins,GRE,4,
-Cattaraugus,East Otto,President,,Howie Hawkins,GRE,0,1
+Cattaraugus,Early Voting - Little Valley 1,President,,Howie Hawkins,GRE,6,0
+Cattaraugus,Early Voting - Little Valley 2,President,,Howie Hawkins,GRE,2,0
+Cattaraugus,Early Voting - Olean 1,President,,Howie Hawkins,GRE,13,0
+Cattaraugus,Early Voting - Olean 2,President,,Howie Hawkins,GRE,4,0
+Cattaraugus,East Otto,President,,Howie Hawkins,GRE,1,1
 Cattaraugus,Ellicottville,President,,Howie Hawkins,GRE,1,0
-Cattaraugus,Farmersville,President,,Howie Hawkins,GRE,1,0
-Cattaraugus,Franklinville District 1,President,,Howie Hawkins,GRE,0,1
+Cattaraugus,Farmersville,President,,Howie Hawkins,GRE,3,2
+Cattaraugus,Franklinville District 1,President,,Howie Hawkins,GRE,0,0
 Cattaraugus,Franklinville District 2,President,,Howie Hawkins,GRE,3,0
-Cattaraugus,Freedom,President,,Howie Hawkins,GRE,2,0
+Cattaraugus,Freedom,President,,Howie Hawkins,GRE,3,1
 Cattaraugus,Great Valley 1,President,,Howie Hawkins,GRE,1,0
 Cattaraugus,Great Valley 2,President,,Howie Hawkins,GRE,0,0
-Cattaraugus,Hinsdale,President,,Howie Hawkins,GRE,2,1
-Cattaraugus,Humphrey,President,,Howie Hawkins,GRE,1,1
+Cattaraugus,Hinsdale,President,,Howie Hawkins,GRE,3,1
+Cattaraugus,Humphrey,President,,Howie Hawkins,GRE,2,1
 Cattaraugus,Ischua,President,,Howie Hawkins,GRE,0,0
-Cattaraugus,Leon,President,,Howie Hawkins,GRE,0,2
-Cattaraugus,Little Valley,President,,Howie Hawkins,GRE,2,1
+Cattaraugus,Leon,President,,Howie Hawkins,GRE,0,0
+Cattaraugus,Little Valley,President,,Howie Hawkins,GRE,3,1
 Cattaraugus,Lyndon,President,,Howie Hawkins,GRE,0,0
-Cattaraugus,Machias,President,,Howie Hawkins,GRE,2,0
-Cattaraugus,Mansfield,President,,Howie Hawkins,GRE,1,2
+Cattaraugus,Machias,President,,Howie Hawkins,GRE,3,1
+Cattaraugus,Mansfield,President,,Howie Hawkins,GRE,1,0
 Cattaraugus,Napoli,President,,Howie Hawkins,GRE,1,0
 Cattaraugus,New Albion,President,,Howie Hawkins,GRE,2,0
 Cattaraugus,Otto,President,,Howie Hawkins,GRE,1,0
 Cattaraugus,Perrysburg,President,,Howie Hawkins,GRE,5,0
 Cattaraugus,Persia,President,,Howie Hawkins,GRE,1,0
-Cattaraugus,Portville 1,President,,Howie Hawkins,GRE,1,0
-Cattaraugus,Portville 2,President,,Howie Hawkins,GRE,1,1
+Cattaraugus,Portville 1,President,,Howie Hawkins,GRE,3,2
+Cattaraugus,Portville 2,President,,Howie Hawkins,GRE,1,0
 Cattaraugus,Randolph District 1,President,,Howie Hawkins,GRE,0,0
 Cattaraugus,Randolph District 2,President,,Howie Hawkins,GRE,1,0
-Cattaraugus,Red House,President,,Howie Hawkins,GRE,0,1
-Cattaraugus,South Valley,President,,Howie Hawkins,GRE,0,1
+Cattaraugus,Red House,President,,Howie Hawkins,GRE,0,0
+Cattaraugus,South Valley,President,,Howie Hawkins,GRE,0,0
 Cattaraugus,Town of Olean 1,President,,Howie Hawkins,GRE,1,0
 Cattaraugus,Town of Olean 2,President,,Howie Hawkins,GRE,0,0
 Cattaraugus,Town of Salamanca,President,,Howie Hawkins,GRE,1,0
 Cattaraugus,Yorkshire 1,President,,Howie Hawkins,GRE,0,0
 Cattaraugus,Yorkshire 2,President,,Howie Hawkins,GRE,3,0
-Cattaraugus,Allegany District 1,President,,Jo Jorgensen,LIB,5,1
+Cattaraugus,Allegany District 1,President,,Jo Jorgensen,LIB,6,1
 Cattaraugus,Allegany District 2,President,,Jo Jorgensen,LIB,2,0
-Cattaraugus,Allegany District 3,President,,Jo Jorgensen,LIB,8,1
-Cattaraugus,Allegany District 4,President,,Jo Jorgensen,LIB,2,1
-Cattaraugus,Allegany District 5,President,,Jo Jorgensen,LIB,6,1
-Cattaraugus,Ashford District 1,President,,Jo Jorgensen,LIB,6,1
-Cattaraugus,Ashford District 2,President,,Jo Jorgensen,LIB,5,2
-Cattaraugus,Carrollton,President,,Jo Jorgensen,LIB,6,1
-Cattaraugus,City of Olean - Ward 1,President,,Jo Jorgensen,LIB,11,2
-Cattaraugus,City of Olean - Ward 2,President,,Jo Jorgensen,LIB,8,2
-Cattaraugus,City of Olean - Ward 3,President,,Jo Jorgensen,LIB,5,1
-Cattaraugus,City of Olean - Ward 4,President,,Jo Jorgensen,LIB,7,1
-Cattaraugus,City of Olean - Ward 5,President,,Jo Jorgensen,LIB,11,0
-Cattaraugus,City of Olean - Ward 6,President,,Jo Jorgensen,LIB,7,1
-Cattaraugus,City of Olean - Ward 7,President,,Jo Jorgensen,LIB,5,0
+Cattaraugus,Allegany District 3,President,,Jo Jorgensen,LIB,9,1
+Cattaraugus,Allegany District 4,President,,Jo Jorgensen,LIB,3,1
+Cattaraugus,Allegany District 5,President,,Jo Jorgensen,LIB,7,1
+Cattaraugus,Ashford District 1,President,,Jo Jorgensen,LIB,7,1
+Cattaraugus,Ashford District 2,President,,Jo Jorgensen,LIB,7,2
+Cattaraugus,Carrollton,President,,Jo Jorgensen,LIB,8,2
+Cattaraugus,City of Olean - Ward 1,President,,Jo Jorgensen,LIB,13,2
+Cattaraugus,City of Olean - Ward 2,President,,Jo Jorgensen,LIB,8,0
+Cattaraugus,City of Olean - Ward 3,President,,Jo Jorgensen,LIB,13,8
+Cattaraugus,City of Olean - Ward 4,President,,Jo Jorgensen,LIB,9,2
+Cattaraugus,City of Olean - Ward 5,President,,Jo Jorgensen,LIB,13,2
+Cattaraugus,City of Olean - Ward 6,President,,Jo Jorgensen,LIB,11,4
+Cattaraugus,City of Olean - Ward 7,President,,Jo Jorgensen,LIB,7,2
 Cattaraugus,City of Salamanca - Ward 1,President,,Jo Jorgensen,LIB,1,0
-Cattaraugus,City of Salamanca - Ward 2,President,,Jo Jorgensen,LIB,6,1
+Cattaraugus,City of Salamanca - Ward 2,President,,Jo Jorgensen,LIB,6,0
 Cattaraugus,City of Salamanca - Ward 3,President,,Jo Jorgensen,LIB,2,0
-Cattaraugus,City of Salamanca - Ward 4,President,,Jo Jorgensen,LIB,4,1
-Cattaraugus,City of Salamanca - Ward 5,President,,Jo Jorgensen,LIB,4,0
-Cattaraugus,Coldspring,President,,Jo Jorgensen,LIB,3,0
-Cattaraugus,Conewango,President,,Jo Jorgensen,LIB,12,0
-Cattaraugus,Dayton,President,,Jo Jorgensen,LIB,6,0
-Cattaraugus,Early Voting - Little Valley 1,President,,Jo Jorgensen,LIB,4,
-Cattaraugus,Early Voting - Little Valley 2,President,,Jo Jorgensen,LIB,11,
-Cattaraugus,Early Voting - Olean 1,President,,Jo Jorgensen,LIB,34,
-Cattaraugus,Early Voting - Olean 2,President,,Jo Jorgensen,LIB,13,
-Cattaraugus,East Otto,President,,Jo Jorgensen,LIB,3,3
-Cattaraugus,Ellicottville,President,,Jo Jorgensen,LIB,10,0
-Cattaraugus,Farmersville,President,,Jo Jorgensen,LIB,4,1
-Cattaraugus,Franklinville District 1,President,,Jo Jorgensen,LIB,5,2
-Cattaraugus,Franklinville District 2,President,,Jo Jorgensen,LIB,4,5
+Cattaraugus,City of Salamanca - Ward 4,President,,Jo Jorgensen,LIB,4,0
+Cattaraugus,City of Salamanca - Ward 5,President,,Jo Jorgensen,LIB,6,2
+Cattaraugus,Coldspring,President,,Jo Jorgensen,LIB,4,1
+Cattaraugus,Conewango,President,,Jo Jorgensen,LIB,14,2
+Cattaraugus,Dayton,President,,Jo Jorgensen,LIB,7,1
+Cattaraugus,Early Voting - Little Valley 1,President,,Jo Jorgensen,LIB,4,0
+Cattaraugus,Early Voting - Little Valley 2,President,,Jo Jorgensen,LIB,11,0
+Cattaraugus,Early Voting - Olean 1,President,,Jo Jorgensen,LIB,34,0
+Cattaraugus,Early Voting - Olean 2,President,,Jo Jorgensen,LIB,13,0
+Cattaraugus,East Otto,President,,Jo Jorgensen,LIB,3,0
+Cattaraugus,Ellicottville,President,,Jo Jorgensen,LIB,11,1
+Cattaraugus,Farmersville,President,,Jo Jorgensen,LIB,5,1
+Cattaraugus,Franklinville District 1,President,,Jo Jorgensen,LIB,5,0
+Cattaraugus,Franklinville District 2,President,,Jo Jorgensen,LIB,5,1
 Cattaraugus,Freedom,President,,Jo Jorgensen,LIB,9,0
-Cattaraugus,Great Valley 1,President,,Jo Jorgensen,LIB,3,1
-Cattaraugus,Great Valley 2,President,,Jo Jorgensen,LIB,9,2
+Cattaraugus,Great Valley 1,President,,Jo Jorgensen,LIB,3,0
+Cattaraugus,Great Valley 2,President,,Jo Jorgensen,LIB,10,1
 Cattaraugus,Hinsdale,President,,Jo Jorgensen,LIB,8,0
-Cattaraugus,Humphrey,President,,Jo Jorgensen,LIB,3,8
-Cattaraugus,Ischua,President,,Jo Jorgensen,LIB,3,2
-Cattaraugus,Leon,President,,Jo Jorgensen,LIB,6,2
-Cattaraugus,Little Valley,President,,Jo Jorgensen,LIB,16,4
-Cattaraugus,Lyndon,President,,Jo Jorgensen,LIB,3,2
-Cattaraugus,Machias,President,,Jo Jorgensen,LIB,6,1
-Cattaraugus,Mansfield,President,,Jo Jorgensen,LIB,3,2
-Cattaraugus,Napoli,President,,Jo Jorgensen,LIB,2,1
-Cattaraugus,New Albion,President,,Jo Jorgensen,LIB,10,0
-Cattaraugus,Otto,President,,Jo Jorgensen,LIB,3,1
-Cattaraugus,Perrysburg,President,,Jo Jorgensen,LIB,3,1
-Cattaraugus,Persia,President,,Jo Jorgensen,LIB,6,0
-Cattaraugus,Portville 1,President,,Jo Jorgensen,LIB,15,0
-Cattaraugus,Portville 2,President,,Jo Jorgensen,LIB,13,0
-Cattaraugus,Randolph District 1,President,,Jo Jorgensen,LIB,8,0
-Cattaraugus,Randolph District 2,President,,Jo Jorgensen,LIB,9,0
+Cattaraugus,Humphrey,President,,Jo Jorgensen,LIB,3,0
+Cattaraugus,Ischua,President,,Jo Jorgensen,LIB,3,0
+Cattaraugus,Leon,President,,Jo Jorgensen,LIB,6,0
+Cattaraugus,Little Valley,President,,Jo Jorgensen,LIB,19,3
+Cattaraugus,Lyndon,President,,Jo Jorgensen,LIB,3,0
+Cattaraugus,Machias,President,,Jo Jorgensen,LIB,8,2
+Cattaraugus,Mansfield,President,,Jo Jorgensen,LIB,4,1
+Cattaraugus,Napoli,President,,Jo Jorgensen,LIB,2,0
+Cattaraugus,New Albion,President,,Jo Jorgensen,LIB,15,5
+Cattaraugus,Otto,President,,Jo Jorgensen,LIB,4,1
+Cattaraugus,Perrysburg,President,,Jo Jorgensen,LIB,3,0
+Cattaraugus,Persia,President,,Jo Jorgensen,LIB,7,1
+Cattaraugus,Portville 1,President,,Jo Jorgensen,LIB,17,2
+Cattaraugus,Portville 2,President,,Jo Jorgensen,LIB,14,1
+Cattaraugus,Randolph District 1,President,,Jo Jorgensen,LIB,9,1
+Cattaraugus,Randolph District 2,President,,Jo Jorgensen,LIB,10,1
 Cattaraugus,Red House,President,,Jo Jorgensen,LIB,0,0
-Cattaraugus,South Valley,President,,Jo Jorgensen,LIB,1,2
+Cattaraugus,South Valley,President,,Jo Jorgensen,LIB,1,0
 Cattaraugus,Town of Olean 1,President,,Jo Jorgensen,LIB,3,0
-Cattaraugus,Town of Olean 2,President,,Jo Jorgensen,LIB,3,2
+Cattaraugus,Town of Olean 2,President,,Jo Jorgensen,LIB,5,2
 Cattaraugus,Town of Salamanca,President,,Jo Jorgensen,LIB,3,0
-Cattaraugus,Yorkshire 1,President,,Jo Jorgensen,LIB,6,2
-Cattaraugus,Yorkshire 2,President,,Jo Jorgensen,LIB,13,2
-Cattaraugus,Allegany District 1,President,,Brock Pierce,IND,4,2
+Cattaraugus,Yorkshire 1,President,,Jo Jorgensen,LIB,8,2
+Cattaraugus,Yorkshire 2,President,,Jo Jorgensen,LIB,15,2
+Cattaraugus,Allegany District 1,President,,Brock Pierce,IND,6,2
 Cattaraugus,Allegany District 2,President,,Brock Pierce,IND,2,0
 Cattaraugus,Allegany District 3,President,,Brock Pierce,IND,1,0
 Cattaraugus,Allegany District 4,President,,Brock Pierce,IND,3,0
 Cattaraugus,Allegany District 5,President,,Brock Pierce,IND,0,0
-Cattaraugus,Ashford District 1,President,,Brock Pierce,IND,1,1
-Cattaraugus,Ashford District 2,President,,Brock Pierce,IND,0,2
+Cattaraugus,Ashford District 1,President,,Brock Pierce,IND,2,1
+Cattaraugus,Ashford District 2,President,,Brock Pierce,IND,2,2
 Cattaraugus,Carrollton,President,,Brock Pierce,IND,1,0
-Cattaraugus,City of Olean - Ward 1,President,,Brock Pierce,IND,3,0
-Cattaraugus,City of Olean - Ward 2,President,,Brock Pierce,IND,3,0
-Cattaraugus,City of Olean - Ward 3,President,,Brock Pierce,IND,3,0
+Cattaraugus,City of Olean - Ward 1,President,,Brock Pierce,IND,4,1
+Cattaraugus,City of Olean - Ward 2,President,,Brock Pierce,IND,4,1
+Cattaraugus,City of Olean - Ward 3,President,,Brock Pierce,IND,4,1
 Cattaraugus,City of Olean - Ward 4,President,,Brock Pierce,IND,0,0
 Cattaraugus,City of Olean - Ward 5,President,,Brock Pierce,IND,1,0
 Cattaraugus,City of Olean - Ward 6,President,,Brock Pierce,IND,4,0
-Cattaraugus,City of Olean - Ward 7,President,,Brock Pierce,IND,5,1
-Cattaraugus,City of Salamanca - Ward 1,President,,Brock Pierce,IND,0,1
-Cattaraugus,City of Salamanca - Ward 2,President,,Brock Pierce,IND,4,0
-Cattaraugus,City of Salamanca - Ward 3,President,,Brock Pierce,IND,0,1
+Cattaraugus,City of Olean - Ward 7,President,,Brock Pierce,IND,5,0
+Cattaraugus,City of Salamanca - Ward 1,President,,Brock Pierce,IND,0,0
+Cattaraugus,City of Salamanca - Ward 2,President,,Brock Pierce,IND,5,1
+Cattaraugus,City of Salamanca - Ward 3,President,,Brock Pierce,IND,0,0
 Cattaraugus,City of Salamanca - Ward 4,President,,Brock Pierce,IND,4,0
-Cattaraugus,City of Salamanca - Ward 5,President,,Brock Pierce,IND,1,0
+Cattaraugus,City of Salamanca - Ward 5,President,,Brock Pierce,IND,2,1
 Cattaraugus,Coldspring,President,,Brock Pierce,IND,3,0
 Cattaraugus,Conewango,President,,Brock Pierce,IND,7,0
 Cattaraugus,Dayton,President,,Brock Pierce,IND,3,0
-Cattaraugus,Early Voting - Little Valley 1,President,,Brock Pierce,IND,2,
-Cattaraugus,Early Voting - Little Valley 2,President,,Brock Pierce,IND,1,
-Cattaraugus,Early Voting - Olean 1,President,,Brock Pierce,IND,3,
-Cattaraugus,Early Voting - Olean 2,President,,Brock Pierce,IND,3,
+Cattaraugus,Early Voting - Little Valley 1,President,,Brock Pierce,IND,2,0
+Cattaraugus,Early Voting - Little Valley 2,President,,Brock Pierce,IND,1,0
+Cattaraugus,Early Voting - Olean 1,President,,Brock Pierce,IND,3,0
+Cattaraugus,Early Voting - Olean 2,President,,Brock Pierce,IND,3,0
 Cattaraugus,East Otto,President,,Brock Pierce,IND,4,0
 Cattaraugus,Ellicottville,President,,Brock Pierce,IND,1,0
 Cattaraugus,Farmersville,President,,Brock Pierce,IND,0,0
-Cattaraugus,Franklinville District 1,President,,Brock Pierce,IND,4,1
+Cattaraugus,Franklinville District 1,President,,Brock Pierce,IND,5,1
 Cattaraugus,Franklinville District 2,President,,Brock Pierce,IND,3,0
-Cattaraugus,Freedom,President,,Brock Pierce,IND,3,0
-Cattaraugus,Great Valley 1,President,,Brock Pierce,IND,2,1
-Cattaraugus,Great Valley 2,President,,Brock Pierce,IND,0,1
-Cattaraugus,Hinsdale,President,,Brock Pierce,IND,4,1
-Cattaraugus,Humphrey,President,,Brock Pierce,IND,0,1
+Cattaraugus,Freedom,President,,Brock Pierce,IND,4,1
+Cattaraugus,Great Valley 1,President,,Brock Pierce,IND,3,1
+Cattaraugus,Great Valley 2,President,,Brock Pierce,IND,0,0
+Cattaraugus,Hinsdale,President,,Brock Pierce,IND,4,0
+Cattaraugus,Humphrey,President,,Brock Pierce,IND,0,0
 Cattaraugus,Ischua,President,,Brock Pierce,IND,3,0
 Cattaraugus,Leon,President,,Brock Pierce,IND,3,0
 Cattaraugus,Little Valley,President,,Brock Pierce,IND,2,0
 Cattaraugus,Lyndon,President,,Brock Pierce,IND,2,0
-Cattaraugus,Machias,President,,Brock Pierce,IND,5,1
+Cattaraugus,Machias,President,,Brock Pierce,IND,6,1
 Cattaraugus,Mansfield,President,,Brock Pierce,IND,2,0
-Cattaraugus,Napoli,President,,Brock Pierce,IND,0,1
-Cattaraugus,New Albion,President,,Brock Pierce,IND,1,1
-Cattaraugus,Otto,President,,Brock Pierce,IND,1,0
-Cattaraugus,Perrysburg,President,,Brock Pierce,IND,4,1
-Cattaraugus,Persia,President,,Brock Pierce,IND,5,0
+Cattaraugus,Napoli,President,,Brock Pierce,IND,0,0
+Cattaraugus,New Albion,President,,Brock Pierce,IND,1,0
+Cattaraugus,Otto,President,,Brock Pierce,IND,2,1
+Cattaraugus,Perrysburg,President,,Brock Pierce,IND,5,1
+Cattaraugus,Persia,President,,Brock Pierce,IND,6,1
 Cattaraugus,Portville 1,President,,Brock Pierce,IND,4,0
-Cattaraugus,Portville 2,President,,Brock Pierce,IND,3,0
-Cattaraugus,Randolph District 1,President,,Brock Pierce,IND,4,1
-Cattaraugus,Randolph District 2,President,,Brock Pierce,IND,3,0
+Cattaraugus,Portville 2,President,,Brock Pierce,IND,4,1
+Cattaraugus,Randolph District 1,President,,Brock Pierce,IND,4,0
+Cattaraugus,Randolph District 2,President,,Brock Pierce,IND,4,1
 Cattaraugus,Red House,President,,Brock Pierce,IND,0,0
-Cattaraugus,South Valley,President,,Brock Pierce,IND,1,1
+Cattaraugus,South Valley,President,,Brock Pierce,IND,1,0
 Cattaraugus,Town of Olean 1,President,,Brock Pierce,IND,0,0
-Cattaraugus,Town of Olean 2,President,,Brock Pierce,IND,1,1
+Cattaraugus,Town of Olean 2,President,,Brock Pierce,IND,2,1
 Cattaraugus,Town of Salamanca,President,,Brock Pierce,IND,1,0
 Cattaraugus,Yorkshire 1,President,,Brock Pierce,IND,4,0
 Cattaraugus,Yorkshire 2,President,,Brock Pierce,IND,2,0
@@ -484,20 +484,20 @@ Cattaraugus,City of Olean - Ward 2,President,,Write-ins,,1,0
 Cattaraugus,City of Olean - Ward 3,President,,Write-ins,,0,0
 Cattaraugus,City of Olean - Ward 4,President,,Write-ins,,2,0
 Cattaraugus,City of Olean - Ward 5,President,,Write-ins,,0,0
-Cattaraugus,City of Olean - Ward 6,President,,Write-ins,,0,0
+Cattaraugus,City of Olean - Ward 6,President,,Write-ins,,1,1
 Cattaraugus,City of Olean - Ward 7,President,,Write-ins,,0,0
 Cattaraugus,City of Salamanca - Ward 1,President,,Write-ins,,0,0
 Cattaraugus,City of Salamanca - Ward 2,President,,Write-ins,,0,0
 Cattaraugus,City of Salamanca - Ward 3,President,,Write-ins,,0,0
 Cattaraugus,City of Salamanca - Ward 4,President,,Write-ins,,0,0
-Cattaraugus,City of Salamanca - Ward 5,President,,Write-ins,,0,1
+Cattaraugus,City of Salamanca - Ward 5,President,,Write-ins,,0,0
 Cattaraugus,Coldspring,President,,Write-ins,,0,0
 Cattaraugus,Conewango,President,,Write-ins,,0,0
 Cattaraugus,Dayton,President,,Write-ins,,0,0
-Cattaraugus,Early Voting - Little Valley 1,President,,Write-ins,,0,
-Cattaraugus,Early Voting - Little Valley 2,President,,Write-ins,,0,
-Cattaraugus,Early Voting - Olean 1,President,,Write-ins,,0,
-Cattaraugus,Early Voting - Olean 2,President,,Write-ins,,0,
+Cattaraugus,Early Voting - Little Valley 1,President,,Write-ins,,0,0
+Cattaraugus,Early Voting - Little Valley 2,President,,Write-ins,,0,0
+Cattaraugus,Early Voting - Olean 1,President,,Write-ins,,0,0
+Cattaraugus,Early Voting - Olean 2,President,,Write-ins,,0,0
 Cattaraugus,East Otto,President,,Write-ins,,0,0
 Cattaraugus,Ellicottville,President,,Write-ins,,0,0
 Cattaraugus,Farmersville,President,,Write-ins,,0,0
@@ -506,11 +506,11 @@ Cattaraugus,Franklinville District 2,President,,Write-ins,,0,0
 Cattaraugus,Freedom,President,,Write-ins,,0,0
 Cattaraugus,Great Valley 1,President,,Write-ins,,0,0
 Cattaraugus,Great Valley 2,President,,Write-ins,,0,0
-Cattaraugus,Hinsdale,President,,Write-ins,,0,0
+Cattaraugus,Hinsdale,President,,Write-ins,,1,1
 Cattaraugus,Humphrey,President,,Write-ins,,0,0
 Cattaraugus,Ischua,President,,Write-ins,,0,0
 Cattaraugus,Leon,President,,Write-ins,,0,0
-Cattaraugus,Little Valley,President,,Write-ins,,0,1
+Cattaraugus,Little Valley,President,,Write-ins,,0,0
 Cattaraugus,Lyndon,President,,Write-ins,,0,0
 Cattaraugus,Machias,President,,Write-ins,,0,0
 Cattaraugus,Mansfield,President,,Write-ins,,0,0
@@ -531,57 +531,57 @@ Cattaraugus,Town of Salamanca,President,,Write-ins,,1,0
 Cattaraugus,Yorkshire 1,President,,Write-ins,,1,0
 Cattaraugus,Yorkshire 2,President,,Write-ins,,0,0
 Cattaraugus,Allegany District 1,President,,Voids,,3,0
-Cattaraugus,Allegany District 2,President,,Voids,,2,3
+Cattaraugus,Allegany District 2,President,,Voids,,5,3
 Cattaraugus,Allegany District 3,President,,Voids,,1,0
 Cattaraugus,Allegany District 4,President,,Voids,,0,0
-Cattaraugus,Allegany District 5,President,,Voids,,2,1
+Cattaraugus,Allegany District 5,President,,Voids,,3,1
 Cattaraugus,Ashford District 1,President,,Voids,,0,0
-Cattaraugus,Ashford District 2,President,,Voids,,1,1
-Cattaraugus,Carrollton,President,,Voids,,2,1
-Cattaraugus,City of Olean - Ward 1,President,,Voids,,4,0
-Cattaraugus,City of Olean - Ward 2,President,,Voids,,2,0
-Cattaraugus,City of Olean - Ward 3,President,,Voids,,2,0
-Cattaraugus,City of Olean - Ward 4,President,,Voids,,1,2
-Cattaraugus,City of Olean - Ward 5,President,,Voids,,1,1
-Cattaraugus,City of Olean - Ward 6,President,,Voids,,0,2
-Cattaraugus,City of Olean - Ward 7,President,,Voids,,0,1
-Cattaraugus,City of Salamanca - Ward 1,President,,Voids,,0,1
+Cattaraugus,Ashford District 2,President,,Voids,,2,1
+Cattaraugus,Carrollton,President,,Voids,,2,0
+Cattaraugus,City of Olean - Ward 1,President,,Voids,,6,2
+Cattaraugus,City of Olean - Ward 2,President,,Voids,,3,1
+Cattaraugus,City of Olean - Ward 3,President,,Voids,,5,3
+Cattaraugus,City of Olean - Ward 4,President,,Voids,,1,0
+Cattaraugus,City of Olean - Ward 5,President,,Voids,,2,1
+Cattaraugus,City of Olean - Ward 6,President,,Voids,,1,1
+Cattaraugus,City of Olean - Ward 7,President,,Voids,,1,1
+Cattaraugus,City of Salamanca - Ward 1,President,,Voids,,2,2
 Cattaraugus,City of Salamanca - Ward 2,President,,Voids,,2,0
-Cattaraugus,City of Salamanca - Ward 3,President,,Voids,,1,3
-Cattaraugus,City of Salamanca - Ward 4,President,,Voids,,1,1
+Cattaraugus,City of Salamanca - Ward 3,President,,Voids,,1,0
+Cattaraugus,City of Salamanca - Ward 4,President,,Voids,,1,0
 Cattaraugus,City of Salamanca - Ward 5,President,,Voids,,0,0
-Cattaraugus,Coldspring,President,,Voids,,0,0
+Cattaraugus,Coldspring,President,,Voids,,1,1
 Cattaraugus,Conewango,President,,Voids,,0,0
-Cattaraugus,Dayton,President,,Voids,,1,1
-Cattaraugus,Early Voting - Little Valley 1,President,,Voids,,0,
-Cattaraugus,Early Voting - Little Valley 2,President,,Voids,,0,
-Cattaraugus,Early Voting - Olean 1,President,,Voids,,5,
-Cattaraugus,Early Voting - Olean 2,President,,Voids,,0,
-Cattaraugus,East Otto,President,,Voids,,0,1
-Cattaraugus,Ellicottville,President,,Voids,,3,0
-Cattaraugus,Farmersville,President,,Voids,,0,0
-Cattaraugus,Franklinville District 1,President,,Voids,,0,0
+Cattaraugus,Dayton,President,,Voids,,1,0
+Cattaraugus,Early Voting - Little Valley 1,President,,Voids,,0,0
+Cattaraugus,Early Voting - Little Valley 2,President,,Voids,,0,0
+Cattaraugus,Early Voting - Olean 1,President,,Voids,,5,0
+Cattaraugus,Early Voting - Olean 2,President,,Voids,,0,0
+Cattaraugus,East Otto,President,,Voids,,1,1
+Cattaraugus,Ellicottville,President,,Voids,,5,2
+Cattaraugus,Farmersville,President,,Voids,,2,2
+Cattaraugus,Franklinville District 1,President,,Voids,,1,1
 Cattaraugus,Franklinville District 2,President,,Voids,,0,0
-Cattaraugus,Freedom,President,,Voids,,2,0
-Cattaraugus,Great Valley 1,President,,Voids,,0,0
-Cattaraugus,Great Valley 2,President,,Voids,,1,2
-Cattaraugus,Hinsdale,President,,Voids,,0,1
-Cattaraugus,Humphrey,President,,Voids,,0,3
+Cattaraugus,Freedom,President,,Voids,,3,1
+Cattaraugus,Great Valley 1,President,,Voids,,3,3
+Cattaraugus,Great Valley 2,President,,Voids,,2,1
+Cattaraugus,Hinsdale,President,,Voids,,0,0
+Cattaraugus,Humphrey,President,,Voids,,0,0
 Cattaraugus,Ischua,President,,Voids,,1,0
-Cattaraugus,Leon,President,,Voids,,0,1
-Cattaraugus,Little Valley,President,,Voids,,1,1
-Cattaraugus,Lyndon,President,,Voids,,2,1
-Cattaraugus,Machias,President,,Voids,,2,1
-Cattaraugus,Mansfield,President,,Voids,,0,1
-Cattaraugus,Napoli,President,,Voids,,0,2
-Cattaraugus,New Albion,President,,Voids,,0,1
+Cattaraugus,Leon,President,,Voids,,1,1
+Cattaraugus,Little Valley,President,,Voids,,2,1
+Cattaraugus,Lyndon,President,,Voids,,2,0
+Cattaraugus,Machias,President,,Voids,,2,0
+Cattaraugus,Mansfield,President,,Voids,,0,0
+Cattaraugus,Napoli,President,,Voids,,0,0
+Cattaraugus,New Albion,President,,Voids,,0,0
 Cattaraugus,Otto,President,,Voids,,0,0
-Cattaraugus,Perrysburg,President,,Voids,,4,1
-Cattaraugus,Persia,President,,Voids,,2,0
-Cattaraugus,Portville 1,President,,Voids,,2,0
-Cattaraugus,Portville 2,President,,Voids,,0,2
+Cattaraugus,Perrysburg,President,,Voids,,5,1
+Cattaraugus,Persia,President,,Voids,,3,1
+Cattaraugus,Portville 1,President,,Voids,,3,1
+Cattaraugus,Portville 2,President,,Voids,,2,2
 Cattaraugus,Randolph District 1,President,,Voids,,2,0
-Cattaraugus,Randolph District 2,President,,Voids,,2,0
+Cattaraugus,Randolph District 2,President,,Voids,,3,1
 Cattaraugus,Red House,President,,Voids,,0,0
 Cattaraugus,South Valley,President,,Voids,,0,0
 Cattaraugus,Town of Olean 1,President,,Voids,,0,0
@@ -590,412 +590,412 @@ Cattaraugus,Town of Salamanca,President,,Voids,,1,0
 Cattaraugus,Yorkshire 1,President,,Voids,,0,0
 Cattaraugus,Yorkshire 2,President,,Voids,,2,0
 Cattaraugus,Allegany District 1,President,,Blanks,,3,0
-Cattaraugus,Allegany District 2,President,,Blanks,,1,1
-Cattaraugus,Allegany District 3,President,,Blanks,,1,1
-Cattaraugus,Allegany District 4,President,,Blanks,,0,1
+Cattaraugus,Allegany District 2,President,,Blanks,,2,1
+Cattaraugus,Allegany District 3,President,,Blanks,,2,1
+Cattaraugus,Allegany District 4,President,,Blanks,,1,1
 Cattaraugus,Allegany District 5,President,,Blanks,,0,0
 Cattaraugus,Ashford District 1,President,,Blanks,,1,0
 Cattaraugus,Ashford District 2,President,,Blanks,,4,0
 Cattaraugus,Carrollton,President,,Blanks,,1,0
-Cattaraugus,City of Olean - Ward 1,President,,Blanks,,4,0
+Cattaraugus,City of Olean - Ward 1,President,,Blanks,,5,1
 Cattaraugus,City of Olean - Ward 2,President,,Blanks,,0,0
-Cattaraugus,City of Olean - Ward 3,President,,Blanks,,0,1
-Cattaraugus,City of Olean - Ward 4,President,,Blanks,,2,0
+Cattaraugus,City of Olean - Ward 3,President,,Blanks,,0,0
+Cattaraugus,City of Olean - Ward 4,President,,Blanks,,3,1
 Cattaraugus,City of Olean - Ward 5,President,,Blanks,,1,0
-Cattaraugus,City of Olean - Ward 6,President,,Blanks,,2,0
+Cattaraugus,City of Olean - Ward 6,President,,Blanks,,4,2
 Cattaraugus,City of Olean - Ward 7,President,,Blanks,,2,0
 Cattaraugus,City of Salamanca - Ward 1,President,,Blanks,,0,0
-Cattaraugus,City of Salamanca - Ward 2,President,,Blanks,,4,0
-Cattaraugus,City of Salamanca - Ward 3,President,,Blanks,,0,0
-Cattaraugus,City of Salamanca - Ward 4,President,,Blanks,,4,0
-Cattaraugus,City of Salamanca - Ward 5,President,,Blanks,,1,1
+Cattaraugus,City of Salamanca - Ward 2,President,,Blanks,,8,4
+Cattaraugus,City of Salamanca - Ward 3,President,,Blanks,,2,2
+Cattaraugus,City of Salamanca - Ward 4,President,,Blanks,,5,1
+Cattaraugus,City of Salamanca - Ward 5,President,,Blanks,,10,9
 Cattaraugus,Coldspring,President,,Blanks,,1,0
-Cattaraugus,Conewango,President,,Blanks,,0,2
-Cattaraugus,Dayton,President,,Blanks,,2,0
-Cattaraugus,Early Voting - Little Valley 1,President,,Blanks,,7,
-Cattaraugus,Early Voting - Little Valley 2,President,,Blanks,,4,
-Cattaraugus,Early Voting - Olean 1,President,,Blanks,,8,
-Cattaraugus,Early Voting - Olean 2,President,,Blanks,,4,
+Cattaraugus,Conewango,President,,Blanks,,0,0
+Cattaraugus,Dayton,President,,Blanks,,3,1
+Cattaraugus,Early Voting - Little Valley 1,President,,Blanks,,7,0
+Cattaraugus,Early Voting - Little Valley 2,President,,Blanks,,4,0
+Cattaraugus,Early Voting - Olean 1,President,,Blanks,,8,0
+Cattaraugus,Early Voting - Olean 2,President,,Blanks,,4,0
 Cattaraugus,East Otto,President,,Blanks,,1,0
-Cattaraugus,Ellicottville,President,,Blanks,,2,1
+Cattaraugus,Ellicottville,President,,Blanks,,2,0
 Cattaraugus,Farmersville,President,,Blanks,,1,0
-Cattaraugus,Franklinville District 1,President,,Blanks,,3,1
-Cattaraugus,Franklinville District 2,President,,Blanks,,1,5
-Cattaraugus,Freedom,President,,Blanks,,5,1
-Cattaraugus,Great Valley 1,President,,Blanks,,0,1
-Cattaraugus,Great Valley 2,President,,Blanks,,3,1
-Cattaraugus,Hinsdale,President,,Blanks,,3,0
+Cattaraugus,Franklinville District 1,President,,Blanks,,3,0
+Cattaraugus,Franklinville District 2,President,,Blanks,,1,0
+Cattaraugus,Freedom,President,,Blanks,,5,0
+Cattaraugus,Great Valley 1,President,,Blanks,,0,0
+Cattaraugus,Great Valley 2,President,,Blanks,,3,0
+Cattaraugus,Hinsdale,President,,Blanks,,4,1
 Cattaraugus,Humphrey,President,,Blanks,,3,0
-Cattaraugus,Ischua,President,,Blanks,,1,1
+Cattaraugus,Ischua,President,,Blanks,,3,2
 Cattaraugus,Leon,President,,Blanks,,0,0
-Cattaraugus,Little Valley,President,,Blanks,,0,2
-Cattaraugus,Lyndon,President,,Blanks,,2,0
-Cattaraugus,Machias,President,,Blanks,,3,2
-Cattaraugus,Mansfield,President,,Blanks,,0,1
-Cattaraugus,Napoli,President,,Blanks,,3,3
-Cattaraugus,New Albion,President,,Blanks,,2,2
-Cattaraugus,Otto,President,,Blanks,,0,4
-Cattaraugus,Perrysburg,President,,Blanks,,1,0
-Cattaraugus,Persia,President,,Blanks,,4,0
-Cattaraugus,Portville 1,President,,Blanks,,3,0
-Cattaraugus,Portville 2,President,,Blanks,,2,0
-Cattaraugus,Randolph District 1,President,,Blanks,,1,4
-Cattaraugus,Randolph District 2,President,,Blanks,,0,2
-Cattaraugus,Red House,President,,Blanks,,1,1
-Cattaraugus,South Valley,President,,Blanks,,0,9
+Cattaraugus,Little Valley,President,,Blanks,,0,0
+Cattaraugus,Lyndon,President,,Blanks,,3,1
+Cattaraugus,Machias,President,,Blanks,,4,1
+Cattaraugus,Mansfield,President,,Blanks,,0,0
+Cattaraugus,Napoli,President,,Blanks,,4,1
+Cattaraugus,New Albion,President,,Blanks,,7,5
+Cattaraugus,Otto,President,,Blanks,,1,1
+Cattaraugus,Perrysburg,President,,Blanks,,3,2
+Cattaraugus,Persia,President,,Blanks,,6,2
+Cattaraugus,Portville 1,President,,Blanks,,4,1
+Cattaraugus,Portville 2,President,,Blanks,,5,3
+Cattaraugus,Randolph District 1,President,,Blanks,,5,4
+Cattaraugus,Randolph District 2,President,,Blanks,,0,0
+Cattaraugus,Red House,President,,Blanks,,1,0
+Cattaraugus,South Valley,President,,Blanks,,0,0
 Cattaraugus,Town of Olean 1,President,,Blanks,,0,0
-Cattaraugus,Town of Olean 2,President,,Blanks,,2,1
+Cattaraugus,Town of Olean 2,President,,Blanks,,3,1
 Cattaraugus,Town of Salamanca,President,,Blanks,,0,0
-Cattaraugus,Yorkshire 1,President,,Blanks,,2,4
+Cattaraugus,Yorkshire 1,President,,Blanks,,6,4
 Cattaraugus,Yorkshire 2,President,,Blanks,,5,0
-Cattaraugus,Allegany District 1,U.S. House,23,Tracy Mitrano,DEM,137,81
-Cattaraugus,Allegany District 2,U.S. House,23,Tracy Mitrano,DEM,50,69
-Cattaraugus,Allegany District 3,U.S. House,23,Tracy Mitrano,DEM,86,55
-Cattaraugus,Allegany District 4,U.S. House,23,Tracy Mitrano,DEM,85,41
-Cattaraugus,Allegany District 5,U.S. House,23,Tracy Mitrano,DEM,98,61
-Cattaraugus,Ashford District 1,U.S. House,23,Tracy Mitrano,DEM,64,20
-Cattaraugus,Ashford District 2,U.S. House,23,Tracy Mitrano,DEM,130,50
-Cattaraugus,Carrollton,U.S. House,23,Tracy Mitrano,DEM,90,9
-Cattaraugus,City of Olean - Ward 1,U.S. House,23,Tracy Mitrano,DEM,135,23
-Cattaraugus,City of Olean - Ward 2,U.S. House,23,Tracy Mitrano,DEM,114,28
-Cattaraugus,City of Olean - Ward 3,U.S. House,23,Tracy Mitrano,DEM,92,41
-Cattaraugus,City of Olean - Ward 4,U.S. House,23,Tracy Mitrano,DEM,76,64
-Cattaraugus,City of Olean - Ward 5,U.S. House,23,Tracy Mitrano,DEM,121,22
-Cattaraugus,City of Olean - Ward 6,U.S. House,23,Tracy Mitrano,DEM,124,24
-Cattaraugus,City of Olean - Ward 7,U.S. House,23,Tracy Mitrano,DEM,100,57
-Cattaraugus,City of Salamanca - Ward 1,U.S. House,23,Tracy Mitrano,DEM,60,40
-Cattaraugus,City of Salamanca - Ward 2,U.S. House,23,Tracy Mitrano,DEM,161,33
-Cattaraugus,City of Salamanca - Ward 3,U.S. House,23,Tracy Mitrano,DEM,79,24
-Cattaraugus,City of Salamanca - Ward 4,U.S. House,23,Tracy Mitrano,DEM,122,43
-Cattaraugus,City of Salamanca - Ward 5,U.S. House,23,Tracy Mitrano,DEM,78,45
-Cattaraugus,Coldspring,U.S. House,23,Tracy Mitrano,DEM,54,9
-Cattaraugus,Conewango,U.S. House,23,Tracy Mitrano,DEM,68,35
-Cattaraugus,Dayton,U.S. House,23,Tracy Mitrano,DEM,77,8
-Cattaraugus,Early Voting - Little Valley 1,U.S. House,23,Tracy Mitrano,DEM,532,
-Cattaraugus,Early Voting - Little Valley 2,U.S. House,23,Tracy Mitrano,DEM,408,
-Cattaraugus,Early Voting - Olean 1,U.S. House,23,Tracy Mitrano,DEM,1240,
-Cattaraugus,Early Voting - Olean 2,U.S. House,23,Tracy Mitrano,DEM,668,
-Cattaraugus,East Otto,U.S. House,23,Tracy Mitrano,DEM,64,37
-Cattaraugus,Ellicottville,U.S. House,23,Tracy Mitrano,DEM,147,15
-Cattaraugus,Farmersville,U.S. House,23,Tracy Mitrano,DEM,65,37
-Cattaraugus,Franklinville District 1,U.S. House,23,Tracy Mitrano,DEM,90,54
-Cattaraugus,Franklinville District 2,U.S. House,23,Tracy Mitrano,DEM,84,39
-Cattaraugus,Freedom,U.S. House,23,Tracy Mitrano,DEM,143,15
-Cattaraugus,Great Valley 1,U.S. House,23,Tracy Mitrano,DEM,93,25
-Cattaraugus,Great Valley 2,U.S. House,23,Tracy Mitrano,DEM,107,103
-Cattaraugus,Hinsdale,U.S. House,23,Tracy Mitrano,DEM,138,90
-Cattaraugus,Humphrey,U.S. House,23,Tracy Mitrano,DEM,53,73
-Cattaraugus,Ischua,U.S. House,23,Tracy Mitrano,DEM,59,78
-Cattaraugus,Leon,U.S. House,23,Tracy Mitrano,DEM,41,77
-Cattaraugus,Little Valley,U.S. House,23,Tracy Mitrano,DEM,61,78
-Cattaraugus,Lyndon,U.S. House,23,Tracy Mitrano,DEM,69,58
-Cattaraugus,Machias,U.S. House,23,Tracy Mitrano,DEM,126,80
-Cattaraugus,Mansfield,U.S. House,23,Tracy Mitrano,DEM,40,64
-Cattaraugus,Napoli,U.S. House,23,Tracy Mitrano,DEM,55,43
-Cattaraugus,New Albion,U.S. House,23,Tracy Mitrano,DEM,116,54
-Cattaraugus,Otto,U.S. House,23,Tracy Mitrano,DEM,64,40
-Cattaraugus,Perrysburg,U.S. House,23,Tracy Mitrano,DEM,169,27
-Cattaraugus,Persia,U.S. House,23,Tracy Mitrano,DEM,142,3
-Cattaraugus,Portville 1,U.S. House,23,Tracy Mitrano,DEM,115,6
-Cattaraugus,Portville 2,U.S. House,23,Tracy Mitrano,DEM,96,33
-Cattaraugus,Randolph District 1,U.S. House,23,Tracy Mitrano,DEM,73,57
-Cattaraugus,Randolph District 2,U.S. House,23,Tracy Mitrano,DEM,86,12
-Cattaraugus,Red House,U.S. House,23,Tracy Mitrano,DEM,2,38
-Cattaraugus,South Valley,U.S. House,23,Tracy Mitrano,DEM,41,46
-Cattaraugus,Town of Olean 1,U.S. House,23,Tracy Mitrano,DEM,51,22
-Cattaraugus,Town of Olean 2,U.S. House,23,Tracy Mitrano,DEM,61,64
-Cattaraugus,Town of Salamanca,U.S. House,23,Tracy Mitrano,DEM,80,26
-Cattaraugus,Yorkshire 1,U.S. House,23,Tracy Mitrano,DEM,121,31
-Cattaraugus,Yorkshire 2,U.S. House,23,Tracy Mitrano,DEM,109,61
-Cattaraugus,Allegany District 1,U.S. House,23,Tom Reed,REP,317,33
-Cattaraugus,Allegany District 2,U.S. House,23,Tom Reed,REP,126,20
-Cattaraugus,Allegany District 3,U.S. House,23,Tom Reed,REP,288,25
-Cattaraugus,Allegany District 4,U.S. House,23,Tom Reed,REP,365,35
-Cattaraugus,Allegany District 5,U.S. House,23,Tom Reed,REP,315,24
-Cattaraugus,Ashford District 1,U.S. House,23,Tom Reed,REP,182,17
-Cattaraugus,Ashford District 2,U.S. House,23,Tom Reed,REP,362,42
-Cattaraugus,Carrollton,U.S. House,23,Tom Reed,REP,358,14
-Cattaraugus,City of Olean - Ward 1,U.S. House,23,Tom Reed,REP,362,13
-Cattaraugus,City of Olean - Ward 2,U.S. House,23,Tom Reed,REP,334,22
-Cattaraugus,City of Olean - Ward 3,U.S. House,23,Tom Reed,REP,189,46
-Cattaraugus,City of Olean - Ward 4,U.S. House,23,Tom Reed,REP,134,55
-Cattaraugus,City of Olean - Ward 5,U.S. House,23,Tom Reed,REP,207,37
-Cattaraugus,City of Olean - Ward 6,U.S. House,23,Tom Reed,REP,211,29
-Cattaraugus,City of Olean - Ward 7,U.S. House,23,Tom Reed,REP,320,48
-Cattaraugus,City of Salamanca - Ward 1,U.S. House,23,Tom Reed,REP,113,38
-Cattaraugus,City of Salamanca - Ward 2,U.S. House,23,Tom Reed,REP,203,22
-Cattaraugus,City of Salamanca - Ward 3,U.S. House,23,Tom Reed,REP,112,15
-Cattaraugus,City of Salamanca - Ward 4,U.S. House,23,Tom Reed,REP,155,27
-Cattaraugus,City of Salamanca - Ward 5,U.S. House,23,Tom Reed,REP,177,42
-Cattaraugus,Coldspring,U.S. House,23,Tom Reed,REP,244,5
-Cattaraugus,Conewango,U.S. House,23,Tom Reed,REP,222,17
-Cattaraugus,Dayton,U.S. House,23,Tom Reed,REP,398,14
-Cattaraugus,Early Voting - Little Valley 1,U.S. House,23,Tom Reed,REP,481,
-Cattaraugus,Early Voting - Little Valley 2,U.S. House,23,Tom Reed,REP,543,
-Cattaraugus,Early Voting - Olean 1,U.S. House,23,Tom Reed,REP,1031,
-Cattaraugus,Early Voting - Olean 2,U.S. House,23,Tom Reed,REP,566,
-Cattaraugus,East Otto,U.S. House,23,Tom Reed,REP,266,51
-Cattaraugus,Ellicottville,U.S. House,23,Tom Reed,REP,295,9
-Cattaraugus,Farmersville,U.S. House,23,Tom Reed,REP,326,20
-Cattaraugus,Franklinville District 1,U.S. House,23,Tom Reed,REP,376,79
-Cattaraugus,Franklinville District 2,U.S. House,23,Tom Reed,REP,293,41
-Cattaraugus,Freedom,U.S. House,23,Tom Reed,REP,631,32
-Cattaraugus,Great Valley 1,U.S. House,23,Tom Reed,REP,175,12
-Cattaraugus,Great Valley 2,U.S. House,23,Tom Reed,REP,343,65
-Cattaraugus,Hinsdale,U.S. House,23,Tom Reed,REP,473,44
-Cattaraugus,Humphrey,U.S. House,23,Tom Reed,REP,180,28
-Cattaraugus,Ischua,U.S. House,23,Tom Reed,REP,215,28
-Cattaraugus,Leon,U.S. House,23,Tom Reed,REP,193,49
-Cattaraugus,Little Valley,U.S. House,23,Tom Reed,REP,291,55
-Cattaraugus,Lyndon,U.S. House,23,Tom Reed,REP,178,45
-Cattaraugus,Machias,U.S. House,23,Tom Reed,REP,528,55
-Cattaraugus,Mansfield,U.S. House,23,Tom Reed,REP,188,41
-Cattaraugus,Napoli,U.S. House,23,Tom Reed,REP,268,48
-Cattaraugus,New Albion,U.S. House,23,Tom Reed,REP,412,31
-Cattaraugus,Otto,U.S. House,23,Tom Reed,REP,199,33
-Cattaraugus,Perrysburg,U.S. House,23,Tom Reed,REP,410,35
-Cattaraugus,Persia,U.S. House,23,Tom Reed,REP,440,2
-Cattaraugus,Portville 1,U.S. House,23,Tom Reed,REP,463,5
-Cattaraugus,Portville 2,U.S. House,23,Tom Reed,REP,452,9
-Cattaraugus,Randolph District 1,U.S. House,23,Tom Reed,REP,289,41
-Cattaraugus,Randolph District 2,U.S. House,23,Tom Reed,REP,353,17
-Cattaraugus,Red House,U.S. House,23,Tom Reed,REP,16,17
-Cattaraugus,South Valley,U.S. House,23,Tom Reed,REP,66,38
-Cattaraugus,Town of Olean 1,U.S. House,23,Tom Reed,REP,163,15
-Cattaraugus,Town of Olean 2,U.S. House,23,Tom Reed,REP,272,41
-Cattaraugus,Town of Salamanca,U.S. House,23,Tom Reed,REP,141,8
-Cattaraugus,Yorkshire 1,U.S. House,23,Tom Reed,REP,402,43
-Cattaraugus,Yorkshire 2,U.S. House,23,Tom Reed,REP,420,34
-Cattaraugus,Allegany District 1,U.S. House,23,Tom Reed,CON,20,7
-Cattaraugus,Allegany District 2,U.S. House,23,Tom Reed,CON,7,2
-Cattaraugus,Allegany District 3,U.S. House,23,Tom Reed,CON,19,3
-Cattaraugus,Allegany District 4,U.S. House,23,Tom Reed,CON,32,2
-Cattaraugus,Allegany District 5,U.S. House,23,Tom Reed,CON,24,2
-Cattaraugus,Ashford District 1,U.S. House,23,Tom Reed,CON,23,3
-Cattaraugus,Ashford District 2,U.S. House,23,Tom Reed,CON,49,6
-Cattaraugus,Carrollton,U.S. House,23,Tom Reed,CON,24,1
-Cattaraugus,City of Olean - Ward 1,U.S. House,23,Tom Reed,CON,22,7
-Cattaraugus,City of Olean - Ward 2,U.S. House,23,Tom Reed,CON,28,1
-Cattaraugus,City of Olean - Ward 3,U.S. House,23,Tom Reed,CON,25,4
-Cattaraugus,City of Olean - Ward 4,U.S. House,23,Tom Reed,CON,20,3
-Cattaraugus,City of Olean - Ward 5,U.S. House,23,Tom Reed,CON,20,3
-Cattaraugus,City of Olean - Ward 6,U.S. House,23,Tom Reed,CON,21,5
-Cattaraugus,City of Olean - Ward 7,U.S. House,23,Tom Reed,CON,39,8
-Cattaraugus,City of Salamanca - Ward 1,U.S. House,23,Tom Reed,CON,8,2
-Cattaraugus,City of Salamanca - Ward 2,U.S. House,23,Tom Reed,CON,30,2
-Cattaraugus,City of Salamanca - Ward 3,U.S. House,23,Tom Reed,CON,13,0
-Cattaraugus,City of Salamanca - Ward 4,U.S. House,23,Tom Reed,CON,15,2
-Cattaraugus,City of Salamanca - Ward 5,U.S. House,23,Tom Reed,CON,14,4
-Cattaraugus,Coldspring,U.S. House,23,Tom Reed,CON,27,2
-Cattaraugus,Conewango,U.S. House,23,Tom Reed,CON,23,2
-Cattaraugus,Dayton,U.S. House,23,Tom Reed,CON,37,0
-Cattaraugus,Early Voting - Little Valley 1,U.S. House,23,Tom Reed,CON,49,
-Cattaraugus,Early Voting - Little Valley 2,U.S. House,23,Tom Reed,CON,61,
-Cattaraugus,Early Voting - Olean 1,U.S. House,23,Tom Reed,CON,71,
-Cattaraugus,Early Voting - Olean 2,U.S. House,23,Tom Reed,CON,43,
-Cattaraugus,East Otto,U.S. House,23,Tom Reed,CON,35,1
-Cattaraugus,Ellicottville,U.S. House,23,Tom Reed,CON,23,1
-Cattaraugus,Farmersville,U.S. House,23,Tom Reed,CON,28,0
-Cattaraugus,Franklinville District 1,U.S. House,23,Tom Reed,CON,38,6
-Cattaraugus,Franklinville District 2,U.S. House,23,Tom Reed,CON,20,8
-Cattaraugus,Freedom,U.S. House,23,Tom Reed,CON,66,5
-Cattaraugus,Great Valley 1,U.S. House,23,Tom Reed,CON,23,1
-Cattaraugus,Great Valley 2,U.S. House,23,Tom Reed,CON,30,5
-Cattaraugus,Hinsdale,U.S. House,23,Tom Reed,CON,63,0
-Cattaraugus,Humphrey,U.S. House,23,Tom Reed,CON,25,6
-Cattaraugus,Ischua,U.S. House,23,Tom Reed,CON,17,2
-Cattaraugus,Leon,U.S. House,23,Tom Reed,CON,28,6
-Cattaraugus,Little Valley,U.S. House,23,Tom Reed,CON,28,8
-Cattaraugus,Lyndon,U.S. House,23,Tom Reed,CON,18,7
-Cattaraugus,Machias,U.S. House,23,Tom Reed,CON,58,9
-Cattaraugus,Mansfield,U.S. House,23,Tom Reed,CON,9,2
-Cattaraugus,Napoli,U.S. House,23,Tom Reed,CON,36,5
-Cattaraugus,New Albion,U.S. House,23,Tom Reed,CON,50,5
-Cattaraugus,Otto,U.S. House,23,Tom Reed,CON,31,8
-Cattaraugus,Perrysburg,U.S. House,23,Tom Reed,CON,63,5
-Cattaraugus,Persia,U.S. House,23,Tom Reed,CON,68,0
-Cattaraugus,Portville 1,U.S. House,23,Tom Reed,CON,34,0
-Cattaraugus,Portville 2,U.S. House,23,Tom Reed,CON,50,1
-Cattaraugus,Randolph District 1,U.S. House,23,Tom Reed,CON,37,2
-Cattaraugus,Randolph District 2,U.S. House,23,Tom Reed,CON,19,2
-Cattaraugus,Red House,U.S. House,23,Tom Reed,CON,2,1
-Cattaraugus,South Valley,U.S. House,23,Tom Reed,CON,10,5
+Cattaraugus,Allegany District 1,U.S. House,23,Tracy Mitrano,DEM,218,81
+Cattaraugus,Allegany District 2,U.S. House,23,Tracy Mitrano,DEM,119,69
+Cattaraugus,Allegany District 3,U.S. House,23,Tracy Mitrano,DEM,141,55
+Cattaraugus,Allegany District 4,U.S. House,23,Tracy Mitrano,DEM,126,41
+Cattaraugus,Allegany District 5,U.S. House,23,Tracy Mitrano,DEM,159,61
+Cattaraugus,Ashford District 1,U.S. House,23,Tracy Mitrano,DEM,84,20
+Cattaraugus,Ashford District 2,U.S. House,23,Tracy Mitrano,DEM,180,50
+Cattaraugus,Carrollton,U.S. House,23,Tracy Mitrano,DEM,118,28
+Cattaraugus,City of Olean - Ward 1,U.S. House,23,Tracy Mitrano,DEM,238,103
+Cattaraugus,City of Olean - Ward 2,U.S. House,23,Tracy Mitrano,DEM,204,90
+Cattaraugus,City of Olean - Ward 3,U.S. House,23,Tracy Mitrano,DEM,165,73
+Cattaraugus,City of Olean - Ward 4,U.S. House,23,Tracy Mitrano,DEM,154,78
+Cattaraugus,City of Olean - Ward 5,U.S. House,23,Tracy Mitrano,DEM,198,77
+Cattaraugus,City of Olean - Ward 6,U.S. House,23,Tracy Mitrano,DEM,202,78
+Cattaraugus,City of Olean - Ward 7,U.S. House,23,Tracy Mitrano,DEM,158,58
+Cattaraugus,City of Salamanca - Ward 1,U.S. House,23,Tracy Mitrano,DEM,93,33
+Cattaraugus,City of Salamanca - Ward 2,U.S. House,23,Tracy Mitrano,DEM,218,57
+Cattaraugus,City of Salamanca - Ward 3,U.S. House,23,Tracy Mitrano,DEM,91,12
+Cattaraugus,City of Salamanca - Ward 4,U.S. House,23,Tracy Mitrano,DEM,160,38
+Cattaraugus,City of Salamanca - Ward 5,U.S. House,23,Tracy Mitrano,DEM,124,46
+Cattaraugus,Coldspring,U.S. House,23,Tracy Mitrano,DEM,63,9
+Cattaraugus,Conewango,U.S. House,23,Tracy Mitrano,DEM,91,23
+Cattaraugus,Dayton,U.S. House,23,Tracy Mitrano,DEM,118,41
+Cattaraugus,Early Voting - Little Valley 1,U.S. House,23,Tracy Mitrano,DEM,532,0
+Cattaraugus,Early Voting - Little Valley 2,U.S. House,23,Tracy Mitrano,DEM,408,0
+Cattaraugus,Early Voting - Olean 1,U.S. House,23,Tracy Mitrano,DEM,1240,0
+Cattaraugus,Early Voting - Olean 2,U.S. House,23,Tracy Mitrano,DEM,668,0
+Cattaraugus,East Otto,U.S. House,23,Tracy Mitrano,DEM,86,22
+Cattaraugus,Ellicottville,U.S. House,23,Tracy Mitrano,DEM,211,64
+Cattaraugus,Farmersville,U.S. House,23,Tracy Mitrano,DEM,89,24
+Cattaraugus,Franklinville District 1,U.S. House,23,Tracy Mitrano,DEM,130,40
+Cattaraugus,Franklinville District 2,U.S. House,23,Tracy Mitrano,DEM,117,33
+Cattaraugus,Freedom,U.S. House,23,Tracy Mitrano,DEM,200,57
+Cattaraugus,Great Valley 1,U.S. House,23,Tracy Mitrano,DEM,117,24
+Cattaraugus,Great Valley 2,U.S. House,23,Tracy Mitrano,DEM,150,43
+Cattaraugus,Hinsdale,U.S. House,23,Tracy Mitrano,DEM,183,45
+Cattaraugus,Humphrey,U.S. House,23,Tracy Mitrano,DEM,62,9
+Cattaraugus,Ischua,U.S. House,23,Tracy Mitrano,DEM,94,35
+Cattaraugus,Leon,U.S. House,23,Tracy Mitrano,DEM,49,8
+Cattaraugus,Little Valley,U.S. House,23,Tracy Mitrano,DEM,98,37
+Cattaraugus,Lyndon,U.S. House,23,Tracy Mitrano,DEM,84,15
+Cattaraugus,Machias,U.S. House,23,Tracy Mitrano,DEM,180,54
+Cattaraugus,Mansfield,U.S. House,23,Tracy Mitrano,DEM,77,37
+Cattaraugus,Napoli,U.S. House,23,Tracy Mitrano,DEM,70,15
+Cattaraugus,New Albion,U.S. House,23,Tracy Mitrano,DEM,155,39
+Cattaraugus,Otto,U.S. House,23,Tracy Mitrano,DEM,89,25
+Cattaraugus,Perrysburg,U.S. House,23,Tracy Mitrano,DEM,223,54
+Cattaraugus,Persia,U.S. House,23,Tracy Mitrano,DEM,222,80
+Cattaraugus,Portville 1,U.S. House,23,Tracy Mitrano,DEM,179,64
+Cattaraugus,Portville 2,U.S. House,23,Tracy Mitrano,DEM,139,43
+Cattaraugus,Randolph District 1,U.S. House,23,Tracy Mitrano,DEM,113,40
+Cattaraugus,Randolph District 2,U.S. House,23,Tracy Mitrano,DEM,113,27
+Cattaraugus,Red House,U.S. House,23,Tracy Mitrano,DEM,5,3
+Cattaraugus,South Valley,U.S. House,23,Tracy Mitrano,DEM,47,6
+Cattaraugus,Town of Olean 1,U.S. House,23,Tracy Mitrano,DEM,73,22
+Cattaraugus,Town of Olean 2,U.S. House,23,Tracy Mitrano,DEM,125,64
+Cattaraugus,Town of Salamanca,U.S. House,23,Tracy Mitrano,DEM,106,26
+Cattaraugus,Yorkshire 1,U.S. House,23,Tracy Mitrano,DEM,152,31
+Cattaraugus,Yorkshire 2,U.S. House,23,Tracy Mitrano,DEM,170,61
+Cattaraugus,Allegany District 1,U.S. House,23,Tom Reed,REP,350,33
+Cattaraugus,Allegany District 2,U.S. House,23,Tom Reed,REP,146,20
+Cattaraugus,Allegany District 3,U.S. House,23,Tom Reed,REP,313,25
+Cattaraugus,Allegany District 4,U.S. House,23,Tom Reed,REP,400,35
+Cattaraugus,Allegany District 5,U.S. House,23,Tom Reed,REP,339,24
+Cattaraugus,Ashford District 1,U.S. House,23,Tom Reed,REP,199,17
+Cattaraugus,Ashford District 2,U.S. House,23,Tom Reed,REP,404,42
+Cattaraugus,Carrollton,U.S. House,23,Tom Reed,REP,380,22
+Cattaraugus,City of Olean - Ward 1,U.S. House,23,Tom Reed,REP,427,65
+Cattaraugus,City of Olean - Ward 2,U.S. House,23,Tom Reed,REP,378,44
+Cattaraugus,City of Olean - Ward 3,U.S. House,23,Tom Reed,REP,217,28
+Cattaraugus,City of Olean - Ward 4,U.S. House,23,Tom Reed,REP,162,28
+Cattaraugus,City of Olean - Ward 5,U.S. House,23,Tom Reed,REP,256,49
+Cattaraugus,City of Olean - Ward 6,U.S. House,23,Tom Reed,REP,266,55
+Cattaraugus,City of Olean - Ward 7,U.S. House,23,Tom Reed,REP,365,45
+Cattaraugus,City of Salamanca - Ward 1,U.S. House,23,Tom Reed,REP,122,9
+Cattaraugus,City of Salamanca - Ward 2,U.S. House,23,Tom Reed,REP,244,41
+Cattaraugus,City of Salamanca - Ward 3,U.S. House,23,Tom Reed,REP,129,17
+Cattaraugus,City of Salamanca - Ward 4,U.S. House,23,Tom Reed,REP,172,17
+Cattaraugus,City of Salamanca - Ward 5,U.S. House,23,Tom Reed,REP,215,38
+Cattaraugus,Coldspring,U.S. House,23,Tom Reed,REP,258,14
+Cattaraugus,Conewango,U.S. House,23,Tom Reed,REP,235,13
+Cattaraugus,Dayton,U.S. House,23,Tom Reed,REP,444,46
+Cattaraugus,Early Voting - Little Valley 1,U.S. House,23,Tom Reed,REP,481,0
+Cattaraugus,Early Voting - Little Valley 2,U.S. House,23,Tom Reed,REP,543,0
+Cattaraugus,Early Voting - Olean 1,U.S. House,23,Tom Reed,REP,1031,0
+Cattaraugus,Early Voting - Olean 2,U.S. House,23,Tom Reed,REP,566,0
+Cattaraugus,East Otto,U.S. House,23,Tom Reed,REP,303,37
+Cattaraugus,Ellicottville,U.S. House,23,Tom Reed,REP,350,55
+Cattaraugus,Farmersville,U.S. House,23,Tom Reed,REP,355,29
+Cattaraugus,Franklinville District 1,U.S. House,23,Tom Reed,REP,414,38
+Cattaraugus,Franklinville District 2,U.S. House,23,Tom Reed,REP,315,22
+Cattaraugus,Freedom,U.S. House,23,Tom Reed,REP,679,48
+Cattaraugus,Great Valley 1,U.S. House,23,Tom Reed,REP,190,15
+Cattaraugus,Great Valley 2,U.S. House,23,Tom Reed,REP,370,27
+Cattaraugus,Hinsdale,U.S. House,23,Tom Reed,REP,515,42
+Cattaraugus,Humphrey,U.S. House,23,Tom Reed,REP,185,5
+Cattaraugus,Ischua,U.S. House,23,Tom Reed,REP,232,17
+Cattaraugus,Leon,U.S. House,23,Tom Reed,REP,207,14
+Cattaraugus,Little Valley,U.S. House,23,Tom Reed,REP,342,51
+Cattaraugus,Lyndon,U.S. House,23,Tom Reed,REP,187,9
+Cattaraugus,Machias,U.S. House,23,Tom Reed,REP,607,79
+Cattaraugus,Mansfield,U.S. House,23,Tom Reed,REP,208,20
+Cattaraugus,Napoli,U.S. House,23,Tom Reed,REP,300,32
+Cattaraugus,New Albion,U.S. House,23,Tom Reed,REP,453,41
+Cattaraugus,Otto,U.S. House,23,Tom Reed,REP,211,12
+Cattaraugus,Perrysburg,U.S. House,23,Tom Reed,REP,441,31
+Cattaraugus,Persia,U.S. House,23,Tom Reed,REP,495,55
+Cattaraugus,Portville 1,U.S. House,23,Tom Reed,REP,504,41
+Cattaraugus,Portville 2,U.S. House,23,Tom Reed,REP,500,48
+Cattaraugus,Randolph District 1,U.S. House,23,Tom Reed,REP,322,33
+Cattaraugus,Randolph District 2,U.S. House,23,Tom Reed,REP,388,35
+Cattaraugus,Red House,U.S. House,23,Tom Reed,REP,18,2
+Cattaraugus,South Valley,U.S. House,23,Tom Reed,REP,71,5
+Cattaraugus,Town of Olean 1,U.S. House,23,Tom Reed,REP,178,15
+Cattaraugus,Town of Olean 2,U.S. House,23,Tom Reed,REP,313,41
+Cattaraugus,Town of Salamanca,U.S. House,23,Tom Reed,REP,149,8
+Cattaraugus,Yorkshire 1,U.S. House,23,Tom Reed,REP,445,43
+Cattaraugus,Yorkshire 2,U.S. House,23,Tom Reed,REP,454,34
+Cattaraugus,Allegany District 1,U.S. House,23,Tom Reed,CON,27,7
+Cattaraugus,Allegany District 2,U.S. House,23,Tom Reed,CON,9,2
+Cattaraugus,Allegany District 3,U.S. House,23,Tom Reed,CON,22,3
+Cattaraugus,Allegany District 4,U.S. House,23,Tom Reed,CON,34,2
+Cattaraugus,Allegany District 5,U.S. House,23,Tom Reed,CON,26,2
+Cattaraugus,Ashford District 1,U.S. House,23,Tom Reed,CON,26,3
+Cattaraugus,Ashford District 2,U.S. House,23,Tom Reed,CON,55,6
+Cattaraugus,Carrollton,U.S. House,23,Tom Reed,CON,25,1
+Cattaraugus,City of Olean - Ward 1,U.S. House,23,Tom Reed,CON,27,5
+Cattaraugus,City of Olean - Ward 2,U.S. House,23,Tom Reed,CON,28,0
+Cattaraugus,City of Olean - Ward 3,U.S. House,23,Tom Reed,CON,31,6
+Cattaraugus,City of Olean - Ward 4,U.S. House,23,Tom Reed,CON,22,2
+Cattaraugus,City of Olean - Ward 5,U.S. House,23,Tom Reed,CON,26,6
+Cattaraugus,City of Olean - Ward 6,U.S. House,23,Tom Reed,CON,29,8
+Cattaraugus,City of Olean - Ward 7,U.S. House,23,Tom Reed,CON,46,7
+Cattaraugus,City of Salamanca - Ward 1,U.S. House,23,Tom Reed,CON,9,1
+Cattaraugus,City of Salamanca - Ward 2,U.S. House,23,Tom Reed,CON,32,2
+Cattaraugus,City of Salamanca - Ward 3,U.S. House,23,Tom Reed,CON,15,2
+Cattaraugus,City of Salamanca - Ward 4,U.S. House,23,Tom Reed,CON,16,1
+Cattaraugus,City of Salamanca - Ward 5,U.S. House,23,Tom Reed,CON,19,5
+Cattaraugus,Coldspring,U.S. House,23,Tom Reed,CON,28,1
+Cattaraugus,Conewango,U.S. House,23,Tom Reed,CON,30,7
+Cattaraugus,Dayton,U.S. House,23,Tom Reed,CON,41,4
+Cattaraugus,Early Voting - Little Valley 1,U.S. House,23,Tom Reed,CON,49,0
+Cattaraugus,Early Voting - Little Valley 2,U.S. House,23,Tom Reed,CON,61,0
+Cattaraugus,Early Voting - Olean 1,U.S. House,23,Tom Reed,CON,71,0
+Cattaraugus,Early Voting - Olean 2,U.S. House,23,Tom Reed,CON,43,0
+Cattaraugus,East Otto,U.S. House,23,Tom Reed,CON,38,3
+Cattaraugus,Ellicottville,U.S. House,23,Tom Reed,CON,26,3
+Cattaraugus,Farmersville,U.S. House,23,Tom Reed,CON,33,5
+Cattaraugus,Franklinville District 1,U.S. House,23,Tom Reed,CON,40,2
+Cattaraugus,Franklinville District 2,U.S. House,23,Tom Reed,CON,22,2
+Cattaraugus,Freedom,U.S. House,23,Tom Reed,CON,74,8
+Cattaraugus,Great Valley 1,U.S. House,23,Tom Reed,CON,23,0
+Cattaraugus,Great Valley 2,U.S. House,23,Tom Reed,CON,32,2
+Cattaraugus,Hinsdale,U.S. House,23,Tom Reed,CON,67,4
+Cattaraugus,Humphrey,U.S. House,23,Tom Reed,CON,27,2
+Cattaraugus,Ischua,U.S. House,23,Tom Reed,CON,19,2
+Cattaraugus,Leon,U.S. House,23,Tom Reed,CON,28,0
+Cattaraugus,Little Valley,U.S. House,23,Tom Reed,CON,29,1
+Cattaraugus,Lyndon,U.S. House,23,Tom Reed,CON,19,1
+Cattaraugus,Machias,U.S. House,23,Tom Reed,CON,64,6
+Cattaraugus,Mansfield,U.S. House,23,Tom Reed,CON,9,0
+Cattaraugus,Napoli,U.S. House,23,Tom Reed,CON,41,5
+Cattaraugus,New Albion,U.S. House,23,Tom Reed,CON,58,8
+Cattaraugus,Otto,U.S. House,23,Tom Reed,CON,32,1
+Cattaraugus,Perrysburg,U.S. House,23,Tom Reed,CON,68,5
+Cattaraugus,Persia,U.S. House,23,Tom Reed,CON,77,9
+Cattaraugus,Portville 1,U.S. House,23,Tom Reed,CON,36,2
+Cattaraugus,Portville 2,U.S. House,23,Tom Reed,CON,55,5
+Cattaraugus,Randolph District 1,U.S. House,23,Tom Reed,CON,45,8
+Cattaraugus,Randolph District 2,U.S. House,23,Tom Reed,CON,24,5
+Cattaraugus,Red House,U.S. House,23,Tom Reed,CON,2,0
+Cattaraugus,South Valley,U.S. House,23,Tom Reed,CON,10,0
 Cattaraugus,Town of Olean 1,U.S. House,23,Tom Reed,CON,12,0
-Cattaraugus,Town of Olean 2,U.S. House,23,Tom Reed,CON,14,5
-Cattaraugus,Town of Salamanca,U.S. House,23,Tom Reed,CON,20,1
-Cattaraugus,Yorkshire 1,U.S. House,23,Tom Reed,CON,67,8
-Cattaraugus,Yorkshire 2,U.S. House,23,Tom Reed,CON,49,4
-Cattaraugus,Allegany District 1,U.S. House,23,Tracy Mitrano,WOR,7,6
-Cattaraugus,Allegany District 2,U.S. House,23,Tracy Mitrano,WOR,4,4
-Cattaraugus,Allegany District 3,U.S. House,23,Tracy Mitrano,WOR,6,5
-Cattaraugus,Allegany District 4,U.S. House,23,Tracy Mitrano,WOR,13,4
-Cattaraugus,Allegany District 5,U.S. House,23,Tracy Mitrano,WOR,17,1
-Cattaraugus,Ashford District 1,U.S. House,23,Tracy Mitrano,WOR,7,6
-Cattaraugus,Ashford District 2,U.S. House,23,Tracy Mitrano,WOR,18,3
-Cattaraugus,Carrollton,U.S. House,23,Tracy Mitrano,WOR,12,1
-Cattaraugus,City of Olean - Ward 1,U.S. House,23,Tracy Mitrano,WOR,13,4
+Cattaraugus,Town of Olean 2,U.S. House,23,Tom Reed,CON,19,5
+Cattaraugus,Town of Salamanca,U.S. House,23,Tom Reed,CON,21,1
+Cattaraugus,Yorkshire 1,U.S. House,23,Tom Reed,CON,75,8
+Cattaraugus,Yorkshire 2,U.S. House,23,Tom Reed,CON,53,4
+Cattaraugus,Allegany District 1,U.S. House,23,Tracy Mitrano,WOR,13,6
+Cattaraugus,Allegany District 2,U.S. House,23,Tracy Mitrano,WOR,8,4
+Cattaraugus,Allegany District 3,U.S. House,23,Tracy Mitrano,WOR,11,5
+Cattaraugus,Allegany District 4,U.S. House,23,Tracy Mitrano,WOR,17,4
+Cattaraugus,Allegany District 5,U.S. House,23,Tracy Mitrano,WOR,18,1
+Cattaraugus,Ashford District 1,U.S. House,23,Tracy Mitrano,WOR,13,6
+Cattaraugus,Ashford District 2,U.S. House,23,Tracy Mitrano,WOR,21,3
+Cattaraugus,Carrollton,U.S. House,23,Tracy Mitrano,WOR,12,0
+Cattaraugus,City of Olean - Ward 1,U.S. House,23,Tracy Mitrano,WOR,18,5
 Cattaraugus,City of Olean - Ward 2,U.S. House,23,Tracy Mitrano,WOR,13,0
-Cattaraugus,City of Olean - Ward 3,U.S. House,23,Tracy Mitrano,WOR,14,3
-Cattaraugus,City of Olean - Ward 4,U.S. House,23,Tracy Mitrano,WOR,5,5
-Cattaraugus,City of Olean - Ward 5,U.S. House,23,Tracy Mitrano,WOR,14,2
-Cattaraugus,City of Olean - Ward 6,U.S. House,23,Tracy Mitrano,WOR,12,8
-Cattaraugus,City of Olean - Ward 7,U.S. House,23,Tracy Mitrano,WOR,11,4
-Cattaraugus,City of Salamanca - Ward 1,U.S. House,23,Tracy Mitrano,WOR,9,2
-Cattaraugus,City of Salamanca - Ward 2,U.S. House,23,Tracy Mitrano,WOR,9,2
-Cattaraugus,City of Salamanca - Ward 3,U.S. House,23,Tracy Mitrano,WOR,6,1
-Cattaraugus,City of Salamanca - Ward 4,U.S. House,23,Tracy Mitrano,WOR,11,7
-Cattaraugus,City of Salamanca - Ward 5,U.S. House,23,Tracy Mitrano,WOR,13,2
-Cattaraugus,Coldspring,U.S. House,23,Tracy Mitrano,WOR,6,3
-Cattaraugus,Conewango,U.S. House,23,Tracy Mitrano,WOR,12,0
-Cattaraugus,Dayton,U.S. House,23,Tracy Mitrano,WOR,7,0
-Cattaraugus,Early Voting - Little Valley 1,U.S. House,23,Tracy Mitrano,WOR,42,
-Cattaraugus,Early Voting - Little Valley 2,U.S. House,23,Tracy Mitrano,WOR,37,
-Cattaraugus,Early Voting - Olean 1,U.S. House,23,Tracy Mitrano,WOR,79,
-Cattaraugus,Early Voting - Olean 2,U.S. House,23,Tracy Mitrano,WOR,48,
-Cattaraugus,East Otto,U.S. House,23,Tracy Mitrano,WOR,10,4
-Cattaraugus,Ellicottville,U.S. House,23,Tracy Mitrano,WOR,11,1
-Cattaraugus,Farmersville,U.S. House,23,Tracy Mitrano,WOR,2,3
-Cattaraugus,Franklinville District 1,U.S. House,23,Tracy Mitrano,WOR,19,3
-Cattaraugus,Franklinville District 2,U.S. House,23,Tracy Mitrano,WOR,14,2
-Cattaraugus,Freedom,U.S. House,23,Tracy Mitrano,WOR,19,2
-Cattaraugus,Great Valley 1,U.S. House,23,Tracy Mitrano,WOR,7,5
-Cattaraugus,Great Valley 2,U.S. House,23,Tracy Mitrano,WOR,13,5
-Cattaraugus,Hinsdale,U.S. House,23,Tracy Mitrano,WOR,16,0
-Cattaraugus,Humphrey,U.S. House,23,Tracy Mitrano,WOR,11,8
-Cattaraugus,Ischua,U.S. House,23,Tracy Mitrano,WOR,7,6
-Cattaraugus,Leon,U.S. House,23,Tracy Mitrano,WOR,7,2
-Cattaraugus,Little Valley,U.S. House,23,Tracy Mitrano,WOR,13,8
-Cattaraugus,Lyndon,U.S. House,23,Tracy Mitrano,WOR,7,2
-Cattaraugus,Machias,U.S. House,23,Tracy Mitrano,WOR,21,4
-Cattaraugus,Mansfield,U.S. House,23,Tracy Mitrano,WOR,7,3
-Cattaraugus,Napoli,U.S. House,23,Tracy Mitrano,WOR,7,0
-Cattaraugus,New Albion,U.S. House,23,Tracy Mitrano,WOR,21,3
-Cattaraugus,Otto,U.S. House,23,Tracy Mitrano,WOR,4,1
-Cattaraugus,Perrysburg,U.S. House,23,Tracy Mitrano,WOR,28,2
-Cattaraugus,Persia,U.S. House,23,Tracy Mitrano,WOR,22,0
-Cattaraugus,Portville 1,U.S. House,23,Tracy Mitrano,WOR,12,0
+Cattaraugus,City of Olean - Ward 3,U.S. House,23,Tracy Mitrano,WOR,22,8
+Cattaraugus,City of Olean - Ward 4,U.S. House,23,Tracy Mitrano,WOR,11,6
+Cattaraugus,City of Olean - Ward 5,U.S. House,23,Tracy Mitrano,WOR,16,2
+Cattaraugus,City of Olean - Ward 6,U.S. House,23,Tracy Mitrano,WOR,20,8
+Cattaraugus,City of Olean - Ward 7,U.S. House,23,Tracy Mitrano,WOR,13,2
+Cattaraugus,City of Salamanca - Ward 1,U.S. House,23,Tracy Mitrano,WOR,9,0
+Cattaraugus,City of Salamanca - Ward 2,U.S. House,23,Tracy Mitrano,WOR,11,2
+Cattaraugus,City of Salamanca - Ward 3,U.S. House,23,Tracy Mitrano,WOR,6,0
+Cattaraugus,City of Salamanca - Ward 4,U.S. House,23,Tracy Mitrano,WOR,11,0
+Cattaraugus,City of Salamanca - Ward 5,U.S. House,23,Tracy Mitrano,WOR,16,3
+Cattaraugus,Coldspring,U.S. House,23,Tracy Mitrano,WOR,7,1
+Cattaraugus,Conewango,U.S. House,23,Tracy Mitrano,WOR,16,4
+Cattaraugus,Dayton,U.S. House,23,Tracy Mitrano,WOR,10,3
+Cattaraugus,Early Voting - Little Valley 1,U.S. House,23,Tracy Mitrano,WOR,42,0
+Cattaraugus,Early Voting - Little Valley 2,U.S. House,23,Tracy Mitrano,WOR,37,0
+Cattaraugus,Early Voting - Olean 1,U.S. House,23,Tracy Mitrano,WOR,79,0
+Cattaraugus,Early Voting - Olean 2,U.S. House,23,Tracy Mitrano,WOR,48,0
+Cattaraugus,East Otto,U.S. House,23,Tracy Mitrano,WOR,12,2
+Cattaraugus,Ellicottville,U.S. House,23,Tracy Mitrano,WOR,16,5
+Cattaraugus,Farmersville,U.S. House,23,Tracy Mitrano,WOR,10,8
+Cattaraugus,Franklinville District 1,U.S. House,23,Tracy Mitrano,WOR,21,2
+Cattaraugus,Franklinville District 2,U.S. House,23,Tracy Mitrano,WOR,16,2
+Cattaraugus,Freedom,U.S. House,23,Tracy Mitrano,WOR,23,4
+Cattaraugus,Great Valley 1,U.S. House,23,Tracy Mitrano,WOR,8,1
+Cattaraugus,Great Valley 2,U.S. House,23,Tracy Mitrano,WOR,20,7
+Cattaraugus,Hinsdale,U.S. House,23,Tracy Mitrano,WOR,18,2
+Cattaraugus,Humphrey,U.S. House,23,Tracy Mitrano,WOR,14,3
+Cattaraugus,Ischua,U.S. House,23,Tracy Mitrano,WOR,7,0
+Cattaraugus,Leon,U.S. House,23,Tracy Mitrano,WOR,7,0
+Cattaraugus,Little Valley,U.S. House,23,Tracy Mitrano,WOR,17,4
+Cattaraugus,Lyndon,U.S. House,23,Tracy Mitrano,WOR,8,1
+Cattaraugus,Machias,U.S. House,23,Tracy Mitrano,WOR,24,3
+Cattaraugus,Mansfield,U.S. House,23,Tracy Mitrano,WOR,10,3
+Cattaraugus,Napoli,U.S. House,23,Tracy Mitrano,WOR,9,2
+Cattaraugus,New Albion,U.S. House,23,Tracy Mitrano,WOR,23,2
+Cattaraugus,Otto,U.S. House,23,Tracy Mitrano,WOR,9,5
+Cattaraugus,Perrysburg,U.S. House,23,Tracy Mitrano,WOR,31,3
+Cattaraugus,Persia,U.S. House,23,Tracy Mitrano,WOR,26,4
+Cattaraugus,Portville 1,U.S. House,23,Tracy Mitrano,WOR,15,3
 Cattaraugus,Portville 2,U.S. House,23,Tracy Mitrano,WOR,6,0
-Cattaraugus,Randolph District 1,U.S. House,23,Tracy Mitrano,WOR,12,2
-Cattaraugus,Randolph District 2,U.S. House,23,Tracy Mitrano,WOR,17,0
+Cattaraugus,Randolph District 1,U.S. House,23,Tracy Mitrano,WOR,13,1
+Cattaraugus,Randolph District 2,U.S. House,23,Tracy Mitrano,WOR,19,2
 Cattaraugus,Red House,U.S. House,23,Tracy Mitrano,WOR,0,0
-Cattaraugus,South Valley,U.S. House,23,Tracy Mitrano,WOR,5,3
-Cattaraugus,Town of Olean 1,U.S. House,23,Tracy Mitrano,WOR,6,1
-Cattaraugus,Town of Olean 2,U.S. House,23,Tracy Mitrano,WOR,2,5
-Cattaraugus,Town of Salamanca,U.S. House,23,Tracy Mitrano,WOR,7,5
-Cattaraugus,Yorkshire 1,U.S. House,23,Tracy Mitrano,WOR,13,4
-Cattaraugus,Yorkshire 2,U.S. House,23,Tracy Mitrano,WOR,27,4
-Cattaraugus,Allegany District 1,U.S. House,23,Andrew M. Kolstee,LIB,9,1
+Cattaraugus,South Valley,U.S. House,23,Tracy Mitrano,WOR,5,0
+Cattaraugus,Town of Olean 1,U.S. House,23,Tracy Mitrano,WOR,7,1
+Cattaraugus,Town of Olean 2,U.S. House,23,Tracy Mitrano,WOR,7,5
+Cattaraugus,Town of Salamanca,U.S. House,23,Tracy Mitrano,WOR,12,5
+Cattaraugus,Yorkshire 1,U.S. House,23,Tracy Mitrano,WOR,17,4
+Cattaraugus,Yorkshire 2,U.S. House,23,Tracy Mitrano,WOR,31,4
+Cattaraugus,Allegany District 1,U.S. House,23,Andrew M. Kolstee,LIB,10,1
 Cattaraugus,Allegany District 2,U.S. House,23,Andrew M. Kolstee,LIB,0,0
 Cattaraugus,Allegany District 3,U.S. House,23,Andrew M. Kolstee,LIB,6,0
-Cattaraugus,Allegany District 4,U.S. House,23,Andrew M. Kolstee,LIB,3,1
+Cattaraugus,Allegany District 4,U.S. House,23,Andrew M. Kolstee,LIB,4,1
 Cattaraugus,Allegany District 5,U.S. House,23,Andrew M. Kolstee,LIB,10,0
-Cattaraugus,Ashford District 1,U.S. House,23,Andrew M. Kolstee,LIB,6,1
+Cattaraugus,Ashford District 1,U.S. House,23,Andrew M. Kolstee,LIB,7,1
 Cattaraugus,Ashford District 2,U.S. House,23,Andrew M. Kolstee,LIB,9,0
-Cattaraugus,Carrollton,U.S. House,23,Andrew M. Kolstee,LIB,9,0
-Cattaraugus,City of Olean - Ward 1,U.S. House,23,Andrew M. Kolstee,LIB,11,1
-Cattaraugus,City of Olean - Ward 2,U.S. House,23,Andrew M. Kolstee,LIB,6,2
-Cattaraugus,City of Olean - Ward 3,U.S. House,23,Andrew M. Kolstee,LIB,3,2
-Cattaraugus,City of Olean - Ward 4,U.S. House,23,Andrew M. Kolstee,LIB,7,2
-Cattaraugus,City of Olean - Ward 5,U.S. House,23,Andrew M. Kolstee,LIB,7,0
-Cattaraugus,City of Olean - Ward 6,U.S. House,23,Andrew M. Kolstee,LIB,5,2
-Cattaraugus,City of Olean - Ward 7,U.S. House,23,Andrew M. Kolstee,LIB,2,2
+Cattaraugus,Carrollton,U.S. House,23,Andrew M. Kolstee,LIB,11,2
+Cattaraugus,City of Olean - Ward 1,U.S. House,23,Andrew M. Kolstee,LIB,13,2
+Cattaraugus,City of Olean - Ward 2,U.S. House,23,Andrew M. Kolstee,LIB,7,1
+Cattaraugus,City of Olean - Ward 3,U.S. House,23,Andrew M. Kolstee,LIB,7,4
+Cattaraugus,City of Olean - Ward 4,U.S. House,23,Andrew M. Kolstee,LIB,8,1
+Cattaraugus,City of Olean - Ward 5,U.S. House,23,Andrew M. Kolstee,LIB,10,3
+Cattaraugus,City of Olean - Ward 6,U.S. House,23,Andrew M. Kolstee,LIB,6,1
+Cattaraugus,City of Olean - Ward 7,U.S. House,23,Andrew M. Kolstee,LIB,2,0
 Cattaraugus,City of Salamanca - Ward 1,U.S. House,23,Andrew M. Kolstee,LIB,1,0
-Cattaraugus,City of Salamanca - Ward 2,U.S. House,23,Andrew M. Kolstee,LIB,8,0
+Cattaraugus,City of Salamanca - Ward 2,U.S. House,23,Andrew M. Kolstee,LIB,9,1
 Cattaraugus,City of Salamanca - Ward 3,U.S. House,23,Andrew M. Kolstee,LIB,1,0
-Cattaraugus,City of Salamanca - Ward 4,U.S. House,23,Andrew M. Kolstee,LIB,4,2
-Cattaraugus,City of Salamanca - Ward 5,U.S. House,23,Andrew M. Kolstee,LIB,6,1
+Cattaraugus,City of Salamanca - Ward 4,U.S. House,23,Andrew M. Kolstee,LIB,5,1
+Cattaraugus,City of Salamanca - Ward 5,U.S. House,23,Andrew M. Kolstee,LIB,7,1
 Cattaraugus,Coldspring,U.S. House,23,Andrew M. Kolstee,LIB,2,0
-Cattaraugus,Conewango,U.S. House,23,Andrew M. Kolstee,LIB,7,0
-Cattaraugus,Dayton,U.S. House,23,Andrew M. Kolstee,LIB,7,1
-Cattaraugus,Early Voting - Little Valley 1,U.S. House,23,Andrew M. Kolstee,LIB,15,
-Cattaraugus,Early Voting - Little Valley 2,U.S. House,23,Andrew M. Kolstee,LIB,13,
-Cattaraugus,Early Voting - Olean 1,U.S. House,23,Andrew M. Kolstee,LIB,24,
-Cattaraugus,Early Voting - Olean 2,U.S. House,23,Andrew M. Kolstee,LIB,11,
-Cattaraugus,East Otto,U.S. House,23,Andrew M. Kolstee,LIB,5,1
-Cattaraugus,Ellicottville,U.S. House,23,Andrew M. Kolstee,LIB,6,0
-Cattaraugus,Farmersville,U.S. House,23,Andrew M. Kolstee,LIB,4,0
-Cattaraugus,Franklinville District 1,U.S. House,23,Andrew M. Kolstee,LIB,2,1
-Cattaraugus,Franklinville District 2,U.S. House,23,Andrew M. Kolstee,LIB,3,3
-Cattaraugus,Freedom,U.S. House,23,Andrew M. Kolstee,LIB,12,2
-Cattaraugus,Great Valley 1,U.S. House,23,Andrew M. Kolstee,LIB,6,1
-Cattaraugus,Great Valley 2,U.S. House,23,Andrew M. Kolstee,LIB,7,2
-Cattaraugus,Hinsdale,U.S. House,23,Andrew M. Kolstee,LIB,5,1
-Cattaraugus,Humphrey,U.S. House,23,Andrew M. Kolstee,LIB,1,4
-Cattaraugus,Ischua,U.S. House,23,Andrew M. Kolstee,LIB,3,1
-Cattaraugus,Leon,U.S. House,23,Andrew M. Kolstee,LIB,4,3
-Cattaraugus,Little Valley,U.S. House,23,Andrew M. Kolstee,LIB,9,1
+Cattaraugus,Conewango,U.S. House,23,Andrew M. Kolstee,LIB,8,1
+Cattaraugus,Dayton,U.S. House,23,Andrew M. Kolstee,LIB,9,2
+Cattaraugus,Early Voting - Little Valley 1,U.S. House,23,Andrew M. Kolstee,LIB,15,0
+Cattaraugus,Early Voting - Little Valley 2,U.S. House,23,Andrew M. Kolstee,LIB,13,0
+Cattaraugus,Early Voting - Olean 1,U.S. House,23,Andrew M. Kolstee,LIB,24,0
+Cattaraugus,Early Voting - Olean 2,U.S. House,23,Andrew M. Kolstee,LIB,11,0
+Cattaraugus,East Otto,U.S. House,23,Andrew M. Kolstee,LIB,5,0
+Cattaraugus,Ellicottville,U.S. House,23,Andrew M. Kolstee,LIB,8,2
+Cattaraugus,Farmersville,U.S. House,23,Andrew M. Kolstee,LIB,6,2
+Cattaraugus,Franklinville District 1,U.S. House,23,Andrew M. Kolstee,LIB,2,0
+Cattaraugus,Franklinville District 2,U.S. House,23,Andrew M. Kolstee,LIB,3,0
+Cattaraugus,Freedom,U.S. House,23,Andrew M. Kolstee,LIB,14,2
+Cattaraugus,Great Valley 1,U.S. House,23,Andrew M. Kolstee,LIB,6,0
+Cattaraugus,Great Valley 2,U.S. House,23,Andrew M. Kolstee,LIB,9,2
+Cattaraugus,Hinsdale,U.S. House,23,Andrew M. Kolstee,LIB,6,1
+Cattaraugus,Humphrey,U.S. House,23,Andrew M. Kolstee,LIB,1,0
+Cattaraugus,Ischua,U.S. House,23,Andrew M. Kolstee,LIB,3,0
+Cattaraugus,Leon,U.S. House,23,Andrew M. Kolstee,LIB,5,1
+Cattaraugus,Little Valley,U.S. House,23,Andrew M. Kolstee,LIB,10,1
 Cattaraugus,Lyndon,U.S. House,23,Andrew M. Kolstee,LIB,4,0
-Cattaraugus,Machias,U.S. House,23,Andrew M. Kolstee,LIB,9,2
-Cattaraugus,Mansfield,U.S. House,23,Andrew M. Kolstee,LIB,5,2
-Cattaraugus,Napoli,U.S. House,23,Andrew M. Kolstee,LIB,5,0
-Cattaraugus,New Albion,U.S. House,23,Andrew M. Kolstee,LIB,13,0
-Cattaraugus,Otto,U.S. House,23,Andrew M. Kolstee,LIB,3,1
+Cattaraugus,Machias,U.S. House,23,Andrew M. Kolstee,LIB,10,1
+Cattaraugus,Mansfield,U.S. House,23,Andrew M. Kolstee,LIB,5,0
+Cattaraugus,Napoli,U.S. House,23,Andrew M. Kolstee,LIB,7,2
+Cattaraugus,New Albion,U.S. House,23,Andrew M. Kolstee,LIB,16,3
+Cattaraugus,Otto,U.S. House,23,Andrew M. Kolstee,LIB,4,1
 Cattaraugus,Perrysburg,U.S. House,23,Andrew M. Kolstee,LIB,4,0
-Cattaraugus,Persia,U.S. House,23,Andrew M. Kolstee,LIB,6,0
-Cattaraugus,Portville 1,U.S. House,23,Andrew M. Kolstee,LIB,11,0
+Cattaraugus,Persia,U.S. House,23,Andrew M. Kolstee,LIB,8,2
+Cattaraugus,Portville 1,U.S. House,23,Andrew M. Kolstee,LIB,13,2
 Cattaraugus,Portville 2,U.S. House,23,Andrew M. Kolstee,LIB,9,0
-Cattaraugus,Randolph District 1,U.S. House,23,Andrew M. Kolstee,LIB,2,1
+Cattaraugus,Randolph District 1,U.S. House,23,Andrew M. Kolstee,LIB,3,1
 Cattaraugus,Randolph District 2,U.S. House,23,Andrew M. Kolstee,LIB,5,0
-Cattaraugus,Red House,U.S. House,23,Andrew M. Kolstee,LIB,0,1
-Cattaraugus,South Valley,U.S. House,23,Andrew M. Kolstee,LIB,2,1
+Cattaraugus,Red House,U.S. House,23,Andrew M. Kolstee,LIB,0,0
+Cattaraugus,South Valley,U.S. House,23,Andrew M. Kolstee,LIB,2,0
 Cattaraugus,Town of Olean 1,U.S. House,23,Andrew M. Kolstee,LIB,3,0
 Cattaraugus,Town of Olean 2,U.S. House,23,Andrew M. Kolstee,LIB,5,0
 Cattaraugus,Town of Salamanca,U.S. House,23,Andrew M. Kolstee,LIB,4,0
-Cattaraugus,Yorkshire 1,U.S. House,23,Andrew M. Kolstee,LIB,8,2
-Cattaraugus,Yorkshire 2,U.S. House,23,Andrew M. Kolstee,LIB,12,3
-Cattaraugus,Allegany District 1,U.S. House,23,Tom Reed,IND,9,1
-Cattaraugus,Allegany District 2,U.S. House,23,Tom Reed,IND,3,3
-Cattaraugus,Allegany District 3,U.S. House,23,Tom Reed,IND,4,1
+Cattaraugus,Yorkshire 1,U.S. House,23,Andrew M. Kolstee,LIB,10,2
+Cattaraugus,Yorkshire 2,U.S. House,23,Andrew M. Kolstee,LIB,15,3
+Cattaraugus,Allegany District 1,U.S. House,23,Tom Reed,IND,10,1
+Cattaraugus,Allegany District 2,U.S. House,23,Tom Reed,IND,6,3
+Cattaraugus,Allegany District 3,U.S. House,23,Tom Reed,IND,5,1
 Cattaraugus,Allegany District 4,U.S. House,23,Tom Reed,IND,8,0
-Cattaraugus,Allegany District 5,U.S. House,23,Tom Reed,IND,4,1
+Cattaraugus,Allegany District 5,U.S. House,23,Tom Reed,IND,5,1
 Cattaraugus,Ashford District 1,U.S. House,23,Tom Reed,IND,1,0
-Cattaraugus,Ashford District 2,U.S. House,23,Tom Reed,IND,9,1
-Cattaraugus,Carrollton,U.S. House,23,Tom Reed,IND,4,1
-Cattaraugus,City of Olean - Ward 1,U.S. House,23,Tom Reed,IND,7,0
-Cattaraugus,City of Olean - Ward 2,U.S. House,23,Tom Reed,IND,12,0
-Cattaraugus,City of Olean - Ward 3,U.S. House,23,Tom Reed,IND,6,1
-Cattaraugus,City of Olean - Ward 4,U.S. House,23,Tom Reed,IND,5,0
-Cattaraugus,City of Olean - Ward 5,U.S. House,23,Tom Reed,IND,3,0
-Cattaraugus,City of Olean - Ward 6,U.S. House,23,Tom Reed,IND,6,0
-Cattaraugus,City of Olean - Ward 7,U.S. House,23,Tom Reed,IND,8,1
+Cattaraugus,Ashford District 2,U.S. House,23,Tom Reed,IND,10,1
+Cattaraugus,Carrollton,U.S. House,23,Tom Reed,IND,4,0
+Cattaraugus,City of Olean - Ward 1,U.S. House,23,Tom Reed,IND,10,3
+Cattaraugus,City of Olean - Ward 2,U.S. House,23,Tom Reed,IND,14,2
+Cattaraugus,City of Olean - Ward 3,U.S. House,23,Tom Reed,IND,7,1
+Cattaraugus,City of Olean - Ward 4,U.S. House,23,Tom Reed,IND,6,1
+Cattaraugus,City of Olean - Ward 5,U.S. House,23,Tom Reed,IND,4,1
+Cattaraugus,City of Olean - Ward 6,U.S. House,23,Tom Reed,IND,7,1
+Cattaraugus,City of Olean - Ward 7,U.S. House,23,Tom Reed,IND,8,0
 Cattaraugus,City of Salamanca - Ward 1,U.S. House,23,Tom Reed,IND,4,0
-Cattaraugus,City of Salamanca - Ward 2,U.S. House,23,Tom Reed,IND,6,0
-Cattaraugus,City of Salamanca - Ward 3,U.S. House,23,Tom Reed,IND,5,3
-Cattaraugus,City of Salamanca - Ward 4,U.S. House,23,Tom Reed,IND,5,1
-Cattaraugus,City of Salamanca - Ward 5,U.S. House,23,Tom Reed,IND,3,1
-Cattaraugus,Coldspring,U.S. House,23,Tom Reed,IND,2,0
-Cattaraugus,Conewango,U.S. House,23,Tom Reed,IND,6,1
-Cattaraugus,Dayton,U.S. House,23,Tom Reed,IND,10,0
-Cattaraugus,Early Voting - Little Valley 1,U.S. House,23,Tom Reed,IND,10,
-Cattaraugus,Early Voting - Little Valley 2,U.S. House,23,Tom Reed,IND,12,
-Cattaraugus,Early Voting - Olean 1,U.S. House,23,Tom Reed,IND,37,
-Cattaraugus,Early Voting - Olean 2,U.S. House,23,Tom Reed,IND,12,
-Cattaraugus,East Otto,U.S. House,23,Tom Reed,IND,4,2
-Cattaraugus,Ellicottville,U.S. House,23,Tom Reed,IND,6,1
+Cattaraugus,City of Salamanca - Ward 2,U.S. House,23,Tom Reed,IND,7,1
+Cattaraugus,City of Salamanca - Ward 3,U.S. House,23,Tom Reed,IND,5,0
+Cattaraugus,City of Salamanca - Ward 4,U.S. House,23,Tom Reed,IND,6,1
+Cattaraugus,City of Salamanca - Ward 5,U.S. House,23,Tom Reed,IND,3,0
+Cattaraugus,Coldspring,U.S. House,23,Tom Reed,IND,3,1
+Cattaraugus,Conewango,U.S. House,23,Tom Reed,IND,6,0
+Cattaraugus,Dayton,U.S. House,23,Tom Reed,IND,11,1
+Cattaraugus,Early Voting - Little Valley 1,U.S. House,23,Tom Reed,IND,10,0
+Cattaraugus,Early Voting - Little Valley 2,U.S. House,23,Tom Reed,IND,12,0
+Cattaraugus,Early Voting - Olean 1,U.S. House,23,Tom Reed,IND,37,0
+Cattaraugus,Early Voting - Olean 2,U.S. House,23,Tom Reed,IND,12,0
+Cattaraugus,East Otto,U.S. House,23,Tom Reed,IND,4,0
+Cattaraugus,Ellicottville,U.S. House,23,Tom Reed,IND,6,0
 Cattaraugus,Farmersville,U.S. House,23,Tom Reed,IND,5,0
-Cattaraugus,Franklinville District 1,U.S. House,23,Tom Reed,IND,7,3
+Cattaraugus,Franklinville District 1,U.S. House,23,Tom Reed,IND,7,0
 Cattaraugus,Franklinville District 2,U.S. House,23,Tom Reed,IND,4,0
-Cattaraugus,Freedom,U.S. House,23,Tom Reed,IND,10,2
-Cattaraugus,Great Valley 1,U.S. House,23,Tom Reed,IND,4,
-Cattaraugus,Great Valley 2,U.S. House,23,Tom Reed,IND,7,3
-Cattaraugus,Hinsdale,U.S. House,23,Tom Reed,IND,6,2
-Cattaraugus,Humphrey,U.S. House,23,Tom Reed,IND,2,1
-Cattaraugus,Ischua,U.S. House,23,Tom Reed,IND,3,1
-Cattaraugus,Leon,U.S. House,23,Tom Reed,IND,4,1
-Cattaraugus,Little Valley,U.S. House,23,Tom Reed,IND,3,1
-Cattaraugus,Lyndon,U.S. House,23,Tom Reed,IND,2,0
-Cattaraugus,Machias,U.S. House,23,Tom Reed,IND,7,1
+Cattaraugus,Freedom,U.S. House,23,Tom Reed,IND,11,1
+Cattaraugus,Great Valley 1,U.S. House,23,Tom Reed,IND,7,3
+Cattaraugus,Great Valley 2,U.S. House,23,Tom Reed,IND,8,1
+Cattaraugus,Hinsdale,U.S. House,23,Tom Reed,IND,7,1
+Cattaraugus,Humphrey,U.S. House,23,Tom Reed,IND,2,0
+Cattaraugus,Ischua,U.S. House,23,Tom Reed,IND,4,1
+Cattaraugus,Leon,U.S. House,23,Tom Reed,IND,4,0
+Cattaraugus,Little Valley,U.S. House,23,Tom Reed,IND,5,2
+Cattaraugus,Lyndon,U.S. House,23,Tom Reed,IND,3,1
+Cattaraugus,Machias,U.S. House,23,Tom Reed,IND,10,3
 Cattaraugus,Mansfield,U.S. House,23,Tom Reed,IND,4,0
-Cattaraugus,Napoli,U.S. House,23,Tom Reed,IND,3,1
-Cattaraugus,New Albion,U.S. House,23,Tom Reed,IND,8,1
+Cattaraugus,Napoli,U.S. House,23,Tom Reed,IND,5,2
+Cattaraugus,New Albion,U.S. House,23,Tom Reed,IND,8,0
 Cattaraugus,Otto,U.S. House,23,Tom Reed,IND,2,0
-Cattaraugus,Perrysburg,U.S. House,23,Tom Reed,IND,21,0
-Cattaraugus,Persia,U.S. House,23,Tom Reed,IND,11,0
+Cattaraugus,Perrysburg,U.S. House,23,Tom Reed,IND,22,1
+Cattaraugus,Persia,U.S. House,23,Tom Reed,IND,12,1
 Cattaraugus,Portville 1,U.S. House,23,Tom Reed,IND,5,0
-Cattaraugus,Portville 2,U.S. House,23,Tom Reed,IND,6,0
-Cattaraugus,Randolph District 1,U.S. House,23,Tom Reed,IND,7,1
+Cattaraugus,Portville 2,U.S. House,23,Tom Reed,IND,7,1
+Cattaraugus,Randolph District 1,U.S. House,23,Tom Reed,IND,7,0
 Cattaraugus,Randolph District 2,U.S. House,23,Tom Reed,IND,4,0
-Cattaraugus,Red House,U.S. House,23,Tom Reed,IND,0,1
+Cattaraugus,Red House,U.S. House,23,Tom Reed,IND,0,0
 Cattaraugus,South Valley,U.S. House,23,Tom Reed,IND,3,0
 Cattaraugus,Town of Olean 1,U.S. House,23,Tom Reed,IND,4,0
 Cattaraugus,Town of Olean 2,U.S. House,23,Tom Reed,IND,3,0
@@ -1008,10 +1008,10 @@ Cattaraugus,Allegany District 3,U.S. House,23,Write-ins,,0,0
 Cattaraugus,Allegany District 4,U.S. House,23,Write-ins,,0,0
 Cattaraugus,Allegany District 5,U.S. House,23,Write-ins,,0,0
 Cattaraugus,Ashford District 1,U.S. House,23,Write-ins,,0,0
-Cattaraugus,Ashford District 2,U.S. House,23,Write-ins,,0,1
+Cattaraugus,Ashford District 2,U.S. House,23,Write-ins,,1,1
 Cattaraugus,Carrollton,U.S. House,23,Write-ins,,0,0
 Cattaraugus,City of Olean - Ward 1,U.S. House,23,Write-ins,,0,0
-Cattaraugus,City of Olean - Ward 2,U.S. House,23,Write-ins,,0,0
+Cattaraugus,City of Olean - Ward 2,U.S. House,23,Write-ins,,1,1
 Cattaraugus,City of Olean - Ward 3,U.S. House,23,Write-ins,,0,0
 Cattaraugus,City of Olean - Ward 4,U.S. House,23,Write-ins,,0,0
 Cattaraugus,City of Olean - Ward 5,U.S. House,23,Write-ins,,0,0
@@ -1025,19 +1025,19 @@ Cattaraugus,City of Salamanca - Ward 5,U.S. House,23,Write-ins,,0,0
 Cattaraugus,Coldspring,U.S. House,23,Write-ins,,0,0
 Cattaraugus,Conewango,U.S. House,23,Write-ins,,0,0
 Cattaraugus,Dayton,U.S. House,23,Write-ins,,0,0
-Cattaraugus,Early Voting - Little Valley 1,U.S. House,23,Write-ins,,0,
-Cattaraugus,Early Voting - Little Valley 2,U.S. House,23,Write-ins,,0,
-Cattaraugus,Early Voting - Olean 1,U.S. House,23,Write-ins,,0,
-Cattaraugus,Early Voting - Olean 2,U.S. House,23,Write-ins,,0,
+Cattaraugus,Early Voting - Little Valley 1,U.S. House,23,Write-ins,,0,0
+Cattaraugus,Early Voting - Little Valley 2,U.S. House,23,Write-ins,,0,0
+Cattaraugus,Early Voting - Olean 1,U.S. House,23,Write-ins,,0,0
+Cattaraugus,Early Voting - Olean 2,U.S. House,23,Write-ins,,0,0
 Cattaraugus,East Otto,U.S. House,23,Write-ins,,0,0
 Cattaraugus,Ellicottville,U.S. House,23,Write-ins,,0,0
 Cattaraugus,Farmersville,U.S. House,23,Write-ins,,0,0
 Cattaraugus,Franklinville District 1,U.S. House,23,Write-ins,,0,0
 Cattaraugus,Franklinville District 2,U.S. House,23,Write-ins,,0,0
 Cattaraugus,Freedom,U.S. House,23,Write-ins,,0,0
-Cattaraugus,Great Valley 1,U.S. House,23,Write-ins,,0,
+Cattaraugus,Great Valley 1,U.S. House,23,Write-ins,,0,0
 Cattaraugus,Great Valley 2,U.S. House,23,Write-ins,,0,0
-Cattaraugus,Hinsdale,U.S. House,23,Write-ins,,1,1
+Cattaraugus,Hinsdale,U.S. House,23,Write-ins,,1,0
 Cattaraugus,Humphrey,U.S. House,23,Write-ins,,0,0
 Cattaraugus,Ischua,U.S. House,23,Write-ins,,0,0
 Cattaraugus,Leon,U.S. House,23,Write-ins,,0,0
@@ -1062,44 +1062,44 @@ Cattaraugus,Town of Salamanca,U.S. House,23,Write-ins,,0,0
 Cattaraugus,Yorkshire 1,U.S. House,23,Write-ins,,0,0
 Cattaraugus,Yorkshire 2,U.S. House,23,Write-ins,,0,0
 Cattaraugus,Allegany District 1,U.S. House,23,Voids,,0,0
-Cattaraugus,Allegany District 2,U.S. House,23,Voids,,0,3
+Cattaraugus,Allegany District 2,U.S. House,23,Voids,,3,3
 Cattaraugus,Allegany District 3,U.S. House,23,Voids,,0,0
 Cattaraugus,Allegany District 4,U.S. House,23,Voids,,0,0
-Cattaraugus,Allegany District 5,U.S. House,23,Voids,,1,1
+Cattaraugus,Allegany District 5,U.S. House,23,Voids,,2,1
 Cattaraugus,Ashford District 1,U.S. House,23,Voids,,0,0
 Cattaraugus,Ashford District 2,U.S. House,23,Voids,,1,0
 Cattaraugus,Carrollton,U.S. House,23,Voids,,0,0
 Cattaraugus,City of Olean - Ward 1,U.S. House,23,Voids,,0,0
 Cattaraugus,City of Olean - Ward 2,U.S. House,23,Voids,,0,0
-Cattaraugus,City of Olean - Ward 3,U.S. House,23,Voids,,0,0
-Cattaraugus,City of Olean - Ward 4,U.S. House,23,Voids,,0,2
-Cattaraugus,City of Olean - Ward 5,U.S. House,23,Voids,,0,1
-Cattaraugus,City of Olean - Ward 6,U.S. House,23,Voids,,0,1
-Cattaraugus,City of Olean - Ward 7,U.S. House,23,Voids,,0,1
-Cattaraugus,City of Salamanca - Ward 1,U.S. House,23,Voids,,0,1
+Cattaraugus,City of Olean - Ward 3,U.S. House,23,Voids,,4,4
+Cattaraugus,City of Olean - Ward 4,U.S. House,23,Voids,,0,0
+Cattaraugus,City of Olean - Ward 5,U.S. House,23,Voids,,1,1
+Cattaraugus,City of Olean - Ward 6,U.S. House,23,Voids,,0,0
+Cattaraugus,City of Olean - Ward 7,U.S. House,23,Voids,,0,0
+Cattaraugus,City of Salamanca - Ward 1,U.S. House,23,Voids,,1,1
 Cattaraugus,City of Salamanca - Ward 2,U.S. House,23,Voids,,0,0
 Cattaraugus,City of Salamanca - Ward 3,U.S. House,23,Voids,,0,0
-Cattaraugus,City of Salamanca - Ward 4,U.S. House,23,Voids,,1,1
+Cattaraugus,City of Salamanca - Ward 4,U.S. House,23,Voids,,1,0
 Cattaraugus,City of Salamanca - Ward 5,U.S. House,23,Voids,,0,0
 Cattaraugus,Coldspring,U.S. House,23,Voids,,1,0
-Cattaraugus,Conewango,U.S. House,23,Voids,,0,1
-Cattaraugus,Dayton,U.S. House,23,Voids,,2,1
-Cattaraugus,Early Voting - Little Valley 1,U.S. House,23,Voids,,0,
-Cattaraugus,Early Voting - Little Valley 2,U.S. House,23,Voids,,1,
-Cattaraugus,Early Voting - Olean 1,U.S. House,23,Voids,,0,
-Cattaraugus,Early Voting - Olean 2,U.S. House,23,Voids,,0,
-Cattaraugus,East Otto,U.S. House,23,Voids,,0,0
-Cattaraugus,Ellicottville,U.S. House,23,Voids,,0,0
-Cattaraugus,Farmersville,U.S. House,23,Voids,,0,0
-Cattaraugus,Franklinville District 1,U.S. House,23,Voids,,0,0
+Cattaraugus,Conewango,U.S. House,23,Voids,,0,0
+Cattaraugus,Dayton,U.S. House,23,Voids,,2,0
+Cattaraugus,Early Voting - Little Valley 1,U.S. House,23,Voids,,0,0
+Cattaraugus,Early Voting - Little Valley 2,U.S. House,23,Voids,,1,0
+Cattaraugus,Early Voting - Olean 1,U.S. House,23,Voids,,0,0
+Cattaraugus,Early Voting - Olean 2,U.S. House,23,Voids,,0,0
+Cattaraugus,East Otto,U.S. House,23,Voids,,1,1
+Cattaraugus,Ellicottville,U.S. House,23,Voids,,2,2
+Cattaraugus,Farmersville,U.S. House,23,Voids,,1,1
+Cattaraugus,Franklinville District 1,U.S. House,23,Voids,,1,1
 Cattaraugus,Franklinville District 2,U.S. House,23,Voids,,0,0
-Cattaraugus,Freedom,U.S. House,23,Voids,,0,0
-Cattaraugus,Great Valley 1,U.S. House,23,Voids,,1,
-Cattaraugus,Great Valley 2,U.S. House,23,Voids,,1,0
+Cattaraugus,Freedom,U.S. House,23,Voids,,1,1
+Cattaraugus,Great Valley 1,U.S. House,23,Voids,,1,0
+Cattaraugus,Great Valley 2,U.S. House,23,Voids,,2,1
 Cattaraugus,Hinsdale,U.S. House,23,Voids,,0,0
-Cattaraugus,Humphrey,U.S. House,23,Voids,,0,4
-Cattaraugus,Ischua,U.S. House,23,Voids,,0,0
-Cattaraugus,Leon,U.S. House,23,Voids,,0,1
+Cattaraugus,Humphrey,U.S. House,23,Voids,,0,0
+Cattaraugus,Ischua,U.S. House,23,Voids,,1,1
+Cattaraugus,Leon,U.S. House,23,Voids,,1,1
 Cattaraugus,Little Valley,U.S. House,23,Voids,,0,0
 Cattaraugus,Lyndon,U.S. House,23,Voids,,0,0
 Cattaraugus,Machias,U.S. House,23,Voids,,2,0
@@ -1110,7 +1110,7 @@ Cattaraugus,Otto,U.S. House,23,Voids,,0,0
 Cattaraugus,Perrysburg,U.S. House,23,Voids,,0,0
 Cattaraugus,Persia,U.S. House,23,Voids,,0,0
 Cattaraugus,Portville 1,U.S. House,23,Voids,,1,0
-Cattaraugus,Portville 2,U.S. House,23,Voids,,0,1
+Cattaraugus,Portville 2,U.S. House,23,Voids,,0,0
 Cattaraugus,Randolph District 1,U.S. House,23,Voids,,0,0
 Cattaraugus,Randolph District 2,U.S. House,23,Voids,,0,0
 Cattaraugus,Red House,U.S. House,23,Voids,,0,0
@@ -1121,351 +1121,351 @@ Cattaraugus,Town of Salamanca,U.S. House,23,Voids,,1,0
 Cattaraugus,Yorkshire 1,U.S. House,23,Voids,,0,0
 Cattaraugus,Yorkshire 2,U.S. House,23,Voids,,1,0
 Cattaraugus,Allegany District 1,U.S. House,23,Blanks,,19,0
-Cattaraugus,Allegany District 2,U.S. House,23,Blanks,,6,8
+Cattaraugus,Allegany District 2,U.S. House,23,Blanks,,14,8
 Cattaraugus,Allegany District 3,U.S. House,23,Blanks,,5,0
 Cattaraugus,Allegany District 4,U.S. House,23,Blanks,,9,0
-Cattaraugus,Allegany District 5,U.S. House,23,Blanks,,15,5
+Cattaraugus,Allegany District 5,U.S. House,23,Blanks,,20,5
 Cattaraugus,Ashford District 1,U.S. House,23,Blanks,,12,0
-Cattaraugus,Ashford District 2,U.S. House,23,Blanks,,16,3
-Cattaraugus,Carrollton,U.S. House,23,Blanks,,18,0
-Cattaraugus,City of Olean - Ward 1,U.S. House,23,Blanks,,23,0
-Cattaraugus,City of Olean - Ward 2,U.S. House,23,Blanks,,12,4
-Cattaraugus,City of Olean - Ward 3,U.S. House,23,Blanks,,11,3
-Cattaraugus,City of Olean - Ward 4,U.S. House,23,Blanks,,15,8
-Cattaraugus,City of Olean - Ward 5,U.S. House,23,Blanks,,16,1
-Cattaraugus,City of Olean - Ward 6,U.S. House,23,Blanks,,10,1
-Cattaraugus,City of Olean - Ward 7,U.S. House,23,Blanks,,25,4
-Cattaraugus,City of Salamanca - Ward 1,U.S. House,23,Blanks,,11,5
-Cattaraugus,City of Salamanca - Ward 2,U.S. House,23,Blanks,,24,3
-Cattaraugus,City of Salamanca - Ward 3,U.S. House,23,Blanks,,10,0
-Cattaraugus,City of Salamanca - Ward 4,U.S. House,23,Blanks,,21,5
-Cattaraugus,City of Salamanca - Ward 5,U.S. House,23,Blanks,,11,5
-Cattaraugus,Coldspring,U.S. House,23,Blanks,,16,2
-Cattaraugus,Conewango,U.S. House,23,Blanks,,13,5
-Cattaraugus,Dayton,U.S. House,23,Blanks,,27,1
-Cattaraugus,Early Voting - Little Valley 1,U.S. House,23,Blanks,,39,
-Cattaraugus,Early Voting - Little Valley 2,U.S. House,23,Blanks,,27,
-Cattaraugus,Early Voting - Olean 1,U.S. House,23,Blanks,,46,
-Cattaraugus,Early Voting - Olean 2,U.S. House,23,Blanks,,27,
-Cattaraugus,East Otto,U.S. House,23,Blanks,,11,7
-Cattaraugus,Ellicottville,U.S. House,23,Blanks,,15,4
-Cattaraugus,Farmersville,U.S. House,23,Blanks,,12,3
-Cattaraugus,Franklinville District 1,U.S. House,23,Blanks,,15,7
-Cattaraugus,Franklinville District 2,U.S. House,23,Blanks,,18,7
-Cattaraugus,Freedom,U.S. House,23,Blanks,,66,1
-Cattaraugus,Great Valley 1,U.S. House,23,Blanks,,8,3
-Cattaraugus,Great Valley 2,U.S. House,23,Blanks,,15,15
-Cattaraugus,Hinsdale,U.S. House,23,Blanks,,18,3
-Cattaraugus,Humphrey,U.S. House,23,Blanks,,2,6
-Cattaraugus,Ischua,U.S. House,23,Blanks,,5,6
-Cattaraugus,Leon,U.S. House,23,Blanks,,4,4
-Cattaraugus,Little Valley,U.S. House,23,Blanks,,9,4
-Cattaraugus,Lyndon,U.S. House,23,Blanks,,15,2
-Cattaraugus,Machias,U.S. House,23,Blanks,,31,9
-Cattaraugus,Mansfield,U.S. House,23,Blanks,,9,3
-Cattaraugus,Napoli,U.S. House,23,Blanks,,18,7
-Cattaraugus,New Albion,U.S. House,23,Blanks,,20,6
-Cattaraugus,Otto,U.S. House,23,Blanks,,11,5
-Cattaraugus,Perrysburg,U.S. House,23,Blanks,,17,1
-Cattaraugus,Persia,U.S. House,23,Blanks,,30,0
-Cattaraugus,Portville 1,U.S. House,23,Blanks,,9,0
-Cattaraugus,Portville 2,U.S. House,23,Blanks,,17,3
-Cattaraugus,Randolph District 1,U.S. House,23,Blanks,,12,10
-Cattaraugus,Randolph District 2,U.S. House,23,Blanks,,10,2
-Cattaraugus,Red House,U.S. House,23,Blanks,,1,5
-Cattaraugus,South Valley,U.S. House,23,Blanks,,3,28
+Cattaraugus,Ashford District 2,U.S. House,23,Blanks,,19,3
+Cattaraugus,Carrollton,U.S. House,23,Blanks,,22,4
+Cattaraugus,City of Olean - Ward 1,U.S. House,23,Blanks,,38,15
+Cattaraugus,City of Olean - Ward 2,U.S. House,23,Blanks,,15,3
+Cattaraugus,City of Olean - Ward 3,U.S. House,23,Blanks,,17,6
+Cattaraugus,City of Olean - Ward 4,U.S. House,23,Blanks,,21,6
+Cattaraugus,City of Olean - Ward 5,U.S. House,23,Blanks,,20,4
+Cattaraugus,City of Olean - Ward 6,U.S. House,23,Blanks,,14,4
+Cattaraugus,City of Olean - Ward 7,U.S. House,23,Blanks,,27,2
+Cattaraugus,City of Salamanca - Ward 1,U.S. House,23,Blanks,,14,3
+Cattaraugus,City of Salamanca - Ward 2,U.S. House,23,Blanks,,34,10
+Cattaraugus,City of Salamanca - Ward 3,U.S. House,23,Blanks,,12,2
+Cattaraugus,City of Salamanca - Ward 4,U.S. House,23,Blanks,,26,5
+Cattaraugus,City of Salamanca - Ward 5,U.S. House,23,Blanks,,39,28
+Cattaraugus,Coldspring,U.S. House,23,Blanks,,16,0
+Cattaraugus,Conewango,U.S. House,23,Blanks,,13,0
+Cattaraugus,Dayton,U.S. House,23,Blanks,,30,3
+Cattaraugus,Early Voting - Little Valley 1,U.S. House,23,Blanks,,39,0
+Cattaraugus,Early Voting - Little Valley 2,U.S. House,23,Blanks,,27,0
+Cattaraugus,Early Voting - Olean 1,U.S. House,23,Blanks,,46,0
+Cattaraugus,Early Voting - Olean 2,U.S. House,23,Blanks,,27,0
+Cattaraugus,East Otto,U.S. House,23,Blanks,,12,1
+Cattaraugus,Ellicottville,U.S. House,23,Blanks,,23,8
+Cattaraugus,Farmersville,U.S. House,23,Blanks,,13,1
+Cattaraugus,Franklinville District 1,U.S. House,23,Blanks,,20,5
+Cattaraugus,Franklinville District 2,U.S. House,23,Blanks,,21,3
+Cattaraugus,Freedom,U.S. House,23,Blanks,,70,4
+Cattaraugus,Great Valley 1,U.S. House,23,Blanks,,8,0
+Cattaraugus,Great Valley 2,U.S. House,23,Blanks,,20,5
+Cattaraugus,Hinsdale,U.S. House,23,Blanks,,23,5
+Cattaraugus,Humphrey,U.S. House,23,Blanks,,4,2
+Cattaraugus,Ischua,U.S. House,23,Blanks,,10,5
+Cattaraugus,Leon,U.S. House,23,Blanks,,5,1
+Cattaraugus,Little Valley,U.S. House,23,Blanks,,16,7
+Cattaraugus,Lyndon,U.S. House,23,Blanks,,19,4
+Cattaraugus,Machias,U.S. House,23,Blanks,,38,7
+Cattaraugus,Mansfield,U.S. House,23,Blanks,,12,3
+Cattaraugus,Napoli,U.S. House,23,Blanks,,19,1
+Cattaraugus,New Albion,U.S. House,23,Blanks,,27,7
+Cattaraugus,Otto,U.S. House,23,Blanks,,14,3
+Cattaraugus,Perrysburg,U.S. House,23,Blanks,,23,6
+Cattaraugus,Persia,U.S. House,23,Blanks,,39,9
+Cattaraugus,Portville 1,U.S. House,23,Blanks,,12,3
+Cattaraugus,Portville 2,U.S. House,23,Blanks,,24,7
+Cattaraugus,Randolph District 1,U.S. House,23,Blanks,,17,5
+Cattaraugus,Randolph District 2,U.S. House,23,Blanks,,11,1
+Cattaraugus,Red House,U.S. House,23,Blanks,,1,0
+Cattaraugus,South Valley,U.S. House,23,Blanks,,3,0
 Cattaraugus,Town of Olean 1,U.S. House,23,Blanks,,9,0
-Cattaraugus,Town of Olean 2,U.S. House,23,Blanks,,15,6
-Cattaraugus,Town of Salamanca,U.S. House,23,Blanks,,19,2
-Cattaraugus,Yorkshire 1,U.S. House,23,Blanks,,26,5
-Cattaraugus,Yorkshire 2,U.S. House,23,Blanks,,26,10
-Cattaraugus,Allegany District 1,State Senate,57,Frank V. Puglisi,DEM,118,76
-Cattaraugus,Allegany District 2,State Senate,57,Frank V. Puglisi,DEM,49,19
-Cattaraugus,Allegany District 3,State Senate,57,Frank V. Puglisi,DEM,67,26
-Cattaraugus,Allegany District 4,State Senate,57,Frank V. Puglisi,DEM,73,33
-Cattaraugus,Allegany District 5,State Senate,57,Frank V. Puglisi,DEM,70,96
-Cattaraugus,Ashford District 1,State Senate,57,Frank V. Puglisi,DEM,59,79
-Cattaraugus,Ashford District 2,State Senate,57,Frank V. Puglisi,DEM,113,69
-Cattaraugus,Carrollton,State Senate,57,Frank V. Puglisi,DEM,74,62
-Cattaraugus,City of Olean - Ward 1,State Senate,57,Frank V. Puglisi,DEM,121,57
-Cattaraugus,City of Olean - Ward 2,State Senate,57,Frank V. Puglisi,DEM,93,47
-Cattaraugus,City of Olean - Ward 3,State Senate,57,Frank V. Puglisi,DEM,72,64
-Cattaraugus,City of Olean - Ward 4,State Senate,57,Frank V. Puglisi,DEM,67,49
-Cattaraugus,City of Olean - Ward 5,State Senate,57,Frank V. Puglisi,DEM,95,33
-Cattaraugus,City of Olean - Ward 6,State Senate,57,Frank V. Puglisi,DEM,99,50
-Cattaraugus,City of Olean - Ward 7,State Senate,57,Frank V. Puglisi,DEM,85,22
-Cattaraugus,City of Salamanca - Ward 1,State Senate,57,Frank V. Puglisi,DEM,53,50
-Cattaraugus,City of Salamanca - Ward 2,State Senate,57,Frank V. Puglisi,DEM,161,8
-Cattaraugus,City of Salamanca - Ward 3,State Senate,57,Frank V. Puglisi,DEM,69,50
-Cattaraugus,City of Salamanca - Ward 4,State Senate,57,Frank V. Puglisi,DEM,116,18
-Cattaraugus,City of Salamanca - Ward 5,State Senate,57,Frank V. Puglisi,DEM,69,23
-Cattaraugus,Coldspring,State Senate,57,Frank V. Puglisi,DEM,51,53
-Cattaraugus,Conewango,State Senate,57,Frank V. Puglisi,DEM,48,38
-Cattaraugus,Dayton,State Senate,57,Frank V. Puglisi,DEM,55,29
-Cattaraugus,Early Voting - Little Valley 1,State Senate,57,Frank V. Puglisi,DEM,474,
-Cattaraugus,Early Voting - Little Valley 2,State Senate,57,Frank V. Puglisi,DEM,373,
-Cattaraugus,Early Voting - Olean 1,State Senate,57,Frank V. Puglisi,DEM,1074,
-Cattaraugus,Early Voting - Olean 2,State Senate,57,Frank V. Puglisi,DEM,560,
-Cattaraugus,East Otto,State Senate,57,Frank V. Puglisi,DEM,57,23
-Cattaraugus,Ellicottville,State Senate,57,Frank V. Puglisi,DEM,123,39
-Cattaraugus,Farmersville,State Senate,57,Frank V. Puglisi,DEM,49,41
-Cattaraugus,Franklinville District 1,State Senate,57,Frank V. Puglisi,DEM,82,8
-Cattaraugus,Franklinville District 2,State Senate,57,Frank V. Puglisi,DEM,65,23
-Cattaraugus,Freedom,State Senate,57,Frank V. Puglisi,DEM,119,6
-Cattaraugus,Great Valley 1,State Senate,57,Frank V. Puglisi,DEM,79,30
-Cattaraugus,Great Valley 2,State Senate,57,Frank V. Puglisi,DEM,88,12
-Cattaraugus,Hinsdale,State Senate,57,Frank V. Puglisi,DEM,107,28
-Cattaraugus,Humphrey,State Senate,57,Frank V. Puglisi,DEM,44,49
-Cattaraugus,Ischua,State Senate,57,Frank V. Puglisi,DEM,47,32
-Cattaraugus,Leon,State Senate,57,Frank V. Puglisi,DEM,27,15
-Cattaraugus,Little Valley,State Senate,57,Frank V. Puglisi,DEM,55,23
-Cattaraugus,Lyndon,State Senate,57,Frank V. Puglisi,DEM,67,62
-Cattaraugus,Machias,State Senate,57,Frank V. Puglisi,DEM,111,78
-Cattaraugus,Mansfield,State Senate,57,Frank V. Puglisi,DEM,34,57
-Cattaraugus,Napoli,State Senate,57,Frank V. Puglisi,DEM,45,52
-Cattaraugus,New Albion,State Senate,57,Frank V. Puglisi,DEM,104,36
-Cattaraugus,Otto,State Senate,57,Frank V. Puglisi,DEM,41,35
-Cattaraugus,Perrysburg,State Senate,57,Frank V. Puglisi,DEM,130,23
-Cattaraugus,Persia,State Senate,57,Frank V. Puglisi,DEM,128,2
-Cattaraugus,Portville 1,State Senate,57,Frank V. Puglisi,DEM,104,6
-Cattaraugus,Portville 2,State Senate,57,Frank V. Puglisi,DEM,72,22
-Cattaraugus,Randolph District 1,State Senate,57,Frank V. Puglisi,DEM,53,49
-Cattaraugus,Randolph District 2,State Senate,57,Frank V. Puglisi,DEM,64,13
-Cattaraugus,Red House,State Senate,57,Frank V. Puglisi,DEM,1,35
-Cattaraugus,South Valley,State Senate,57,Frank V. Puglisi,DEM,40,44
-Cattaraugus,Town of Olean 1,State Senate,57,Frank V. Puglisi,DEM,39,18
-Cattaraugus,Town of Olean 2,State Senate,57,Frank V. Puglisi,DEM,50,57
-Cattaraugus,Town of Salamanca,State Senate,57,Frank V. Puglisi,DEM,72,29
-Cattaraugus,Yorkshire 1,State Senate,57,Frank V. Puglisi,DEM,119,29
-Cattaraugus,Yorkshire 2,State Senate,57,Frank V. Puglisi,DEM,104,54
-Cattaraugus,Allegany District 1,State Senate,57,George M. Borrello,REP,322,31
-Cattaraugus,Allegany District 2,State Senate,57,George M. Borrello,REP,123,15
-Cattaraugus,Allegany District 3,State Senate,57,George M. Borrello,REP,291,21
-Cattaraugus,Allegany District 4,State Senate,57,George M. Borrello,REP,363,53
-Cattaraugus,Allegany District 5,State Senate,57,George M. Borrello,REP,334,72
-Cattaraugus,Ashford District 1,State Senate,57,George M. Borrello,REP,182,50
-Cattaraugus,Ashford District 2,State Senate,57,George M. Borrello,REP,375,54
-Cattaraugus,Carrollton,State Senate,57,George M. Borrello,REP,362,59
-Cattaraugus,City of Olean - Ward 1,State Senate,57,George M. Borrello,REP,376,38
-Cattaraugus,City of Olean - Ward 2,State Senate,57,George M. Borrello,REP,338,33
-Cattaraugus,City of Olean - Ward 3,State Senate,57,George M. Borrello,REP,200,23
-Cattaraugus,City of Olean - Ward 4,State Senate,57,George M. Borrello,REP,140,31
-Cattaraugus,City of Olean - Ward 5,State Senate,57,George M. Borrello,REP,217,39
-Cattaraugus,City of Olean - Ward 6,State Senate,57,George M. Borrello,REP,213,25
-Cattaraugus,City of Olean - Ward 7,State Senate,57,George M. Borrello,REP,322,14
-Cattaraugus,City of Salamanca - Ward 1,State Senate,57,George M. Borrello,REP,106,41
-Cattaraugus,City of Salamanca - Ward 2,State Senate,57,George M. Borrello,REP,192,14
-Cattaraugus,City of Salamanca - Ward 3,State Senate,57,George M. Borrello,REP,115,56
-Cattaraugus,City of Salamanca - Ward 4,State Senate,57,George M. Borrello,REP,151,38
-Cattaraugus,City of Salamanca - Ward 5,State Senate,57,George M. Borrello,REP,180,30
-Cattaraugus,Coldspring,State Senate,57,George M. Borrello,REP,244,46
-Cattaraugus,Conewango,State Senate,57,George M. Borrello,REP,237,35
-Cattaraugus,Dayton,State Senate,57,George M. Borrello,REP,412,23
-Cattaraugus,Early Voting - Little Valley 1,State Senate,57,George M. Borrello,REP,517,
-Cattaraugus,Early Voting - Little Valley 2,State Senate,57,George M. Borrello,REP,568,
-Cattaraugus,Early Voting - Olean 1,State Senate,57,George M. Borrello,REP,1115,
-Cattaraugus,Early Voting - Olean 2,State Senate,57,George M. Borrello,REP,605,
-Cattaraugus,East Otto,State Senate,57,George M. Borrello,REP,271,14
-Cattaraugus,Ellicottville,State Senate,57,George M. Borrello,REP,307,31
-Cattaraugus,Farmersville,State Senate,57,George M. Borrello,REP,333,41
-Cattaraugus,Franklinville District 1,State Senate,57,George M. Borrello,REP,372,6
-Cattaraugus,Franklinville District 2,State Senate,57,George M. Borrello,REP,301,22
-Cattaraugus,Freedom,State Senate,57,George M. Borrello,REP,619,17
-Cattaraugus,Great Valley 1,State Senate,57,George M. Borrello,REP,178,54
-Cattaraugus,Great Valley 2,State Senate,57,George M. Borrello,REP,347,11
-Cattaraugus,Hinsdale,State Senate,57,George M. Borrello,REP,487,25
-Cattaraugus,Humphrey,State Senate,57,George M. Borrello,REP,185,79
-Cattaraugus,Ischua,State Senate,57,George M. Borrello,REP,214,41
-Cattaraugus,Leon,State Senate,57,George M. Borrello,REP,198,33
-Cattaraugus,Little Valley,State Senate,57,George M. Borrello,REP,291,14
-Cattaraugus,Lyndon,State Senate,57,George M. Borrello,REP,173,28
-Cattaraugus,Machias,State Senate,57,George M. Borrello,REP,530,26
-Cattaraugus,Mansfield,State Senate,57,George M. Borrello,REP,194,61
-Cattaraugus,Napoli,State Senate,57,George M. Borrello,REP,276,49
-Cattaraugus,New Albion,State Senate,57,George M. Borrello,REP,424,48
-Cattaraugus,Otto,State Senate,57,George M. Borrello,REP,215,37
-Cattaraugus,Perrysburg,State Senate,57,George M. Borrello,REP,440,39
-Cattaraugus,Persia,State Senate,57,George M. Borrello,REP,452,2
-Cattaraugus,Portville 1,State Senate,57,George M. Borrello,REP,473,5
-Cattaraugus,Portville 2,State Senate,57,George M. Borrello,REP,459,14
-Cattaraugus,Randolph District 1,State Senate,57,George M. Borrello,REP,305,42
-Cattaraugus,Randolph District 2,State Senate,57,George M. Borrello,REP,362,15
-Cattaraugus,Red House,State Senate,57,George M. Borrello,REP,14,19
-Cattaraugus,South Valley,State Senate,57,George M. Borrello,REP,69,29
-Cattaraugus,Town of Olean 1,State Senate,57,George M. Borrello,REP,165,16
-Cattaraugus,Town of Olean 2,State Senate,57,George M. Borrello,REP,279,43
-Cattaraugus,Town of Salamanca,State Senate,57,George M. Borrello,REP,135,6
-Cattaraugus,Yorkshire 1,State Senate,57,George M. Borrello,REP,396,48
-Cattaraugus,Yorkshire 2,State Senate,57,George M. Borrello,REP,420,38
-Cattaraugus,Allegany District 1,State Senate,57,George M. Borrello,CON,18,11
-Cattaraugus,Allegany District 2,State Senate,57,George M. Borrello,CON,8,4
-Cattaraugus,Allegany District 3,State Senate,57,George M. Borrello,CON,20,2
-Cattaraugus,Allegany District 4,State Senate,57,George M. Borrello,CON,35,6
-Cattaraugus,Allegany District 5,State Senate,57,George M. Borrello,CON,27,7
-Cattaraugus,Ashford District 1,State Senate,57,George M. Borrello,CON,22,2
-Cattaraugus,Ashford District 2,State Senate,57,George M. Borrello,CON,44,4
-Cattaraugus,Carrollton,State Senate,57,George M. Borrello,CON,23,8
-Cattaraugus,City of Olean - Ward 1,State Senate,57,George M. Borrello,CON,21,7
-Cattaraugus,City of Olean - Ward 2,State Senate,57,George M. Borrello,CON,32,6
-Cattaraugus,City of Olean - Ward 3,State Senate,57,George M. Borrello,CON,25,3
-Cattaraugus,City of Olean - Ward 4,State Senate,57,George M. Borrello,CON,18,3
-Cattaraugus,City of Olean - Ward 5,State Senate,57,George M. Borrello,CON,26,3
-Cattaraugus,City of Olean - Ward 6,State Senate,57,George M. Borrello,CON,22,6
-Cattaraugus,City of Olean - Ward 7,State Senate,57,George M. Borrello,CON,42,3
-Cattaraugus,City of Salamanca - Ward 1,State Senate,57,George M. Borrello,CON,8,6
-Cattaraugus,City of Salamanca - Ward 2,State Senate,57,George M. Borrello,CON,25,1
-Cattaraugus,City of Salamanca - Ward 3,State Senate,57,George M. Borrello,CON,10,3
-Cattaraugus,City of Salamanca - Ward 4,State Senate,57,George M. Borrello,CON,16,2
-Cattaraugus,City of Salamanca - Ward 5,State Senate,57,George M. Borrello,CON,14,6
-Cattaraugus,Coldspring,State Senate,57,George M. Borrello,CON,26,10
-Cattaraugus,Conewango,State Senate,57,George M. Borrello,CON,22,5
-Cattaraugus,Dayton,State Senate,57,George M. Borrello,CON,40,2
-Cattaraugus,Early Voting - Little Valley 1,State Senate,57,George M. Borrello,CON,50,
-Cattaraugus,Early Voting - Little Valley 2,State Senate,57,George M. Borrello,CON,61,
-Cattaraugus,Early Voting - Olean 1,State Senate,57,George M. Borrello,CON,87,
-Cattaraugus,Early Voting - Olean 2,State Senate,57,George M. Borrello,CON,50,
-Cattaraugus,East Otto,State Senate,57,George M. Borrello,CON,41,1
-Cattaraugus,Ellicottville,State Senate,57,George M. Borrello,CON,25,2
-Cattaraugus,Farmersville,State Senate,57,George M. Borrello,CON,28,7
-Cattaraugus,Franklinville District 1,State Senate,57,George M. Borrello,CON,39,2
-Cattaraugus,Franklinville District 2,State Senate,57,George M. Borrello,CON,20,2
-Cattaraugus,Freedom,State Senate,57,George M. Borrello,CON,72,0
-Cattaraugus,Great Valley 1,State Senate,57,George M. Borrello,CON,26,5
-Cattaraugus,Great Valley 2,State Senate,57,George M. Borrello,CON,33,1
-Cattaraugus,Hinsdale,State Senate,57,George M. Borrello,CON,60,1
-Cattaraugus,Humphrey,State Senate,57,George M. Borrello,CON,25,8
-Cattaraugus,Ischua,State Senate,57,George M. Borrello,CON,12,8
-Cattaraugus,Leon,State Senate,57,George M. Borrello,CON,31,4
-Cattaraugus,Little Valley,State Senate,57,George M. Borrello,CON,27,4
-Cattaraugus,Lyndon,State Senate,57,George M. Borrello,CON,17,7
-Cattaraugus,Machias,State Senate,57,George M. Borrello,CON,59,5
-Cattaraugus,Mansfield,State Senate,57,George M. Borrello,CON,8,13
-Cattaraugus,Napoli,State Senate,57,George M. Borrello,CON,39,3
-Cattaraugus,New Albion,State Senate,57,George M. Borrello,CON,50,6
-Cattaraugus,Otto,State Senate,57,George M. Borrello,CON,27,6
-Cattaraugus,Perrysburg,State Senate,57,George M. Borrello,CON,69,6
-Cattaraugus,Persia,State Senate,57,George M. Borrello,CON,69,0
-Cattaraugus,Portville 1,State Senate,57,George M. Borrello,CON,36,0
-Cattaraugus,Portville 2,State Senate,57,George M. Borrello,CON,50,1
-Cattaraugus,Randolph District 1,State Senate,57,George M. Borrello,CON,37,1
-Cattaraugus,Randolph District 2,State Senate,57,George M. Borrello,CON,21,2
-Cattaraugus,Red House,State Senate,57,George M. Borrello,CON,2,1
-Cattaraugus,South Valley,State Senate,57,George M. Borrello,CON,7,8
+Cattaraugus,Town of Olean 2,U.S. House,23,Blanks,,21,6
+Cattaraugus,Town of Salamanca,U.S. House,23,Blanks,,21,2
+Cattaraugus,Yorkshire 1,U.S. House,23,Blanks,,31,5
+Cattaraugus,Yorkshire 2,U.S. House,23,Blanks,,36,10
+Cattaraugus,Allegany District 1,State Senate,57,Frank V. Puglisi,DEM,194,76
+Cattaraugus,Allegany District 2,State Senate,57,Frank V. Puglisi,DEM,113,64
+Cattaraugus,Allegany District 3,State Senate,57,Frank V. Puglisi,DEM,116,49
+Cattaraugus,Allegany District 4,State Senate,57,Frank V. Puglisi,DEM,106,33
+Cattaraugus,Allegany District 5,State Senate,57,Frank V. Puglisi,DEM,120,50
+Cattaraugus,Ashford District 1,State Senate,57,Frank V. Puglisi,DEM,81,22
+Cattaraugus,Ashford District 2,State Senate,57,Frank V. Puglisi,DEM,163,50
+Cattaraugus,Carrollton,State Senate,57,Frank V. Puglisi,DEM,100,26
+Cattaraugus,City of Olean - Ward 1,State Senate,57,Frank V. Puglisi,DEM,217,96
+Cattaraugus,City of Olean - Ward 2,State Senate,57,Frank V. Puglisi,DEM,172,79
+Cattaraugus,City of Olean - Ward 3,State Senate,57,Frank V. Puglisi,DEM,134,62
+Cattaraugus,City of Olean - Ward 4,State Senate,57,Frank V. Puglisi,DEM,145,78
+Cattaraugus,City of Olean - Ward 5,State Senate,57,Frank V. Puglisi,DEM,164,69
+Cattaraugus,City of Olean - Ward 6,State Senate,57,Frank V. Puglisi,DEM,161,62
+Cattaraugus,City of Olean - Ward 7,State Senate,57,Frank V. Puglisi,DEM,142,57
+Cattaraugus,City of Salamanca - Ward 1,State Senate,57,Frank V. Puglisi,DEM,75,22
+Cattaraugus,City of Salamanca - Ward 2,State Senate,57,Frank V. Puglisi,DEM,210,49
+Cattaraugus,City of Salamanca - Ward 3,State Senate,57,Frank V. Puglisi,DEM,82,13
+Cattaraugus,City of Salamanca - Ward 4,State Senate,57,Frank V. Puglisi,DEM,151,35
+Cattaraugus,City of Salamanca - Ward 5,State Senate,57,Frank V. Puglisi,DEM,113,44
+Cattaraugus,Coldspring,State Senate,57,Frank V. Puglisi,DEM,59,8
+Cattaraugus,Conewango,State Senate,57,Frank V. Puglisi,DEM,67,19
+Cattaraugus,Dayton,State Senate,57,Frank V. Puglisi,DEM,88,33
+Cattaraugus,Early Voting - Little Valley 1,State Senate,57,Frank V. Puglisi,DEM,474,0
+Cattaraugus,Early Voting - Little Valley 2,State Senate,57,Frank V. Puglisi,DEM,373,0
+Cattaraugus,Early Voting - Olean 1,State Senate,57,Frank V. Puglisi,DEM,1074,0
+Cattaraugus,Early Voting - Olean 2,State Senate,57,Frank V. Puglisi,DEM,560,0
+Cattaraugus,East Otto,State Senate,57,Frank V. Puglisi,DEM,75,18
+Cattaraugus,Ellicottville,State Senate,57,Frank V. Puglisi,DEM,173,50
+Cattaraugus,Farmersville,State Senate,57,Frank V. Puglisi,DEM,72,23
+Cattaraugus,Franklinville District 1,State Senate,57,Frank V. Puglisi,DEM,120,38
+Cattaraugus,Franklinville District 2,State Senate,57,Frank V. Puglisi,DEM,94,29
+Cattaraugus,Freedom,State Senate,57,Frank V. Puglisi,DEM,172,53
+Cattaraugus,Great Valley 1,State Senate,57,Frank V. Puglisi,DEM,102,23
+Cattaraugus,Great Valley 2,State Senate,57,Frank V. Puglisi,DEM,127,39
+Cattaraugus,Hinsdale,State Senate,57,Frank V. Puglisi,DEM,148,41
+Cattaraugus,Humphrey,State Senate,57,Frank V. Puglisi,DEM,52,8
+Cattaraugus,Ischua,State Senate,57,Frank V. Puglisi,DEM,70,23
+Cattaraugus,Leon,State Senate,57,Frank V. Puglisi,DEM,33,6
+Cattaraugus,Little Valley,State Senate,57,Frank V. Puglisi,DEM,85,30
+Cattaraugus,Lyndon,State Senate,57,Frank V. Puglisi,DEM,79,12
+Cattaraugus,Machias,State Senate,57,Frank V. Puglisi,DEM,160,49
+Cattaraugus,Mansfield,State Senate,57,Frank V. Puglisi,DEM,62,28
+Cattaraugus,Napoli,State Senate,57,Frank V. Puglisi,DEM,60,15
+Cattaraugus,New Albion,State Senate,57,Frank V. Puglisi,DEM,136,32
+Cattaraugus,Otto,State Senate,57,Frank V. Puglisi,DEM,64,23
+Cattaraugus,Perrysburg,State Senate,57,Frank V. Puglisi,DEM,177,47
+Cattaraugus,Persia,State Senate,57,Frank V. Puglisi,DEM,185,57
+Cattaraugus,Portville 1,State Senate,57,Frank V. Puglisi,DEM,156,52
+Cattaraugus,Portville 2,State Senate,57,Frank V. Puglisi,DEM,108,36
+Cattaraugus,Randolph District 1,State Senate,57,Frank V. Puglisi,DEM,88,35
+Cattaraugus,Randolph District 2,State Senate,57,Frank V. Puglisi,DEM,87,23
+Cattaraugus,Red House,State Senate,57,Frank V. Puglisi,DEM,3,2
+Cattaraugus,South Valley,State Senate,57,Frank V. Puglisi,DEM,46,6
+Cattaraugus,Town of Olean 1,State Senate,57,Frank V. Puglisi,DEM,57,18
+Cattaraugus,Town of Olean 2,State Senate,57,Frank V. Puglisi,DEM,107,57
+Cattaraugus,Town of Salamanca,State Senate,57,Frank V. Puglisi,DEM,101,29
+Cattaraugus,Yorkshire 1,State Senate,57,Frank V. Puglisi,DEM,148,29
+Cattaraugus,Yorkshire 2,State Senate,57,Frank V. Puglisi,DEM,158,54
+Cattaraugus,Allegany District 1,State Senate,57,George M. Borrello,REP,353,31
+Cattaraugus,Allegany District 2,State Senate,57,George M. Borrello,REP,146,23
+Cattaraugus,Allegany District 3,State Senate,57,George M. Borrello,REP,322,31
+Cattaraugus,Allegany District 4,State Senate,57,George M. Borrello,REP,402,39
+Cattaraugus,Allegany District 5,State Senate,57,George M. Borrello,REP,359,25
+Cattaraugus,Ashford District 1,State Senate,57,George M. Borrello,REP,196,14
+Cattaraugus,Ashford District 2,State Senate,57,George M. Borrello,REP,416,41
+Cattaraugus,Carrollton,State Senate,57,George M. Borrello,REP,383,21
+Cattaraugus,City of Olean - Ward 1,State Senate,57,George M. Borrello,REP,448,72
+Cattaraugus,City of Olean - Ward 2,State Senate,57,George M. Borrello,REP,388,50
+Cattaraugus,City of Olean - Ward 3,State Senate,57,George M. Borrello,REP,228,28
+Cattaraugus,City of Olean - Ward 4,State Senate,57,George M. Borrello,REP,166,26
+Cattaraugus,City of Olean - Ward 5,State Senate,57,George M. Borrello,REP,271,54
+Cattaraugus,City of Olean - Ward 6,State Senate,57,George M. Borrello,REP,272,59
+Cattaraugus,City of Olean - Ward 7,State Senate,57,George M. Borrello,REP,360,38
+Cattaraugus,City of Salamanca - Ward 1,State Senate,57,George M. Borrello,REP,120,14
+Cattaraugus,City of Salamanca - Ward 2,State Senate,57,George M. Borrello,REP,234,42
+Cattaraugus,City of Salamanca - Ward 3,State Senate,57,George M. Borrello,REP,130,15
+Cattaraugus,City of Salamanca - Ward 4,State Senate,57,George M. Borrello,REP,170,19
+Cattaraugus,City of Salamanca - Ward 5,State Senate,57,George M. Borrello,REP,209,29
+Cattaraugus,Coldspring,State Senate,57,George M. Borrello,REP,258,14
+Cattaraugus,Conewango,State Senate,57,George M. Borrello,REP,252,15
+Cattaraugus,Dayton,State Senate,57,George M. Borrello,REP,465,53
+Cattaraugus,Early Voting - Little Valley 1,State Senate,57,George M. Borrello,REP,517,0
+Cattaraugus,Early Voting - Little Valley 2,State Senate,57,George M. Borrello,REP,568,0
+Cattaraugus,Early Voting - Olean 1,State Senate,57,George M. Borrello,REP,1115,0
+Cattaraugus,Early Voting - Olean 2,State Senate,57,George M. Borrello,REP,605,0
+Cattaraugus,East Otto,State Senate,57,George M. Borrello,REP,309,38
+Cattaraugus,Ellicottville,State Senate,57,George M. Borrello,REP,363,56
+Cattaraugus,Farmersville,State Senate,57,George M. Borrello,REP,363,30
+Cattaraugus,Franklinville District 1,State Senate,57,George M. Borrello,REP,407,35
+Cattaraugus,Franklinville District 2,State Senate,57,George M. Borrello,REP,324,23
+Cattaraugus,Freedom,State Senate,57,George M. Borrello,REP,665,46
+Cattaraugus,Great Valley 1,State Senate,57,George M. Borrello,REP,192,14
+Cattaraugus,Great Valley 2,State Senate,57,George M. Borrello,REP,378,31
+Cattaraugus,Hinsdale,State Senate,57,George M. Borrello,REP,528,41
+Cattaraugus,Humphrey,State Senate,57,George M. Borrello,REP,191,6
+Cattaraugus,Ischua,State Senate,57,George M. Borrello,REP,236,22
+Cattaraugus,Leon,State Senate,57,George M. Borrello,REP,215,17
+Cattaraugus,Little Valley,State Senate,57,George M. Borrello,REP,345,54
+Cattaraugus,Lyndon,State Senate,57,George M. Borrello,REP,184,11
+Cattaraugus,Machias,State Senate,57,George M. Borrello,REP,609,79
+Cattaraugus,Mansfield,State Senate,57,George M. Borrello,REP,219,25
+Cattaraugus,Napoli,State Senate,57,George M. Borrello,REP,309,33
+Cattaraugus,New Albion,State Senate,57,George M. Borrello,REP,465,41
+Cattaraugus,Otto,State Senate,57,George M. Borrello,REP,229,14
+Cattaraugus,Perrysburg,State Senate,57,George M. Borrello,REP,473,33
+Cattaraugus,Persia,State Senate,57,George M. Borrello,REP,513,61
+Cattaraugus,Portville 1,State Senate,57,George M. Borrello,REP,522,49
+Cattaraugus,Portville 2,State Senate,57,George M. Borrello,REP,507,48
+Cattaraugus,Randolph District 1,State Senate,57,George M. Borrello,REP,342,37
+Cattaraugus,Randolph District 2,State Senate,57,George M. Borrello,REP,401,39
+Cattaraugus,Red House,State Senate,57,George M. Borrello,REP,16,2
+Cattaraugus,South Valley,State Senate,57,George M. Borrello,REP,74,5
+Cattaraugus,Town of Olean 1,State Senate,57,George M. Borrello,REP,181,16
+Cattaraugus,Town of Olean 2,State Senate,57,George M. Borrello,REP,322,43
+Cattaraugus,Town of Salamanca,State Senate,57,George M. Borrello,REP,141,6
+Cattaraugus,Yorkshire 1,State Senate,57,George M. Borrello,REP,444,48
+Cattaraugus,Yorkshire 2,State Senate,57,George M. Borrello,REP,458,38
+Cattaraugus,Allegany District 1,State Senate,57,George M. Borrello,CON,29,11
+Cattaraugus,Allegany District 2,State Senate,57,George M. Borrello,CON,11,3
+Cattaraugus,Allegany District 3,State Senate,57,George M. Borrello,CON,23,3
+Cattaraugus,Allegany District 4,State Senate,57,George M. Borrello,CON,38,3
+Cattaraugus,Allegany District 5,State Senate,57,George M. Borrello,CON,33,6
+Cattaraugus,Ashford District 1,State Senate,57,George M. Borrello,CON,25,3
+Cattaraugus,Ashford District 2,State Senate,57,George M. Borrello,CON,50,6
+Cattaraugus,Carrollton,State Senate,57,George M. Borrello,CON,25,2
+Cattaraugus,City of Olean - Ward 1,State Senate,57,George M. Borrello,CON,28,7
+Cattaraugus,City of Olean - Ward 2,State Senate,57,George M. Borrello,CON,34,2
+Cattaraugus,City of Olean - Ward 3,State Senate,57,George M. Borrello,CON,32,7
+Cattaraugus,City of Olean - Ward 4,State Senate,57,George M. Borrello,CON,23,5
+Cattaraugus,City of Olean - Ward 5,State Senate,57,George M. Borrello,CON,30,4
+Cattaraugus,City of Olean - Ward 6,State Senate,57,George M. Borrello,CON,30,8
+Cattaraugus,City of Olean - Ward 7,State Senate,57,George M. Borrello,CON,49,7
+Cattaraugus,City of Salamanca - Ward 1,State Senate,57,George M. Borrello,CON,9,1
+Cattaraugus,City of Salamanca - Ward 2,State Senate,57,George M. Borrello,CON,26,1
+Cattaraugus,City of Salamanca - Ward 3,State Senate,57,George M. Borrello,CON,12,2
+Cattaraugus,City of Salamanca - Ward 4,State Senate,57,George M. Borrello,CON,17,1
+Cattaraugus,City of Salamanca - Ward 5,State Senate,57,George M. Borrello,CON,22,8
+Cattaraugus,Coldspring,State Senate,57,George M. Borrello,CON,27,1
+Cattaraugus,Conewango,State Senate,57,George M. Borrello,CON,26,4
+Cattaraugus,Dayton,State Senate,57,George M. Borrello,CON,46,6
+Cattaraugus,Early Voting - Little Valley 1,State Senate,57,George M. Borrello,CON,50,0
+Cattaraugus,Early Voting - Little Valley 2,State Senate,57,George M. Borrello,CON,61,0
+Cattaraugus,Early Voting - Olean 1,State Senate,57,George M. Borrello,CON,87,0
+Cattaraugus,Early Voting - Olean 2,State Senate,57,George M. Borrello,CON,50,0
+Cattaraugus,East Otto,State Senate,57,George M. Borrello,CON,43,2
+Cattaraugus,Ellicottville,State Senate,57,George M. Borrello,CON,28,3
+Cattaraugus,Farmersville,State Senate,57,George M. Borrello,CON,34,6
+Cattaraugus,Franklinville District 1,State Senate,57,George M. Borrello,CON,44,5
+Cattaraugus,Franklinville District 2,State Senate,57,George M. Borrello,CON,22,2
+Cattaraugus,Freedom,State Senate,57,George M. Borrello,CON,82,10
+Cattaraugus,Great Valley 1,State Senate,57,George M. Borrello,CON,27,1
+Cattaraugus,Great Valley 2,State Senate,57,George M. Borrello,CON,35,2
+Cattaraugus,Hinsdale,State Senate,57,George M. Borrello,CON,67,7
+Cattaraugus,Humphrey,State Senate,57,George M. Borrello,CON,27,2
+Cattaraugus,Ischua,State Senate,57,George M. Borrello,CON,14,2
+Cattaraugus,Leon,State Senate,57,George M. Borrello,CON,31,0
+Cattaraugus,Little Valley,State Senate,57,George M. Borrello,CON,32,5
+Cattaraugus,Lyndon,State Senate,57,George M. Borrello,CON,18,1
+Cattaraugus,Machias,State Senate,57,George M. Borrello,CON,67,8
+Cattaraugus,Mansfield,State Senate,57,George M. Borrello,CON,9,1
+Cattaraugus,Napoli,State Senate,57,George M. Borrello,CON,43,4
+Cattaraugus,New Albion,State Senate,57,George M. Borrello,CON,58,8
+Cattaraugus,Otto,State Senate,57,George M. Borrello,CON,31,4
+Cattaraugus,Perrysburg,State Senate,57,George M. Borrello,CON,75,6
+Cattaraugus,Persia,State Senate,57,George M. Borrello,CON,82,13
+Cattaraugus,Portville 1,State Senate,57,George M. Borrello,CON,39,3
+Cattaraugus,Portville 2,State Senate,57,George M. Borrello,CON,56,6
+Cattaraugus,Randolph District 1,State Senate,57,George M. Borrello,CON,43,6
+Cattaraugus,Randolph District 2,State Senate,57,George M. Borrello,CON,27,6
+Cattaraugus,Red House,State Senate,57,George M. Borrello,CON,2,0
+Cattaraugus,South Valley,State Senate,57,George M. Borrello,CON,7,0
 Cattaraugus,Town of Olean 1,State Senate,57,George M. Borrello,CON,16,0
-Cattaraugus,Town of Olean 2,State Senate,57,George M. Borrello,CON,14,6
-Cattaraugus,Town of Salamanca,State Senate,57,George M. Borrello,CON,19,1
-Cattaraugus,Yorkshire 1,State Senate,57,George M. Borrello,CON,65,6
-Cattaraugus,Yorkshire 2,State Senate,57,George M. Borrello,CON,52,4
-Cattaraugus,Allegany District 1,State Senate,57,Frank V. Puglisi,WOR,7,3
-Cattaraugus,Allegany District 2,State Senate,57,Frank V. Puglisi,WOR,2,5
-Cattaraugus,Allegany District 3,State Senate,57,Frank V. Puglisi,WOR,4,0
-Cattaraugus,Allegany District 4,State Senate,57,Frank V. Puglisi,WOR,11,3
-Cattaraugus,Allegany District 5,State Senate,57,Frank V. Puglisi,WOR,11,4
-Cattaraugus,Ashford District 1,State Senate,57,Frank V. Puglisi,WOR,7,1
-Cattaraugus,Ashford District 2,State Senate,57,Frank V. Puglisi,WOR,11,3
-Cattaraugus,Carrollton,State Senate,57,Frank V. Puglisi,WOR,10,6
-Cattaraugus,City of Olean - Ward 1,State Senate,57,Frank V. Puglisi,WOR,11,4
-Cattaraugus,City of Olean - Ward 2,State Senate,57,Frank V. Puglisi,WOR,12,4
-Cattaraugus,City of Olean - Ward 3,State Senate,57,Frank V. Puglisi,WOR,14,2
-Cattaraugus,City of Olean - Ward 4,State Senate,57,Frank V. Puglisi,WOR,7,3
-Cattaraugus,City of Olean - Ward 5,State Senate,57,Frank V. Puglisi,WOR,10,4
-Cattaraugus,City of Olean - Ward 6,State Senate,57,Frank V. Puglisi,WOR,8,1
-Cattaraugus,City of Olean - Ward 7,State Senate,57,Frank V. Puglisi,WOR,5,5
-Cattaraugus,City of Salamanca - Ward 1,State Senate,57,Frank V. Puglisi,WOR,7,1
-Cattaraugus,City of Salamanca - Ward 2,State Senate,57,Frank V. Puglisi,WOR,8,2
-Cattaraugus,City of Salamanca - Ward 3,State Senate,57,Frank V. Puglisi,WOR,4,6
-Cattaraugus,City of Salamanca - Ward 4,State Senate,57,Frank V. Puglisi,WOR,10,2
-Cattaraugus,City of Salamanca - Ward 5,State Senate,57,Frank V. Puglisi,WOR,10,3
-Cattaraugus,Coldspring,State Senate,57,Frank V. Puglisi,WOR,3,5
-Cattaraugus,Conewango,State Senate,57,Frank V. Puglisi,WOR,11,2
-Cattaraugus,Dayton,State Senate,57,Frank V. Puglisi,WOR,11,2
-Cattaraugus,Early Voting - Little Valley 1,State Senate,57,Frank V. Puglisi,WOR,36,
-Cattaraugus,Early Voting - Little Valley 2,State Senate,57,Frank V. Puglisi,WOR,30,
-Cattaraugus,Early Voting - Olean 1,State Senate,57,Frank V. Puglisi,WOR,75,
-Cattaraugus,Early Voting - Olean 2,State Senate,57,Frank V. Puglisi,WOR,49,
-Cattaraugus,East Otto,State Senate,57,Frank V. Puglisi,WOR,7,0
-Cattaraugus,Ellicottville,State Senate,57,Frank V. Puglisi,WOR,12,4
-Cattaraugus,Farmersville,State Senate,57,Frank V. Puglisi,WOR,5,1
-Cattaraugus,Franklinville District 1,State Senate,57,Frank V. Puglisi,WOR,17,1
-Cattaraugus,Franklinville District 2,State Senate,57,Frank V. Puglisi,WOR,11,0
-Cattaraugus,Freedom,State Senate,57,Frank V. Puglisi,WOR,10,0
-Cattaraugus,Great Valley 1,State Senate,57,Frank V. Puglisi,WOR,4,2
-Cattaraugus,Great Valley 2,State Senate,57,Frank V. Puglisi,WOR,5,2
-Cattaraugus,Hinsdale,State Senate,57,Frank V. Puglisi,WOR,12,1
-Cattaraugus,Humphrey,State Senate,57,Frank V. Puglisi,WOR,5,3
+Cattaraugus,Town of Olean 2,State Senate,57,George M. Borrello,CON,20,6
+Cattaraugus,Town of Salamanca,State Senate,57,George M. Borrello,CON,20,1
+Cattaraugus,Yorkshire 1,State Senate,57,George M. Borrello,CON,71,6
+Cattaraugus,Yorkshire 2,State Senate,57,George M. Borrello,CON,56,4
+Cattaraugus,Allegany District 1,State Senate,57,Frank V. Puglisi,WOR,10,3
+Cattaraugus,Allegany District 2,State Senate,57,Frank V. Puglisi,WOR,4,2
+Cattaraugus,Allegany District 3,State Senate,57,Frank V. Puglisi,WOR,7,3
+Cattaraugus,Allegany District 4,State Senate,57,Frank V. Puglisi,WOR,15,4
+Cattaraugus,Allegany District 5,State Senate,57,Frank V. Puglisi,WOR,12,1
+Cattaraugus,Ashford District 1,State Senate,57,Frank V. Puglisi,WOR,12,5
+Cattaraugus,Ashford District 2,State Senate,57,Frank V. Puglisi,WOR,12,1
+Cattaraugus,Carrollton,State Senate,57,Frank V. Puglisi,WOR,10,0
+Cattaraugus,City of Olean - Ward 1,State Senate,57,Frank V. Puglisi,WOR,15,4
+Cattaraugus,City of Olean - Ward 2,State Senate,57,Frank V. Puglisi,WOR,13,1
+Cattaraugus,City of Olean - Ward 3,State Senate,57,Frank V. Puglisi,WOR,21,7
+Cattaraugus,City of Olean - Ward 4,State Senate,57,Frank V. Puglisi,WOR,10,3
+Cattaraugus,City of Olean - Ward 5,State Senate,57,Frank V. Puglisi,WOR,13,3
+Cattaraugus,City of Olean - Ward 6,State Senate,57,Frank V. Puglisi,WOR,14,6
+Cattaraugus,City of Olean - Ward 7,State Senate,57,Frank V. Puglisi,WOR,9,4
+Cattaraugus,City of Salamanca - Ward 1,State Senate,57,Frank V. Puglisi,WOR,7,0
+Cattaraugus,City of Salamanca - Ward 2,State Senate,57,Frank V. Puglisi,WOR,11,3
+Cattaraugus,City of Salamanca - Ward 3,State Senate,57,Frank V. Puglisi,WOR,4,0
+Cattaraugus,City of Salamanca - Ward 4,State Senate,57,Frank V. Puglisi,WOR,11,1
+Cattaraugus,City of Salamanca - Ward 5,State Senate,57,Frank V. Puglisi,WOR,14,4
+Cattaraugus,Coldspring,State Senate,57,Frank V. Puglisi,WOR,5,2
+Cattaraugus,Conewango,State Senate,57,Frank V. Puglisi,WOR,16,5
+Cattaraugus,Dayton,State Senate,57,Frank V. Puglisi,WOR,14,3
+Cattaraugus,Early Voting - Little Valley 1,State Senate,57,Frank V. Puglisi,WOR,36,0
+Cattaraugus,Early Voting - Little Valley 2,State Senate,57,Frank V. Puglisi,WOR,30,0
+Cattaraugus,Early Voting - Olean 1,State Senate,57,Frank V. Puglisi,WOR,75,0
+Cattaraugus,Early Voting - Olean 2,State Senate,57,Frank V. Puglisi,WOR,49,0
+Cattaraugus,East Otto,State Senate,57,Frank V. Puglisi,WOR,9,2
+Cattaraugus,Ellicottville,State Senate,57,Frank V. Puglisi,WOR,18,6
+Cattaraugus,Farmersville,State Senate,57,Frank V. Puglisi,WOR,8,3
+Cattaraugus,Franklinville District 1,State Senate,57,Frank V. Puglisi,WOR,19,2
+Cattaraugus,Franklinville District 2,State Senate,57,Frank V. Puglisi,WOR,13,2
+Cattaraugus,Freedom,State Senate,57,Frank V. Puglisi,WOR,15,5
+Cattaraugus,Great Valley 1,State Senate,57,Frank V. Puglisi,WOR,4,0
+Cattaraugus,Great Valley 2,State Senate,57,Frank V. Puglisi,WOR,9,4
+Cattaraugus,Hinsdale,State Senate,57,Frank V. Puglisi,WOR,13,1
+Cattaraugus,Humphrey,State Senate,57,Frank V. Puglisi,WOR,6,1
 Cattaraugus,Ischua,State Senate,57,Frank V. Puglisi,WOR,6,0
-Cattaraugus,Leon,State Senate,57,Frank V. Puglisi,WOR,6,3
-Cattaraugus,Little Valley,State Senate,57,Frank V. Puglisi,WOR,6,3
-Cattaraugus,Lyndon,State Senate,57,Frank V. Puglisi,WOR,12,7
-Cattaraugus,Machias,State Senate,57,Frank V. Puglisi,WOR,19,3
-Cattaraugus,Mansfield,State Senate,57,Frank V. Puglisi,WOR,9,3
-Cattaraugus,Napoli,State Senate,57,Frank V. Puglisi,WOR,5,5
+Cattaraugus,Leon,State Senate,57,Frank V. Puglisi,WOR,6,0
+Cattaraugus,Little Valley,State Senate,57,Frank V. Puglisi,WOR,8,2
+Cattaraugus,Lyndon,State Senate,57,Frank V. Puglisi,WOR,14,2
+Cattaraugus,Machias,State Senate,57,Frank V. Puglisi,WOR,22,3
+Cattaraugus,Mansfield,State Senate,57,Frank V. Puglisi,WOR,10,1
+Cattaraugus,Napoli,State Senate,57,Frank V. Puglisi,WOR,8,3
 Cattaraugus,New Albion,State Senate,57,Frank V. Puglisi,WOR,8,0
-Cattaraugus,Otto,State Senate,57,Frank V. Puglisi,WOR,2,0
-Cattaraugus,Perrysburg,State Senate,57,Frank V. Puglisi,WOR,14,1
-Cattaraugus,Persia,State Senate,57,Frank V. Puglisi,WOR,15,0
-Cattaraugus,Portville 1,State Senate,57,Frank V. Puglisi,WOR,7,0
+Cattaraugus,Otto,State Senate,57,Frank V. Puglisi,WOR,5,3
+Cattaraugus,Perrysburg,State Senate,57,Frank V. Puglisi,WOR,18,4
+Cattaraugus,Persia,State Senate,57,Frank V. Puglisi,WOR,18,3
+Cattaraugus,Portville 1,State Senate,57,Frank V. Puglisi,WOR,12,5
 Cattaraugus,Portville 2,State Senate,57,Frank V. Puglisi,WOR,6,0
-Cattaraugus,Randolph District 1,State Senate,57,Frank V. Puglisi,WOR,5,3
-Cattaraugus,Randolph District 2,State Senate,57,Frank V. Puglisi,WOR,6,0
-Cattaraugus,Red House,State Senate,57,Frank V. Puglisi,WOR,0,1
-Cattaraugus,South Valley,State Senate,57,Frank V. Puglisi,WOR,3,4
-Cattaraugus,Town of Olean 1,State Senate,57,Frank V. Puglisi,WOR,7,1
-Cattaraugus,Town of Olean 2,State Senate,57,Frank V. Puglisi,WOR,6,3
-Cattaraugus,Town of Salamanca,State Senate,57,Frank V. Puglisi,WOR,5,3
-Cattaraugus,Yorkshire 1,State Senate,57,Frank V. Puglisi,WOR,4,2
-Cattaraugus,Yorkshire 2,State Senate,57,Frank V. Puglisi,WOR,15,2
-Cattaraugus,Allegany District 1,State Senate,57,George M. Borrello,LIB,8,2
-Cattaraugus,Allegany District 2,State Senate,57,George M. Borrello,LIB,2,2
-Cattaraugus,Allegany District 3,State Senate,57,George M. Borrello,LIB,7,2
-Cattaraugus,Allegany District 4,State Senate,57,George M. Borrello,LIB,1,1
+Cattaraugus,Randolph District 1,State Senate,57,Frank V. Puglisi,WOR,5,0
+Cattaraugus,Randolph District 2,State Senate,57,Frank V. Puglisi,WOR,7,1
+Cattaraugus,Red House,State Senate,57,Frank V. Puglisi,WOR,0,0
+Cattaraugus,South Valley,State Senate,57,Frank V. Puglisi,WOR,3,0
+Cattaraugus,Town of Olean 1,State Senate,57,Frank V. Puglisi,WOR,8,1
+Cattaraugus,Town of Olean 2,State Senate,57,Frank V. Puglisi,WOR,9,3
+Cattaraugus,Town of Salamanca,State Senate,57,Frank V. Puglisi,WOR,8,3
+Cattaraugus,Yorkshire 1,State Senate,57,Frank V. Puglisi,WOR,6,2
+Cattaraugus,Yorkshire 2,State Senate,57,Frank V. Puglisi,WOR,17,2
+Cattaraugus,Allegany District 1,State Senate,57,George M. Borrello,LIB,10,2
+Cattaraugus,Allegany District 2,State Senate,57,George M. Borrello,LIB,2,0
+Cattaraugus,Allegany District 3,State Senate,57,George M. Borrello,LIB,7,0
+Cattaraugus,Allegany District 4,State Senate,57,George M. Borrello,LIB,3,2
 Cattaraugus,Allegany District 5,State Senate,57,George M. Borrello,LIB,6,0
-Cattaraugus,Ashford District 1,State Senate,57,George M. Borrello,LIB,6,1
-Cattaraugus,Ashford District 2,State Senate,57,George M. Borrello,LIB,5,2
-Cattaraugus,Carrollton,State Senate,57,George M. Borrello,LIB,7,3
-Cattaraugus,City of Olean - Ward 1,State Senate,57,George M. Borrello,LIB,6,1
-Cattaraugus,City of Olean - Ward 2,State Senate,57,George M. Borrello,LIB,4,1
-Cattaraugus,City of Olean - Ward 3,State Senate,57,George M. Borrello,LIB,2,0
-Cattaraugus,City of Olean - Ward 4,State Senate,57,George M. Borrello,LIB,6,0
-Cattaraugus,City of Olean - Ward 5,State Senate,57,George M. Borrello,LIB,7,2
-Cattaraugus,City of Olean - Ward 6,State Senate,57,George M. Borrello,LIB,6,0
-Cattaraugus,City of Olean - Ward 7,State Senate,57,George M. Borrello,LIB,5,1
-Cattaraugus,City of Salamanca - Ward 1,State Senate,57,George M. Borrello,LIB,1,0
+Cattaraugus,Ashford District 1,State Senate,57,George M. Borrello,LIB,7,1
+Cattaraugus,Ashford District 2,State Senate,57,George M. Borrello,LIB,5,0
+Cattaraugus,Carrollton,State Senate,57,George M. Borrello,LIB,9,2
+Cattaraugus,City of Olean - Ward 1,State Senate,57,George M. Borrello,LIB,6,0
+Cattaraugus,City of Olean - Ward 2,State Senate,57,George M. Borrello,LIB,5,1
+Cattaraugus,City of Olean - Ward 3,State Senate,57,George M. Borrello,LIB,8,6
+Cattaraugus,City of Olean - Ward 4,State Senate,57,George M. Borrello,LIB,9,3
+Cattaraugus,City of Olean - Ward 5,State Senate,57,George M. Borrello,LIB,9,2
+Cattaraugus,City of Olean - Ward 6,State Senate,57,George M. Borrello,LIB,9,3
+Cattaraugus,City of Olean - Ward 7,State Senate,57,George M. Borrello,LIB,6,1
+Cattaraugus,City of Salamanca - Ward 1,State Senate,57,George M. Borrello,LIB,2,1
 Cattaraugus,City of Salamanca - Ward 2,State Senate,57,George M. Borrello,LIB,4,0
-Cattaraugus,City of Salamanca - Ward 3,State Senate,57,George M. Borrello,LIB,2,2
+Cattaraugus,City of Salamanca - Ward 3,State Senate,57,George M. Borrello,LIB,2,0
 Cattaraugus,City of Salamanca - Ward 4,State Senate,57,George M. Borrello,LIB,2,0
-Cattaraugus,City of Salamanca - Ward 5,State Senate,57,George M. Borrello,LIB,2,1
-Cattaraugus,Coldspring,State Senate,57,George M. Borrello,LIB,3,2
-Cattaraugus,Conewango,State Senate,57,George M. Borrello,LIB,8,0
-Cattaraugus,Dayton,State Senate,57,George M. Borrello,LIB,8,0
-Cattaraugus,Early Voting - Little Valley 1,State Senate,57,George M. Borrello,LIB,14,
-Cattaraugus,Early Voting - Little Valley 2,State Senate,57,George M. Borrello,LIB,6,
-Cattaraugus,Early Voting - Olean 1,State Senate,57,George M. Borrello,LIB,24,
-Cattaraugus,Early Voting - Olean 2,State Senate,57,George M. Borrello,LIB,12,
-Cattaraugus,East Otto,State Senate,57,George M. Borrello,LIB,3,1
-Cattaraugus,Ellicottville,State Senate,57,George M. Borrello,LIB,5,1
-Cattaraugus,Farmersville,State Senate,57,George M. Borrello,LIB,2,2
+Cattaraugus,City of Salamanca - Ward 5,State Senate,57,George M. Borrello,LIB,2,0
+Cattaraugus,Coldspring,State Senate,57,George M. Borrello,LIB,3,0
+Cattaraugus,Conewango,State Senate,57,George M. Borrello,LIB,10,2
+Cattaraugus,Dayton,State Senate,57,George M. Borrello,LIB,9,1
+Cattaraugus,Early Voting - Little Valley 1,State Senate,57,George M. Borrello,LIB,14,0
+Cattaraugus,Early Voting - Little Valley 2,State Senate,57,George M. Borrello,LIB,6,0
+Cattaraugus,Early Voting - Olean 1,State Senate,57,George M. Borrello,LIB,24,0
+Cattaraugus,Early Voting - Olean 2,State Senate,57,George M. Borrello,LIB,12,0
+Cattaraugus,East Otto,State Senate,57,George M. Borrello,LIB,3,0
+Cattaraugus,Ellicottville,State Senate,57,George M. Borrello,LIB,7,2
+Cattaraugus,Farmersville,State Senate,57,George M. Borrello,LIB,3,1
 Cattaraugus,Franklinville District 1,State Senate,57,George M. Borrello,LIB,3,0
 Cattaraugus,Franklinville District 2,State Senate,57,George M. Borrello,LIB,2,0
-Cattaraugus,Freedom,State Senate,57,George M. Borrello,LIB,7,1
-Cattaraugus,Great Valley 1,State Senate,57,George M. Borrello,LIB,7,1
-Cattaraugus,Great Valley 2,State Senate,57,George M. Borrello,LIB,6,0
-Cattaraugus,Hinsdale,State Senate,57,George M. Borrello,LIB,8,0
-Cattaraugus,Humphrey,State Senate,57,George M. Borrello,LIB,3,1
-Cattaraugus,Ischua,State Senate,57,George M. Borrello,LIB,3,2
-Cattaraugus,Leon,State Senate,57,George M. Borrello,LIB,5,0
-Cattaraugus,Little Valley,State Senate,57,George M. Borrello,LIB,6,0
-Cattaraugus,Lyndon,State Senate,57,George M. Borrello,LIB,2,6
-Cattaraugus,Machias,State Senate,57,George M. Borrello,LIB,4,3
-Cattaraugus,Mansfield,State Senate,57,George M. Borrello,LIB,3,1
-Cattaraugus,Napoli,State Senate,57,George M. Borrello,LIB,5,1
-Cattaraugus,New Albion,State Senate,57,George M. Borrello,LIB,12,1
-Cattaraugus,Otto,State Senate,57,George M. Borrello,LIB,2,1
-Cattaraugus,Perrysburg,State Senate,57,George M. Borrello,LIB,3,0
-Cattaraugus,Persia,State Senate,57,George M. Borrello,LIB,8,0
-Cattaraugus,Portville 1,State Senate,57,George M. Borrello,LIB,9,0
-Cattaraugus,Portville 2,State Senate,57,George M. Borrello,LIB,5,1
-Cattaraugus,Randolph District 1,State Senate,57,George M. Borrello,LIB,3,0
+Cattaraugus,Freedom,State Senate,57,George M. Borrello,LIB,9,2
+Cattaraugus,Great Valley 1,State Senate,57,George M. Borrello,LIB,8,1
+Cattaraugus,Great Valley 2,State Senate,57,George M. Borrello,LIB,7,1
+Cattaraugus,Hinsdale,State Senate,57,George M. Borrello,LIB,10,2
+Cattaraugus,Humphrey,State Senate,57,George M. Borrello,LIB,3,0
+Cattaraugus,Ischua,State Senate,57,George M. Borrello,LIB,3,0
+Cattaraugus,Leon,State Senate,57,George M. Borrello,LIB,6,1
+Cattaraugus,Little Valley,State Senate,57,George M. Borrello,LIB,7,1
+Cattaraugus,Lyndon,State Senate,57,George M. Borrello,LIB,2,0
+Cattaraugus,Machias,State Senate,57,George M. Borrello,LIB,5,1
+Cattaraugus,Mansfield,State Senate,57,George M. Borrello,LIB,3,0
+Cattaraugus,Napoli,State Senate,57,George M. Borrello,LIB,5,0
+Cattaraugus,New Albion,State Senate,57,George M. Borrello,LIB,14,2
+Cattaraugus,Otto,State Senate,57,George M. Borrello,LIB,2,0
+Cattaraugus,Perrysburg,State Senate,57,George M. Borrello,LIB,4,1
+Cattaraugus,Persia,State Senate,57,George M. Borrello,LIB,9,1
+Cattaraugus,Portville 1,State Senate,57,George M. Borrello,LIB,10,1
+Cattaraugus,Portville 2,State Senate,57,George M. Borrello,LIB,6,1
+Cattaraugus,Randolph District 1,State Senate,57,George M. Borrello,LIB,4,1
 Cattaraugus,Randolph District 2,State Senate,57,George M. Borrello,LIB,5,0
 Cattaraugus,Red House,State Senate,57,George M. Borrello,LIB,0,0
 Cattaraugus,South Valley,State Senate,57,George M. Borrello,LIB,3,0
@@ -1473,65 +1473,65 @@ Cattaraugus,Town of Olean 1,State Senate,57,George M. Borrello,LIB,2,0
 Cattaraugus,Town of Olean 2,State Senate,57,George M. Borrello,LIB,3,0
 Cattaraugus,Town of Salamanca,State Senate,57,George M. Borrello,LIB,4,0
 Cattaraugus,Yorkshire 1,State Senate,57,George M. Borrello,LIB,7,0
-Cattaraugus,Yorkshire 2,State Senate,57,George M. Borrello,LIB,15,1
-Cattaraugus,Allegany District 1,State Senate,57,George M. Borrello,IND,11,3
-Cattaraugus,Allegany District 2,State Senate,57,George M. Borrello,IND,4,0
-Cattaraugus,Allegany District 3,State Senate,57,George M. Borrello,IND,7,0
+Cattaraugus,Yorkshire 2,State Senate,57,George M. Borrello,LIB,16,1
+Cattaraugus,Allegany District 1,State Senate,57,George M. Borrello,IND,14,3
+Cattaraugus,Allegany District 2,State Senate,57,George M. Borrello,IND,7,3
+Cattaraugus,Allegany District 3,State Senate,57,George M. Borrello,IND,8,1
 Cattaraugus,Allegany District 4,State Senate,57,George M. Borrello,IND,11,0
-Cattaraugus,Allegany District 5,State Senate,57,George M. Borrello,IND,9,3
-Cattaraugus,Ashford District 1,State Senate,57,George M. Borrello,IND,3,1
-Cattaraugus,Ashford District 2,State Senate,57,George M. Borrello,IND,7,0
-Cattaraugus,Carrollton,State Senate,57,George M. Borrello,IND,6,2
-Cattaraugus,City of Olean - Ward 1,State Senate,57,George M. Borrello,IND,7,0
-Cattaraugus,City of Olean - Ward 2,State Senate,57,George M. Borrello,IND,13,1
-Cattaraugus,City of Olean - Ward 3,State Senate,57,George M. Borrello,IND,9,3
-Cattaraugus,City of Olean - Ward 4,State Senate,57,George M. Borrello,IND,3,1
+Cattaraugus,Allegany District 5,State Senate,57,George M. Borrello,IND,12,3
+Cattaraugus,Ashford District 1,State Senate,57,George M. Borrello,IND,3,0
+Cattaraugus,Ashford District 2,State Senate,57,George M. Borrello,IND,8,1
+Cattaraugus,Carrollton,State Senate,57,George M. Borrello,IND,6,0
+Cattaraugus,City of Olean - Ward 1,State Senate,57,George M. Borrello,IND,10,3
+Cattaraugus,City of Olean - Ward 2,State Senate,57,George M. Borrello,IND,14,1
+Cattaraugus,City of Olean - Ward 3,State Senate,57,George M. Borrello,IND,9,0
+Cattaraugus,City of Olean - Ward 4,State Senate,57,George M. Borrello,IND,3,0
 Cattaraugus,City of Olean - Ward 5,State Senate,57,George M. Borrello,IND,4,0
-Cattaraugus,City of Olean - Ward 6,State Senate,57,George M. Borrello,IND,6,3
+Cattaraugus,City of Olean - Ward 6,State Senate,57,George M. Borrello,IND,8,2
 Cattaraugus,City of Olean - Ward 7,State Senate,57,George M. Borrello,IND,10,0
-Cattaraugus,City of Salamanca - Ward 1,State Senate,57,George M. Borrello,IND,3,1
-Cattaraugus,City of Salamanca - Ward 2,State Senate,57,George M. Borrello,IND,10,1
+Cattaraugus,City of Salamanca - Ward 1,State Senate,57,George M. Borrello,IND,5,2
+Cattaraugus,City of Salamanca - Ward 2,State Senate,57,George M. Borrello,IND,11,1
 Cattaraugus,City of Salamanca - Ward 3,State Senate,57,George M. Borrello,IND,2,0
-Cattaraugus,City of Salamanca - Ward 4,State Senate,57,George M. Borrello,IND,5,0
-Cattaraugus,City of Salamanca - Ward 5,State Senate,57,George M. Borrello,IND,6,1
-Cattaraugus,Coldspring,State Senate,57,George M. Borrello,IND,4,1
+Cattaraugus,City of Salamanca - Ward 4,State Senate,57,George M. Borrello,IND,6,1
+Cattaraugus,City of Salamanca - Ward 5,State Senate,57,George M. Borrello,IND,6,0
+Cattaraugus,Coldspring,State Senate,57,George M. Borrello,IND,5,1
 Cattaraugus,Conewango,State Senate,57,George M. Borrello,IND,4,0
 Cattaraugus,Dayton,State Senate,57,George M. Borrello,IND,9,0
-Cattaraugus,Early Voting - Little Valley 1,State Senate,57,George M. Borrello,IND,17,
-Cattaraugus,Early Voting - Little Valley 2,State Senate,57,George M. Borrello,IND,11,
-Cattaraugus,Early Voting - Olean 1,State Senate,57,George M. Borrello,IND,41,
-Cattaraugus,Early Voting - Olean 2,State Senate,57,George M. Borrello,IND,21,
-Cattaraugus,East Otto,State Senate,57,George M. Borrello,IND,4,2
-Cattaraugus,Ellicottville,State Senate,57,George M. Borrello,IND,7,2
-Cattaraugus,Farmersville,State Senate,57,George M. Borrello,IND,6,1
+Cattaraugus,Early Voting - Little Valley 1,State Senate,57,George M. Borrello,IND,17,0
+Cattaraugus,Early Voting - Little Valley 2,State Senate,57,George M. Borrello,IND,11,0
+Cattaraugus,Early Voting - Olean 1,State Senate,57,George M. Borrello,IND,41,0
+Cattaraugus,Early Voting - Olean 2,State Senate,57,George M. Borrello,IND,21,0
+Cattaraugus,East Otto,State Senate,57,George M. Borrello,IND,4,0
+Cattaraugus,Ellicottville,State Senate,57,George M. Borrello,IND,7,0
+Cattaraugus,Farmersville,State Senate,57,George M. Borrello,IND,7,1
 Cattaraugus,Franklinville District 1,State Senate,57,George M. Borrello,IND,6,0
 Cattaraugus,Franklinville District 2,State Senate,57,George M. Borrello,IND,4,0
-Cattaraugus,Freedom,State Senate,57,George M. Borrello,IND,13,0
-Cattaraugus,Great Valley 1,State Senate,57,George M. Borrello,IND,5,2
-Cattaraugus,Great Valley 2,State Senate,57,George M. Borrello,IND,12,0
-Cattaraugus,Hinsdale,State Senate,57,George M. Borrello,IND,6,1
-Cattaraugus,Humphrey,State Senate,57,George M. Borrello,IND,2,3
-Cattaraugus,Ischua,State Senate,57,George M. Borrello,IND,5,2
-Cattaraugus,Leon,State Senate,57,George M. Borrello,IND,7,2
-Cattaraugus,Little Valley,State Senate,57,George M. Borrello,IND,7,0
+Cattaraugus,Freedom,State Senate,57,George M. Borrello,IND,14,1
+Cattaraugus,Great Valley 1,State Senate,57,George M. Borrello,IND,7,2
+Cattaraugus,Great Valley 2,State Senate,57,George M. Borrello,IND,14,2
+Cattaraugus,Hinsdale,State Senate,57,George M. Borrello,IND,7,1
+Cattaraugus,Humphrey,State Senate,57,George M. Borrello,IND,2,0
+Cattaraugus,Ischua,State Senate,57,George M. Borrello,IND,5,0
+Cattaraugus,Leon,State Senate,57,George M. Borrello,IND,7,0
+Cattaraugus,Little Valley,State Senate,57,George M. Borrello,IND,9,2
 Cattaraugus,Lyndon,State Senate,57,George M. Borrello,IND,5,0
-Cattaraugus,Machias,State Senate,57,George M. Borrello,IND,13,0
-Cattaraugus,Mansfield,State Senate,57,George M. Borrello,IND,2,2
-Cattaraugus,Napoli,State Senate,57,George M. Borrello,IND,3,0
-Cattaraugus,New Albion,State Senate,57,George M. Borrello,IND,5,1
-Cattaraugus,Otto,State Senate,57,George M. Borrello,IND,6,2
-Cattaraugus,Perrysburg,State Senate,57,George M. Borrello,IND,30,0
-Cattaraugus,Persia,State Senate,57,George M. Borrello,IND,9,0
+Cattaraugus,Machias,State Senate,57,George M. Borrello,IND,16,3
+Cattaraugus,Mansfield,State Senate,57,George M. Borrello,IND,3,1
+Cattaraugus,Napoli,State Senate,57,George M. Borrello,IND,5,2
+Cattaraugus,New Albion,State Senate,57,George M. Borrello,IND,7,2
+Cattaraugus,Otto,State Senate,57,George M. Borrello,IND,6,0
+Cattaraugus,Perrysburg,State Senate,57,George M. Borrello,IND,31,1
+Cattaraugus,Persia,State Senate,57,George M. Borrello,IND,11,2
 Cattaraugus,Portville 1,State Senate,57,George M. Borrello,IND,2,0
-Cattaraugus,Portville 2,State Senate,57,George M. Borrello,IND,7,2
-Cattaraugus,Randolph District 1,State Senate,57,George M. Borrello,IND,11,1
+Cattaraugus,Portville 2,State Senate,57,George M. Borrello,IND,8,1
+Cattaraugus,Randolph District 1,State Senate,57,George M. Borrello,IND,13,2
 Cattaraugus,Randolph District 2,State Senate,57,George M. Borrello,IND,8,0
-Cattaraugus,Red House,State Senate,57,George M. Borrello,IND,0,1
+Cattaraugus,Red House,State Senate,57,George M. Borrello,IND,0,0
 Cattaraugus,South Valley,State Senate,57,George M. Borrello,IND,2,0
 Cattaraugus,Town of Olean 1,State Senate,57,George M. Borrello,IND,5,0
 Cattaraugus,Town of Olean 2,State Senate,57,George M. Borrello,IND,3,0
-Cattaraugus,Town of Salamanca,State Senate,57,George M. Borrello,IND,3,2
-Cattaraugus,Yorkshire 1,State Senate,57,George M. Borrello,IND,6,2
+Cattaraugus,Town of Salamanca,State Senate,57,George M. Borrello,IND,5,2
+Cattaraugus,Yorkshire 1,State Senate,57,George M. Borrello,IND,8,2
 Cattaraugus,Yorkshire 2,State Senate,57,George M. Borrello,IND,6,0
 Cattaraugus,Allegany District 1,State Senate,57,Write-ins,,0,0
 Cattaraugus,Allegany District 2,State Senate,57,Write-ins,,0,0
@@ -1539,7 +1539,7 @@ Cattaraugus,Allegany District 3,State Senate,57,Write-ins,,0,0
 Cattaraugus,Allegany District 4,State Senate,57,Write-ins,,0,0
 Cattaraugus,Allegany District 5,State Senate,57,Write-ins,,0,0
 Cattaraugus,Ashford District 1,State Senate,57,Write-ins,,0,0
-Cattaraugus,Ashford District 2,State Senate,57,Write-ins,,0,0
+Cattaraugus,Ashford District 2,State Senate,57,Write-ins,,1,1
 Cattaraugus,Carrollton,State Senate,57,Write-ins,,0,0
 Cattaraugus,City of Olean - Ward 1,State Senate,57,Write-ins,,0,0
 Cattaraugus,City of Olean - Ward 2,State Senate,57,Write-ins,,0,0
@@ -1548,7 +1548,7 @@ Cattaraugus,City of Olean - Ward 4,State Senate,57,Write-ins,,0,0
 Cattaraugus,City of Olean - Ward 5,State Senate,57,Write-ins,,0,0
 Cattaraugus,City of Olean - Ward 6,State Senate,57,Write-ins,,0,0
 Cattaraugus,City of Olean - Ward 7,State Senate,57,Write-ins,,0,0
-Cattaraugus,City of Salamanca - Ward 1,State Senate,57,Write-ins,,0,1
+Cattaraugus,City of Salamanca - Ward 1,State Senate,57,Write-ins,,0,0
 Cattaraugus,City of Salamanca - Ward 2,State Senate,57,Write-ins,,0,0
 Cattaraugus,City of Salamanca - Ward 3,State Senate,57,Write-ins,,0,0
 Cattaraugus,City of Salamanca - Ward 4,State Senate,57,Write-ins,,0,0
@@ -1556,10 +1556,10 @@ Cattaraugus,City of Salamanca - Ward 5,State Senate,57,Write-ins,,0,0
 Cattaraugus,Coldspring,State Senate,57,Write-ins,,0,0
 Cattaraugus,Conewango,State Senate,57,Write-ins,,0,0
 Cattaraugus,Dayton,State Senate,57,Write-ins,,0,0
-Cattaraugus,Early Voting - Little Valley 1,State Senate,57,Write-ins,,0,
-Cattaraugus,Early Voting - Little Valley 2,State Senate,57,Write-ins,,0,
-Cattaraugus,Early Voting - Olean 1,State Senate,57,Write-ins,,1,
-Cattaraugus,Early Voting - Olean 2,State Senate,57,Write-ins,,2,
+Cattaraugus,Early Voting - Little Valley 1,State Senate,57,Write-ins,,0,0
+Cattaraugus,Early Voting - Little Valley 2,State Senate,57,Write-ins,,0,0
+Cattaraugus,Early Voting - Olean 1,State Senate,57,Write-ins,,1,0
+Cattaraugus,Early Voting - Olean 2,State Senate,57,Write-ins,,2,0
 Cattaraugus,East Otto,State Senate,57,Write-ins,,0,0
 Cattaraugus,Ellicottville,State Senate,57,Write-ins,,0,0
 Cattaraugus,Farmersville,State Senate,57,Write-ins,,0,0
@@ -1593,359 +1593,359 @@ Cattaraugus,Town of Salamanca,State Senate,57,Write-ins,,0,0
 Cattaraugus,Yorkshire 1,State Senate,57,Write-ins,,0,0
 Cattaraugus,Yorkshire 2,State Senate,57,Write-ins,,0,0
 Cattaraugus,Allegany District 1,State Senate,57,Voids,,0,0
-Cattaraugus,Allegany District 2,State Senate,57,Voids,,0,0
+Cattaraugus,Allegany District 2,State Senate,57,Voids,,3,3
 Cattaraugus,Allegany District 3,State Senate,57,Voids,,0,0
 Cattaraugus,Allegany District 4,State Senate,57,Voids,,0,0
-Cattaraugus,Allegany District 5,State Senate,57,Voids,,0,0
+Cattaraugus,Allegany District 5,State Senate,57,Voids,,1,1
 Cattaraugus,Ashford District 1,State Senate,57,Voids,,0,0
-Cattaraugus,Ashford District 2,State Senate,57,Voids,,1,1
+Cattaraugus,Ashford District 2,State Senate,57,Voids,,1,0
 Cattaraugus,Carrollton,State Senate,57,Voids,,0,0
 Cattaraugus,City of Olean - Ward 1,State Senate,57,Voids,,0,0
 Cattaraugus,City of Olean - Ward 2,State Senate,57,Voids,,0,0
-Cattaraugus,City of Olean - Ward 3,State Senate,57,Voids,,0,3
+Cattaraugus,City of Olean - Ward 3,State Senate,57,Voids,,3,3
 Cattaraugus,City of Olean - Ward 4,State Senate,57,Voids,,0,0
-Cattaraugus,City of Olean - Ward 5,State Senate,57,Voids,,0,0
-Cattaraugus,City of Olean - Ward 6,State Senate,57,Voids,,0,1
+Cattaraugus,City of Olean - Ward 5,State Senate,57,Voids,,1,1
+Cattaraugus,City of Olean - Ward 6,State Senate,57,Voids,,0,0
 Cattaraugus,City of Olean - Ward 7,State Senate,57,Voids,,0,0
-Cattaraugus,City of Salamanca - Ward 1,State Senate,57,Voids,,0,0
+Cattaraugus,City of Salamanca - Ward 1,State Senate,57,Voids,,1,1
 Cattaraugus,City of Salamanca - Ward 2,State Senate,57,Voids,,0,0
-Cattaraugus,City of Salamanca - Ward 3,State Senate,57,Voids,,0,2
-Cattaraugus,City of Salamanca - Ward 4,State Senate,57,Voids,,0,1
-Cattaraugus,City of Salamanca - Ward 5,State Senate,57,Voids,,0,1
-Cattaraugus,Coldspring,State Senate,57,Voids,,0,1
-Cattaraugus,Conewango,State Senate,57,Voids,,0,1
+Cattaraugus,City of Salamanca - Ward 3,State Senate,57,Voids,,0,0
+Cattaraugus,City of Salamanca - Ward 4,State Senate,57,Voids,,0,0
+Cattaraugus,City of Salamanca - Ward 5,State Senate,57,Voids,,1,1
+Cattaraugus,Coldspring,State Senate,57,Voids,,0,0
+Cattaraugus,Conewango,State Senate,57,Voids,,0,0
 Cattaraugus,Dayton,State Senate,57,Voids,,0,0
-Cattaraugus,Early Voting - Little Valley 1,State Senate,57,Voids,,0,
-Cattaraugus,Early Voting - Little Valley 2,State Senate,57,Voids,,0,
-Cattaraugus,Early Voting - Olean 1,State Senate,57,Voids,,0,
-Cattaraugus,Early Voting - Olean 2,State Senate,57,Voids,,0,
-Cattaraugus,East Otto,State Senate,57,Voids,,0,0
-Cattaraugus,Ellicottville,State Senate,57,Voids,,0,1
-Cattaraugus,Farmersville,State Senate,57,Voids,,0,0
-Cattaraugus,Franklinville District 1,State Senate,57,Voids,,0,0
+Cattaraugus,Early Voting - Little Valley 1,State Senate,57,Voids,,0,0
+Cattaraugus,Early Voting - Little Valley 2,State Senate,57,Voids,,0,0
+Cattaraugus,Early Voting - Olean 1,State Senate,57,Voids,,0,0
+Cattaraugus,Early Voting - Olean 2,State Senate,57,Voids,,0,0
+Cattaraugus,East Otto,State Senate,57,Voids,,1,1
+Cattaraugus,Ellicottville,State Senate,57,Voids,,2,2
+Cattaraugus,Farmersville,State Senate,57,Voids,,1,1
+Cattaraugus,Franklinville District 1,State Senate,57,Voids,,1,1
 Cattaraugus,Franklinville District 2,State Senate,57,Voids,,0,0
-Cattaraugus,Freedom,State Senate,57,Voids,,0,0
+Cattaraugus,Freedom,State Senate,57,Voids,,1,1
 Cattaraugus,Great Valley 1,State Senate,57,Voids,,0,0
-Cattaraugus,Great Valley 2,State Senate,57,Voids,,0,0
+Cattaraugus,Great Valley 2,State Senate,57,Voids,,1,1
 Cattaraugus,Hinsdale,State Senate,57,Voids,,0,0
 Cattaraugus,Humphrey,State Senate,57,Voids,,0,0
 Cattaraugus,Ischua,State Senate,57,Voids,,0,0
-Cattaraugus,Leon,State Senate,57,Voids,,0,1
+Cattaraugus,Leon,State Senate,57,Voids,,0,0
 Cattaraugus,Little Valley,State Senate,57,Voids,,0,0
-Cattaraugus,Lyndon,State Senate,57,Voids,,0,3
+Cattaraugus,Lyndon,State Senate,57,Voids,,0,0
 Cattaraugus,Machias,State Senate,57,Voids,,1,0
-Cattaraugus,Mansfield,State Senate,57,Voids,,0,1
-Cattaraugus,Napoli,State Senate,57,Voids,,0,0
+Cattaraugus,Mansfield,State Senate,57,Voids,,0,0
+Cattaraugus,Napoli,State Senate,57,Voids,,1,1
 Cattaraugus,New Albion,State Senate,57,Voids,,0,0
 Cattaraugus,Otto,State Senate,57,Voids,,0,0
 Cattaraugus,Perrysburg,State Senate,57,Voids,,0,0
-Cattaraugus,Persia,State Senate,57,Voids,,0,0
+Cattaraugus,Persia,State Senate,57,Voids,,1,1
 Cattaraugus,Portville 1,State Senate,57,Voids,,0,0
-Cattaraugus,Portville 2,State Senate,57,Voids,,0,1
+Cattaraugus,Portville 2,State Senate,57,Voids,,0,0
 Cattaraugus,Randolph District 1,State Senate,57,Voids,,0,0
 Cattaraugus,Randolph District 2,State Senate,57,Voids,,0,0
 Cattaraugus,Red House,State Senate,57,Voids,,0,0
-Cattaraugus,South Valley,State Senate,57,Voids,,0,1
+Cattaraugus,South Valley,State Senate,57,Voids,,0,0
 Cattaraugus,Town of Olean 1,State Senate,57,Voids,,0,0
 Cattaraugus,Town of Olean 2,State Senate,57,Voids,,0,0
 Cattaraugus,Town of Salamanca,State Senate,57,Voids,,1,0
-Cattaraugus,Yorkshire 1,State Senate,57,Voids,,0,1
+Cattaraugus,Yorkshire 1,State Senate,57,Voids,,1,1
 Cattaraugus,Yorkshire 2,State Senate,57,Voids,,0,0
-Cattaraugus,Allegany District 1,State Senate,57,Blanks,,34,2
-Cattaraugus,Allegany District 2,State Senate,57,Blanks,,8,3
-Cattaraugus,Allegany District 3,State Senate,57,Blanks,,18,6
-Cattaraugus,Allegany District 4,State Senate,57,Blanks,,21,4
-Cattaraugus,Allegany District 5,State Senate,57,Blanks,,27,15
-Cattaraugus,Ashford District 1,State Senate,57,Blanks,,16,6
-Cattaraugus,Ashford District 2,State Senate,57,Blanks,,38,7
-Cattaraugus,Carrollton,State Senate,57,Blanks,,33,14
-Cattaraugus,City of Olean - Ward 1,State Senate,57,Blanks,,31,7
-Cattaraugus,City of Olean - Ward 2,State Senate,57,Blanks,,27,8
-Cattaraugus,City of Olean - Ward 3,State Senate,57,Blanks,,18,10
-Cattaraugus,City of Olean - Ward 4,State Senate,57,Blanks,,21,2
-Cattaraugus,City of Olean - Ward 5,State Senate,57,Blanks,,29,1
-Cattaraugus,City of Olean - Ward 6,State Senate,57,Blanks,,35,9
-Cattaraugus,City of Olean - Ward 7,State Senate,57,Blanks,,36,2
-Cattaraugus,City of Salamanca - Ward 1,State Senate,57,Blanks,,28,4
-Cattaraugus,City of Salamanca - Ward 2,State Senate,57,Blanks,,41,0
-Cattaraugus,City of Salamanca - Ward 3,State Senate,57,Blanks,,24,8
-Cattaraugus,City of Salamanca - Ward 4,State Senate,57,Blanks,,34,2
-Cattaraugus,City of Salamanca - Ward 5,State Senate,57,Blanks,,21,5
-Cattaraugus,Coldspring,State Senate,57,Blanks,,21,6
-Cattaraugus,Conewango,State Senate,57,Blanks,,21,6
-Cattaraugus,Dayton,State Senate,57,Blanks,,30,6
-Cattaraugus,Early Voting - Little Valley 1,State Senate,57,Blanks,,60,
-Cattaraugus,Early Voting - Little Valley 2,State Senate,57,Blanks,,53,
-Cattaraugus,Early Voting - Olean 1,State Senate,57,Blanks,,111,
-Cattaraugus,Early Voting - Olean 2,State Senate,57,Blanks,,76,
-Cattaraugus,East Otto,State Senate,57,Blanks,,12,2
-Cattaraugus,Ellicottville,State Senate,57,Blanks,,24,5
-Cattaraugus,Farmersville,State Senate,57,Blanks,,19,6
-Cattaraugus,Franklinville District 1,State Senate,57,Blanks,,28,1
-Cattaraugus,Franklinville District 2,State Senate,57,Blanks,,33,8
-Cattaraugus,Freedom,State Senate,57,Blanks,,107,1
-Cattaraugus,Great Valley 1,State Senate,57,Blanks,,18,6
-Cattaraugus,Great Valley 2,State Senate,57,Blanks,,32,5
-Cattaraugus,Hinsdale,State Senate,57,Blanks,,40,5
-Cattaraugus,Humphrey,State Senate,57,Blanks,,10,10
-Cattaraugus,Ischua,State Senate,57,Blanks,,22,7
-Cattaraugus,Leon,State Senate,57,Blanks,,7,1
-Cattaraugus,Little Valley,State Senate,57,Blanks,,22,3
-Cattaraugus,Lyndon,State Senate,57,Blanks,,17,14
-Cattaraugus,Machias,State Senate,57,Blanks,,45,7
-Cattaraugus,Mansfield,State Senate,57,Blanks,,12,14
-Cattaraugus,Napoli,State Senate,57,Blanks,,20,5
-Cattaraugus,New Albion,State Senate,57,Blanks,,38,10
-Cattaraugus,Otto,State Senate,57,Blanks,,21,7
-Cattaraugus,Perrysburg,State Senate,57,Blanks,,25,1
-Cattaraugus,Persia,State Senate,57,Blanks,,38,1
-Cattaraugus,Portville 1,State Senate,57,Blanks,,19,0
-Cattaraugus,Portville 2,State Senate,57,Blanks,,37,6
-Cattaraugus,Randolph District 1,State Senate,57,Blanks,,18,14
-Cattaraugus,Randolph District 2,State Senate,57,Blanks,,28,2
-Cattaraugus,Red House,State Senate,57,Blanks,,4,5
-Cattaraugus,South Valley,State Senate,57,Blanks,,6,35
-Cattaraugus,Town of Olean 1,State Senate,57,Blanks,,14,3
-Cattaraugus,Town of Olean 2,State Senate,57,Blanks,,17,11
-Cattaraugus,Town of Salamanca,State Senate,57,Blanks,,36,1
-Cattaraugus,Yorkshire 1,State Senate,57,Blanks,,46,5
-Cattaraugus,Yorkshire 2,State Senate,57,Blanks,,43,15
-Cattaraugus,Allegany District 1,State Assembly,148,W. Ross Scott,DEM,112,72
-Cattaraugus,Allegany District 2,State Assembly,148,W. Ross Scott,DEM,47,59
-Cattaraugus,Allegany District 3,State Assembly,148,W. Ross Scott,DEM,77,49
-Cattaraugus,Allegany District 4,State Assembly,148,W. Ross Scott,DEM,72,34
-Cattaraugus,Allegany District 5,State Assembly,148,W. Ross Scott,DEM,78,49
-Cattaraugus,Ashford District 1,State Assembly,148,W. Ross Scott,DEM,60,22
-Cattaraugus,Ashford District 2,State Assembly,148,W. Ross Scott,DEM,121,49
-Cattaraugus,Carrollton,State Assembly,148,W. Ross Scott,DEM,82,9
-Cattaraugus,City of Olean - Ward 1,State Assembly,148,W. Ross Scott,DEM,112,22
-Cattaraugus,City of Olean - Ward 2,State Assembly,148,W. Ross Scott,DEM,97,28
-Cattaraugus,City of Olean - Ward 3,State Assembly,148,W. Ross Scott,DEM,82,33
-Cattaraugus,City of Olean - Ward 4,State Assembly,148,W. Ross Scott,DEM,69,55
-Cattaraugus,City of Olean - Ward 5,State Assembly,148,W. Ross Scott,DEM,103,20
-Cattaraugus,City of Olean - Ward 6,State Assembly,148,W. Ross Scott,DEM,94,27
-Cattaraugus,City of Olean - Ward 7,State Assembly,148,W. Ross Scott,DEM,86,55
-Cattaraugus,City of Salamanca - Ward 1,State Assembly,148,W. Ross Scott,DEM,49,36
-Cattaraugus,City of Salamanca - Ward 2,State Assembly,148,W. Ross Scott,DEM,144,29
-Cattaraugus,City of Salamanca - Ward 3,State Assembly,148,W. Ross Scott,DEM,67,20
-Cattaraugus,City of Salamanca - Ward 4,State Assembly,148,W. Ross Scott,DEM,111,38
-Cattaraugus,City of Salamanca - Ward 5,State Assembly,148,W. Ross Scott,DEM,74,37
-Cattaraugus,Coldspring,State Assembly,148,W. Ross Scott,DEM,55,8
-Cattaraugus,Conewango,State Assembly,148,W. Ross Scott,DEM,60,23
-Cattaraugus,Dayton,State Assembly,148,W. Ross Scott,DEM,66,8
-Cattaraugus,Early Voting - Little Valley 1,State Assembly,148,W. Ross Scott,DEM,474,
-Cattaraugus,Early Voting - Little Valley 2,State Assembly,148,W. Ross Scott,DEM,378,
-Cattaraugus,Early Voting - Olean 1,State Assembly,148,W. Ross Scott,DEM,1075,
-Cattaraugus,Early Voting - Olean 2,State Assembly,148,W. Ross Scott,DEM,571,
-Cattaraugus,East Otto,State Assembly,148,W. Ross Scott,DEM,62,34
-Cattaraugus,Ellicottville,State Assembly,148,W. Ross Scott,DEM,126,12
-Cattaraugus,Farmersville,State Assembly,148,W. Ross Scott,DEM,55,29
-Cattaraugus,Franklinville District 1,State Assembly,148,W. Ross Scott,DEM,84,52
-Cattaraugus,Franklinville District 2,State Assembly,148,W. Ross Scott,DEM,75,33
-Cattaraugus,Freedom,State Assembly,148,W. Ross Scott,DEM,127,19
-Cattaraugus,Great Valley 1,State Assembly,148,W. Ross Scott,DEM,78,25
-Cattaraugus,Great Valley 2,State Assembly,148,W. Ross Scott,DEM,93,90
-Cattaraugus,Hinsdale,State Assembly,148,W. Ross Scott,DEM,100,76
-Cattaraugus,Humphrey,State Assembly,148,W. Ross Scott,DEM,54,67
-Cattaraugus,Ischua,State Assembly,148,W. Ross Scott,DEM,54,80
-Cattaraugus,Leon,State Assembly,148,W. Ross Scott,DEM,33,63
-Cattaraugus,Little Valley,State Assembly,148,W. Ross Scott,DEM,50,67
-Cattaraugus,Lyndon,State Assembly,148,W. Ross Scott,DEM,52,59
-Cattaraugus,Machias,State Assembly,148,W. Ross Scott,DEM,120,52
-Cattaraugus,Mansfield,State Assembly,148,W. Ross Scott,DEM,37,51
-Cattaraugus,Napoli,State Assembly,148,W. Ross Scott,DEM,49,35
-Cattaraugus,New Albion,State Assembly,148,W. Ross Scott,DEM,110,46
-Cattaraugus,Otto,State Assembly,148,W. Ross Scott,DEM,41,34
-Cattaraugus,Perrysburg,State Assembly,148,W. Ross Scott,DEM,143,21
-Cattaraugus,Persia,State Assembly,148,W. Ross Scott,DEM,121,2
-Cattaraugus,Portville 1,State Assembly,148,W. Ross Scott,DEM,99,6
-Cattaraugus,Portville 2,State Assembly,148,W. Ross Scott,DEM,77,25
-Cattaraugus,Randolph District 1,State Assembly,148,W. Ross Scott,DEM,60,43
-Cattaraugus,Randolph District 2,State Assembly,148,W. Ross Scott,DEM,61,10
-Cattaraugus,Red House,State Assembly,148,W. Ross Scott,DEM,1,35
-Cattaraugus,South Valley,State Assembly,148,W. Ross Scott,DEM,41,40
-Cattaraugus,Town of Olean 1,State Assembly,148,W. Ross Scott,DEM,44,15
-Cattaraugus,Town of Olean 2,State Assembly,148,W. Ross Scott,DEM,51,56
-Cattaraugus,Town of Salamanca,State Assembly,148,W. Ross Scott,DEM,67,25
-Cattaraugus,Yorkshire 1,State Assembly,148,W. Ross Scott,DEM,125,29
-Cattaraugus,Yorkshire 2,State Assembly,148,W. Ross Scott,DEM,115,55
-Cattaraugus,Allegany District 1,State Assembly,148,Joseph M. Giglio,REP,336,35
-Cattaraugus,Allegany District 2,State Assembly,148,Joseph M. Giglio,REP,125,27
-Cattaraugus,Allegany District 3,State Assembly,148,Joseph M. Giglio,REP,291,33
-Cattaraugus,Allegany District 4,State Assembly,148,Joseph M. Giglio,REP,378,45
-Cattaraugus,Allegany District 5,State Assembly,148,Joseph M. Giglio,REP,339,24
-Cattaraugus,Ashford District 1,State Assembly,148,Joseph M. Giglio,REP,185,17
-Cattaraugus,Ashford District 2,State Assembly,148,Joseph M. Giglio,REP,384,40
-Cattaraugus,Carrollton,State Assembly,148,Joseph M. Giglio,REP,374,15
-Cattaraugus,City of Olean - Ward 1,State Assembly,148,Joseph M. Giglio,REP,392,16
-Cattaraugus,City of Olean - Ward 2,State Assembly,148,Joseph M. Giglio,REP,349,19
-Cattaraugus,City of Olean - Ward 3,State Assembly,148,Joseph M. Giglio,REP,198,54
-Cattaraugus,City of Olean - Ward 4,State Assembly,148,Joseph M. Giglio,REP,144,56
-Cattaraugus,City of Olean - Ward 5,State Assembly,148,Joseph M. Giglio,REP,228,38
-Cattaraugus,City of Olean - Ward 6,State Assembly,148,Joseph M. Giglio,REP,237,30
-Cattaraugus,City of Olean - Ward 7,State Assembly,148,Joseph M. Giglio,REP,325,53
-Cattaraugus,City of Salamanca - Ward 1,State Assembly,148,Joseph M. Giglio,REP,122,40
-Cattaraugus,City of Salamanca - Ward 2,State Assembly,148,Joseph M. Giglio,REP,215,24
-Cattaraugus,City of Salamanca - Ward 3,State Assembly,148,Joseph M. Giglio,REP,115,19
-Cattaraugus,City of Salamanca - Ward 4,State Assembly,148,Joseph M. Giglio,REP,167,35
-Cattaraugus,City of Salamanca - Ward 5,State Assembly,148,Joseph M. Giglio,REP,187,48
-Cattaraugus,Coldspring,State Assembly,148,Joseph M. Giglio,REP,240,6
-Cattaraugus,Conewango,State Assembly,148,Joseph M. Giglio,REP,239,23
-Cattaraugus,Dayton,State Assembly,148,Joseph M. Giglio,REP,409,14
-Cattaraugus,Early Voting - Little Valley 1,State Assembly,148,Joseph M. Giglio,REP,542,
-Cattaraugus,Early Voting - Little Valley 2,State Assembly,148,Joseph M. Giglio,REP,576,
-Cattaraugus,Early Voting - Olean 1,State Assembly,148,Joseph M. Giglio,REP,1179,
-Cattaraugus,Early Voting - Olean 2,State Assembly,148,Joseph M. Giglio,REP,655,
-Cattaraugus,East Otto,State Assembly,148,Joseph M. Giglio,REP,270,54
-Cattaraugus,Ellicottville,State Assembly,148,Joseph M. Giglio,REP,316,12
-Cattaraugus,Farmersville,State Assembly,148,Joseph M. Giglio,REP,330,25
-Cattaraugus,Franklinville District 1,State Assembly,148,Joseph M. Giglio,REP,392,80
-Cattaraugus,Franklinville District 2,State Assembly,148,Joseph M. Giglio,REP,297,41
-Cattaraugus,Freedom,State Assembly,148,Joseph M. Giglio,REP,625,33
-Cattaraugus,Great Valley 1,State Assembly,148,Joseph M. Giglio,REP,190,15
-Cattaraugus,Great Valley 2,State Assembly,148,Joseph M. Giglio,REP,364,82
-Cattaraugus,Hinsdale,State Assembly,148,Joseph M. Giglio,REP,513,54
-Cattaraugus,Humphrey,State Assembly,148,Joseph M. Giglio,REP,189,33
-Cattaraugus,Ischua,State Assembly,148,Joseph M. Giglio,REP,217,30
-Cattaraugus,Leon,State Assembly,148,Joseph M. Giglio,REP,194,57
-Cattaraugus,Little Valley,State Assembly,148,Joseph M. Giglio,REP,307,62
-Cattaraugus,Lyndon,State Assembly,148,Joseph M. Giglio,REP,190,41
-Cattaraugus,Machias,State Assembly,148,Joseph M. Giglio,REP,530,71
-Cattaraugus,Mansfield,State Assembly,148,Joseph M. Giglio,REP,197,51
-Cattaraugus,Napoli,State Assembly,148,Joseph M. Giglio,REP,279,48
-Cattaraugus,New Albion,State Assembly,148,Joseph M. Giglio,REP,427,35
-Cattaraugus,Otto,State Assembly,148,Joseph M. Giglio,REP,217,40
-Cattaraugus,Perrysburg,State Assembly,148,Joseph M. Giglio,REP,442,41
-Cattaraugus,Persia,State Assembly,148,Joseph M. Giglio,REP,466,3
-Cattaraugus,Portville 1,State Assembly,148,Joseph M. Giglio,REP,486,5
-Cattaraugus,Portville 2,State Assembly,148,Joseph M. Giglio,REP,469,14
-Cattaraugus,Randolph District 1,State Assembly,148,Joseph M. Giglio,REP,297,47
-Cattaraugus,Randolph District 2,State Assembly,148,Joseph M. Giglio,REP,361,18
-Cattaraugus,Red House,State Assembly,148,Joseph M. Giglio,REP,16,20
-Cattaraugus,South Valley,State Assembly,148,Joseph M. Giglio,REP,70,42
-Cattaraugus,Town of Olean 1,State Assembly,148,Joseph M. Giglio,REP,163,19
-Cattaraugus,Town of Olean 2,State Assembly,148,Joseph M. Giglio,REP,288,49
-Cattaraugus,Town of Salamanca,State Assembly,148,Joseph M. Giglio,REP,146,12
-Cattaraugus,Yorkshire 1,State Assembly,148,Joseph M. Giglio,REP,402,49
-Cattaraugus,Yorkshire 2,State Assembly,148,Joseph M. Giglio,REP,427,38
-Cattaraugus,Allegany District 1,State Assembly,148,Joseph M. Giglio,CON,27,12
-Cattaraugus,Allegany District 2,State Assembly,148,Joseph M. Giglio,CON,9,6
-Cattaraugus,Allegany District 3,State Assembly,148,Joseph M. Giglio,CON,22,4
-Cattaraugus,Allegany District 4,State Assembly,148,Joseph M. Giglio,CON,33,2
-Cattaraugus,Allegany District 5,State Assembly,148,Joseph M. Giglio,CON,31,5
-Cattaraugus,Ashford District 1,State Assembly,148,Joseph M. Giglio,CON,26,5
-Cattaraugus,Ashford District 2,State Assembly,148,Joseph M. Giglio,CON,47,6
-Cattaraugus,Carrollton,State Assembly,148,Joseph M. Giglio,CON,20,1
-Cattaraugus,City of Olean - Ward 1,State Assembly,148,Joseph M. Giglio,CON,25,6
-Cattaraugus,City of Olean - Ward 2,State Assembly,148,Joseph M. Giglio,CON,33,1
-Cattaraugus,City of Olean - Ward 3,State Assembly,148,Joseph M. Giglio,CON,27,6
-Cattaraugus,City of Olean - Ward 4,State Assembly,148,Joseph M. Giglio,CON,22,5
-Cattaraugus,City of Olean - Ward 5,State Assembly,148,Joseph M. Giglio,CON,26,1
-Cattaraugus,City of Olean - Ward 6,State Assembly,148,Joseph M. Giglio,CON,27,6
-Cattaraugus,City of Olean - Ward 7,State Assembly,148,Joseph M. Giglio,CON,40,7
-Cattaraugus,City of Salamanca - Ward 1,State Assembly,148,Joseph M. Giglio,CON,11,3
-Cattaraugus,City of Salamanca - Ward 2,State Assembly,148,Joseph M. Giglio,CON,33,2
-Cattaraugus,City of Salamanca - Ward 3,State Assembly,148,Joseph M. Giglio,CON,14,0
-Cattaraugus,City of Salamanca - Ward 4,State Assembly,148,Joseph M. Giglio,CON,19,3
-Cattaraugus,City of Salamanca - Ward 5,State Assembly,148,Joseph M. Giglio,CON,14,6
-Cattaraugus,Coldspring,State Assembly,148,Joseph M. Giglio,CON,30,2
-Cattaraugus,Conewango,State Assembly,148,Joseph M. Giglio,CON,25,2
-Cattaraugus,Dayton,State Assembly,148,Joseph M. Giglio,CON,45,0
-Cattaraugus,Early Voting - Little Valley 1,State Assembly,148,Joseph M. Giglio,CON,62,
-Cattaraugus,Early Voting - Little Valley 2,State Assembly,148,Joseph M. Giglio,CON,71,
-Cattaraugus,Early Voting - Olean 1,State Assembly,148,Joseph M. Giglio,CON,103,
-Cattaraugus,Early Voting - Olean 2,State Assembly,148,Joseph M. Giglio,CON,59,
-Cattaraugus,East Otto,State Assembly,148,Joseph M. Giglio,CON,44,2
-Cattaraugus,Ellicottville,State Assembly,148,Joseph M. Giglio,CON,30,2
-Cattaraugus,Farmersville,State Assembly,148,Joseph M. Giglio,CON,29,1
-Cattaraugus,Franklinville District 1,State Assembly,148,Joseph M. Giglio,CON,42,6
-Cattaraugus,Franklinville District 2,State Assembly,148,Joseph M. Giglio,CON,30,7
-Cattaraugus,Freedom,State Assembly,148,Joseph M. Giglio,CON,73,5
-Cattaraugus,Great Valley 1,State Assembly,148,Joseph M. Giglio,CON,27,4
-Cattaraugus,Great Valley 2,State Assembly,148,Joseph M. Giglio,CON,30,8
-Cattaraugus,Hinsdale,State Assembly,148,Joseph M. Giglio,CON,61,3
-Cattaraugus,Humphrey,State Assembly,148,Joseph M. Giglio,CON,22,8
-Cattaraugus,Ischua,State Assembly,148,Joseph M. Giglio,CON,13,5
-Cattaraugus,Leon,State Assembly,148,Joseph M. Giglio,CON,32,8
-Cattaraugus,Little Valley,State Assembly,148,Joseph M. Giglio,CON,30,9
-Cattaraugus,Lyndon,State Assembly,148,Joseph M. Giglio,CON,19,5
-Cattaraugus,Machias,State Assembly,148,Joseph M. Giglio,CON,65,15
-Cattaraugus,Mansfield,State Assembly,148,Joseph M. Giglio,CON,11,5
-Cattaraugus,Napoli,State Assembly,148,Joseph M. Giglio,CON,39,7
-Cattaraugus,New Albion,State Assembly,148,Joseph M. Giglio,CON,57,11
-Cattaraugus,Otto,State Assembly,148,Joseph M. Giglio,CON,32,6
-Cattaraugus,Perrysburg,State Assembly,148,Joseph M. Giglio,CON,65,5
-Cattaraugus,Persia,State Assembly,148,Joseph M. Giglio,CON,80,0
-Cattaraugus,Portville 1,State Assembly,148,Joseph M. Giglio,CON,36,0
-Cattaraugus,Portville 2,State Assembly,148,Joseph M. Giglio,CON,49,2
-Cattaraugus,Randolph District 1,State Assembly,148,Joseph M. Giglio,CON,42,4
-Cattaraugus,Randolph District 2,State Assembly,148,Joseph M. Giglio,CON,27,2
-Cattaraugus,Red House,State Assembly,148,Joseph M. Giglio,CON,2,1
-Cattaraugus,South Valley,State Assembly,148,Joseph M. Giglio,CON,11,5
-Cattaraugus,Town of Olean 1,State Assembly,148,Joseph M. Giglio,CON,22,1
-Cattaraugus,Town of Olean 2,State Assembly,148,Joseph M. Giglio,CON,14,6
-Cattaraugus,Town of Salamanca,State Assembly,148,Joseph M. Giglio,CON,19,1
-Cattaraugus,Yorkshire 1,State Assembly,148,Joseph M. Giglio,CON,66,8
-Cattaraugus,Yorkshire 2,State Assembly,148,Joseph M. Giglio,CON,56,4
-Cattaraugus,Allegany District 1,State Assembly,148,Joseph M. Giglio,IND,14,3
-Cattaraugus,Allegany District 2,State Assembly,148,Joseph M. Giglio,IND,5,3
-Cattaraugus,Allegany District 3,State Assembly,148,Joseph M. Giglio,IND,7,1
+Cattaraugus,Allegany District 1,State Senate,57,Blanks,,36,2
+Cattaraugus,Allegany District 2,State Senate,57,Blanks,,18,10
+Cattaraugus,Allegany District 3,State Senate,57,Blanks,,20,2
+Cattaraugus,Allegany District 4,State Senate,57,Blanks,,22,1
+Cattaraugus,Allegany District 5,State Senate,57,Blanks,,36,9
+Cattaraugus,Ashford District 1,State Senate,57,Blanks,,18,2
+Cattaraugus,Ashford District 2,State Senate,57,Blanks,,42,4
+Cattaraugus,Carrollton,State Senate,57,Blanks,,39,6
+Cattaraugus,City of Olean - Ward 1,State Senate,57,Blanks,,46,15
+Cattaraugus,City of Olean - Ward 2,State Senate,57,Blanks,,33,6
+Cattaraugus,City of Olean - Ward 3,State Senate,57,Blanks,,32,14
+Cattaraugus,City of Olean - Ward 4,State Senate,57,Blanks,,28,7
+Cattaraugus,City of Olean - Ward 5,State Senate,57,Blanks,,36,7
+Cattaraugus,City of Olean - Ward 6,State Senate,57,Blanks,,49,14
+Cattaraugus,City of Olean - Ward 7,State Senate,57,Blanks,,43,7
+Cattaraugus,City of Salamanca - Ward 1,State Senate,57,Blanks,,34,6
+Cattaraugus,City of Salamanca - Ward 2,State Senate,57,Blanks,,55,14
+Cattaraugus,City of Salamanca - Ward 3,State Senate,57,Blanks,,26,2
+Cattaraugus,City of Salamanca - Ward 4,State Senate,57,Blanks,,39,5
+Cattaraugus,City of Salamanca - Ward 5,State Senate,57,Blanks,,56,35
+Cattaraugus,Coldspring,State Senate,57,Blanks,,21,0
+Cattaraugus,Conewango,State Senate,57,Blanks,,24,3
+Cattaraugus,Dayton,State Senate,57,Blanks,,34,4
+Cattaraugus,Early Voting - Little Valley 1,State Senate,57,Blanks,,60,0
+Cattaraugus,Early Voting - Little Valley 2,State Senate,57,Blanks,,53,0
+Cattaraugus,Early Voting - Olean 1,State Senate,57,Blanks,,111,0
+Cattaraugus,Early Voting - Olean 2,State Senate,57,Blanks,,76,0
+Cattaraugus,East Otto,State Senate,57,Blanks,,14,2
+Cattaraugus,Ellicottville,State Senate,57,Blanks,,32,8
+Cattaraugus,Farmersville,State Senate,57,Blanks,,24,5
+Cattaraugus,Franklinville District 1,State Senate,57,Blanks,,34,6
+Cattaraugus,Franklinville District 2,State Senate,57,Blanks,,39,6
+Cattaraugus,Freedom,State Senate,57,Blanks,,113,6
+Cattaraugus,Great Valley 1,State Senate,57,Blanks,,20,2
+Cattaraugus,Great Valley 2,State Senate,57,Blanks,,37,5
+Cattaraugus,Hinsdale,State Senate,57,Blanks,,46,6
+Cattaraugus,Humphrey,State Senate,57,Blanks,,11,1
+Cattaraugus,Ischua,State Senate,57,Blanks,,30,8
+Cattaraugus,Leon,State Senate,57,Blanks,,8,1
+Cattaraugus,Little Valley,State Senate,57,Blanks,,28,6
+Cattaraugus,Lyndon,State Senate,57,Blanks,,22,5
+Cattaraugus,Machias,State Senate,57,Blanks,,55,10
+Cattaraugus,Mansfield,State Senate,57,Blanks,,17,5
+Cattaraugus,Napoli,State Senate,57,Blanks,,21,1
+Cattaraugus,New Albion,State Senate,57,Blanks,,45,7
+Cattaraugus,Otto,State Senate,57,Blanks,,24,3
+Cattaraugus,Perrysburg,State Senate,57,Blanks,,33,8
+Cattaraugus,Persia,State Senate,57,Blanks,,52,14
+Cattaraugus,Portville 1,State Senate,57,Blanks,,24,5
+Cattaraugus,Portville 2,State Senate,57,Blanks,,47,10
+Cattaraugus,Randolph District 1,State Senate,57,Blanks,,25,7
+Cattaraugus,Randolph District 2,State Senate,57,Blanks,,29,1
+Cattaraugus,Red House,State Senate,57,Blanks,,5,1
+Cattaraugus,South Valley,State Senate,57,Blanks,,6,0
+Cattaraugus,Town of Olean 1,State Senate,57,Blanks,,17,3
+Cattaraugus,Town of Olean 2,State Senate,57,Blanks,,28,11
+Cattaraugus,Town of Salamanca,State Senate,57,Blanks,,37,1
+Cattaraugus,Yorkshire 1,State Senate,57,Blanks,,51,5
+Cattaraugus,Yorkshire 2,State Senate,57,Blanks,,58,15
+Cattaraugus,Allegany District 1,State Assembly,148,W. Ross Scott,DEM,184,72
+Cattaraugus,Allegany District 2,State Assembly,148,W. Ross Scott,DEM,106,59
+Cattaraugus,Allegany District 3,State Assembly,148,W. Ross Scott,DEM,126,49
+Cattaraugus,Allegany District 4,State Assembly,148,W. Ross Scott,DEM,106,34
+Cattaraugus,Allegany District 5,State Assembly,148,W. Ross Scott,DEM,127,49
+Cattaraugus,Ashford District 1,State Assembly,148,W. Ross Scott,DEM,82,22
+Cattaraugus,Ashford District 2,State Assembly,148,W. Ross Scott,DEM,170,49
+Cattaraugus,Carrollton,State Assembly,148,W. Ross Scott,DEM,110,28
+Cattaraugus,City of Olean - Ward 1,State Assembly,148,W. Ross Scott,DEM,202,90
+Cattaraugus,City of Olean - Ward 2,State Assembly,148,W. Ross Scott,DEM,173,76
+Cattaraugus,City of Olean - Ward 3,State Assembly,148,W. Ross Scott,DEM,149,67
+Cattaraugus,City of Olean - Ward 4,State Assembly,148,W. Ross Scott,DEM,149,80
+Cattaraugus,City of Olean - Ward 5,State Assembly,148,W. Ross Scott,DEM,166,63
+Cattaraugus,City of Olean - Ward 6,State Assembly,148,W. Ross Scott,DEM,161,67
+Cattaraugus,City of Olean - Ward 7,State Assembly,148,W. Ross Scott,DEM,145,59
+Cattaraugus,City of Salamanca - Ward 1,State Assembly,148,W. Ross Scott,DEM,74,25
+Cattaraugus,City of Salamanca - Ward 2,State Assembly,148,W. Ross Scott,DEM,187,43
+Cattaraugus,City of Salamanca - Ward 3,State Assembly,148,W. Ross Scott,DEM,77,10
+Cattaraugus,City of Salamanca - Ward 4,State Assembly,148,W. Ross Scott,DEM,146,35
+Cattaraugus,City of Salamanca - Ward 5,State Assembly,148,W. Ross Scott,DEM,114,40
+Cattaraugus,Coldspring,State Assembly,148,W. Ross Scott,DEM,64,9
+Cattaraugus,Conewango,State Assembly,148,W. Ross Scott,DEM,82,22
+Cattaraugus,Dayton,State Assembly,148,W. Ross Scott,DEM,99,33
+Cattaraugus,Early Voting - Little Valley 1,State Assembly,148,W. Ross Scott,DEM,474,0
+Cattaraugus,Early Voting - Little Valley 2,State Assembly,148,W. Ross Scott,DEM,378,0
+Cattaraugus,Early Voting - Olean 1,State Assembly,148,W. Ross Scott,DEM,1075,0
+Cattaraugus,Early Voting - Olean 2,State Assembly,148,W. Ross Scott,DEM,571,0
+Cattaraugus,East Otto,State Assembly,148,W. Ross Scott,DEM,82,20
+Cattaraugus,Ellicottville,State Assembly,148,W. Ross Scott,DEM,181,55
+Cattaraugus,Farmersville,State Assembly,148,W. Ross Scott,DEM,82,27
+Cattaraugus,Franklinville District 1,State Assembly,148,W. Ross Scott,DEM,120,36
+Cattaraugus,Franklinville District 2,State Assembly,148,W. Ross Scott,DEM,104,29
+Cattaraugus,Freedom,State Assembly,148,W. Ross Scott,DEM,182,55
+Cattaraugus,Great Valley 1,State Assembly,148,W. Ross Scott,DEM,98,20
+Cattaraugus,Great Valley 2,State Assembly,148,W. Ross Scott,DEM,131,38
+Cattaraugus,Hinsdale,State Assembly,148,W. Ross Scott,DEM,137,37
+Cattaraugus,Humphrey,State Assembly,148,W. Ross Scott,DEM,62,8
+Cattaraugus,Ischua,State Assembly,148,W. Ross Scott,DEM,77,23
+Cattaraugus,Leon,State Assembly,148,W. Ross Scott,DEM,41,8
+Cattaraugus,Little Valley,State Assembly,148,W. Ross Scott,DEM,84,34
+Cattaraugus,Lyndon,State Assembly,148,W. Ross Scott,DEM,64,12
+Cattaraugus,Machias,State Assembly,148,W. Ross Scott,DEM,172,52
+Cattaraugus,Mansfield,State Assembly,148,W. Ross Scott,DEM,66,29
+Cattaraugus,Napoli,State Assembly,148,W. Ross Scott,DEM,68,19
+Cattaraugus,New Albion,State Assembly,148,W. Ross Scott,DEM,143,33
+Cattaraugus,Otto,State Assembly,148,W. Ross Scott,DEM,66,25
+Cattaraugus,Perrysburg,State Assembly,148,W. Ross Scott,DEM,189,46
+Cattaraugus,Persia,State Assembly,148,W. Ross Scott,DEM,173,52
+Cattaraugus,Portville 1,State Assembly,148,W. Ross Scott,DEM,150,51
+Cattaraugus,Portville 2,State Assembly,148,W. Ross Scott,DEM,112,35
+Cattaraugus,Randolph District 1,State Assembly,148,W. Ross Scott,DEM,94,34
+Cattaraugus,Randolph District 2,State Assembly,148,W. Ross Scott,DEM,82,21
+Cattaraugus,Red House,State Assembly,148,W. Ross Scott,DEM,3,2
+Cattaraugus,South Valley,State Assembly,148,W. Ross Scott,DEM,47,6
+Cattaraugus,Town of Olean 1,State Assembly,148,W. Ross Scott,DEM,59,15
+Cattaraugus,Town of Olean 2,State Assembly,148,W. Ross Scott,DEM,107,56
+Cattaraugus,Town of Salamanca,State Assembly,148,W. Ross Scott,DEM,92,25
+Cattaraugus,Yorkshire 1,State Assembly,148,W. Ross Scott,DEM,154,29
+Cattaraugus,Yorkshire 2,State Assembly,148,W. Ross Scott,DEM,170,55
+Cattaraugus,Allegany District 1,State Assembly,148,Joseph M. Giglio,REP,371,35
+Cattaraugus,Allegany District 2,State Assembly,148,Joseph M. Giglio,REP,152,27
+Cattaraugus,Allegany District 3,State Assembly,148,Joseph M. Giglio,REP,324,33
+Cattaraugus,Allegany District 4,State Assembly,148,Joseph M. Giglio,REP,423,45
+Cattaraugus,Allegany District 5,State Assembly,148,Joseph M. Giglio,REP,363,24
+Cattaraugus,Ashford District 1,State Assembly,148,Joseph M. Giglio,REP,202,17
+Cattaraugus,Ashford District 2,State Assembly,148,Joseph M. Giglio,REP,424,40
+Cattaraugus,Carrollton,State Assembly,148,Joseph M. Giglio,REP,393,19
+Cattaraugus,City of Olean - Ward 1,State Assembly,148,Joseph M. Giglio,REP,474,82
+Cattaraugus,City of Olean - Ward 2,State Assembly,148,Joseph M. Giglio,REP,403,54
+Cattaraugus,City of Olean - Ward 3,State Assembly,148,Joseph M. Giglio,REP,231,33
+Cattaraugus,City of Olean - Ward 4,State Assembly,148,Joseph M. Giglio,REP,174,30
+Cattaraugus,City of Olean - Ward 5,State Assembly,148,Joseph M. Giglio,REP,285,57
+Cattaraugus,City of Olean - Ward 6,State Assembly,148,Joseph M. Giglio,REP,299,62
+Cattaraugus,City of Olean - Ward 7,State Assembly,148,Joseph M. Giglio,REP,366,41
+Cattaraugus,City of Salamanca - Ward 1,State Assembly,148,Joseph M. Giglio,REP,136,14
+Cattaraugus,City of Salamanca - Ward 2,State Assembly,148,Joseph M. Giglio,REP,262,47
+Cattaraugus,City of Salamanca - Ward 3,State Assembly,148,Joseph M. Giglio,REP,133,18
+Cattaraugus,City of Salamanca - Ward 4,State Assembly,148,Joseph M. Giglio,REP,187,20
+Cattaraugus,City of Salamanca - Ward 5,State Assembly,148,Joseph M. Giglio,REP,229,42
+Cattaraugus,Coldspring,State Assembly,148,Joseph M. Giglio,REP,255,15
+Cattaraugus,Conewango,State Assembly,148,Joseph M. Giglio,REP,255,16
+Cattaraugus,Dayton,State Assembly,148,Joseph M. Giglio,REP,463,54
+Cattaraugus,Early Voting - Little Valley 1,State Assembly,148,Joseph M. Giglio,REP,542,0
+Cattaraugus,Early Voting - Little Valley 2,State Assembly,148,Joseph M. Giglio,REP,576,0
+Cattaraugus,Early Voting - Olean 1,State Assembly,148,Joseph M. Giglio,REP,1179,0
+Cattaraugus,Early Voting - Olean 2,State Assembly,148,Joseph M. Giglio,REP,655,0
+Cattaraugus,East Otto,State Assembly,148,Joseph M. Giglio,REP,308,38
+Cattaraugus,Ellicottville,State Assembly,148,Joseph M. Giglio,REP,372,56
+Cattaraugus,Farmersville,State Assembly,148,Joseph M. Giglio,REP,360,30
+Cattaraugus,Franklinville District 1,State Assembly,148,Joseph M. Giglio,REP,432,40
+Cattaraugus,Franklinville District 2,State Assembly,148,Joseph M. Giglio,REP,321,24
+Cattaraugus,Freedom,State Assembly,148,Joseph M. Giglio,REP,678,53
+Cattaraugus,Great Valley 1,State Assembly,148,Joseph M. Giglio,REP,209,19
+Cattaraugus,Great Valley 2,State Assembly,148,Joseph M. Giglio,REP,399,35
+Cattaraugus,Hinsdale,State Assembly,148,Joseph M. Giglio,REP,561,48
+Cattaraugus,Humphrey,State Assembly,148,Joseph M. Giglio,REP,195,6
+Cattaraugus,Ischua,State Assembly,148,Joseph M. Giglio,REP,240,23
+Cattaraugus,Leon,State Assembly,148,Joseph M. Giglio,REP,208,14
+Cattaraugus,Little Valley,State Assembly,148,Joseph M. Giglio,REP,361,54
+Cattaraugus,Lyndon,State Assembly,148,Joseph M. Giglio,REP,202,12
+Cattaraugus,Machias,State Assembly,148,Joseph M. Giglio,REP,610,80
+Cattaraugus,Mansfield,State Assembly,148,Joseph M. Giglio,REP,222,25
+Cattaraugus,Napoli,State Assembly,148,Joseph M. Giglio,REP,312,33
+Cattaraugus,New Albion,State Assembly,148,Joseph M. Giglio,REP,468,41
+Cattaraugus,Otto,State Assembly,148,Joseph M. Giglio,REP,232,15
+Cattaraugus,Perrysburg,State Assembly,148,Joseph M. Giglio,REP,477,35
+Cattaraugus,Persia,State Assembly,148,Joseph M. Giglio,REP,537,71
+Cattaraugus,Portville 1,State Assembly,148,Joseph M. Giglio,REP,537,51
+Cattaraugus,Portville 2,State Assembly,148,Joseph M. Giglio,REP,517,48
+Cattaraugus,Randolph District 1,State Assembly,148,Joseph M. Giglio,REP,337,40
+Cattaraugus,Randolph District 2,State Assembly,148,Joseph M. Giglio,REP,402,41
+Cattaraugus,Red House,State Assembly,148,Joseph M. Giglio,REP,19,3
+Cattaraugus,South Valley,State Assembly,148,Joseph M. Giglio,REP,75,5
+Cattaraugus,Town of Olean 1,State Assembly,148,Joseph M. Giglio,REP,182,19
+Cattaraugus,Town of Olean 2,State Assembly,148,Joseph M. Giglio,REP,337,49
+Cattaraugus,Town of Salamanca,State Assembly,148,Joseph M. Giglio,REP,158,12
+Cattaraugus,Yorkshire 1,State Assembly,148,Joseph M. Giglio,REP,451,49
+Cattaraugus,Yorkshire 2,State Assembly,148,Joseph M. Giglio,REP,465,38
+Cattaraugus,Allegany District 1,State Assembly,148,Joseph M. Giglio,CON,39,12
+Cattaraugus,Allegany District 2,State Assembly,148,Joseph M. Giglio,CON,15,6
+Cattaraugus,Allegany District 3,State Assembly,148,Joseph M. Giglio,CON,26,4
+Cattaraugus,Allegany District 4,State Assembly,148,Joseph M. Giglio,CON,35,2
+Cattaraugus,Allegany District 5,State Assembly,148,Joseph M. Giglio,CON,36,5
+Cattaraugus,Ashford District 1,State Assembly,148,Joseph M. Giglio,CON,31,5
+Cattaraugus,Ashford District 2,State Assembly,148,Joseph M. Giglio,CON,53,6
+Cattaraugus,Carrollton,State Assembly,148,Joseph M. Giglio,CON,21,1
+Cattaraugus,City of Olean - Ward 1,State Assembly,148,Joseph M. Giglio,CON,33,8
+Cattaraugus,City of Olean - Ward 2,State Assembly,148,Joseph M. Giglio,CON,36,3
+Cattaraugus,City of Olean - Ward 3,State Assembly,148,Joseph M. Giglio,CON,35,8
+Cattaraugus,City of Olean - Ward 4,State Assembly,148,Joseph M. Giglio,CON,27,5
+Cattaraugus,City of Olean - Ward 5,State Assembly,148,Joseph M. Giglio,CON,34,8
+Cattaraugus,City of Olean - Ward 6,State Assembly,148,Joseph M. Giglio,CON,36,9
+Cattaraugus,City of Olean - Ward 7,State Assembly,148,Joseph M. Giglio,CON,45,5
+Cattaraugus,City of Salamanca - Ward 1,State Assembly,148,Joseph M. Giglio,CON,13,2
+Cattaraugus,City of Salamanca - Ward 2,State Assembly,148,Joseph M. Giglio,CON,37,4
+Cattaraugus,City of Salamanca - Ward 3,State Assembly,148,Joseph M. Giglio,CON,16,2
+Cattaraugus,City of Salamanca - Ward 4,State Assembly,148,Joseph M. Giglio,CON,20,1
+Cattaraugus,City of Salamanca - Ward 5,State Assembly,148,Joseph M. Giglio,CON,19,5
+Cattaraugus,Coldspring,State Assembly,148,Joseph M. Giglio,CON,31,1
+Cattaraugus,Conewango,State Assembly,148,Joseph M. Giglio,CON,31,6
+Cattaraugus,Dayton,State Assembly,148,Joseph M. Giglio,CON,51,6
+Cattaraugus,Early Voting - Little Valley 1,State Assembly,148,Joseph M. Giglio,CON,62,0
+Cattaraugus,Early Voting - Little Valley 2,State Assembly,148,Joseph M. Giglio,CON,71,0
+Cattaraugus,Early Voting - Olean 1,State Assembly,148,Joseph M. Giglio,CON,103,0
+Cattaraugus,Early Voting - Olean 2,State Assembly,148,Joseph M. Giglio,CON,59,0
+Cattaraugus,East Otto,State Assembly,148,Joseph M. Giglio,CON,45,1
+Cattaraugus,Ellicottville,State Assembly,148,Joseph M. Giglio,CON,35,5
+Cattaraugus,Farmersville,State Assembly,148,Joseph M. Giglio,CON,35,6
+Cattaraugus,Franklinville District 1,State Assembly,148,Joseph M. Giglio,CON,45,3
+Cattaraugus,Franklinville District 2,State Assembly,148,Joseph M. Giglio,CON,32,2
+Cattaraugus,Freedom,State Assembly,148,Joseph M. Giglio,CON,80,7
+Cattaraugus,Great Valley 1,State Assembly,148,Joseph M. Giglio,CON,27,0
+Cattaraugus,Great Valley 2,State Assembly,148,Joseph M. Giglio,CON,33,3
+Cattaraugus,Hinsdale,State Assembly,148,Joseph M. Giglio,CON,67,6
+Cattaraugus,Humphrey,State Assembly,148,Joseph M. Giglio,CON,24,2
+Cattaraugus,Ischua,State Assembly,148,Joseph M. Giglio,CON,15,2
+Cattaraugus,Leon,State Assembly,148,Joseph M. Giglio,CON,32,0
+Cattaraugus,Little Valley,State Assembly,148,Joseph M. Giglio,CON,32,2
+Cattaraugus,Lyndon,State Assembly,148,Joseph M. Giglio,CON,21,2
+Cattaraugus,Machias,State Assembly,148,Joseph M. Giglio,CON,71,6
+Cattaraugus,Mansfield,State Assembly,148,Joseph M. Giglio,CON,12,1
+Cattaraugus,Napoli,State Assembly,148,Joseph M. Giglio,CON,44,5
+Cattaraugus,New Albion,State Assembly,148,Joseph M. Giglio,CON,64,7
+Cattaraugus,Otto,State Assembly,148,Joseph M. Giglio,CON,36,4
+Cattaraugus,Perrysburg,State Assembly,148,Joseph M. Giglio,CON,76,11
+Cattaraugus,Persia,State Assembly,148,Joseph M. Giglio,CON,95,15
+Cattaraugus,Portville 1,State Assembly,148,Joseph M. Giglio,CON,41,5
+Cattaraugus,Portville 2,State Assembly,148,Joseph M. Giglio,CON,56,7
+Cattaraugus,Randolph District 1,State Assembly,148,Joseph M. Giglio,CON,48,6
+Cattaraugus,Randolph District 2,State Assembly,148,Joseph M. Giglio,CON,32,5
+Cattaraugus,Red House,State Assembly,148,Joseph M. Giglio,CON,2,0
+Cattaraugus,South Valley,State Assembly,148,Joseph M. Giglio,CON,11,0
+Cattaraugus,Town of Olean 1,State Assembly,148,Joseph M. Giglio,CON,23,1
+Cattaraugus,Town of Olean 2,State Assembly,148,Joseph M. Giglio,CON,20,6
+Cattaraugus,Town of Salamanca,State Assembly,148,Joseph M. Giglio,CON,20,1
+Cattaraugus,Yorkshire 1,State Assembly,148,Joseph M. Giglio,CON,74,8
+Cattaraugus,Yorkshire 2,State Assembly,148,Joseph M. Giglio,CON,60,4
+Cattaraugus,Allegany District 1,State Assembly,148,Joseph M. Giglio,IND,17,3
+Cattaraugus,Allegany District 2,State Assembly,148,Joseph M. Giglio,IND,8,3
+Cattaraugus,Allegany District 3,State Assembly,148,Joseph M. Giglio,IND,8,1
 Cattaraugus,Allegany District 4,State Assembly,148,Joseph M. Giglio,IND,9,0
-Cattaraugus,Allegany District 5,State Assembly,148,Joseph M. Giglio,IND,9,4
-Cattaraugus,Ashford District 1,State Assembly,148,Joseph M. Giglio,IND,6,1
-Cattaraugus,Ashford District 2,State Assembly,148,Joseph M. Giglio,IND,8,4
-Cattaraugus,Carrollton,State Assembly,148,Joseph M. Giglio,IND,9,1
-Cattaraugus,City of Olean - Ward 1,State Assembly,148,Joseph M. Giglio,IND,10,1
-Cattaraugus,City of Olean - Ward 2,State Assembly,148,Joseph M. Giglio,IND,13,2
-Cattaraugus,City of Olean - Ward 3,State Assembly,148,Joseph M. Giglio,IND,10,1
+Cattaraugus,Allegany District 5,State Assembly,148,Joseph M. Giglio,IND,13,4
+Cattaraugus,Ashford District 1,State Assembly,148,Joseph M. Giglio,IND,7,1
+Cattaraugus,Ashford District 2,State Assembly,148,Joseph M. Giglio,IND,12,4
+Cattaraugus,Carrollton,State Assembly,148,Joseph M. Giglio,IND,11,2
+Cattaraugus,City of Olean - Ward 1,State Assembly,148,Joseph M. Giglio,IND,14,4
+Cattaraugus,City of Olean - Ward 2,State Assembly,148,Joseph M. Giglio,IND,15,2
+Cattaraugus,City of Olean - Ward 3,State Assembly,148,Joseph M. Giglio,IND,13,3
 Cattaraugus,City of Olean - Ward 4,State Assembly,148,Joseph M. Giglio,IND,6,0
-Cattaraugus,City of Olean - Ward 5,State Assembly,148,Joseph M. Giglio,IND,4,0
-Cattaraugus,City of Olean - Ward 6,State Assembly,148,Joseph M. Giglio,IND,4,0
-Cattaraugus,City of Olean - Ward 7,State Assembly,148,Joseph M. Giglio,IND,13,2
+Cattaraugus,City of Olean - Ward 5,State Assembly,148,Joseph M. Giglio,IND,6,2
+Cattaraugus,City of Olean - Ward 6,State Assembly,148,Joseph M. Giglio,IND,6,2
+Cattaraugus,City of Olean - Ward 7,State Assembly,148,Joseph M. Giglio,IND,14,1
 Cattaraugus,City of Salamanca - Ward 1,State Assembly,148,Joseph M. Giglio,IND,2,0
-Cattaraugus,City of Salamanca - Ward 2,State Assembly,148,Joseph M. Giglio,IND,8,0
-Cattaraugus,City of Salamanca - Ward 3,State Assembly,148,Joseph M. Giglio,IND,5,2
-Cattaraugus,City of Salamanca - Ward 4,State Assembly,148,Joseph M. Giglio,IND,6,2
-Cattaraugus,City of Salamanca - Ward 5,State Assembly,148,Joseph M. Giglio,IND,8,2
-Cattaraugus,Coldspring,State Assembly,148,Joseph M. Giglio,IND,4,0
-Cattaraugus,Conewango,State Assembly,148,Joseph M. Giglio,IND,4,0
-Cattaraugus,Dayton,State Assembly,148,Joseph M. Giglio,IND,11,0
-Cattaraugus,Early Voting - Little Valley 1,State Assembly,148,Joseph M. Giglio,IND,25,
-Cattaraugus,Early Voting - Little Valley 2,State Assembly,148,Joseph M. Giglio,IND,19,
-Cattaraugus,Early Voting - Olean 1,State Assembly,148,Joseph M. Giglio,IND,56,
-Cattaraugus,Early Voting - Olean 2,State Assembly,148,Joseph M. Giglio,IND,19,
-Cattaraugus,East Otto,State Assembly,148,Joseph M. Giglio,IND,6,3
+Cattaraugus,City of Salamanca - Ward 2,State Assembly,148,Joseph M. Giglio,IND,9,1
+Cattaraugus,City of Salamanca - Ward 3,State Assembly,148,Joseph M. Giglio,IND,5,0
+Cattaraugus,City of Salamanca - Ward 4,State Assembly,148,Joseph M. Giglio,IND,7,1
+Cattaraugus,City of Salamanca - Ward 5,State Assembly,148,Joseph M. Giglio,IND,10,2
+Cattaraugus,Coldspring,State Assembly,148,Joseph M. Giglio,IND,5,1
+Cattaraugus,Conewango,State Assembly,148,Joseph M. Giglio,IND,5,1
+Cattaraugus,Dayton,State Assembly,148,Joseph M. Giglio,IND,12,1
+Cattaraugus,Early Voting - Little Valley 1,State Assembly,148,Joseph M. Giglio,IND,25,0
+Cattaraugus,Early Voting - Little Valley 2,State Assembly,148,Joseph M. Giglio,IND,19,0
+Cattaraugus,Early Voting - Olean 1,State Assembly,148,Joseph M. Giglio,IND,56,0
+Cattaraugus,Early Voting - Olean 2,State Assembly,148,Joseph M. Giglio,IND,19,0
+Cattaraugus,East Otto,State Assembly,148,Joseph M. Giglio,IND,6,0
 Cattaraugus,Ellicottville,State Assembly,148,Joseph M. Giglio,IND,7,0
-Cattaraugus,Farmersville,State Assembly,148,Joseph M. Giglio,IND,4,1
-Cattaraugus,Franklinville District 1,State Assembly,148,Joseph M. Giglio,IND,6,6
-Cattaraugus,Franklinville District 2,State Assembly,148,Joseph M. Giglio,IND,4,4
-Cattaraugus,Freedom,State Assembly,148,Joseph M. Giglio,IND,11,2
-Cattaraugus,Great Valley 1,State Assembly,148,Joseph M. Giglio,IND,6,0
-Cattaraugus,Great Valley 2,State Assembly,148,Joseph M. Giglio,IND,13,4
-Cattaraugus,Hinsdale,State Assembly,148,Joseph M. Giglio,IND,8,2
-Cattaraugus,Humphrey,State Assembly,148,Joseph M. Giglio,IND,1,3
+Cattaraugus,Farmersville,State Assembly,148,Joseph M. Giglio,IND,4,0
+Cattaraugus,Franklinville District 1,State Assembly,148,Joseph M. Giglio,IND,6,0
+Cattaraugus,Franklinville District 2,State Assembly,148,Joseph M. Giglio,IND,4,0
+Cattaraugus,Freedom,State Assembly,148,Joseph M. Giglio,IND,13,2
+Cattaraugus,Great Valley 1,State Assembly,148,Joseph M. Giglio,IND,8,2
+Cattaraugus,Great Valley 2,State Assembly,148,Joseph M. Giglio,IND,15,2
+Cattaraugus,Hinsdale,State Assembly,148,Joseph M. Giglio,IND,10,2
+Cattaraugus,Humphrey,State Assembly,148,Joseph M. Giglio,IND,1,0
 Cattaraugus,Ischua,State Assembly,148,Joseph M. Giglio,IND,4,0
-Cattaraugus,Leon,State Assembly,148,Joseph M. Giglio,IND,11,2
-Cattaraugus,Little Valley,State Assembly,148,Joseph M. Giglio,IND,8,2
-Cattaraugus,Lyndon,State Assembly,148,Joseph M. Giglio,IND,5,1
-Cattaraugus,Machias,State Assembly,148,Joseph M. Giglio,IND,18,3
-Cattaraugus,Mansfield,State Assembly,148,Joseph M. Giglio,IND,5,1
-Cattaraugus,Napoli,State Assembly,148,Joseph M. Giglio,IND,4,2
-Cattaraugus,New Albion,State Assembly,148,Joseph M. Giglio,IND,11,0
-Cattaraugus,Otto,State Assembly,148,Joseph M. Giglio,IND,6,2
-Cattaraugus,Perrysburg,State Assembly,148,Joseph M. Giglio,IND,26,1
-Cattaraugus,Persia,State Assembly,148,Joseph M. Giglio,IND,10,0
-Cattaraugus,Portville 1,State Assembly,148,Joseph M. Giglio,IND,10,0
-Cattaraugus,Portville 2,State Assembly,148,Joseph M. Giglio,IND,8,0
-Cattaraugus,Randolph District 1,State Assembly,148,Joseph M. Giglio,IND,12,1
-Cattaraugus,Randolph District 2,State Assembly,148,Joseph M. Giglio,IND,7,0
-Cattaraugus,Red House,State Assembly,148,Joseph M. Giglio,IND,0,1
-Cattaraugus,South Valley,State Assembly,148,Joseph M. Giglio,IND,0,2
+Cattaraugus,Leon,State Assembly,148,Joseph M. Giglio,IND,11,0
+Cattaraugus,Little Valley,State Assembly,148,Joseph M. Giglio,IND,11,3
+Cattaraugus,Lyndon,State Assembly,148,Joseph M. Giglio,IND,5,0
+Cattaraugus,Machias,State Assembly,148,Joseph M. Giglio,IND,24,6
+Cattaraugus,Mansfield,State Assembly,148,Joseph M. Giglio,IND,6,1
+Cattaraugus,Napoli,State Assembly,148,Joseph M. Giglio,IND,6,2
+Cattaraugus,New Albion,State Assembly,148,Joseph M. Giglio,IND,15,4
+Cattaraugus,Otto,State Assembly,148,Joseph M. Giglio,IND,6,0
+Cattaraugus,Perrysburg,State Assembly,148,Joseph M. Giglio,IND,26,0
+Cattaraugus,Persia,State Assembly,148,Joseph M. Giglio,IND,13,3
+Cattaraugus,Portville 1,State Assembly,148,Joseph M. Giglio,IND,11,1
+Cattaraugus,Portville 2,State Assembly,148,Joseph M. Giglio,IND,10,2
+Cattaraugus,Randolph District 1,State Assembly,148,Joseph M. Giglio,IND,14,2
+Cattaraugus,Randolph District 2,State Assembly,148,Joseph M. Giglio,IND,8,1
+Cattaraugus,Red House,State Assembly,148,Joseph M. Giglio,IND,0,0
+Cattaraugus,South Valley,State Assembly,148,Joseph M. Giglio,IND,0,0
 Cattaraugus,Town of Olean 1,State Assembly,148,Joseph M. Giglio,IND,5,0
-Cattaraugus,Town of Olean 2,State Assembly,148,Joseph M. Giglio,IND,2,1
-Cattaraugus,Town of Salamanca,State Assembly,148,Joseph M. Giglio,IND,1,2
-Cattaraugus,Yorkshire 1,State Assembly,148,Joseph M. Giglio,IND,5,2
-Cattaraugus,Yorkshire 2,State Assembly,148,Joseph M. Giglio,IND,11,3
+Cattaraugus,Town of Olean 2,State Assembly,148,Joseph M. Giglio,IND,3,1
+Cattaraugus,Town of Salamanca,State Assembly,148,Joseph M. Giglio,IND,3,2
+Cattaraugus,Yorkshire 1,State Assembly,148,Joseph M. Giglio,IND,7,2
+Cattaraugus,Yorkshire 2,State Assembly,148,Joseph M. Giglio,IND,14,3
 Cattaraugus,Allegany District 1,State Assembly,148,Write-ins,,0,0
 Cattaraugus,Allegany District 2,State Assembly,148,Write-ins,,0,0
 Cattaraugus,Allegany District 3,State Assembly,148,Write-ins,,0,0
@@ -1969,10 +1969,10 @@ Cattaraugus,City of Salamanca - Ward 5,State Assembly,148,Write-ins,,0,0
 Cattaraugus,Coldspring,State Assembly,148,Write-ins,,0,0
 Cattaraugus,Conewango,State Assembly,148,Write-ins,,0,0
 Cattaraugus,Dayton,State Assembly,148,Write-ins,,0,0
-Cattaraugus,Early Voting - Little Valley 1,State Assembly,148,Write-ins,,0,
-Cattaraugus,Early Voting - Little Valley 2,State Assembly,148,Write-ins,,0,
-Cattaraugus,Early Voting - Olean 1,State Assembly,148,Write-ins,,0,
-Cattaraugus,Early Voting - Olean 2,State Assembly,148,Write-ins,,0,
+Cattaraugus,Early Voting - Little Valley 1,State Assembly,148,Write-ins,,0,0
+Cattaraugus,Early Voting - Little Valley 2,State Assembly,148,Write-ins,,0,0
+Cattaraugus,Early Voting - Olean 1,State Assembly,148,Write-ins,,0,0
+Cattaraugus,Early Voting - Olean 2,State Assembly,148,Write-ins,,0,0
 Cattaraugus,East Otto,State Assembly,148,Write-ins,,0,0
 Cattaraugus,Ellicottville,State Assembly,148,Write-ins,,0,0
 Cattaraugus,Farmersville,State Assembly,148,Write-ins,,0,0
@@ -2006,44 +2006,44 @@ Cattaraugus,Town of Salamanca,State Assembly,148,Write-ins,,0,0
 Cattaraugus,Yorkshire 1,State Assembly,148,Write-ins,,0,0
 Cattaraugus,Yorkshire 2,State Assembly,148,Write-ins,,0,0
 Cattaraugus,Allegany District 1,State Assembly,148,Voids,,0,0
-Cattaraugus,Allegany District 2,State Assembly,148,Voids,,0,3
+Cattaraugus,Allegany District 2,State Assembly,148,Voids,,3,3
 Cattaraugus,Allegany District 3,State Assembly,148,Voids,,0,0
 Cattaraugus,Allegany District 4,State Assembly,148,Voids,,0,0
-Cattaraugus,Allegany District 5,State Assembly,148,Voids,,0,1
+Cattaraugus,Allegany District 5,State Assembly,148,Voids,,1,1
 Cattaraugus,Ashford District 1,State Assembly,148,Voids,,0,0
 Cattaraugus,Ashford District 2,State Assembly,148,Voids,,0,0
 Cattaraugus,Carrollton,State Assembly,148,Voids,,0,0
 Cattaraugus,City of Olean - Ward 1,State Assembly,148,Voids,,0,0
 Cattaraugus,City of Olean - Ward 2,State Assembly,148,Voids,,0,0
-Cattaraugus,City of Olean - Ward 3,State Assembly,148,Voids,,0,1
-Cattaraugus,City of Olean - Ward 4,State Assembly,148,Voids,,0,2
-Cattaraugus,City of Olean - Ward 5,State Assembly,148,Voids,,0,1
-Cattaraugus,City of Olean - Ward 6,State Assembly,148,Voids,,0,1
-Cattaraugus,City of Olean - Ward 7,State Assembly,148,Voids,,0,1
-Cattaraugus,City of Salamanca - Ward 1,State Assembly,148,Voids,,0,1
+Cattaraugus,City of Olean - Ward 3,State Assembly,148,Voids,,3,3
+Cattaraugus,City of Olean - Ward 4,State Assembly,148,Voids,,0,0
+Cattaraugus,City of Olean - Ward 5,State Assembly,148,Voids,,1,1
+Cattaraugus,City of Olean - Ward 6,State Assembly,148,Voids,,0,0
+Cattaraugus,City of Olean - Ward 7,State Assembly,148,Voids,,0,0
+Cattaraugus,City of Salamanca - Ward 1,State Assembly,148,Voids,,1,1
 Cattaraugus,City of Salamanca - Ward 2,State Assembly,148,Voids,,0,0
 Cattaraugus,City of Salamanca - Ward 3,State Assembly,148,Voids,,0,0
-Cattaraugus,City of Salamanca - Ward 4,State Assembly,148,Voids,,0,1
+Cattaraugus,City of Salamanca - Ward 4,State Assembly,148,Voids,,0,0
 Cattaraugus,City of Salamanca - Ward 5,State Assembly,148,Voids,,0,0
 Cattaraugus,Coldspring,State Assembly,148,Voids,,0,0
 Cattaraugus,Conewango,State Assembly,148,Voids,,0,0
-Cattaraugus,Dayton,State Assembly,148,Voids,,1,0
-Cattaraugus,Early Voting - Little Valley 1,State Assembly,148,Voids,,0,
-Cattaraugus,Early Voting - Little Valley 2,State Assembly,148,Voids,,0,
-Cattaraugus,Early Voting - Olean 1,State Assembly,148,Voids,,1,
-Cattaraugus,Early Voting - Olean 2,State Assembly,148,Voids,,0,
-Cattaraugus,East Otto,State Assembly,148,Voids,,0,0
-Cattaraugus,Ellicottville,State Assembly,148,Voids,,0,0
-Cattaraugus,Farmersville,State Assembly,148,Voids,,0,0
-Cattaraugus,Franklinville District 1,State Assembly,148,Voids,,0,0
+Cattaraugus,Dayton,State Assembly,148,Voids,,2,1
+Cattaraugus,Early Voting - Little Valley 1,State Assembly,148,Voids,,0,0
+Cattaraugus,Early Voting - Little Valley 2,State Assembly,148,Voids,,0,0
+Cattaraugus,Early Voting - Olean 1,State Assembly,148,Voids,,1,0
+Cattaraugus,Early Voting - Olean 2,State Assembly,148,Voids,,0,0
+Cattaraugus,East Otto,State Assembly,148,Voids,,1,1
+Cattaraugus,Ellicottville,State Assembly,148,Voids,,2,2
+Cattaraugus,Farmersville,State Assembly,148,Voids,,1,1
+Cattaraugus,Franklinville District 1,State Assembly,148,Voids,,1,1
 Cattaraugus,Franklinville District 2,State Assembly,148,Voids,,0,0
-Cattaraugus,Freedom,State Assembly,148,Voids,,0,0
+Cattaraugus,Freedom,State Assembly,148,Voids,,1,1
 Cattaraugus,Great Valley 1,State Assembly,148,Voids,,0,0
-Cattaraugus,Great Valley 2,State Assembly,148,Voids,,0,0
+Cattaraugus,Great Valley 2,State Assembly,148,Voids,,1,1
 Cattaraugus,Hinsdale,State Assembly,148,Voids,,0,0
-Cattaraugus,Humphrey,State Assembly,148,Voids,,0,3
+Cattaraugus,Humphrey,State Assembly,148,Voids,,0,0
 Cattaraugus,Ischua,State Assembly,148,Voids,,0,0
-Cattaraugus,Leon,State Assembly,148,Voids,,0,1
+Cattaraugus,Leon,State Assembly,148,Voids,,0,0
 Cattaraugus,Little Valley,State Assembly,148,Voids,,0,0
 Cattaraugus,Lyndon,State Assembly,148,Voids,,0,0
 Cattaraugus,Machias,State Assembly,148,Voids,,0,0
@@ -2054,7 +2054,7 @@ Cattaraugus,Otto,State Assembly,148,Voids,,0,0
 Cattaraugus,Perrysburg,State Assembly,148,Voids,,0,0
 Cattaraugus,Persia,State Assembly,148,Voids,,0,0
 Cattaraugus,Portville 1,State Assembly,148,Voids,,1,0
-Cattaraugus,Portville 2,State Assembly,148,Voids,,0,1
+Cattaraugus,Portville 2,State Assembly,148,Voids,,0,0
 Cattaraugus,Randolph District 1,State Assembly,148,Voids,,0,0
 Cattaraugus,Randolph District 2,State Assembly,148,Voids,,0,0
 Cattaraugus,Red House,State Assembly,148,Voids,,0,0
@@ -2064,62 +2064,62 @@ Cattaraugus,Town of Olean 2,State Assembly,148,Voids,,0,0
 Cattaraugus,Town of Salamanca,State Assembly,148,Voids,,1,0
 Cattaraugus,Yorkshire 1,State Assembly,148,Voids,,0,0
 Cattaraugus,Yorkshire 2,State Assembly,148,Voids,,0,0
-Cattaraugus,Allegany District 1,State Assembly,148,Blanks,,29,6
-Cattaraugus,Allegany District 2,State Assembly,148,Blanks,,10,10
-Cattaraugus,Allegany District 3,State Assembly,148,Blanks,,17,2
-Cattaraugus,Allegany District 4,State Assembly,148,Blanks,,23,1
-Cattaraugus,Allegany District 5,State Assembly,148,Blanks,,27,12
-Cattaraugus,Ashford District 1,State Assembly,148,Blanks,,18,2
-Cattaraugus,Ashford District 2,State Assembly,148,Blanks,,34,5
-Cattaraugus,Carrollton,State Assembly,148,Blanks,,30,0
-Cattaraugus,City of Olean - Ward 1,State Assembly,148,Blanks,,34,3
-Cattaraugus,City of Olean - Ward 2,State Assembly,148,Blanks,,27,7
-Cattaraugus,City of Olean - Ward 3,State Assembly,148,Blanks,,23,5
-Cattaraugus,City of Olean - Ward 4,State Assembly,148,Blanks,,21,9
-Cattaraugus,City of Olean - Ward 5,State Assembly,148,Blanks,,27,3
-Cattaraugus,City of Olean - Ward 6,State Assembly,148,Blanks,,27,6
-Cattaraugus,City of Olean - Ward 7,State Assembly,148,Blanks,,40,6
-Cattaraugus,City of Salamanca - Ward 1,State Assembly,148,Blanks,,22,7
-Cattaraugus,City of Salamanca - Ward 2,State Assembly,148,Blanks,,41,7
-Cattaraugus,City of Salamanca - Ward 3,State Assembly,148,Blanks,,25,2
-Cattaraugus,City of Salamanca - Ward 4,State Assembly,148,Blanks,,31,6
-Cattaraugus,City of Salamanca - Ward 5,State Assembly,148,Blanks,,19,6
-Cattaraugus,Coldspring,State Assembly,148,Blanks,,23,2
-Cattaraugus,Conewango,State Assembly,148,Blanks,,23,7
-Cattaraugus,Dayton,State Assembly,148,Blanks,,33,3
-Cattaraugus,Early Voting - Little Valley 1,State Assembly,148,Blanks,,65,
-Cattaraugus,Early Voting - Little Valley 2,State Assembly,148,Blanks,,58,
-Cattaraugus,Early Voting - Olean 1,State Assembly,148,Blanks,,114,
-Cattaraugus,Early Voting - Olean 2,State Assembly,148,Blanks,,71,
-Cattaraugus,East Otto,State Assembly,148,Blanks,,13,7
-Cattaraugus,Ellicottville,State Assembly,148,Blanks,,24,5
-Cattaraugus,Farmersville,State Assembly,148,Blanks,,24,5
-Cattaraugus,Franklinville District 1,State Assembly,148,Blanks,,23,9
-Cattaraugus,Franklinville District 2,State Assembly,148,Blanks,,30,7
-Cattaraugus,Freedom,State Assembly,148,Blanks,,111,0
-Cattaraugus,Great Valley 1,State Assembly,148,Blanks,,16,3
-Cattaraugus,Great Valley 2,State Assembly,148,Blanks,,23,13
-Cattaraugus,Hinsdale,State Assembly,148,Blanks,,38,5
-Cattaraugus,Humphrey,State Assembly,148,Blanks,,8,13
-Cattaraugus,Ischua,State Assembly,148,Blanks,,21,7
-Cattaraugus,Leon,State Assembly,148,Blanks,,11,9
-Cattaraugus,Little Valley,State Assembly,148,Blanks,,19,14
-Cattaraugus,Lyndon,State Assembly,148,Blanks,,27,8
-Cattaraugus,Machias,State Assembly,148,Blanks,,49,11
-Cattaraugus,Mansfield,State Assembly,148,Blanks,,12,7
-Cattaraugus,Napoli,State Assembly,148,Blanks,,22,10
-Cattaraugus,New Albion,State Assembly,148,Blanks,,36,8
-Cattaraugus,Otto,State Assembly,148,Blanks,,18,6
-Cattaraugus,Perrysburg,State Assembly,148,Blanks,,35,2
-Cattaraugus,Persia,State Assembly,148,Blanks,,42,0
-Cattaraugus,Portville 1,State Assembly,148,Blanks,,18,0
-Cattaraugus,Portville 2,State Assembly,148,Blanks,,33,5
-Cattaraugus,Randolph District 1,State Assembly,148,Blanks,,21,15
-Cattaraugus,Randolph District 2,State Assembly,148,Blanks,,38,2
-Cattaraugus,Red House,State Assembly,148,Blanks,,2,5
-Cattaraugus,South Valley,State Assembly,148,Blanks,,8,32
-Cattaraugus,Town of Olean 1,State Assembly,148,Blanks,,14,3
-Cattaraugus,Town of Olean 2,State Assembly,148,Blanks,,17,8
-Cattaraugus,Town of Salamanca,State Assembly,148,Blanks,,41,2
-Cattaraugus,Yorkshire 1,State Assembly,148,Blanks,,45,5
-Cattaraugus,Yorkshire 2,State Assembly,148,Blanks,,46,14
+Cattaraugus,Allegany District 1,State Assembly,148,Blanks,,35,6
+Cattaraugus,Allegany District 2,State Assembly,148,Blanks,,20,10
+Cattaraugus,Allegany District 3,State Assembly,148,Blanks,,19,2
+Cattaraugus,Allegany District 4,State Assembly,148,Blanks,,24,1
+Cattaraugus,Allegany District 5,State Assembly,148,Blanks,,39,12
+Cattaraugus,Ashford District 1,State Assembly,148,Blanks,,20,2
+Cattaraugus,Ashford District 2,State Assembly,148,Blanks,,39,5
+Cattaraugus,Carrollton,State Assembly,148,Blanks,,37,7
+Cattaraugus,City of Olean - Ward 1,State Assembly,148,Blanks,,47,13
+Cattaraugus,City of Olean - Ward 2,State Assembly,148,Blanks,,32,5
+Cattaraugus,City of Olean - Ward 3,State Assembly,148,Blanks,,36,13
+Cattaraugus,City of Olean - Ward 4,State Assembly,148,Blanks,,28,7
+Cattaraugus,City of Olean - Ward 5,State Assembly,148,Blanks,,36,9
+Cattaraugus,City of Olean - Ward 6,State Assembly,148,Blanks,,41,14
+Cattaraugus,City of Olean - Ward 7,State Assembly,148,Blanks,,48,8
+Cattaraugus,City of Salamanca - Ward 1,State Assembly,148,Blanks,,27,5
+Cattaraugus,City of Salamanca - Ward 2,State Assembly,148,Blanks,,56,15
+Cattaraugus,City of Salamanca - Ward 3,State Assembly,148,Blanks,,27,2
+Cattaraugus,City of Salamanca - Ward 4,State Assembly,148,Blanks,,36,5
+Cattaraugus,City of Salamanca - Ward 5,State Assembly,148,Blanks,,51,32
+Cattaraugus,Coldspring,State Assembly,148,Blanks,,23,0
+Cattaraugus,Conewango,State Assembly,148,Blanks,,26,3
+Cattaraugus,Dayton,State Assembly,148,Blanks,,38,5
+Cattaraugus,Early Voting - Little Valley 1,State Assembly,148,Blanks,,65,0
+Cattaraugus,Early Voting - Little Valley 2,State Assembly,148,Blanks,,58,0
+Cattaraugus,Early Voting - Olean 1,State Assembly,148,Blanks,,114,0
+Cattaraugus,Early Voting - Olean 2,State Assembly,148,Blanks,,71,0
+Cattaraugus,East Otto,State Assembly,148,Blanks,,16,3
+Cattaraugus,Ellicottville,State Assembly,148,Blanks,,33,9
+Cattaraugus,Farmersville,State Assembly,148,Blanks,,30,6
+Cattaraugus,Franklinville District 1,State Assembly,148,Blanks,,30,7
+Cattaraugus,Franklinville District 2,State Assembly,148,Blanks,,37,7
+Cattaraugus,Freedom,State Assembly,148,Blanks,,117,6
+Cattaraugus,Great Valley 1,State Assembly,148,Blanks,,18,2
+Cattaraugus,Great Valley 2,State Assembly,148,Blanks,,29,6
+Cattaraugus,Hinsdale,State Assembly,148,Blanks,,44,6
+Cattaraugus,Humphrey,State Assembly,148,Blanks,,10,2
+Cattaraugus,Ischua,State Assembly,148,Blanks,,28,7
+Cattaraugus,Leon,State Assembly,148,Blanks,,14,3
+Cattaraugus,Little Valley,State Assembly,148,Blanks,,26,7
+Cattaraugus,Lyndon,State Assembly,148,Blanks,,32,5
+Cattaraugus,Machias,State Assembly,148,Blanks,,58,9
+Cattaraugus,Mansfield,State Assembly,148,Blanks,,17,5
+Cattaraugus,Napoli,State Assembly,148,Blanks,,22,0
+Cattaraugus,New Albion,State Assembly,148,Blanks,,43,7
+Cattaraugus,Otto,State Assembly,148,Blanks,,21,3
+Cattaraugus,Perrysburg,State Assembly,148,Blanks,,43,8
+Cattaraugus,Persia,State Assembly,148,Blanks,,53,11
+Cattaraugus,Portville 1,State Assembly,148,Blanks,,25,7
+Cattaraugus,Portville 2,State Assembly,148,Blanks,,43,10
+Cattaraugus,Randolph District 1,State Assembly,148,Blanks,,27,6
+Cattaraugus,Randolph District 2,State Assembly,148,Blanks,,40,2
+Cattaraugus,Red House,State Assembly,148,Blanks,,2,0
+Cattaraugus,South Valley,State Assembly,148,Blanks,,8,0
+Cattaraugus,Town of Olean 1,State Assembly,148,Blanks,,17,3
+Cattaraugus,Town of Olean 2,State Assembly,148,Blanks,,25,8
+Cattaraugus,Town of Salamanca,State Assembly,148,Blanks,,43,2
+Cattaraugus,Yorkshire 1,State Assembly,148,Blanks,,50,5
+Cattaraugus,Yorkshire 2,State Assembly,148,Blanks,,60,14

--- a/cattaraugus_2020_parse.py
+++ b/cattaraugus_2020_parse.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""Regenerate the 2020 Cattaraugus precinct CSV from the source PDF (issue #118).
+
+Root cause (verified with cattaraugus_2020_verify.py / _align.py): the existing
+CSV's per-candidate `votes` (machine) column is a faithful extraction of the PDF,
+but the `absentee` column is corrupted for many precincts (e.g. Red House: CSV
+absentee sums to 63 against only 21 machine ballots). The PDF is the source of
+truth.
+
+OpenElections convention: `votes` = TOTAL (machine + absentee); `absentee` =
+the absentee subset. This parser keeps the CSV as a scaffold (county, precinct,
+office, district, candidate, party are correct and preserved) and replaces
+only `votes` and `absentee` from the PDF:
+
+  votes    = PDF machine per-line + PDF absentee per-line
+  absentee = PDF absentee per-line
+
+PDF row layout per precinct/office (a machine row, then an "Absentees &
+Affidavits" row with the same column layout):
+
+  [Total Votes Cast][candidate-total cols][per-line votes in party order]
+  [write-ins][voids][blanks][occasional stray trailing value]
+
+Column mapping is by X-COORDINATE, not by counting columns, because rows are
+not uniformly sized: some machine rows carry a stray trailing value, and some
+absentee rows omit zero columns (e.g. Otto). Crucially, each precinct's machine
+row and its absentee row share the same column grid, so we derive the per-line
+column x0 positions from the precinct's OWN (complete) machine row and match
+that precinct's absentee digits to those same x0 positions (value 0 when a
+column is absent). The per-line columns are the machine data columns
+[1+ntotals : 1+ntotals+plc]; ntotals (candidate-total column count) is constant
+per office and is detected by best-match of PDF machine per-line vs the CSV's
+existing (correct) machine values.
+
+"Ballots Cast" is a turnout row not printed as its own PDF office; the existing
+file derives it from the President "Total Votes Cast" figures, so we do too:
+  Ballots Cast votes    = President machine total + President absentee total
+  Ballots Cast absentee = President absentee total
+"""
+import csv
+import sys
+import pdfplumber
+
+PDF = "/Users/dwillis/code/openelections-sources-ny/2020/Cattaraugus NY 2020 GENERAL ELECTION OFFICAL RESULTS.pdf"
+CSV = "2020/counties/20201103__ny__general__cattaraugus__precinct.csv"
+
+OFFICE_PAGES = {
+    "President": [1, 2],
+    "U.S. House": [5, 6],
+    "State Senate": [7, 8],
+    "State Assembly": [9, 10],
+}
+
+SKIP_FIRST = {
+    "PAGE", "VOTE", "TOTAL", "PRESIDENTIAL", "ELECTORS", "FOR", "PRESIDENT",
+    "AND", "VICE", "ONE", "STATE", "SENATOR", "ASSEMBLY", "MEMBER",
+    "REPRESENTATIVE", "CONGRESS", "TOM", "TRACY", "JOSEPH", "DONALD", "HOWIE",
+    "JO", "BROCK", "ANDREW", "FRANK", "GEORGE", "W.",
+}
+
+# Nearest-x0 tolerance for matching an absentee row's digits to the precinct's
+# own machine-row column x0. Machine and absentee rows share the same grid, so
+# the alignment is near-exact; 6px is comfortable and well below the ~17px
+# spacing between adjacent columns.
+TOL = 6.0
+
+
+def toi(s):
+    try:
+        return int(s.replace(",", ""))
+    except (ValueError, AttributeError):
+        return None
+
+
+def is_num(tok):
+    return tok.replace(",", "").isdigit()
+
+
+def cluster_rows(pg, gap=4):
+    """Group words into visual rows (a precinct label and its numbers share a
+    near-equal `top`)."""
+    words = sorted(pg.extract_words(use_text_flow=False, keep_blank_chars=False),
+                  key=lambda w: (w["top"], w["x0"]))
+    out, cur, prev = [], [], None
+    for w in words:
+        if prev is None or abs(w["top"] - prev) <= gap:
+            cur.append(w)
+        else:
+            out.append(cur)
+            cur = [w]
+        prev = w["top"]
+    if cur:
+        out.append(cur)
+    return [sorted(c, key=lambda w: w["x0"]) for c in out]
+
+
+def name_and_data(cl):
+    """Split a machine row into (precinct_name, data_digits) using the largest
+    x0 gap as the name/data boundary. Machine rows are complete (no internal
+    gap larger than the name/data gap), so the largest gap is the name/data
+    boundary. data_digits = (x0, value) for numeric tokens right of it."""
+    s = sorted(cl, key=lambda w: w["x0"])
+    xs = [w["x0"] for w in s]
+    if len(xs) < 2:
+        return " ".join(w["text"] for w in s).strip(), []
+    best, idx = -1.0, len(xs)
+    for i in range(1, len(xs)):
+        g = xs[i] - xs[i - 1]
+        if g > best:
+            best, idx = g, i
+    boundary = xs[idx]
+    name = " ".join(w["text"] for w in s if w["x0"] < boundary).strip()
+    # data columns are right-aligned: use x1 (right edge) as the stable column
+    # key, since x0 (left edge) shifts with the number of digits.
+    data = [(w["x1"], toi(w["text"])) for w in s
+            if w["x0"] >= boundary and is_num(w["text"])]
+    return name, data
+
+
+def digits_of(cl):
+    return [(w["x1"], toi(w["text"])) for w in cl if is_num(w["text"])]
+
+
+def match_to_cols(digits, col_x0):
+    """Return [value for each col_x0] by nearest x0 (within TOL), else 0."""
+    out = []
+    for cx in col_x0:
+        val = 0
+        best = TOL
+        for x, v in digits:
+            d = abs(x - cx)
+            if d <= best:
+                best = d
+                val = v
+        out.append(val)
+    return out
+
+
+def extract_office(pdf_path, pages):
+    """Return {precinct: (mach_data_digits, abs_digits|None)} where
+    mach_data_digits is the sorted (x0,value) list for that precinct's machine
+    row (name already excluded), and abs_digits is its absentee row's digits."""
+    out = {}
+    with pdfplumber.open(pdf_path) as pdoc:
+        for pno in pages:
+            seq = []
+            for cl in cluster_rows(pdoc.pages[pno - 1]):
+                full = " ".join(w["text"] for w in cl)
+                low = full.lower()
+                if "absent" in low or "affidavit" in low:
+                    seq.append(("abs", None, digits_of(cl)))
+                    continue
+                name, data = name_and_data(cl)
+                if not name or not name[0].isalpha():
+                    continue
+                if name.split()[0].upper() in SKIP_FIRST or name.upper().startswith("CATTARAUGUS"):
+                    continue
+                seq.append(("mach", name, data))
+            i = 0
+            while i < len(seq):
+                kind, name, data = seq[i]
+                if kind == "mach":
+                    ab = None
+                    if i + 1 < len(seq) and seq[i + 1][0] == "abs":
+                        ab = seq[i + 1][2]
+                        i += 2
+                    else:
+                        i += 1
+                    out[name] = (data, ab)
+                else:
+                    i += 1
+    return out
+
+
+def per_line_columns(mach_data, ntotals, plc):
+    """The per-line column x0 = mach data x0[1+ntotals : 1+ntotals+plc]."""
+    xs = sorted(x for x, _ in mach_data)
+    return xs[1 + ntotals:1 + ntotals + plc], (xs[0] if xs else None)
+
+
+def detect_ntotals(records, csv_machine_by_prec, plc):
+    """Pick ntotals in [0..6] maximizing exact machine per-line matches."""
+    best, best_score = 0, -1
+    for nt in range(0, 7):
+        score = 0
+        for name, (mach, _ab) in records.items():
+            cm = csv_machine_by_prec.get(name)
+            if cm is None or len(cm) != plc:
+                continue
+            col_x0, _tot = per_line_columns(mach, nt, plc)
+            if len(col_x0) != plc:
+                continue
+            # machine per-line values: exact (the precinct's own columns)
+            xs_val = {x: v for x, v in mach}
+            per = [xs_val.get(cx, 0) for cx in col_x0]
+            if per == cm:
+                score += 1
+        if score > best_score:
+            best, best_score = nt, score
+    return best, best_score
+
+
+def main():
+    verify_only = "--verify" in sys.argv
+
+    scaffold = {}
+    with open(CSV, newline="", encoding="utf-8-sig") as fh:
+        for r in csv.DictReader(fh):
+            scaffold.setdefault(r["office"], {}).setdefault(r["precinct"], []).append(r)
+
+    pdf = {}
+    ntotals = {}
+    for office, pages in OFFICE_PAGES.items():
+        recs = extract_office(PDF, pages)
+        pdf[office] = recs
+        csv_mach = {p: [int(r["votes"]) for r in rows] for p, rows in scaffold[office].items()}
+        plc = len(next(iter(csv_mach.values()))) if csv_mach else 0
+        nt, score = detect_ntotals(recs, csv_mach, plc)
+        ntotals[office] = nt
+        print(f"{office}: ntotals={nt} (matched {score}/{len(csv_mach)}), "
+              f"PDF precincts={len(recs)}, plc={plc}")
+
+    corrected = {}
+    problems = 0
+    for office in OFFICE_PAGES:
+        nt = ntotals[office]
+        for prec, rows in scaffold[office].items():
+            plc = len(rows)
+            rec = pdf[office].get(prec)
+            if rec is None:
+                print(f"  MISSING in PDF: {office} / {prec!r}")
+                problems += 1
+                continue
+            mach, ab = rec
+            col_x0, tot_x0 = per_line_columns(mach, nt, plc)
+            if len(col_x0) != plc:
+                print(f"  FEW COLS: {office} / {prec!r}: mach data len {len(mach)} (need {1+nt+plc})")
+                problems += 1
+                continue
+            xs_val = {x: v for x, v in mach}
+            mach_per = [xs_val.get(cx, 0) for cx in col_x0]
+            csv_mach = [int(r["votes"]) for r in rows]
+            if mach_per != csv_mach:
+                print(f"  MACHINE MISMATCH {office} / {prec!r}: pdf={mach_per} csv={csv_mach}")
+                problems += 1
+                continue
+            abs_per = match_to_cols(ab, col_x0) if ab else [0] * plc
+            # invariant: sum of absentee per-line == absentee row's Total Votes Cast
+            if ab is not None:
+                ab_tot = next((v for x, v in ab if abs(x - tot_x0) <= TOL), 0)
+                if sum(abs_per) != ab_tot:
+                    print(f"  ABSENTEE SUM MISMATCH {office} / {prec!r}: "
+                          f"sum={sum(abs_per)} pdf_total={ab_tot} per={abs_per}")
+                    problems += 1
+                    continue
+            corrected[(office, prec)] = [(m + a, a) for m, a in zip(mach_per, abs_per)]
+
+    # Ballots Cast from President totals.
+    pres = pdf["President"]
+    for prec, rows in scaffold.get("Ballots Cast", {}).items():
+        if prec not in pres:
+            print(f"  MISSING President for Ballots Cast / {prec!r}")
+            problems += 1
+            continue
+        mach, ab = pres[prec]
+        tot_x0 = sorted(x for x, _ in mach)[0]
+        m_tot = next((v for x, v in mach if abs(x - tot_x0) <= TOL), 0)
+        a_tot = 0
+        if ab:
+            a_tot = next((v for x, v in ab if abs(x - tot_x0) <= TOL), 0)
+        corrected[("Ballots Cast", prec)] = [(m_tot + a_tot, a_tot)]
+
+    print(f"\nAlignment problems: {problems}")
+
+    changed = 0
+    bad = 0
+    for office in list(OFFICE_PAGES) + ["Ballots Cast"]:
+        for prec, rows in scaffold.get(office, {}).items():
+            key = (office, prec)
+            if key not in corrected:
+                continue
+            for r, (v, a) in zip(rows, corrected[key]):
+                old_a = int(r["absentee"]) if r["absentee"] else 0
+                if old_a != a:
+                    changed += 1
+                if a > v:
+                    bad += 1
+    print(f"Rows with changed absentee: {changed}")
+    print(f"Rows with absentee > votes (must be 0): {bad}")
+
+    if verify_only or problems or bad:
+        return 1 if (problems or bad) else 0
+
+    # Build a per-row lookup keyed by (office, precinct, candidate, party), then
+    # iterate the ORIGINAL file in order so only votes/absentee change and the row
+    # order (office/precinct/candidate) is preserved exactly — minimal diff.
+    lookup = {}
+    for office in OFFICE_PAGES:
+        for prec, rows in scaffold[office].items():
+            key = (office, prec)
+            if key not in corrected:
+                continue
+            for r, (v, a) in zip(rows, corrected[key]):
+                lookup[(r["office"], r["precinct"], r["candidate"], r["party"])] = (v, a)
+    for prec, rows in scaffold.get("Ballots Cast", {}).items():
+        key = ("Ballots Cast", prec)
+        if key not in corrected:
+            continue
+        for r, (v, a) in zip(rows, corrected[key]):
+            lookup[(r["office"], r["precinct"], r["candidate"], r["party"])] = (v, a)
+
+    header = ["county", "precinct", "office", "district", "candidate", "party", "votes", "absentee"]
+    with open(CSV, newline="", encoding="utf-8-sig") as inf:
+        rows_in = list(csv.DictReader(inf))
+    written = 0
+    with open(CSV, "w", newline="", encoding="utf-8") as fh:
+        w = csv.writer(fh)
+        w.writerow(header)
+        for r in rows_in:
+            v, a = lookup.get((r["office"], r["precinct"], r["candidate"], r["party"]),
+                              (r["votes"], r["absentee"]))
+            w.writerow([r["county"], r["precinct"], r["office"], r["district"],
+                        r["candidate"], r["party"], v, a])
+            written += 1
+    print(f"wrote {written} rows to {CSV}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #118.

## Problem

The 2020 Cattaraugus precinct CSV (`2020/counties/20201103__ny__general__cattaraugus__precinct.csv`) had a corrupted `absentee` column for many precincts. For example, Red House's absentee rows summed to 63 against only 21 machine ballots, producing rows where `absentee > votes`. This fails the `vote_breakdown_totals` CI test, which rejects any row where `votes < absentee` for the Cattaraugus schema (it is not one of the exact-equality schemas).

## Root cause

The existing per-candidate `votes` (machine) column is a faithful extraction of the source PDF, but the `absentee` column was corrupted during the original extraction.

## Fix

This adds `cattaraugus_2020_parse.py`, which regenerates the CSV from the official source PDF (`Cattaraugus NY 2020 GENERAL ELECTION OFFICAL RESULTS.pdf`), keeping the existing `county, precinct, office, district, candidate, party` scaffold (verified correct) and replacing only `votes` and `absentee`:

- `votes` = PDF machine per-line + PDF absentee per-line
- `absentee` = PDF absentee per-line

Column mapping is by x-coordinate (right edge / `x1`, since the numbers are right-aligned and the left edge shifts with digit count) against each precinct's own complete machine row. This is necessary because rows are not uniformly sized: some machine rows carry a stray trailing value and some absentee rows omit zero-columns (e.g. Otto). The candidate-total column count (`ntotals`) is detected per office by best-match against the CSV's known-correct machine values. `Ballots Cast` (a turnout row not printed as its own PDF office) is derived from the President "Total Votes Cast" figures, matching the existing file's convention.

## Verification

- **0 rows with `absentee > votes`** (was the CI failure condition).
- All four offices match the PDF on machine per-line, absentee per-line, and totals — 236 precinct-offices (4 offices × 59 precincts) verified.
- 59 `Ballots Cast` rows match the PDF President totals (machine + absentee).
- Red House fixed: Biden DEM 7 (4+3), Trump REP 16 (14+2).
- Row order and all non-vote columns are unchanged from the original file — the diff is values-only (1636 rows changed votes/absentee; 1151 changed absentee).
- Office totals all satisfy `absentee ≤ votes`: President 35018/4781, U.S. House 35014/4777, State Senate 34938/4701, State Assembly 34938/4701.

This mirrors the approach taken for #123 (parser script committed alongside the regenerated data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)