### PR TITLE
Fix Queens 2022 ED 045/23: restore dropped affidavit ballot

### DIFF
--- a/2022/counties/20221108__ny__general__queens__precinct.csv
+++ b/2022/counties/20221108__ny__general__queens__precinct.csv
@@ -418,8 +418,8 @@ Queens,045/23,Governor,,,Public Counter,518
 Queens,045/23,Governor,,,Manually Counted Emergency,0
 Queens,045/23,Governor,,,Absentee / Military,64
 Queens,045/23,Governor,,,Federal,1
-Queens,045/23,Governor,,,Affidavit,5
-Queens,045/23,Governor,,DEM,Kathy C. Hochul,250
+Queens,045/23,Governor,,,Affidavit,6
+Queens,045/23,Governor,,DEM,Kathy C. Hochul,251
 Queens,045/23,Governor,,REP,Lee Zeldin,299
 Queens,045/23,Governor,,CON,Lee Zeldin,25
 Queens,045/23,Governor,,WOR,Kathy C. Hochul,12
@@ -11810,8 +11810,8 @@ Queens,045/23,Comptroller,,,Public Counter,518
 Queens,045/23,Comptroller,,,Manually Counted Emergency,0
 Queens,045/23,Comptroller,,,Absentee / Military,64
 Queens,045/23,Comptroller,,,Federal,1
-Queens,045/23,Comptroller,,,Affidavit,5
-Queens,045/23,Comptroller,,DEM,Thomas P. DiNapoli,267
+Queens,045/23,Comptroller,,,Affidavit,6
+Queens,045/23,Comptroller,,DEM,Thomas P. DiNapoli,268
 Queens,045/23,Comptroller,,REP,Paul Rodriguez,270
 Queens,045/23,Comptroller,,CON,Paul Rodriguez,19
 Queens,045/23,Comptroller,,WOR,Thomas P. DiNapoli,16
@@ -22994,8 +22994,8 @@ Queens,045/23,Attorney General,,,Public Counter,518
 Queens,045/23,Attorney General,,,Manually Counted Emergency,0
 Queens,045/23,Attorney General,,,Absentee / Military,64
 Queens,045/23,Attorney General,,,Federal,1
-Queens,045/23,Attorney General,,,Affidavit,5
-Queens,045/23,Attorney General,,DEM,Letitia A. James,246
+Queens,045/23,Attorney General,,,Affidavit,6
+Queens,045/23,Attorney General,,DEM,Letitia A. James,247
 Queens,045/23,Attorney General,,REP,Michael Henry,283
 Queens,045/23,Attorney General,,CON,Michael Henry,23
 Queens,045/23,Attorney General,,WOR,Letitia A. James,15
@@ -34258,8 +34258,8 @@ Queens,045/23,U.S. Senate,,,Public Counter,518
 Queens,045/23,U.S. Senate,,,Manually Counted Emergency,0
 Queens,045/23,U.S. Senate,,,Absentee / Military,64
 Queens,045/23,U.S. Senate,,,Federal,1
-Queens,045/23,U.S. Senate,,,Affidavit,5
-Queens,045/23,U.S. Senate,,DEM,Charles E. Schumer,272
+Queens,045/23,U.S. Senate,,,Affidavit,6
+Queens,045/23,U.S. Senate,,DEM,Charles E. Schumer,273
 Queens,045/23,U.S. Senate,,REP,Joe Pinion,272
 Queens,045/23,U.S. Senate,,CON,Joe Pinion,20
 Queens,045/23,U.S. Senate,,WOR,Charles E. Schumer,12
@@ -46768,14 +46768,14 @@ Queens,045/23,Justice of the Supreme Court,11,,Public Counter,518
 Queens,045/23,Justice of the Supreme Court,11,,Manually Counted Emergency,0
 Queens,045/23,Justice of the Supreme Court,11,,Absentee / Military,64
 Queens,045/23,Justice of the Supreme Court,11,,Federal,1
-Queens,045/23,Justice of the Supreme Court,11,,Affidavit,5
-Queens,045/23,Justice of the Supreme Court,11,DEM,Denise N. Johnson,242
+Queens,045/23,Justice of the Supreme Court,11,,Affidavit,6
+Queens,045/23,Justice of the Supreme Court,11,DEM,Denise N. Johnson,243
 Queens,045/23,Justice of the Supreme Court,11,REP,Denise N. Johnson,261
-Queens,045/23,Justice of the Supreme Court,11,DEM,Leigh K. Cheng,225
+Queens,045/23,Justice of the Supreme Court,11,DEM,Leigh K. Cheng,226
 Queens,045/23,Justice of the Supreme Court,11,REP,Leigh K. Cheng,243
-Queens,045/23,Justice of the Supreme Court,11,DEM,Lee A. Mayersohn,222
+Queens,045/23,Justice of the Supreme Court,11,DEM,Lee A. Mayersohn,223
 Queens,045/23,Justice of the Supreme Court,11,REP,Lee A. Mayersohn,242
-Queens,045/23,Justice of the Supreme Court,11,DEM,Nestor H. Diaz,225
+Queens,045/23,Justice of the Supreme Court,11,DEM,Nestor H. Diaz,226
 Queens,045/23,Justice of the Supreme Court,11,REP,Nestor H. Diaz,238
 Queens,045/23,Justice of the Supreme Court,11,,Scattered,4
 Queens,046/23,Justice of the Supreme Court,11,,Public Counter,563
@@ -62782,12 +62782,12 @@ Queens,045/23,Judge of the Civil Court - County,13,,Public Counter,518
 Queens,045/23,Judge of the Civil Court - County,13,,Manually Counted Emergency,0
 Queens,045/23,Judge of the Civil Court - County,13,,Absentee / Military,64
 Queens,045/23,Judge of the Civil Court - County,13,,Federal,1
-Queens,045/23,Judge of the Civil Court - County,13,,Affidavit,5
-Queens,045/23,Judge of the Civil Court - County,13,DEM,Karen Lin,226
+Queens,045/23,Judge of the Civil Court - County,13,,Affidavit,6
+Queens,045/23,Judge of the Civil Court - County,13,DEM,Karen Lin,227
 Queens,045/23,Judge of the Civil Court - County,13,REP,William D. Shanahan,272
 Queens,045/23,Judge of the Civil Court - County,13,CON,William D. Shanahan,19
 Queens,045/23,Judge of the Civil Court - County,13,IND,William D. Shanahan,4
-Queens,045/23,Judge of the Civil Court - County,13,DEM,Maria T. Gonzalez,230
+Queens,045/23,Judge of the Civil Court - County,13,DEM,Maria T. Gonzalez,231
 Queens,045/23,Judge of the Civil Court - County,13,REP,Daniel Kogan,244
 Queens,045/23,Judge of the Civil Court - County,13,CON,Daniel Kogan,17
 Queens,045/23,Judge of the Civil Court - County,13,IND,Daniel Kogan,3
@@ -79133,8 +79133,8 @@ Queens,045/23,U.S. House,05,,Public Counter,518
 Queens,045/23,U.S. House,05,,Manually Counted Emergency,0
 Queens,045/23,U.S. House,05,,Absentee / Military,64
 Queens,045/23,U.S. House,05,,Federal,1
-Queens,045/23,U.S. House,05,,Affidavit,5
-Queens,045/23,U.S. House,05,DEM,Gregory W. Meeks,257
+Queens,045/23,U.S. House,05,,Affidavit,6
+Queens,045/23,U.S. House,05,DEM,Gregory W. Meeks,258
 Queens,045/23,U.S. House,05,REP,Paul King,279
 Queens,045/23,U.S. House,05,CON,Paul King,19
 Queens,046/23,U.S. House,05,,Public Counter,563
@@ -89062,8 +89062,8 @@ Queens,045/23,State Senate,10,,Public Counter,518
 Queens,045/23,State Senate,10,,Manually Counted Emergency,0
 Queens,045/23,State Senate,10,,Absentee / Military,64
 Queens,045/23,State Senate,10,,Federal,1
-Queens,045/23,State Senate,10,,Affidavit,5
-Queens,045/23,State Senate,10,DEM,James Sanders Jr.,296
+Queens,045/23,State Senate,10,,Affidavit,6
+Queens,045/23,State Senate,10,DEM,James Sanders Jr.,297
 Queens,045/23,State Senate,10,,Scattered,5
 Queens,058/23,State Senate,10,,Public Counter,365
 Queens,058/23,State Senate,10,,Manually Counted Emergency,0
@@ -108489,7 +108489,7 @@ Queens,045/23,"CLEAN WATER, CLEAN AIR, AND GREEN JOBS Environmental Bond Act of 
 Queens,045/23,"CLEAN WATER, CLEAN AIR, AND GREEN JOBS Environmental Bond Act of 2022",,,Manually Counted Emergency,0
 Queens,045/23,"CLEAN WATER, CLEAN AIR, AND GREEN JOBS Environmental Bond Act of 2022",,,Absentee / Military,64
 Queens,045/23,"CLEAN WATER, CLEAN AIR, AND GREEN JOBS Environmental Bond Act of 2022",,,Federal,1
-Queens,045/23,"CLEAN WATER, CLEAN AIR, AND GREEN JOBS Environmental Bond Act of 2022",,,Affidavit,5
+Queens,045/23,"CLEAN WATER, CLEAN AIR, AND GREEN JOBS Environmental Bond Act of 2022",,,Affidavit,6
 Queens,045/23,"CLEAN WATER, CLEAN AIR, AND GREEN JOBS Environmental Bond Act of 2022",,,Yes,332
 Queens,045/23,"CLEAN WATER, CLEAN AIR, AND GREEN JOBS Environmental Bond Act of 2022",,,No,168
 Queens,046/23,"CLEAN WATER, CLEAN AIR, AND GREEN JOBS Environmental Bond Act of 2022",,,Public Counter,563
@@ -117247,7 +117247,7 @@ Queens,045/23,Add a Statement of Values to Guide Government,,,Public Counter,518
 Queens,045/23,Add a Statement of Values to Guide Government,,,Manually Counted Emergency,0
 Queens,045/23,Add a Statement of Values to Guide Government,,,Absentee / Military,64
 Queens,045/23,Add a Statement of Values to Guide Government,,,Federal,1
-Queens,045/23,Add a Statement of Values to Guide Government,,,Affidavit,5
+Queens,045/23,Add a Statement of Values to Guide Government,,,Affidavit,6
 Queens,045/23,Add a Statement of Values to Guide Government,,,Yes,250
 Queens,045/23,Add a Statement of Values to Guide Government,,,No,237
 Queens,046/23,Add a Statement of Values to Guide Government,,,Public Counter,563
@@ -126005,7 +126005,7 @@ Queens,045/23,"Establish a Racial Equity Office, Plan, and Commission",,,Public 
 Queens,045/23,"Establish a Racial Equity Office, Plan, and Commission",,,Manually Counted Emergency,0
 Queens,045/23,"Establish a Racial Equity Office, Plan, and Commission",,,Absentee / Military,64
 Queens,045/23,"Establish a Racial Equity Office, Plan, and Commission",,,Federal,1
-Queens,045/23,"Establish a Racial Equity Office, Plan, and Commission",,,Affidavit,5
+Queens,045/23,"Establish a Racial Equity Office, Plan, and Commission",,,Affidavit,6
 Queens,045/23,"Establish a Racial Equity Office, Plan, and Commission",,,Yes,232
 Queens,045/23,"Establish a Racial Equity Office, Plan, and Commission",,,No,257
 Queens,046/23,"Establish a Racial Equity Office, Plan, and Commission",,,Public Counter,563
@@ -134763,7 +134763,7 @@ Queens,045/23,Measure the True Cost of Living,,,Public Counter,518
 Queens,045/23,Measure the True Cost of Living,,,Manually Counted Emergency,0
 Queens,045/23,Measure the True Cost of Living,,,Absentee / Military,64
 Queens,045/23,Measure the True Cost of Living,,,Federal,1
-Queens,045/23,Measure the True Cost of Living,,,Affidavit,5
+Queens,045/23,Measure the True Cost of Living,,,Affidavit,6
 Queens,045/23,Measure the True Cost of Living,,,Yes,348
 Queens,045/23,Measure the True Cost of Living,,,No,155
 Queens,046/23,Measure the True Cost of Living,,,Public Counter,563


### PR DESCRIPTION
## Summary

Fixes #155. The 2022 NYC conversion's `drop_duplicates()` retained the stale Queens borough EDLevel file over the certified citywide file for ED `045/23` (AD 23), dropping one affidavit ballot. The borough files predate vote.nyc's 2022-12-02 certified repost; only the citywide files were corrected.

## What changed

For precinct `045/23` in Queens, restore the dropped affidavit ballot per the certified vote.nyc citywide EDLevel files and the NYS BOE state canvass:

- **Affidavit counter 5→6** for all 12 contests on the ED's ballot (the ED's certified affidavit count is 6; the borough files are uniformly stale).
- **+1 Democratic line** for all 8 candidate contests:
  - Governor (Hochul 251), Attorney General (James 247), Comptroller (DiNapoli 268), U.S. Senate (Schumer 273) — certified via the citywide EDLevel files; NYS BOE canvass agrees (per #155).
  - U.S. House (Meeks 258) — confirmed via the NYS BOE certified canvass (104,396 = data-ny 104,395 + 1), proving the ballot voted the Democratic line down-ballot.
  - State Senate (Sanders 297), Supreme Court (4 DEM +1), Civil Court (2 DEM +1) — straight-DEM pattern confirmed across the 5 verified candidate races.
- **Ballot proposals (4):** Affidavit 5→6, Yes/No unchanged (the voter undervoted the proposals), per the citywide files.
- WOR/REP/CON/IND/LAR lines, other counters, and Scattered unchanged.

## Files

- `2022/counties/20221108__ny__general__queens__precinct.csv` — 24 cells, byte-preserving (only the unquoted `votes` field changed; all quoting preserved).
- `2022/20221108__ny__general__precinct.csv` (statewide) — 6 DEM candidate rows for `045/23` patched in place. The committed statewide excludes ballot-type counter rows (the Affidavit-counter fix therefore lives only in the county file). The current `statewide_generator.py` has diverged to include those counter rows, so regenerating would introduce ~155k unrelated rows — patched in place to keep the fix scoped.

## Verification

- County file: exactly 24 target lines differ from the backup, 0 collateral changes (prefix identical, only `votes` changed); file parses cleanly (143,210 data rows, 7 cols).
- Statewide: exactly 6 lines differ, only `votes` changed; parses cleanly (552,348 data rows, 15 cols); all 6 DEM rows consistent with the county file.
- 045/23 now matches certified: Governor 6/251, AG 6/247, Comptroller 6/268, U.S. Senate 6/273; NY-05 Meeks 258; proposals Affidavit 6 with unchanged Yes/No.

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)